### PR TITLE
feat: 上付き・下付き文字のサポート

### DIFF
--- a/src/model/text.ts
+++ b/src/model/text.ts
@@ -43,4 +43,5 @@ export interface RunProperties {
   underline: boolean;
   strikethrough: boolean;
   color: ResolvedColor | null;
+  baseline: number;
 }

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -396,6 +396,7 @@ function parseRunProperties(rPr: any, colorResolver: ColorResolver): RunProperti
       underline: false,
       strikethrough: false,
       color: null,
+      baseline: 0,
     };
   }
 
@@ -405,11 +406,12 @@ function parseRunProperties(rPr: any, colorResolver: ColorResolver): RunProperti
   const italic = rPr["@_i"] === "1" || rPr["@_i"] === "true";
   const underline = rPr["@_u"] !== undefined && rPr["@_u"] !== "none";
   const strikethrough = rPr["@_strike"] !== undefined && rPr["@_strike"] !== "noStrike";
+  const baseline = rPr["@_baseline"] ? Number(rPr["@_baseline"]) / 1000 : 0;
 
   let color = colorResolver.resolve(rPr.solidFill ?? rPr);
   if (!rPr.solidFill && !rPr.srgbClr && !rPr.schemeClr && !rPr.sysClr) {
     color = null;
   }
 
-  return { fontSize, fontFamily, bold, italic, underline, strikethrough, color };
+  return { fontSize, fontFamily, bold, italic, underline, strikethrough, color, baseline };
 }

--- a/src/renderer/text-renderer.ts
+++ b/src/renderer/text-renderer.ts
@@ -218,6 +218,12 @@ function buildStyleAttrs(props: RunProperties, fontScale: number = 1): string {
     styles.push(`text-decoration="${decorations.join(" ")}"`);
   }
 
+  if (props.baseline > 0) {
+    styles.push(`baseline-shift="super"`);
+  } else if (props.baseline < 0) {
+    styles.push(`baseline-shift="sub"`);
+  }
+
   return styles.join(" ");
 }
 

--- a/tests/parser/slide-parser.test.ts
+++ b/tests/parser/slide-parser.test.ts
@@ -297,6 +297,135 @@ describe("parseShapeTree", () => {
     expect(shape.textBody!.bodyProperties.lnSpcReduction).toBe(0);
   });
 
+  it("parses superscript baseline from rPr", () => {
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="2" name="TextBox 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="100" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr/>
+            <a:p>
+              <a:r>
+                <a:rPr lang="en-US" sz="1800" baseline="30000"/>
+                <a:t>2</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const elements = parseShapeTree(
+      parsed.spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    const shape = elements[0] as ShapeElement;
+    expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(30);
+  });
+
+  it("parses subscript baseline from rPr", () => {
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="2" name="TextBox 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="100" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr/>
+            <a:p>
+              <a:r>
+                <a:rPr lang="en-US" sz="1800" baseline="-25000"/>
+                <a:t>2</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const elements = parseShapeTree(
+      parsed.spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    const shape = elements[0] as ShapeElement;
+    expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(-25);
+  });
+
+  it("defaults baseline to 0 when not specified", () => {
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="2" name="TextBox 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="100" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr/>
+            <a:p>
+              <a:r>
+                <a:rPr lang="en-US" sz="1800"/>
+                <a:t>Normal</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const elements = parseShapeTree(
+      parsed.spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    const shape = elements[0] as ShapeElement;
+    expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(0);
+  });
+
   it("parses various placeholder types", () => {
     const types = ["title", "body", "dt", "ftr", "sldNum", "ctrTitle", "subTitle"];
     for (const phType of types) {

--- a/tests/renderer/text-renderer.test.ts
+++ b/tests/renderer/text-renderer.test.ts
@@ -50,6 +50,7 @@ function makeTextBody(
             underline: false,
             strikethrough: false,
             color: null,
+            baseline: 0,
           },
         })),
         properties: {
@@ -224,5 +225,151 @@ describe("renderTextBody", () => {
     const xMatches = result.match(/<tspan[^>]*x="/g);
     expect(xMatches).not.toBeNull();
     expect(xMatches!.length).toBeGreaterThan(1);
+  });
+
+  it("上付き文字に baseline-shift=super が設定される", () => {
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "H",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+            {
+              text: "2",
+              properties: {
+                fontSize: 12,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 30,
+              },
+            },
+            {
+              text: "O",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+          ],
+          properties: {
+            alignment: "l",
+            lineSpacing: null,
+            spaceBefore: 0,
+            spaceAfter: 0,
+            level: 0,
+          },
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('baseline-shift="super"');
+  });
+
+  it("下付き文字に baseline-shift=sub が設定される", () => {
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "H",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+            {
+              text: "2",
+              properties: {
+                fontSize: 12,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: -25,
+              },
+            },
+            {
+              text: "O",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+          ],
+          properties: {
+            alignment: "l",
+            lineSpacing: null,
+            spaceBefore: 0,
+            spaceAfter: 0,
+            level: 0,
+          },
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('baseline-shift="sub"');
+  });
+
+  it("baseline=0 の場合は baseline-shift が設定されない", () => {
+    const textBody = makeTextBody(["Normal"]);
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).not.toContain("baseline-shift");
   });
 });


### PR DESCRIPTION
close #11

## Summary
- `rPr` の `baseline` 属性をパースし、上付き文字 (superscript) と下付き文字 (subscript) をサポート
- SVG の `baseline-shift` 属性 (`super` / `sub`) でレンダリング
- パーサー・レンダラーのテストを追加

## 変更内容
- `RunProperties` に `baseline: number` プロパティを追加 (正=上付き、負=下付き、0=通常)
- `parseRunProperties()` で `@_baseline` 属性を読み取り (1/1000 に変換)
- `buildStyleAttrs()` で `baseline-shift="super"` / `baseline-shift="sub"` を出力

## Test plan
- [x] パーサーテスト: 上付き (baseline=30000) → 30 にパースされる
- [x] パーサーテスト: 下付き (baseline=-25000) → -25 にパースされる
- [x] パーサーテスト: baseline 未指定 → 0 にデフォルトされる
- [x] レンダラーテスト: baseline > 0 → `baseline-shift="super"` が出力される
- [x] レンダラーテスト: baseline < 0 → `baseline-shift="sub"` が出力される
- [x] レンダラーテスト: baseline = 0 → `baseline-shift` が出力されない
- [x] 全テスト通過 (97 tests)
- [x] lint / format / typecheck / build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)