### PR TITLE
fix: EOL の Node.js 18 を削除し、Node.js 24 を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

- Node.js 18 は 2025年4月30日に EOL を迎えたため、サポート対象から削除
- CI マトリクスを `[18, 20, 22]` → `[20, 22, 24]` に変更
- `package.json` の `engines.node` を `>=18` から `>=20` に変更

## Test plan

- [x] lint / format:check / typecheck / test / build がすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)