### PR TITLE
refactor: VRT の画像比較を pixelmatch ライブラリに置き換え

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 coverage/
 output/
+tests/vrt/diffs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^25.2.2",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
+        "pixelmatch": "^7.1.0",
         "prettier": "^3.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.21.0",
@@ -25,7 +26,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -3167,6 +3168,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
+      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -3177,6 +3191,16 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^25.2.2",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
+    "pixelmatch": "^7.1.0",
     "prettier": "^3.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.21.0",

--- a/tests/vrt/visual-regression.test.ts
+++ b/tests/vrt/visual-regression.test.ts
@@ -1,14 +1,16 @@
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import pixelmatch from "pixelmatch";
 import sharp from "sharp";
 import { convertPptxToPng } from "../../src/converter.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = join(__dirname, "snapshots");
+const DIFF_DIR = join(__dirname, "diffs");
 const FIXTURE_DIR = join(__dirname, "../fixtures");
 
-const PIXEL_THRESHOLD = 5;
+const PIXEL_THRESHOLD = 0.1;
 const MISMATCH_TOLERANCE = 0.01;
 
 interface CompareResult {
@@ -18,7 +20,11 @@ interface CompareResult {
   passed: boolean;
 }
 
-async function compareImages(actualPng: Buffer, referencePath: string): Promise<CompareResult> {
+async function compareImages(
+  actualPng: Buffer,
+  referencePath: string,
+  diffPath: string,
+): Promise<CompareResult> {
   if (!existsSync(referencePath)) {
     throw new Error(
       `Reference snapshot not found: ${referencePath}. Run "npm run test:vrt:update" to generate.`,
@@ -32,39 +38,39 @@ async function compareImages(actualPng: Buffer, referencePath: string): Promise<
     sharp(refPng).metadata(),
   ]);
 
-  if (actualMeta.width !== refMeta.width || actualMeta.height !== refMeta.height) {
-    const total = (actualMeta.width ?? 0) * (actualMeta.height ?? 0);
+  const width = actualMeta.width ?? 0;
+  const height = actualMeta.height ?? 0;
+
+  if (width !== refMeta.width || height !== refMeta.height) {
+    const total = width * height;
     return { totalPixels: total, mismatchedPixels: total, mismatchPercentage: 1, passed: false };
   }
 
   const [actualRaw, refRaw] = await Promise.all([
-    sharp(actualPng).raw().toBuffer(),
-    sharp(refPng).raw().toBuffer(),
+    sharp(actualPng).ensureAlpha().raw().toBuffer(),
+    sharp(refPng).ensureAlpha().raw().toBuffer(),
   ]);
 
-  const channels = actualMeta.channels ?? 4;
-  const totalPixels = actualRaw.length / channels;
-  let mismatched = 0;
+  const totalPixels = width * height;
+  const diffBuf = new Uint8Array(totalPixels * 4);
 
-  for (let i = 0; i < actualRaw.length; i += channels) {
-    let pixelDiff = false;
-    for (let c = 0; c < channels; c++) {
-      if (Math.abs(actualRaw[i + c] - refRaw[i + c]) > PIXEL_THRESHOLD) {
-        pixelDiff = true;
-        break;
-      }
-    }
-    if (pixelDiff) mismatched++;
-  }
+  const mismatched = pixelmatch(actualRaw, refRaw, diffBuf, width, height, {
+    threshold: PIXEL_THRESHOLD,
+    includeAA: false,
+  });
 
   const mismatchPercentage = mismatched / totalPixels;
+  const passed = mismatchPercentage <= MISMATCH_TOLERANCE;
 
-  return {
-    totalPixels,
-    mismatchedPixels: mismatched,
-    mismatchPercentage,
-    passed: mismatchPercentage <= MISMATCH_TOLERANCE,
-  };
+  if (!passed) {
+    mkdirSync(dirname(diffPath), { recursive: true });
+    const diffPng = await sharp(Buffer.from(diffBuf), { raw: { width, height, channels: 4 } })
+      .png()
+      .toBuffer();
+    writeFileSync(diffPath, diffPng);
+  }
+
+  return { totalPixels, mismatchedPixels: mismatched, mismatchPercentage, passed };
 }
 
 const VRT_CASES = [
@@ -96,7 +102,8 @@ describe("Visual Regression Tests", { timeout: 60000 }, () => {
 
         for (const result of results) {
           const refPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);
-          const comparison = await compareImages(result.png, refPath);
+          const diffPath = join(DIFF_DIR, `${name}-slide${result.slideNumber}-diff.png`);
+          const comparison = await compareImages(result.png, refPath, diffPath);
 
           expect(
             comparison.passed,


### PR DESCRIPTION
## Summary
- VRT のカスタムピクセル比較ロジックを `pixelmatch` ライブラリに置き換え
- アンチエイリアシング検出付きの知覚的な差分比較が可能に
- テスト失敗時に diff 画像を `tests/vrt/diffs/` に出力するようにし、デバッグを改善

## 変更内容
- `pixelmatch` を devDependencies に追加
- `tests/vrt/visual-regression.test.ts` の `compareImages()` を pixelmatch ベースに書き換え
- 失敗時の diff 画像出力を追加
- `.gitignore` に `tests/vrt/diffs/` を追加

## Test plan
- [x] `npm run test` で全 VRT テスト（10 ケース）が通ること
- [x] `npm run lint` / `npm run format:check` / `npm run typecheck` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)