### PR TITLE
feat: テキストのワードラップ処理を実装

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,6 @@ export {
   ROTATION_UNIT,
   FONT_SIZE_UNIT,
 } from "./constants.js";
+export { measureTextWidth } from "./text-measure.js";
+export { wrapParagraph } from "./text-wrap.js";
+export type { LineSegment, WrappedLine } from "./text-wrap.js";

--- a/src/utils/text-measure.ts
+++ b/src/utils/text-measure.ts
@@ -1,0 +1,68 @@
+type CharCategory = "narrow" | "normal" | "wide";
+
+const WIDTH_RATIO: Record<CharCategory, number> = {
+  narrow: 0.3,
+  normal: 0.6,
+  wide: 1.0,
+};
+
+const BOLD_FACTOR = 1.05;
+const PX_PER_PT = 96 / 72;
+
+function categorizeChar(codePoint: number): CharCategory {
+  // CJK 統合漢字、ひらがな、カタカナ、CJK 記号、全角英数
+  if (
+    (codePoint >= 0x3000 && codePoint <= 0x9fff) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
+    (codePoint >= 0x20000 && codePoint <= 0x2a6df)
+  ) {
+    return "wide";
+  }
+
+  // 狭い文字
+  if (
+    codePoint === 0x20 || // space
+    codePoint === 0x21 || // !
+    codePoint === 0x2c || // ,
+    codePoint === 0x2e || // .
+    codePoint === 0x3a || // :
+    codePoint === 0x3b || // ;
+    codePoint === 0x69 || // i
+    codePoint === 0x6a || // j
+    codePoint === 0x6c || // l
+    codePoint === 0x31 || // 1
+    codePoint === 0x7c || // |
+    codePoint === 0x27 || // '
+    codePoint === 0x28 || // (
+    codePoint === 0x29 || // )
+    codePoint === 0x5b || // [
+    codePoint === 0x5d || // ]
+    codePoint === 0x7b || // {
+    codePoint === 0x7d // }
+  ) {
+    return "narrow";
+  }
+
+  return "normal";
+}
+
+/**
+ * テキストの推定幅を計算する (ピクセル単位)
+ */
+export function measureTextWidth(text: string, fontSizePt: number, bold: boolean): number {
+  const baseSizePx = fontSizePt * PX_PER_PT;
+  let totalWidth = 0;
+
+  for (const char of text) {
+    const codePoint = char.codePointAt(0)!;
+    const category = categorizeChar(codePoint);
+    totalWidth += baseSizePx * WIDTH_RATIO[category];
+  }
+
+  if (bold) {
+    totalWidth *= BOLD_FACTOR;
+  }
+
+  return totalWidth;
+}

--- a/src/utils/text-wrap.ts
+++ b/src/utils/text-wrap.ts
@@ -1,0 +1,278 @@
+import type { Paragraph, RunProperties } from "../model/text.js";
+import { measureTextWidth } from "./text-measure.js";
+
+export interface LineSegment {
+  text: string;
+  properties: RunProperties;
+}
+
+export interface WrappedLine {
+  segments: LineSegment[];
+}
+
+interface Token {
+  text: string;
+  properties: RunProperties;
+  width: number;
+  breakable: boolean;
+}
+
+const DEFAULT_FONT_SIZE = 18;
+
+function isCjk(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x3000 && codePoint <= 0x9fff) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
+    (codePoint >= 0x20000 && codePoint <= 0x2a6df)
+  );
+}
+
+function isWhitespace(codePoint: number): boolean {
+  return codePoint === 0x20 || codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+}
+
+/**
+ * テキストをブレーク可能な単位に分割する。
+ * - 空白: 個別トークン (breakable)
+ * - CJK 文字: 1文字ずつ (breakable)
+ * - ラテン文字の連続: 1ワード (先頭以外で breakable)
+ */
+function splitTextIntoFragments(text: string): { fragment: string; breakable: boolean }[] {
+  const fragments: { fragment: string; breakable: boolean }[] = [];
+  let current = "";
+  let currentType: "latin" | "cjk" | "space" | null = null;
+
+  for (const char of text) {
+    const cp = char.codePointAt(0)!;
+
+    if (isWhitespace(cp)) {
+      if (current && currentType !== "space") {
+        fragments.push({ fragment: current, breakable: currentType === "cjk" });
+        current = "";
+      }
+      currentType = "space";
+      current += char;
+    } else if (isCjk(cp)) {
+      if (current) {
+        fragments.push({
+          fragment: current,
+          breakable: currentType === "cjk" || currentType === "space",
+        });
+        current = "";
+      }
+      // CJK 文字は1文字ずつ独立トークン
+      fragments.push({ fragment: char, breakable: true });
+      currentType = "cjk";
+      current = "";
+    } else {
+      // ラテン文字
+      if (current && currentType !== "latin") {
+        fragments.push({ fragment: current, breakable: currentType === "space" });
+        current = "";
+      }
+      currentType = "latin";
+      current += char;
+    }
+  }
+
+  if (current) {
+    fragments.push({
+      fragment: current,
+      breakable: currentType === "space" || currentType === "cjk",
+    });
+  }
+
+  return fragments;
+}
+
+function tokenizeRuns(runs: Paragraph["runs"], defaultFontSize: number): Token[] {
+  const tokens: Token[] = [];
+  let isFirst = true;
+
+  for (const run of runs) {
+    if (run.text.length === 0) continue;
+
+    const fontSize = run.properties.fontSize ?? defaultFontSize;
+    const bold = run.properties.bold;
+    const fragments = splitTextIntoFragments(run.text);
+
+    for (const { fragment, breakable } of fragments) {
+      const width = measureTextWidth(fragment, fontSize, bold);
+      tokens.push({
+        text: fragment,
+        properties: run.properties,
+        width,
+        breakable: isFirst ? false : breakable,
+      });
+      isFirst = false;
+    }
+  }
+
+  return tokens;
+}
+
+function isSpaceOnly(text: string): boolean {
+  for (const char of text) {
+    if (!isWhitespace(char.codePointAt(0)!)) return false;
+  }
+  return true;
+}
+
+/**
+ * 長いトークンを文字単位で強制分割する
+ */
+function splitTokenByChars(
+  token: Token,
+  availableWidth: number,
+  defaultFontSize: number,
+): Token[][] {
+  const lines: Token[][] = [];
+  let currentLine: Token[] = [];
+  let currentWidth = 0;
+  const fontSize = token.properties.fontSize ?? defaultFontSize;
+  const bold = token.properties.bold;
+
+  for (const char of token.text) {
+    const charWidth = measureTextWidth(char, fontSize, bold);
+
+    if (currentWidth + charWidth > availableWidth && currentLine.length > 0) {
+      lines.push(currentLine);
+      currentLine = [];
+      currentWidth = 0;
+    }
+
+    currentLine.push({
+      text: char,
+      properties: token.properties,
+      width: charWidth,
+      breakable: false,
+    });
+    currentWidth += charWidth;
+  }
+
+  if (currentLine.length > 0) {
+    lines.push(currentLine);
+  }
+
+  return lines;
+}
+
+function mergeSegments(tokens: Token[]): LineSegment[] {
+  const segments: LineSegment[] = [];
+
+  for (const token of tokens) {
+    if (segments.length > 0) {
+      const last = segments[segments.length - 1];
+      if (last.properties === token.properties) {
+        last.text += token.text;
+        continue;
+      }
+    }
+    segments.push({ text: token.text, properties: token.properties });
+  }
+
+  return segments;
+}
+
+function trimTrailingSpaces(segments: LineSegment[]): LineSegment[] {
+  if (segments.length === 0) return segments;
+
+  const last = segments[segments.length - 1];
+  const trimmed = last.text.replace(/\s+$/, "");
+
+  if (trimmed.length === 0) {
+    const result = segments.slice(0, -1);
+    return trimTrailingSpaces(result);
+  }
+
+  if (trimmed !== last.text) {
+    return [...segments.slice(0, -1), { text: trimmed, properties: last.properties }];
+  }
+
+  return segments;
+}
+
+function layoutTokensIntoLines(
+  tokens: Token[],
+  availableWidth: number,
+  defaultFontSize: number,
+): WrappedLine[] {
+  if (tokens.length === 0) return [{ segments: [] }];
+
+  const lines: WrappedLine[] = [];
+  let currentLine: Token[] = [];
+  let currentWidth = 0;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (currentWidth + token.width <= availableWidth) {
+      currentLine.push(token);
+      currentWidth += token.width;
+    } else if (currentLine.length === 0) {
+      // 行が空で1トークンすら入らない → 文字単位で強制分割
+      if (isSpaceOnly(token.text)) {
+        // 空白だけのトークンはスキップ
+        continue;
+      }
+      const splitLines = splitTokenByChars(token, availableWidth, defaultFontSize);
+      for (let j = 0; j < splitLines.length; j++) {
+        if (j < splitLines.length - 1) {
+          const segments = trimTrailingSpaces(mergeSegments(splitLines[j]));
+          if (segments.length > 0) lines.push({ segments });
+        } else {
+          // 最後のチャンクは次の行の先頭になる
+          currentLine = splitLines[j];
+          currentWidth = splitLines[j].reduce((sum, t) => sum + t.width, 0);
+        }
+      }
+    } else if (token.breakable) {
+      // 改行可能な位置で改行
+      const segments = trimTrailingSpaces(mergeSegments(currentLine));
+      if (segments.length > 0) lines.push({ segments });
+
+      if (isSpaceOnly(token.text)) {
+        // 行頭の空白はスキップ
+        currentLine = [];
+        currentWidth = 0;
+      } else {
+        currentLine = [token];
+        currentWidth = token.width;
+      }
+    } else {
+      // breakable でないが行に収まらない → 手前で改行してこのトークンを次の行へ
+      const segments = trimTrailingSpaces(mergeSegments(currentLine));
+      if (segments.length > 0) lines.push({ segments });
+      currentLine = [token];
+      currentWidth = token.width;
+    }
+  }
+
+  if (currentLine.length > 0) {
+    const segments = trimTrailingSpaces(mergeSegments(currentLine));
+    if (segments.length > 0) lines.push({ segments });
+  }
+
+  return lines.length > 0 ? lines : [{ segments: [] }];
+}
+
+/**
+ * 段落のランを折り返して行配列に変換する
+ */
+export function wrapParagraph(
+  paragraph: Paragraph,
+  availableWidth: number,
+  defaultFontSize: number = DEFAULT_FONT_SIZE,
+): WrappedLine[] {
+  if (paragraph.runs.length === 0 || !paragraph.runs.some((r) => r.text.length > 0)) {
+    return [{ segments: [] }];
+  }
+
+  const safeWidth = Math.max(availableWidth, 1);
+  const tokens = tokenizeRuns(paragraph.runs, defaultFontSize);
+
+  if (tokens.length === 0) return [{ segments: [] }];
+
+  return layoutTokensIntoLines(tokens, safeWidth, defaultFontSize);
+}

--- a/tests/renderer/text-renderer.test.ts
+++ b/tests/renderer/text-renderer.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import { renderTextBody } from "../../src/renderer/text-renderer.js";
+import type { TextBody } from "../../src/model/text.js";
+import type { Transform } from "../../src/model/shape.js";
+
+function makeTransform(widthEmu: number, heightEmu: number): Transform {
+  return {
+    offsetX: 0,
+    offsetY: 0,
+    extentWidth: widthEmu,
+    extentHeight: heightEmu,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+  };
+}
+
+function makeTextBody(
+  texts: string[],
+  overrides?: {
+    wrap?: "square" | "none";
+    anchor?: "t" | "ctr" | "b";
+    alignment?: "l" | "ctr" | "r" | "just";
+    fontSize?: number;
+  },
+): TextBody {
+  return {
+    bodyProperties: {
+      anchor: overrides?.anchor ?? "t",
+      marginLeft: 91440, // ~9.6px
+      marginRight: 91440,
+      marginTop: 45720, // ~4.8px
+      marginBottom: 45720,
+      wrap: overrides?.wrap ?? "square",
+    },
+    paragraphs: [
+      {
+        runs: texts.map((text) => ({
+          text,
+          properties: {
+            fontSize: overrides?.fontSize ?? 18,
+            fontFamily: null,
+            bold: false,
+            italic: false,
+            underline: false,
+            strikethrough: false,
+            color: null,
+          },
+        })),
+        properties: {
+          alignment: overrides?.alignment ?? "l",
+          lineSpacing: null,
+          spaceBefore: 0,
+          spaceAfter: 0,
+          level: 0,
+        },
+      },
+    ],
+  };
+}
+
+// 16:9 スライドサイズ (EMU)
+const SLIDE_WIDTH = 9144000;
+const SLIDE_HEIGHT = 5143500;
+
+describe("renderTextBody", () => {
+  it("テキストがない場合は空文字列を返す", () => {
+    const textBody = makeTextBody([""]);
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toBe("");
+  });
+
+  it("短いテキストを正しくレンダリングする", () => {
+    const textBody = makeTextBody(["Hello"]);
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain("<text");
+    expect(result).toContain("Hello");
+    expect(result).toContain("<tspan");
+  });
+
+  it("wrap=square の場合、長いテキストが複数の tspan に折り返される", () => {
+    const textBody = makeTextBody(
+      ["The quick brown fox jumps over the lazy dog and continues with more words"],
+      { wrap: "square" },
+    );
+    // 狭い幅のテキストボックス
+    const transform = makeTransform(2000000, 2000000); // ~209px width
+    const result = renderTextBody(textBody, transform);
+
+    // 複数の x 属性を持つ tspan が存在する (= 複数行)
+    const xMatches = result.match(/x="/g);
+    expect(xMatches).not.toBeNull();
+    expect(xMatches!.length).toBeGreaterThan(1);
+  });
+
+  it("wrap=none の場合、テキストは折り返されない", () => {
+    const textBody = makeTextBody(
+      ["The quick brown fox jumps over the lazy dog and continues with more words"],
+      { wrap: "none" },
+    );
+    const transform = makeTransform(2000000, 2000000);
+    const result = renderTextBody(textBody, transform);
+
+    // x 属性を持つ tspan は1つだけ (text 要素の x を除く)
+    const tspanXMatches = result.match(/<tspan[^>]*x="/g);
+    expect(tspanXMatches).toHaveLength(1);
+  });
+
+  it("中央揃えの場合 text-anchor=middle が設定される", () => {
+    const textBody = makeTextBody(["Center"], { alignment: "ctr" });
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('text-anchor="middle"');
+  });
+
+  it("右揃えの場合 text-anchor=end が設定される", () => {
+    const textBody = makeTextBody(["Right"], { alignment: "r" });
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('text-anchor="end"');
+  });
+
+  it("左揃えの場合 text-anchor=start が設定される", () => {
+    const textBody = makeTextBody(["Left"], { alignment: "l" });
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('text-anchor="start"');
+  });
+
+  it("複数段落を正しくレンダリングする", () => {
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "First",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+              },
+            },
+          ],
+          properties: {
+            alignment: "l",
+            lineSpacing: null,
+            spaceBefore: 0,
+            spaceAfter: 0,
+            level: 0,
+          },
+        },
+        {
+          runs: [
+            {
+              text: "Second",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+              },
+            },
+          ],
+          properties: {
+            alignment: "l",
+            lineSpacing: null,
+            spaceBefore: 0,
+            spaceAfter: 0,
+            level: 0,
+          },
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain("First");
+    expect(result).toContain("Second");
+  });
+
+  it("font-size 属性が正しく設定される", () => {
+    const textBody = makeTextBody(["Test"], { fontSize: 24 });
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('font-size="24pt"');
+  });
+
+  it("CJK テキストの折り返しが動作する", () => {
+    const textBody = makeTextBody(["本日は晴天なり今日もいい天気です素晴らしい一日"], {
+      wrap: "square",
+    });
+    const transform = makeTransform(2000000, 2000000);
+    const result = renderTextBody(textBody, transform);
+    const xMatches = result.match(/<tspan[^>]*x="/g);
+    expect(xMatches).not.toBeNull();
+    expect(xMatches!.length).toBeGreaterThan(1);
+  });
+});

--- a/tests/utils/text-measure.test.ts
+++ b/tests/utils/text-measure.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { measureTextWidth } from "../../src/utils/text-measure.js";
+
+const PX_PER_PT = 96 / 72;
+
+describe("measureTextWidth", () => {
+  it("空文字列の幅は 0", () => {
+    expect(measureTextWidth("", 18, false)).toBe(0);
+  });
+
+  it("ASCII テキストの幅を推定する", () => {
+    const width = measureTextWidth("Hello", 18, false);
+    // 'H','e','o' = normal(0.6), 'l','l' = narrow(0.3)
+    // (3 * 0.6 + 2 * 0.3) * 18 * (96/72) = (1.8 + 0.6) * 24 = 57.6
+    expect(width).toBeCloseTo(57.6, 1);
+  });
+
+  it("CJK テキストの幅を推定する", () => {
+    const width = measureTextWidth("漢字", 18, false);
+    // 2 * 1.0 * 18 * (96/72) = 48
+    expect(width).toBeCloseTo(2 * 1.0 * 18 * PX_PER_PT, 1);
+  });
+
+  it("混合テキストの幅を推定する", () => {
+    const width = measureTextWidth("A漢", 18, false);
+    // A=normal(0.6) + 漢=wide(1.0) = 1.6 * 18 * (96/72) = 38.4
+    expect(width).toBeCloseTo(1.6 * 18 * PX_PER_PT, 1);
+  });
+
+  it("太字の場合は幅が増加する", () => {
+    const normalWidth = measureTextWidth("Test", 18, false);
+    const boldWidth = measureTextWidth("Test", 18, true);
+    expect(boldWidth).toBeCloseTo(normalWidth * 1.05, 1);
+  });
+
+  it("スペースの幅を推定する", () => {
+    const width = measureTextWidth(" ", 18, false);
+    // narrow(0.3) * 18 * (96/72) = 7.2
+    expect(width).toBeCloseTo(0.3 * 18 * PX_PER_PT, 1);
+  });
+
+  it("ひらがなを wide として推定する", () => {
+    const width = measureTextWidth("あ", 18, false);
+    expect(width).toBeCloseTo(1.0 * 18 * PX_PER_PT, 1);
+  });
+
+  it("カタカナを wide として推定する", () => {
+    const width = measureTextWidth("ア", 18, false);
+    expect(width).toBeCloseTo(1.0 * 18 * PX_PER_PT, 1);
+  });
+
+  it("フォントサイズに比例する", () => {
+    const width12 = measureTextWidth("A", 12, false);
+    const width24 = measureTextWidth("A", 24, false);
+    expect(width24).toBeCloseTo(width12 * 2, 1);
+  });
+});

--- a/tests/utils/text-wrap.test.ts
+++ b/tests/utils/text-wrap.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { wrapParagraph } from "../../src/utils/text-wrap.js";
+import type { Paragraph, RunProperties } from "../../src/model/text.js";
+
+function makeRunProps(overrides: Partial<RunProperties> = {}): RunProperties {
+  return {
+    fontSize: 18,
+    fontFamily: null,
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    color: null,
+    ...overrides,
+  };
+}
+
+function makeParagraph(texts: string[], props?: Partial<RunProperties>): Paragraph {
+  return {
+    runs: texts.map((text) => ({ text, properties: makeRunProps(props) })),
+    properties: {
+      alignment: "l",
+      lineSpacing: null,
+      spaceBefore: 0,
+      spaceAfter: 0,
+      level: 0,
+    },
+  };
+}
+
+describe("wrapParagraph", () => {
+  it("短いテキストは折り返さない", () => {
+    const para = makeParagraph(["Hi"]);
+    const lines = wrapParagraph(para, 500, 18);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].segments).toHaveLength(1);
+    expect(lines[0].segments[0].text).toBe("Hi");
+  });
+
+  it("長い英語テキストをワード境界で折り返す", () => {
+    const para = makeParagraph(["The quick brown fox jumps over the lazy dog"]);
+    // 幅を狭くして折り返しを発生させる
+    const lines = wrapParagraph(para, 100, 18);
+    expect(lines.length).toBeGreaterThan(1);
+    // 各行の先頭が大文字 or 小文字の単語で始まる
+    for (const line of lines) {
+      expect(line.segments.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("長い CJK テキストを文字境界で折り返す", () => {
+    const para = makeParagraph(["本日は晴天なり今日もいい天気です"]);
+    const lines = wrapParagraph(para, 100, 18);
+    expect(lines.length).toBeGreaterThan(1);
+  });
+
+  it("空の段落は空の行を返す", () => {
+    const para = makeParagraph([]);
+    const lines = wrapParagraph(para, 500, 18);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].segments).toHaveLength(0);
+  });
+
+  it("空テキストのランのみの段落は空の行を返す", () => {
+    const para = makeParagraph([""]);
+    const lines = wrapParagraph(para, 500, 18);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].segments).toHaveLength(0);
+  });
+
+  it("複数の TextRun が正しくセグメントに分割される", () => {
+    const boldProps = makeRunProps({ bold: true });
+    const normalProps = makeRunProps({ bold: false });
+    const para: Paragraph = {
+      runs: [
+        { text: "Bold ", properties: boldProps },
+        { text: "Normal", properties: normalProps },
+      ],
+      properties: {
+        alignment: "l",
+        lineSpacing: null,
+        spaceBefore: 0,
+        spaceAfter: 0,
+        level: 0,
+      },
+    };
+    const lines = wrapParagraph(para, 500, 18);
+    expect(lines).toHaveLength(1);
+    // bold と normal で少なくとも2つのセグメントになるか、マージされない
+    const allText = lines[0].segments.map((s) => s.text).join("");
+    expect(allText).toBe("Bold Normal");
+  });
+
+  it("スタイルが異なる TextRun の境界をまたぐ折り返し", () => {
+    const boldProps = makeRunProps({ bold: true });
+    const normalProps = makeRunProps({ bold: false });
+    const para: Paragraph = {
+      runs: [
+        { text: "First part is bold and ", properties: boldProps },
+        { text: "second part is normal text", properties: normalProps },
+      ],
+      properties: {
+        alignment: "l",
+        lineSpacing: null,
+        spaceBefore: 0,
+        spaceAfter: 0,
+        level: 0,
+      },
+    };
+    const lines = wrapParagraph(para, 150, 18);
+    expect(lines.length).toBeGreaterThan(1);
+    // 各行をスペースで結合して全テキストが保持されていることを確認
+    // (行末空白はトリムされるので行間にスペースを補って結合)
+    const allText = lines.map((l) => l.segments.map((s) => s.text).join("")).join(" ");
+    expect(allText).toContain("First part");
+    expect(allText).toContain("bold and");
+    expect(allText).toContain("second part");
+    expect(allText).toContain("normal text");
+  });
+
+  it("availableWidth が非常に小さい場合でも少なくとも1文字は配置する", () => {
+    const para = makeParagraph(["AB"]);
+    const lines = wrapParagraph(para, 1, 18);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const allText = lines.flatMap((l) => l.segments.map((s) => s.text)).join("");
+    expect(allText).toBe("AB");
+  });
+
+  it("行末の空白がトリムされる", () => {
+    const para = makeParagraph(["Hello World"]);
+    // Hello(~60px) + space(~7px) = ~67px で折り返し
+    const lines = wrapParagraph(para, 80, 18);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const lastSeg = line.segments[line.segments.length - 1];
+      if (lastSeg) {
+        expect(lastSeg.text).not.toMatch(/\s+$/);
+      }
+    }
+  });
+});


### PR DESCRIPTION
close #8

## Summary
- テキストの折り返し (ワードラップ) を実装し、長文テキストがテキストボックス内で適切に折り返されるようにした
- 文字幅推定ユーティリティ (`text-measure.ts`) を追加: 文字種別 (CJK/ラテン/狭い文字) ごとの係数でテキスト幅をピクセル単位で推定
- 折り返しアルゴリズム (`text-wrap.ts`) を追加: ラテン文字はワード境界、CJK文字は文字境界で折り返し
- `text-renderer.ts` を改修:
  - `wrap="square"` 時に折り返し処理を実行
  - 段落ごとの alignment 対応 (tspan に text-anchor を個別設定)
  - `lineSpacing` / `spaceBefore` の dy への反映
  - `estimateTextHeight` を折り返し後の行数に対応

## Test plan
- [x] `text-measure.test.ts`: 文字幅推定のユニットテスト (9 テスト)
- [x] `text-wrap.test.ts`: 折り返しアルゴリズムのユニットテスト (9 テスト)
- [x] `text-renderer.test.ts`: レンダラーの統合テスト (10 テスト)
- [x] 既存の統合テスト (`pptx-to-svg.test.ts`) が引き続き pass
- [x] lint / format / typecheck / build 全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)