### PR TITLE
feat: 高優先度パーサーに構造チェックと警告ログを追加

### DIFF
--- a/src/parser/presentation-parser.ts
+++ b/src/parser/presentation-parser.ts
@@ -6,19 +6,49 @@ export interface PresentationInfo {
   slideRIds: string[];
 }
 
+const WARN_PREFIX = "[pptx-glimpse]";
+const DEFAULT_SLIDE_WIDTH = 9144000;
+const DEFAULT_SLIDE_HEIGHT = 5143500;
+
 export function parsePresentation(xml: string): PresentationInfo {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const parsed = parseXml(xml) as any;
   const pres = parsed.presentation;
 
+  if (!pres) {
+    console.warn(`${WARN_PREFIX} Presentation: missing root element "presentation" in XML`);
+    return {
+      slideSize: { width: DEFAULT_SLIDE_WIDTH, height: DEFAULT_SLIDE_HEIGHT },
+      slideRIds: [],
+    };
+  }
+
   const sldSz = pres.sldSz;
-  const slideSize: SlideSize = {
-    width: Number(sldSz["@_cx"]),
-    height: Number(sldSz["@_cy"]),
-  };
+  let slideSize: SlideSize;
+  if (!sldSz || sldSz["@_cx"] === undefined || sldSz["@_cy"] === undefined) {
+    console.warn(
+      `${WARN_PREFIX} Presentation: sldSz missing, using default ${DEFAULT_SLIDE_WIDTH}x${DEFAULT_SLIDE_HEIGHT} EMU`,
+    );
+    slideSize = { width: DEFAULT_SLIDE_WIDTH, height: DEFAULT_SLIDE_HEIGHT };
+  } else {
+    slideSize = {
+      width: Number(sldSz["@_cx"]),
+      height: Number(sldSz["@_cy"]),
+    };
+  }
 
   const sldIdLst = pres.sldIdLst?.sldId ?? [];
-  const slideRIds = sldIdLst.map((s: Record<string, string>) => s["@_r:id"] ?? s["@_id"]);
+  const slideRIds: string[] = sldIdLst
+    .map((s: Record<string, string>) => s["@_r:id"] ?? s["@_id"])
+    .filter((id: string | undefined) => {
+      if (id === undefined) {
+        console.warn(
+          `${WARN_PREFIX} Presentation: undefined slide relationship ID found, skipping`,
+        );
+        return false;
+      }
+      return true;
+    });
 
   return { slideSize, slideRIds };
 }

--- a/tests/parser/presentation-parser.test.ts
+++ b/tests/parser/presentation-parser.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { parsePresentation } from "../../src/parser/presentation-parser.js";
+
+describe("parsePresentation", () => {
+  it("parses valid presentation XML", () => {
+    const xml = `
+      <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <p:sldSz cx="9144000" cy="5143500"/>
+        <p:sldIdLst>
+          <p:sldId id="256" r:id="rId2"/>
+          <p:sldId id="257" r:id="rId3"/>
+        </p:sldIdLst>
+      </p:presentation>
+    `;
+    const result = parsePresentation(xml);
+
+    expect(result.slideSize.width).toBe(9144000);
+    expect(result.slideSize.height).toBe(5143500);
+    expect(result.slideRIds).toEqual(["rId2", "rId3"]);
+  });
+
+  it("warns and returns defaults when presentation root is missing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `<other/>`;
+    const result = parsePresentation(xml);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Presentation: missing root element "presentation"'),
+    );
+    expect(result.slideSize.width).toBe(9144000);
+    expect(result.slideSize.height).toBe(5143500);
+    expect(result.slideRIds).toEqual([]);
+
+    warnSpy.mockRestore();
+  });
+
+  it("warns and uses default size when sldSz is missing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `
+      <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+        <p:sldIdLst/>
+      </p:presentation>
+    `;
+    const result = parsePresentation(xml);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Presentation: sldSz missing"));
+    expect(result.slideSize.width).toBe(9144000);
+    expect(result.slideSize.height).toBe(5143500);
+
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn for valid XML", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `
+      <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <p:sldSz cx="9144000" cy="5143500"/>
+        <p:sldIdLst>
+          <p:sldId id="256" r:id="rId2"/>
+        </p:sldIdLst>
+      </p:presentation>
+    `;
+    parsePresentation(xml);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/parser/slide-parser.test.ts
+++ b/tests/parser/slide-parser.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { parseShapeTree } from "../../src/parser/slide-parser.js";
+import { describe, it, expect, vi } from "vitest";
+import { parseSlide, parseShapeTree } from "../../src/parser/slide-parser.js";
 import { ColorResolver } from "../../src/color/color-resolver.js";
 import { parseXml } from "../../src/parser/xml-parser.js";
 import type { PptxArchive } from "../../src/parser/pptx-reader.js";
@@ -332,5 +332,134 @@ describe("parseShapeTree", () => {
       );
       expect((elements[0] as ShapeElement).placeholderType).toBe(phType);
     }
+  });
+});
+
+describe("structural validation warnings", () => {
+  it("warns when parseSlide receives XML without sld root", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `<other><cSld/></other>`;
+    const result = parseSlide(
+      xml,
+      "ppt/slides/slide3.xml",
+      3,
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Slide 3: missing root element "sld"'),
+    );
+    expect(result.elements).toEqual([]);
+
+    warnSpy.mockRestore();
+  });
+
+  it("warns when a shape is skipped due to parse returning null", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="2" name="Shape 1"/>
+          </p:nvSpPr>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const elements = parseShapeTree(
+      parsed.spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+      "Slide 1",
+    );
+
+    expect(elements).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Slide 1: shape skipped"));
+
+    warnSpy.mockRestore();
+  });
+
+  it("warns when NaN is detected in transform values", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="2" name="Shape 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="abc" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    const elements = parseShapeTree(
+      parsed.spTree,
+      new Map(),
+      "ppt/slides/slide2.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(elements).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("NaN detected in transform offsetX"),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn for valid structures", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:sp>
+          <p:nvSpPr>
+            <p:cNvPr id="2" name="Shape 1"/>
+            <p:cNvSpPr/>
+            <p:nvPr/>
+          </p:nvSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="100" y="200"/>
+              <a:ext cx="300" cy="400"/>
+            </a:xfrm>
+            <a:prstGeom prst="rect"/>
+          </p:spPr>
+        </p:sp>
+      </p:spTree>
+    `;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parsed = parseXml(xml) as any;
+    parseShapeTree(
+      parsed.spTree,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
close #39

## Summary

- `slide-parser.ts`: `parseSlide` の `sld` 存在チェック、`parseShapeTree` の要素スキップ警告、`parseTransform` の NaN 検出を追加
- `presentation-parser.ts`: `presentation` ルート要素チェック、`sldSz` 欠落チェック、`slideRIds` の undefined フィルタを追加
- 全警告に `[pptx-glimpse]` プレフィックスを統一付与
- 既存動作は変更なし（チェック失敗時もデフォルト値で続行）

## Test plan

- [x] `tests/parser/slide-parser.test.ts` に構造バリデーション警告テスト4件追加
- [x] `tests/parser/presentation-parser.test.ts` を新規作成（正常系・異常系4件）
- [x] `vi.spyOn(console, "warn")` で警告出力を検証
- [x] 全127テスト通過、lint/format/typecheck クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)