### PR TITLE
feat: お試しスクリプトを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.tgz
 .DS_Store
 coverage/
+output/

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-config-prettier": "^10.0.0",
         "prettier": "^3.0.0",
         "tsup": "^8.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.5.0",
         "vitest": "^3.0.0"
       },
@@ -2641,6 +2642,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3319,6 +3333,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -3765,6 +3789,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "format:check": "prettier --check 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "render": "tsx scripts/test-render.ts"
   },
   "files": [
     "dist"
@@ -43,6 +44,7 @@
     "eslint-config-prettier": "^10.0.0",
     "prettier": "^3.0.0",
     "tsup": "^8.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.5.0",
     "vitest": "^3.0.0"
   }

--- a/scripts/test-render.ts
+++ b/scripts/test-render.ts
@@ -1,16 +1,46 @@
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { basename, join, resolve } from "path";
 import { convertPptxToSvg, convertPptxToPng } from "../src/converter.js";
 
 async function main() {
-  const input = readFileSync("tests/fixtures/basic-shapes.pptx");
+  const filePath = process.argv[2];
+
+  if (!filePath) {
+    console.error("Usage: npx tsx scripts/test-render.ts <pptx-file> [output-dir]");
+    console.error("");
+    console.error("Examples:");
+    console.error("  npx tsx scripts/test-render.ts presentation.pptx");
+    console.error("  npx tsx scripts/test-render.ts presentation.pptx ./output");
+    process.exit(1);
+  }
+
+  const outputDir = resolve(process.argv[3] ?? "./output");
+  mkdirSync(outputDir, { recursive: true });
+
+  const input = readFileSync(filePath);
+  const name = basename(filePath, ".pptx");
+
+  console.log(`Converting: ${filePath}`);
+  console.log(`Output dir: ${outputDir}`);
+  console.log("");
 
   const svgResults = await convertPptxToSvg(input);
-  writeFileSync("/tmp/test-slide.svg", svgResults[0].svg);
-  console.log("SVG written to /tmp/test-slide.svg");
-
   const pngResults = await convertPptxToPng(input);
-  writeFileSync("/tmp/test-slide.png", pngResults[0].png);
-  console.log(`PNG written to /tmp/test-slide.png (${pngResults[0].width}x${pngResults[0].height})`);
+
+  for (const svg of svgResults) {
+    const svgPath = join(outputDir, `${name}-slide${svg.slideNumber}.svg`);
+    writeFileSync(svgPath, svg.svg);
+    console.log(`  SVG: ${svgPath}`);
+  }
+
+  for (const png of pngResults) {
+    const pngPath = join(outputDir, `${name}-slide${png.slideNumber}.png`);
+    writeFileSync(pngPath, png.png);
+    console.log(`  PNG: ${pngPath} (${png.width}x${png.height})`);
+  }
+
+  console.log("");
+  console.log(`Done! ${svgResults.length} slide(s) converted.`);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Summary

- `npm run render -- <pptx-file> [output-dir]` でPPTXをSVG/PNGに変換できるお試しスクリプトを追加
- 引数なしでUsageを表示
- 出力先はデフォルトで `./output`（.gitignore済み）
- devDependenciesに `tsx` を追加

## Test plan

- [x] `npm run render -- tests/fixtures/basic-shapes.pptx` で動作確認
- [x] 出力先指定 `npm run render -- file.pptx /tmp/out` で動作確認
- [x] 引数なしでUsage表示を確認
- [x] typecheck / lint / format / test すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)