### PR TITLE
feat: GitHub Actions CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## 概要
- GitHub Actions による CI ワークフローを追加
- `main` ブランチへの push / PR をトリガーに実行

## 実行内容
- Node.js 18 / 20 / 22 のマトリックスビルド
- lint (`eslint`)
- format check (`prettier --check`)
- type check (`tsc --noEmit`)
- test (`vitest run`)
- build (`tsup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)