### PR TITLE
fix: 画像の位置・回転・反転が適用されない問題を修正

### DIFF
--- a/src/renderer/image-renderer.ts
+++ b/src/renderer/image-renderer.ts
@@ -1,9 +1,11 @@
 import type { ImageElement } from "../model/image.js";
 import { emuToPixels } from "../utils/emu.js";
+import { buildTransformAttr } from "./transform.js";
 
 export function renderImage(image: ImageElement): string {
   const w = emuToPixels(image.transform.extentWidth);
   const h = emuToPixels(image.transform.extentHeight);
+  const transformAttr = buildTransformAttr(image.transform);
 
-  return `<image href="data:${image.mimeType};base64,${image.imageData}" width="${w}" height="${h}" preserveAspectRatio="none"/>`;
+  return `<g transform="${transformAttr}"><image href="data:${image.mimeType};base64,${image.imageData}" width="${w}" height="${h}" preserveAspectRatio="none"/></g>`;
 }

--- a/src/renderer/shape-renderer.ts
+++ b/src/renderer/shape-renderer.ts
@@ -1,8 +1,9 @@
-import type { ShapeElement, ConnectorElement, Transform } from "../model/shape.js";
+import type { ShapeElement, ConnectorElement } from "../model/shape.js";
 import { renderGeometry } from "./geometry/index.js";
 import { renderFillAttrs, renderOutlineAttrs } from "./fill-renderer.js";
 import { renderTextBody } from "./text-renderer.js";
 import { emuToPixels } from "../utils/emu.js";
+import { buildTransformAttr } from "./transform.js";
 
 export function renderShape(shape: ShapeElement): string {
   const { transform, geometry, fill, outline, textBody } = shape;
@@ -47,27 +48,4 @@ export function renderConnector(connector: ConnectorElement): string {
   const outlineAttr = renderOutlineAttrs(outline);
 
   return `<g transform="${transformAttr}"><line x1="0" y1="0" x2="${w}" y2="${h}" ${outlineAttr} fill="none"/></g>`;
-}
-
-function buildTransformAttr(t: Transform): string {
-  const x = emuToPixels(t.offsetX);
-  const y = emuToPixels(t.offsetY);
-  const w = emuToPixels(t.extentWidth);
-  const h = emuToPixels(t.extentHeight);
-
-  const parts: string[] = [];
-  parts.push(`translate(${x}, ${y})`);
-
-  if (t.rotation !== 0) {
-    parts.push(`rotate(${t.rotation}, ${w / 2}, ${h / 2})`);
-  }
-
-  if (t.flipH || t.flipV) {
-    const sx = t.flipH ? -1 : 1;
-    const sy = t.flipV ? -1 : 1;
-    parts.push(`translate(${t.flipH ? w : 0}, ${t.flipV ? h : 0})`);
-    parts.push(`scale(${sx}, ${sy})`);
-  }
-
-  return parts.join(" ");
 }

--- a/src/renderer/transform.ts
+++ b/src/renderer/transform.ts
@@ -1,0 +1,25 @@
+import type { Transform } from "../model/shape.js";
+import { emuToPixels } from "../utils/emu.js";
+
+export function buildTransformAttr(t: Transform): string {
+  const x = emuToPixels(t.offsetX);
+  const y = emuToPixels(t.offsetY);
+  const w = emuToPixels(t.extentWidth);
+  const h = emuToPixels(t.extentHeight);
+
+  const parts: string[] = [];
+  parts.push(`translate(${x}, ${y})`);
+
+  if (t.rotation !== 0) {
+    parts.push(`rotate(${t.rotation}, ${w / 2}, ${h / 2})`);
+  }
+
+  if (t.flipH || t.flipV) {
+    const sx = t.flipH ? -1 : 1;
+    const sy = t.flipV ? -1 : 1;
+    parts.push(`translate(${t.flipH ? w : 0}, ${t.flipV ? h : 0})`);
+    parts.push(`scale(${sx}, ${sy})`);
+  }
+
+  return parts.join(" ");
+}


### PR DESCRIPTION
## 概要

`renderImage` で `transform` の `offsetX`/`offsetY` が SVG 出力に反映されておらず、すべての画像が左上 (0, 0) に配置されていた問題を修正しました。

## 変更内容

- `buildTransformAttr` を `src/renderer/transform.ts` に共通モジュールとして切り出し
- `shape-renderer.ts` から重複実装を削除し、共通モジュールを参照
- `image-renderer.ts` で `<g transform="...">` ラッパーを追加し、位置・回転・反転を適用

## テスト計画

- [x] lint / format / typecheck パス
- [x] 全テスト (86件) パス
- [ ] 画像を含む PPTX でレンダリング結果を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)