### PR TITLE
feat: マスター/レイアウトからのシェイプ継承を実装

### DIFF
--- a/src/model/shape.ts
+++ b/src/model/shape.ts
@@ -32,6 +32,8 @@ export interface ShapeElement {
   fill: Fill | null;
   outline: Outline | null;
   textBody: TextBody | null;
+  placeholderType?: string;
+  placeholderIdx?: number;
 }
 
 export interface ConnectorElement {

--- a/src/parser/relationship-parser.ts
+++ b/src/parser/relationship-parser.ts
@@ -25,6 +25,13 @@ export function parseRelationships(xml: string): Map<string, Relationship> {
   return rels;
 }
 
+export function buildRelsPath(xmlPath: string): string {
+  const lastSlash = xmlPath.lastIndexOf("/");
+  const dir = xmlPath.substring(0, lastSlash);
+  const filename = xmlPath.substring(lastSlash + 1);
+  return `${dir}/_rels/${filename}.rels`;
+}
+
 export function resolveRelationshipTarget(basePath: string, relTarget: string): string {
   if (relTarget.startsWith("/")) {
     return relTarget.slice(1);

--- a/src/parser/slide-layout-parser.ts
+++ b/src/parser/slide-layout-parser.ts
@@ -1,6 +1,10 @@
 import type { Background } from "../model/slide.js";
+import type { SlideElement } from "../model/shape.js";
+import type { PptxArchive } from "./pptx-reader.js";
 import { parseXml } from "./xml-parser.js";
 import { parseFillFromNode } from "./fill-parser.js";
+import { parseShapeTree } from "./slide-parser.js";
+import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
 import type { ColorResolver } from "../color/color-resolver.js";
 
 export function parseSlideLayoutBackground(
@@ -17,4 +21,22 @@ export function parseSlideLayoutBackground(
 
   const fill = parseFillFromNode(bgPr, colorResolver);
   return { fill };
+}
+
+export function parseSlideLayoutElements(
+  xml: string,
+  layoutPath: string,
+  archive: PptxArchive,
+  colorResolver: ColorResolver,
+): SlideElement[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parsed = parseXml(xml) as any;
+  const spTree = parsed.sldLayout?.cSld?.spTree;
+  if (!spTree) return [];
+
+  const relsPath = buildRelsPath(layoutPath);
+  const relsXml = archive.files.get(relsPath);
+  const rels = relsXml ? parseRelationships(relsXml) : new Map();
+
+  return parseShapeTree(spTree, rels, layoutPath, archive, colorResolver);
 }

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -52,7 +52,7 @@ function parseBackground(
   return { fill };
 }
 
-function parseShapeTree(
+export function parseShapeTree(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   spTree: any,
   rels: Map<string, Relationship>,
@@ -104,6 +104,10 @@ function parseShape(sp: any, colorResolver: ColorResolver): ShapeElement | null 
   const outline = parseOutline(spPr.ln, colorResolver);
   const textBody = parseTextBody(sp.txBody, colorResolver);
 
+  const ph = sp.nvSpPr?.nvPr?.ph;
+  const placeholderType = ph ? (ph["@_type"] ?? "body") : undefined;
+  const placeholderIdx = ph?.["@_idx"] !== undefined ? Number(ph["@_idx"]) : undefined;
+
   return {
     type: "shape",
     transform,
@@ -111,6 +115,8 @@ function parseShape(sp: any, colorResolver: ColorResolver): ShapeElement | null 
     fill,
     outline,
     textBody,
+    ...(placeholderType !== undefined && { placeholderType }),
+    ...(placeholderIdx !== undefined && { placeholderIdx }),
   };
 }
 

--- a/tests/parser/relationship-parser.test.ts
+++ b/tests/parser/relationship-parser.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { buildRelsPath } from "../../src/parser/relationship-parser.js";
+
+describe("buildRelsPath", () => {
+  it("builds rels path for slide", () => {
+    expect(buildRelsPath("ppt/slides/slide1.xml")).toBe("ppt/slides/_rels/slide1.xml.rels");
+  });
+
+  it("builds rels path for slide layout", () => {
+    expect(buildRelsPath("ppt/slideLayouts/slideLayout1.xml")).toBe(
+      "ppt/slideLayouts/_rels/slideLayout1.xml.rels",
+    );
+  });
+
+  it("builds rels path for slide master", () => {
+    expect(buildRelsPath("ppt/slideMasters/slideMaster1.xml")).toBe(
+      "ppt/slideMasters/_rels/slideMaster1.xml.rels",
+    );
+  });
+
+  it("builds rels path for presentation", () => {
+    expect(buildRelsPath("ppt/presentation.xml")).toBe("ppt/_rels/presentation.xml.rels");
+  });
+});

--- a/tests/parser/slide-layout-parser.test.ts
+++ b/tests/parser/slide-layout-parser.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSlideLayoutBackground,
+  parseSlideLayoutElements,
+} from "../../src/parser/slide-layout-parser.js";
+import { ColorResolver } from "../../src/color/color-resolver.js";
+import type { PptxArchive } from "../../src/parser/pptx-reader.js";
+import type { ShapeElement } from "../../src/model/shape.js";
+
+function createColorResolver() {
+  return new ColorResolver(
+    {
+      dk1: "#000000",
+      lt1: "#FFFFFF",
+      dk2: "#44546A",
+      lt2: "#E7E6E6",
+      accent1: "#4472C4",
+      accent2: "#ED7D31",
+      accent3: "#A5A5A5",
+      accent4: "#FFC000",
+      accent5: "#5B9BD5",
+      accent6: "#70AD47",
+      hlink: "#0563C1",
+      folHlink: "#954F72",
+    },
+    {
+      bg1: "lt1",
+      tx1: "dk1",
+      bg2: "lt2",
+      tx2: "dk2",
+      accent1: "accent1",
+      accent2: "accent2",
+      accent3: "accent3",
+      accent4: "accent4",
+      accent5: "accent5",
+      accent6: "accent6",
+      hlink: "hlink",
+      folHlink: "folHlink",
+    },
+  );
+}
+
+function createEmptyArchive(): PptxArchive {
+  return { files: new Map(), media: new Map() };
+}
+
+describe("parseSlideLayoutBackground", () => {
+  it("returns null when no background defined", () => {
+    const xml = `
+      <p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+        <p:cSld>
+          <p:spTree/>
+        </p:cSld>
+      </p:sldLayout>
+    `;
+    const result = parseSlideLayoutBackground(xml, createColorResolver());
+    expect(result).toBeNull();
+  });
+});
+
+describe("parseSlideLayoutElements", () => {
+  it("parses shapes from layout", () => {
+    const xml = `
+      <p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld>
+          <p:spTree>
+            <p:sp>
+              <p:nvSpPr>
+                <p:cNvPr id="2" name="Title"/>
+                <p:cNvSpPr/>
+                <p:nvPr>
+                  <p:ph type="title"/>
+                </p:nvPr>
+              </p:nvSpPr>
+              <p:spPr>
+                <a:xfrm>
+                  <a:off x="457200" y="274638"/>
+                  <a:ext cx="8229600" cy="1143000"/>
+                </a:xfrm>
+                <a:prstGeom prst="rect"/>
+              </p:spPr>
+            </p:sp>
+            <p:sp>
+              <p:nvSpPr>
+                <p:cNvPr id="3" name="Footer"/>
+                <p:cNvSpPr/>
+                <p:nvPr>
+                  <p:ph type="ftr" idx="10"/>
+                </p:nvPr>
+              </p:nvSpPr>
+              <p:spPr>
+                <a:xfrm>
+                  <a:off x="3124200" y="6356350"/>
+                  <a:ext cx="2895600" cy="365125"/>
+                </a:xfrm>
+                <a:prstGeom prst="rect"/>
+              </p:spPr>
+            </p:sp>
+          </p:spTree>
+        </p:cSld>
+      </p:sldLayout>
+    `;
+
+    const elements = parseSlideLayoutElements(
+      xml,
+      "ppt/slideLayouts/slideLayout1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(2);
+    expect((elements[0] as ShapeElement).placeholderType).toBe("title");
+    expect((elements[1] as ShapeElement).placeholderType).toBe("ftr");
+    expect((elements[1] as ShapeElement).placeholderIdx).toBe(10);
+  });
+
+  it("returns empty array when no spTree", () => {
+    const xml = `
+      <p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+        <p:cSld/>
+      </p:sldLayout>
+    `;
+
+    const elements = parseSlideLayoutElements(
+      xml,
+      "ppt/slideLayouts/slideLayout1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(0);
+  });
+
+  it("parses non-placeholder shapes from layout", () => {
+    const xml = `
+      <p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld>
+          <p:spTree>
+            <p:sp>
+              <p:nvSpPr>
+                <p:cNvPr id="5" name="Logo"/>
+                <p:cNvSpPr/>
+                <p:nvPr/>
+              </p:nvSpPr>
+              <p:spPr>
+                <a:xfrm>
+                  <a:off x="100" y="200"/>
+                  <a:ext cx="500" cy="500"/>
+                </a:xfrm>
+                <a:prstGeom prst="ellipse"/>
+                <a:solidFill>
+                  <a:srgbClr val="FF0000"/>
+                </a:solidFill>
+              </p:spPr>
+            </p:sp>
+          </p:spTree>
+        </p:cSld>
+      </p:sldLayout>
+    `;
+
+    const elements = parseSlideLayoutElements(
+      xml,
+      "ppt/slideLayouts/slideLayout1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(1);
+    const shape = elements[0] as ShapeElement;
+    expect(shape.placeholderType).toBeUndefined();
+    expect(shape.fill).toEqual({ type: "solid", color: { hex: "#FF0000", alpha: 1 } });
+  });
+});

--- a/tests/parser/slide-master-parser.test.ts
+++ b/tests/parser/slide-master-parser.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSlideMasterElements,
+  parseSlideMasterColorMap,
+  parseSlideMasterBackground,
+} from "../../src/parser/slide-master-parser.js";
+import { ColorResolver } from "../../src/color/color-resolver.js";
+import type { PptxArchive } from "../../src/parser/pptx-reader.js";
+import type { ShapeElement } from "../../src/model/shape.js";
+
+function createColorResolver() {
+  return new ColorResolver(
+    {
+      dk1: "#000000",
+      lt1: "#FFFFFF",
+      dk2: "#44546A",
+      lt2: "#E7E6E6",
+      accent1: "#4472C4",
+      accent2: "#ED7D31",
+      accent3: "#A5A5A5",
+      accent4: "#FFC000",
+      accent5: "#5B9BD5",
+      accent6: "#70AD47",
+      hlink: "#0563C1",
+      folHlink: "#954F72",
+    },
+    {
+      bg1: "lt1",
+      tx1: "dk1",
+      bg2: "lt2",
+      tx2: "dk2",
+      accent1: "accent1",
+      accent2: "accent2",
+      accent3: "accent3",
+      accent4: "accent4",
+      accent5: "accent5",
+      accent6: "accent6",
+      hlink: "hlink",
+      folHlink: "folHlink",
+    },
+  );
+}
+
+function createEmptyArchive(): PptxArchive {
+  return { files: new Map(), media: new Map() };
+}
+
+describe("parseSlideMasterColorMap", () => {
+  it("returns default color map when no clrMap", () => {
+    const xml = `<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`;
+    const result = parseSlideMasterColorMap(xml);
+    expect(result.bg1).toBe("lt1");
+    expect(result.tx1).toBe("dk1");
+  });
+});
+
+describe("parseSlideMasterBackground", () => {
+  it("returns null when no background", () => {
+    const xml = `
+      <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+        <p:cSld>
+          <p:spTree/>
+        </p:cSld>
+      </p:sldMaster>
+    `;
+    const result = parseSlideMasterBackground(xml, createColorResolver());
+    expect(result).toBeNull();
+  });
+});
+
+describe("parseSlideMasterElements", () => {
+  it("parses shapes from master", () => {
+    const xml = `
+      <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld>
+          <p:spTree>
+            <p:sp>
+              <p:nvSpPr>
+                <p:cNvPr id="2" name="Title"/>
+                <p:cNvSpPr/>
+                <p:nvPr>
+                  <p:ph type="title"/>
+                </p:nvPr>
+              </p:nvSpPr>
+              <p:spPr>
+                <a:xfrm>
+                  <a:off x="457200" y="274638"/>
+                  <a:ext cx="8229600" cy="1143000"/>
+                </a:xfrm>
+                <a:prstGeom prst="rect"/>
+              </p:spPr>
+            </p:sp>
+            <p:sp>
+              <p:nvSpPr>
+                <p:cNvPr id="5" name="Decorative"/>
+                <p:cNvSpPr/>
+                <p:nvPr/>
+              </p:nvSpPr>
+              <p:spPr>
+                <a:xfrm>
+                  <a:off x="0" y="0"/>
+                  <a:ext cx="9144000" cy="100"/>
+                </a:xfrm>
+                <a:prstGeom prst="rect"/>
+                <a:solidFill>
+                  <a:srgbClr val="4472C4"/>
+                </a:solidFill>
+              </p:spPr>
+            </p:sp>
+          </p:spTree>
+        </p:cSld>
+      </p:sldMaster>
+    `;
+
+    const elements = parseSlideMasterElements(
+      xml,
+      "ppt/slideMasters/slideMaster1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(2);
+    expect((elements[0] as ShapeElement).placeholderType).toBe("title");
+    expect((elements[1] as ShapeElement).placeholderType).toBeUndefined();
+    expect((elements[1] as ShapeElement).fill).toEqual({
+      type: "solid",
+      color: { hex: "#4472C4", alpha: 1 },
+    });
+  });
+
+  it("returns empty array when no spTree", () => {
+    const xml = `
+      <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+        <p:cSld/>
+      </p:sldMaster>
+    `;
+
+    const elements = parseSlideMasterElements(
+      xml,
+      "ppt/slideMasters/slideMaster1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(0);
+  });
+});

--- a/tests/parser/slide-parser.test.ts
+++ b/tests/parser/slide-parser.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { parseShapeTree } from "../../src/parser/slide-parser.js";
+import { ColorResolver } from "../../src/color/color-resolver.js";
+import { parseXml } from "../../src/parser/xml-parser.js";
+import type { PptxArchive } from "../../src/parser/pptx-reader.js";
+import type { ShapeElement } from "../../src/model/shape.js";
+
+function createColorResolver() {
+  return new ColorResolver(
+    {
+      dk1: "#000000",
+      lt1: "#FFFFFF",
+      dk2: "#44546A",
+      lt2: "#E7E6E6",
+      accent1: "#4472C4",
+      accent2: "#ED7D31",
+      accent3: "#A5A5A5",
+      accent4: "#FFC000",
+      accent5: "#5B9BD5",
+      accent6: "#70AD47",
+      hlink: "#0563C1",
+      folHlink: "#954F72",
+    },
+    {
+      bg1: "lt1",
+      tx1: "dk1",
+      bg2: "lt2",
+      tx2: "dk2",
+      accent1: "accent1",
+      accent2: "accent2",
+      accent3: "accent3",
+      accent4: "accent4",
+      accent5: "accent5",
+      accent6: "accent6",
+      hlink: "hlink",
+      folHlink: "folHlink",
+    },
+  );
+}
+
+function createEmptyArchive(): PptxArchive {
+  return { files: new Map(), media: new Map() };
+}
+
+describe("parseShapeTree", () => {
+  it("parses placeholder type from shape", () => {
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="2" name="Title 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr>
+              <p:ph type="title"/>
+            </p:nvPr>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="100" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const spTree = parsed.spTree;
+    const elements = parseShapeTree(
+      spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(1);
+    expect(elements[0].type).toBe("shape");
+    expect((elements[0] as ShapeElement).placeholderType).toBe("title");
+  });
+
+  it("defaults placeholder type to body when type is not specified", () => {
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="3" name="Content 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr>
+              <p:ph idx="1"/>
+            </p:nvPr>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="100" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const spTree = parsed.spTree;
+    const elements = parseShapeTree(
+      spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(1);
+    const shape = elements[0] as ShapeElement;
+    expect(shape.placeholderType).toBe("body");
+    expect(shape.placeholderIdx).toBe(1);
+  });
+
+  it("does not set placeholder fields for non-placeholder shapes", () => {
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="4" name="Rectangle 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="100" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const spTree = parsed.spTree;
+    const elements = parseShapeTree(
+      spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(1);
+    const shape = elements[0] as ShapeElement;
+    expect(shape.placeholderType).toBeUndefined();
+    expect(shape.placeholderIdx).toBeUndefined();
+  });
+
+  it("parses various placeholder types", () => {
+    const types = ["title", "body", "dt", "ftr", "sldNum", "ctrTitle", "subTitle"];
+    for (const phType of types) {
+      const xml = `
+        <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                   xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+          <p:sp>
+            <p:nvSpPr>
+              <p:cNvPr id="2" name="Shape"/>
+              <p:cNvSpPr/>
+              <p:nvPr>
+                <p:ph type="${phType}"/>
+              </p:nvPr>
+            </p:nvSpPr>
+            <p:spPr>
+              <a:xfrm>
+                <a:off x="0" y="0"/>
+                <a:ext cx="100" cy="100"/>
+              </a:xfrm>
+              <a:prstGeom prst="rect"/>
+            </p:spPr>
+          </p:sp>
+        </p:spTree>
+      `;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const parsed = parseXml(xml) as any;
+      const elements = parseShapeTree(
+        parsed.spTree,
+        new Map(),
+        "ppt/slides/slide1.xml",
+        createEmptyArchive(),
+        createColorResolver(),
+      );
+      expect((elements[0] as ShapeElement).placeholderType).toBe(phType);
+    }
+  });
+});


### PR DESCRIPTION
close #26

## 概要

スライドマスター・スライドレイアウトに定義されたシェイプ（ロゴ、装飾要素、フッター等の共通要素）をスライドの SVG/PNG 出力に反映する。

## 変更内容

- **`src/model/shape.ts`**: `ShapeElement` に `placeholderType` / `placeholderIdx` を追加
- **`src/parser/slide-parser.ts`**: `parseShape()` でプレースホルダー情報をパース、`parseShapeTree()` を export
- **`src/parser/slide-layout-parser.ts`**: `parseSlideLayoutElements()` を追加（レイアウトのシェイプをパース）
- **`src/parser/slide-master-parser.ts`**: `parseSlideMasterElements()` を追加（マスターのシェイプをパース）
- **`src/parser/relationship-parser.ts`**: `buildRelsPath()` ヘルパーを追加
- **`src/converter.ts`**: マスター（最背面）→ レイアウト → スライド（最前面）の z-order でシェイプをマージ。プレースホルダーの型別重複排除を実装

## プレースホルダー重複排除

- スライドが持つプレースホルダータイプはレイアウト・マスターのものを上書き
- レイアウトが持つプレースホルダータイプはマスターのものを上書き
- 非プレースホルダーシェイプ（装飾要素等）は常にすべて描画

## スコープ外

- ノートマスター・ハンドアウトマスター対応（スライド描画に影響しないため）
- プレースホルダーのプロパティ継承（フォントサイズ、色など）
- 複数マスター対応

## テスト計画

- [x] `parseShapeTree` のプレースホルダーパーステスト
- [x] `parseSlideLayoutElements` のユニットテスト
- [x] `parseSlideMasterElements` のユニットテスト
- [x] `buildRelsPath` のユニットテスト
- [x] 既存の統合テスト通過確認
- [x] lint / format / typecheck / build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)