### PR TITLE
feat: 仕上げ - 背景フォールバック、カスタムジオメトリ、ユニットテスト追加

### DIFF
--- a/src/renderer/geometry/geometry-renderer.ts
+++ b/src/renderer/geometry/geometry-renderer.ts
@@ -5,6 +5,8 @@ export function renderGeometry(geometry: Geometry, width: number, height: number
   if (geometry.type === "preset") {
     return getPresetGeometrySvg(geometry.preset, width, height, geometry.adjustValues);
   }
-  // custom geometry fallback
+  if (geometry.type === "custom" && geometry.pathData) {
+    return `<path d="${geometry.pathData}"/>`;
+  }
   return `<rect width="${width}" height="${height}"/>`;
 }

--- a/tests/color/color-resolver.test.ts
+++ b/tests/color/color-resolver.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { ColorResolver } from "../../src/color/color-resolver.js";
+import type { ColorScheme, ColorMap } from "../../src/model/theme.js";
+
+const testScheme: ColorScheme = {
+  dk1: "#000000",
+  lt1: "#FFFFFF",
+  dk2: "#44546A",
+  lt2: "#E7E6E6",
+  accent1: "#4472C4",
+  accent2: "#ED7D31",
+  accent3: "#A5A5A5",
+  accent4: "#FFC000",
+  accent5: "#5B9BD5",
+  accent6: "#70AD47",
+  hlink: "#0563C1",
+  folHlink: "#954F72",
+};
+
+const testColorMap: ColorMap = {
+  bg1: "lt1",
+  tx1: "dk1",
+  bg2: "lt2",
+  tx2: "dk2",
+  accent1: "accent1",
+  accent2: "accent2",
+  accent3: "accent3",
+  accent4: "accent4",
+  accent5: "accent5",
+  accent6: "accent6",
+  hlink: "hlink",
+  folHlink: "folHlink",
+};
+
+describe("ColorResolver", () => {
+  const resolver = new ColorResolver(testScheme, testColorMap);
+
+  it("resolves srgbClr", () => {
+    const result = resolver.resolve({ srgbClr: { "@_val": "FF0000" } });
+    expect(result).toEqual({ hex: "#FF0000", alpha: 1 });
+  });
+
+  it("resolves schemeClr accent1", () => {
+    const result = resolver.resolve({ schemeClr: { "@_val": "accent1" } });
+    expect(result).toEqual({ hex: "#4472C4", alpha: 1 });
+  });
+
+  it("resolves schemeClr via colorMap (tx1 → dk1)", () => {
+    const result = resolver.resolve({ schemeClr: { "@_val": "tx1" } });
+    expect(result).toEqual({ hex: "#000000", alpha: 1 });
+  });
+
+  it("resolves schemeClr via colorMap (bg1 → lt1)", () => {
+    const result = resolver.resolve({ schemeClr: { "@_val": "bg1" } });
+    expect(result).toEqual({ hex: "#FFFFFF", alpha: 1 });
+  });
+
+  it("resolves sysClr with lastClr", () => {
+    const result = resolver.resolve({
+      sysClr: { "@_val": "windowText", "@_lastClr": "000000" },
+    });
+    expect(result).toEqual({ hex: "#000000", alpha: 1 });
+  });
+
+  it("applies alpha", () => {
+    const result = resolver.resolve({
+      srgbClr: { "@_val": "FF0000", alpha: { "@_val": "50000" } },
+    });
+    expect(result?.hex).toBe("#FF0000");
+    expect(result?.alpha).toBe(0.5);
+  });
+
+  it("returns null for empty node", () => {
+    expect(resolver.resolve(null)).toBeNull();
+    expect(resolver.resolve({})).toBeNull();
+  });
+});

--- a/tests/parser/theme-parser.test.ts
+++ b/tests/parser/theme-parser.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { parseTheme } from "../../src/parser/theme-parser.js";
+
+const themeXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+  <a:themeElements>
+    <a:clrScheme name="Office">
+      <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+      <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+      <a:dk2><a:srgbClr val="44546A"/></a:dk2>
+      <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+      <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+      <a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+      <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>
+      <a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+      <a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>
+      <a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+      <a:hlink><a:srgbClr val="0563C1"/></a:hlink>
+      <a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+    </a:clrScheme>
+    <a:fontScheme name="Office">
+      <a:majorFont><a:latin typeface="Calibri Light"/></a:majorFont>
+      <a:minorFont><a:latin typeface="Calibri"/></a:minorFont>
+    </a:fontScheme>
+    <a:fmtScheme name="Office"/>
+  </a:themeElements>
+</a:theme>`;
+
+describe("parseTheme", () => {
+  const theme = parseTheme(themeXml);
+
+  it("parses color scheme", () => {
+    expect(theme.colorScheme.dk1).toBe("#000000");
+    expect(theme.colorScheme.lt1).toBe("#FFFFFF");
+    expect(theme.colorScheme.accent1).toBe("#4472C4");
+    expect(theme.colorScheme.accent2).toBe("#ED7D31");
+    expect(theme.colorScheme.hlink).toBe("#0563C1");
+  });
+
+  it("parses font scheme", () => {
+    expect(theme.fontScheme.majorFont).toBe("Calibri Light");
+    expect(theme.fontScheme.minorFont).toBe("Calibri");
+  });
+});

--- a/tests/renderer/fill-renderer.test.ts
+++ b/tests/renderer/fill-renderer.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  renderFillAttrs,
+  renderOutlineAttrs,
+  resetDefsCounter,
+} from "../../src/renderer/fill-renderer.js";
+
+describe("renderFillAttrs", () => {
+  beforeEach(() => resetDefsCounter());
+
+  it("renders null fill as none", () => {
+    const result = renderFillAttrs(null);
+    expect(result.attrs).toBe('fill="none"');
+    expect(result.defs).toBe("");
+  });
+
+  it("renders noFill", () => {
+    const result = renderFillAttrs({ type: "none" });
+    expect(result.attrs).toBe('fill="none"');
+  });
+
+  it("renders solid fill", () => {
+    const result = renderFillAttrs({
+      type: "solid",
+      color: { hex: "#FF0000", alpha: 1 },
+    });
+    expect(result.attrs).toBe('fill="#FF0000"');
+    expect(result.defs).toBe("");
+  });
+
+  it("renders solid fill with alpha", () => {
+    const result = renderFillAttrs({
+      type: "solid",
+      color: { hex: "#FF0000", alpha: 0.5 },
+    });
+    expect(result.attrs).toContain('fill="#FF0000"');
+    expect(result.attrs).toContain('fill-opacity="0.5"');
+  });
+
+  it("renders gradient fill with defs", () => {
+    const result = renderFillAttrs({
+      type: "gradient",
+      angle: 90,
+      stops: [
+        { position: 0, color: { hex: "#FF0000", alpha: 1 } },
+        { position: 1, color: { hex: "#0000FF", alpha: 1 } },
+      ],
+    });
+    expect(result.attrs).toContain("url(#grad-");
+    expect(result.defs).toContain("<linearGradient");
+    expect(result.defs).toContain("#FF0000");
+    expect(result.defs).toContain("#0000FF");
+  });
+});
+
+describe("renderOutlineAttrs", () => {
+  it("renders null outline as stroke none", () => {
+    expect(renderOutlineAttrs(null)).toBe('stroke="none"');
+  });
+
+  it("renders outline with color", () => {
+    const result = renderOutlineAttrs({
+      width: 12700,
+      fill: { type: "solid", color: { hex: "#000000", alpha: 1 } },
+      dashStyle: "solid",
+    });
+    expect(result).toContain('stroke="#000000"');
+    expect(result).toContain("stroke-width=");
+  });
+
+  it("renders dash style", () => {
+    const result = renderOutlineAttrs({
+      width: 12700,
+      fill: { type: "solid", color: { hex: "#000000", alpha: 1 } },
+      dashStyle: "dash",
+    });
+    expect(result).toContain("stroke-dasharray=");
+  });
+});

--- a/tests/renderer/preset-geometries.test.ts
+++ b/tests/renderer/preset-geometries.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { getPresetGeometrySvg } from "../../src/renderer/geometry/preset-geometries.js";
+
+describe("getPresetGeometrySvg", () => {
+  it("generates rect", () => {
+    const svg = getPresetGeometrySvg("rect", 100, 50, {});
+    expect(svg).toBe('<rect width="100" height="50"/>');
+  });
+
+  it("generates ellipse", () => {
+    const svg = getPresetGeometrySvg("ellipse", 200, 100, {});
+    expect(svg).toContain("<ellipse");
+    expect(svg).toContain('cx="100"');
+    expect(svg).toContain('rx="100"');
+    expect(svg).toContain('ry="50"');
+  });
+
+  it("generates roundRect with default radius", () => {
+    const svg = getPresetGeometrySvg("roundRect", 100, 100, {});
+    expect(svg).toContain("<rect");
+    expect(svg).toContain("rx=");
+    expect(svg).toContain("ry=");
+  });
+
+  it("generates roundRect with custom adjust value", () => {
+    const svg = getPresetGeometrySvg("roundRect", 100, 100, { adj: 50000 });
+    expect(svg).toContain("rx=");
+  });
+
+  it("generates triangle", () => {
+    const svg = getPresetGeometrySvg("triangle", 100, 80, {});
+    expect(svg).toContain("<polygon");
+    expect(svg).toContain("points=");
+  });
+
+  it("generates diamond", () => {
+    const svg = getPresetGeometrySvg("diamond", 100, 100, {});
+    expect(svg).toContain("<polygon");
+  });
+
+  it("generates rightArrow", () => {
+    const svg = getPresetGeometrySvg("rightArrow", 200, 100, {});
+    expect(svg).toContain("<polygon");
+  });
+
+  it("falls back to rect for unknown preset", () => {
+    const svg = getPresetGeometrySvg("unknownShape", 100, 50, {});
+    expect(svg).toBe('<rect width="100" height="50"/>');
+  });
+});


### PR DESCRIPTION
## Summary

- **Master/Layout背景のフォールバック**: スライドに背景がない場合に slideLayout → slideMaster の順で背景を探索するようにconverterに接続（パーサーは実装済みだったが未使用だった）
- **カスタムジオメトリ(custGeom)のパース**: OOXML の moveTo/lnTo/cubicBezTo/close をSVG pathデータに変換して描画
- **ユニットテスト追加 (25件)**: ColorResolver, ThemeParser, PresetGeometries, FillRenderer の個別テスト

## Test plan

- [x] 全42テスト (17既存 + 25新規) パス
- [x] typecheck / eslint / prettier すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)