### PR TITLE
feat: latin/ea フォントの文字単位切り替えに対応する

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,6 +1,7 @@
 import { readPptx } from "./parser/pptx-reader.js";
 import { parsePresentation } from "./parser/presentation-parser.js";
 import { parseTheme } from "./parser/theme-parser.js";
+import type { Theme } from "./model/theme.js";
 import {
   parseSlideMasterColorMap,
   parseSlideMasterBackground,
@@ -60,9 +61,14 @@ export async function convertPptxToSvg(
   const presRels = presRelsXml ? parseRelationships(presRelsXml) : new Map();
 
   // Parse theme
-  let theme = {
+  let theme: Theme = {
     colorScheme: defaultColorScheme(),
-    fontScheme: { majorFont: "Calibri", minorFont: "Calibri" },
+    fontScheme: {
+      majorFont: "Calibri",
+      minorFont: "Calibri",
+      majorFontEa: null,
+      minorFontEa: null,
+    },
   };
   for (const [, rel] of presRels) {
     if (rel.type.includes("theme")) {

--- a/src/model/text.ts
+++ b/src/model/text.ts
@@ -60,6 +60,7 @@ export interface TextRun {
 export interface RunProperties {
   fontSize: number | null;
   fontFamily: string | null;
+  fontFamilyEa: string | null;
   bold: boolean;
   italic: boolean;
   underline: boolean;

--- a/src/model/theme.ts
+++ b/src/model/theme.ts
@@ -38,4 +38,6 @@ export interface ColorMap {
 export interface FontScheme {
   majorFont: string;
   minorFont: string;
+  majorFontEa: string | null;
+  minorFontEa: string | null;
 }

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -563,6 +563,7 @@ function parseRunProperties(rPr: any, colorResolver: ColorResolver): RunProperti
     return {
       fontSize: null,
       fontFamily: null,
+      fontFamilyEa: null,
       bold: false,
       italic: false,
       underline: false,
@@ -573,7 +574,8 @@ function parseRunProperties(rPr: any, colorResolver: ColorResolver): RunProperti
   }
 
   const fontSize = rPr["@_sz"] ? hundredthPointToPoint(Number(rPr["@_sz"])) : null;
-  const fontFamily = rPr.latin?.["@_typeface"] ?? rPr.ea?.["@_typeface"] ?? null;
+  const fontFamily = rPr.latin?.["@_typeface"] ?? null;
+  const fontFamilyEa = rPr.ea?.["@_typeface"] ?? null;
   const bold = rPr["@_b"] === "1" || rPr["@_b"] === "true";
   const italic = rPr["@_i"] === "1" || rPr["@_i"] === "true";
   const underline = rPr["@_u"] !== undefined && rPr["@_u"] !== "none";
@@ -585,5 +587,15 @@ function parseRunProperties(rPr: any, colorResolver: ColorResolver): RunProperti
     color = null;
   }
 
-  return { fontSize, fontFamily, bold, italic, underline, strikethrough, color, baseline };
+  return {
+    fontSize,
+    fontFamily,
+    fontFamilyEa,
+    bold,
+    italic,
+    underline,
+    strikethrough,
+    color,
+    baseline,
+  };
 }

--- a/src/parser/theme-parser.ts
+++ b/src/parser/theme-parser.ts
@@ -11,7 +11,12 @@ export function parseTheme(xml: string): Theme {
     console.warn(`${WARN_PREFIX} Theme: missing root element "theme" in XML`);
     return {
       colorScheme: defaultColorScheme(),
-      fontScheme: { majorFont: "Calibri", minorFont: "Calibri" },
+      fontScheme: {
+        majorFont: "Calibri",
+        minorFont: "Calibri",
+        majorFontEa: null,
+        minorFontEa: null,
+      },
     };
   }
 
@@ -20,7 +25,12 @@ export function parseTheme(xml: string): Theme {
     console.warn(`${WARN_PREFIX} Theme: themeElements not found, using defaults`);
     return {
       colorScheme: defaultColorScheme(),
-      fontScheme: { majorFont: "Calibri", minorFont: "Calibri" },
+      fontScheme: {
+        majorFont: "Calibri",
+        minorFont: "Calibri",
+        majorFontEa: null,
+        minorFontEa: null,
+      },
     };
   }
 
@@ -72,12 +82,15 @@ function extractColor(colorNode: any): string {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseFontScheme(fontScheme: any): FontScheme {
-  if (!fontScheme) return { majorFont: "Calibri", minorFont: "Calibri" };
+  if (!fontScheme)
+    return { majorFont: "Calibri", minorFont: "Calibri", majorFontEa: null, minorFontEa: null };
 
   const majorFont = fontScheme.majorFont?.latin?.["@_typeface"] ?? "Calibri";
   const minorFont = fontScheme.minorFont?.latin?.["@_typeface"] ?? "Calibri";
+  const majorFontEa = fontScheme.majorFont?.ea?.["@_typeface"] ?? null;
+  const minorFontEa = fontScheme.minorFont?.ea?.["@_typeface"] ?? null;
 
-  return { majorFont, minorFont };
+  return { majorFont, minorFont, majorFontEa, minorFontEa };
 }
 
 function defaultColorScheme(): ColorScheme {

--- a/src/utils/text-measure.ts
+++ b/src/utils/text-measure.ts
@@ -83,13 +83,17 @@ export function measureTextWidth(
   fontSizePt: number,
   bold: boolean,
   fontFamily?: string | null,
+  fontFamilyEa?: string | null,
 ): number {
   const baseSizePx = fontSizePt * PX_PER_PT;
-  const metrics = getFontMetrics(fontFamily);
+  const latinMetrics = getFontMetrics(fontFamily);
+  const eaMetrics = getFontMetrics(fontFamilyEa);
   let totalWidth = 0;
 
   for (const char of text) {
     const codePoint = char.codePointAt(0)!;
+    const isEa = isCjkCodePoint(codePoint);
+    const metrics = isEa && eaMetrics ? eaMetrics : latinMetrics;
     if (metrics) {
       totalWidth += measureCharMetrics(char, codePoint, baseSizePx, metrics);
     } else {

--- a/src/utils/text-wrap.ts
+++ b/src/utils/text-wrap.ts
@@ -96,10 +96,11 @@ function tokenizeRuns(runs: Paragraph["runs"], defaultFontSize: number): Token[]
     const fontSize = run.properties.fontSize ?? defaultFontSize;
     const bold = run.properties.bold;
     const fontFamily = run.properties.fontFamily;
+    const fontFamilyEa = run.properties.fontFamilyEa;
     const fragments = splitTextIntoFragments(run.text);
 
     for (const { fragment, breakable } of fragments) {
-      const width = measureTextWidth(fragment, fontSize, bold, fontFamily);
+      const width = measureTextWidth(fragment, fontSize, bold, fontFamily, fontFamilyEa);
       tokens.push({
         text: fragment,
         properties: run.properties,
@@ -134,9 +135,10 @@ function splitTokenByChars(
   const fontSize = token.properties.fontSize ?? defaultFontSize;
   const bold = token.properties.bold;
   const fontFamily = token.properties.fontFamily;
+  const fontFamilyEa = token.properties.fontFamilyEa;
 
   for (const char of token.text) {
-    const charWidth = measureTextWidth(char, fontSize, bold, fontFamily);
+    const charWidth = measureTextWidth(char, fontSize, bold, fontFamily, fontFamilyEa);
 
     if (currentWidth + charWidth > availableWidth && currentLine.length > 0) {
       lines.push(currentLine);

--- a/tests/renderer/table-renderer.test.ts
+++ b/tests/renderer/table-renderer.test.ts
@@ -222,6 +222,7 @@ describe("renderTable", () => {
                           properties: {
                             fontSize: 12,
                             fontFamily: null,
+                            fontFamilyEa: null,
                             bold: false,
                             italic: false,
                             underline: false,

--- a/tests/renderer/text-renderer.test.ts
+++ b/tests/renderer/text-renderer.test.ts
@@ -64,6 +64,7 @@ function makeTextBody(
           properties: {
             fontSize: overrides?.fontSize ?? 18,
             fontFamily: null,
+            fontFamilyEa: null,
             bold: false,
             italic: false,
             underline: false,
@@ -108,6 +109,7 @@ function makeBulletTextBody(
           properties: {
             fontSize: 18,
             fontFamily: null,
+            fontFamilyEa: null,
             bold: false,
             italic: false,
             underline: false,
@@ -213,6 +215,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 18,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -231,6 +234,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 18,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -300,6 +304,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 18,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -313,6 +318,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 12,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -326,6 +332,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 18,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -364,6 +371,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 18,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -377,6 +385,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 12,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -390,6 +399,7 @@ describe("renderTextBody", () => {
               properties: {
                 fontSize: 18,
                 fontFamily: null,
+                fontFamilyEa: null,
                 bold: false,
                 italic: false,
                 underline: false,
@@ -526,5 +536,133 @@ describe("formatAutoNum", () => {
   it("alphaLcParenR: a) b) c)", () => {
     expect(formatAutoNum("alphaLcParenR", 1)).toBe("a)");
     expect(formatAutoNum("alphaLcParenR", 2)).toBe("b)");
+  });
+});
+
+describe("latin/ea フォント切り替え", () => {
+  it("fontFamily と fontFamilyEa が異なる場合、スクリプト境界で tspan が分割される", () => {
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "none",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Hello世界Test",
+              properties: {
+                fontSize: 18,
+                fontFamily: "Calibri",
+                fontFamilyEa: "Meiryo",
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('font-family="Calibri"');
+    expect(result).toContain('font-family="Meiryo"');
+    expect(result).toContain("Hello");
+    expect(result).toContain("世界");
+    expect(result).toContain("Test");
+  });
+
+  it("fontFamily と fontFamilyEa が同じ場合は分割されない", () => {
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "none",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Hello世界",
+              properties: {
+                fontSize: 18,
+                fontFamily: "Calibri",
+                fontFamilyEa: "Calibri",
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    // 分割されないので tspan は1つだけ
+    const tspanCount = (result.match(/<tspan/g) ?? []).length;
+    expect(tspanCount).toBe(1);
+    expect(result).toContain("Hello世界");
+  });
+
+  it("fontFamilyEa が null の場合は fontFamily のみで分割されない", () => {
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "none",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Hello世界",
+              properties: {
+                fontSize: 18,
+                fontFamily: "Calibri",
+                fontFamilyEa: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    const tspanCount = (result.match(/<tspan/g) ?? []).length;
+    expect(tspanCount).toBe(1);
+    expect(result).toContain("Hello世界");
   });
 });

--- a/tests/utils/text-measure.test.ts
+++ b/tests/utils/text-measure.test.ts
@@ -118,3 +118,34 @@ describe("measureTextWidth with font metrics", () => {
     expect(width).toBeCloseTo(expected, 1);
   });
 });
+
+describe("measureTextWidth with fontFamilyEa", () => {
+  it("CJK 文字に ea フォントメトリクスを使用する", () => {
+    // NotoSansJP: cjkWidth=1000, unitsPerEm=1000
+    const width = measureTextWidth("漢", 18, false, "Calibri", "Noto Sans JP");
+    const expected = (1000 / 1000) * 18 * PX_PER_PT;
+    expect(width).toBeCloseTo(expected, 1);
+  });
+
+  it("latin 文字には latin フォントメトリクスを使用する", () => {
+    // Carlito: A=1185, unitsPerEm=2048
+    const width = measureTextWidth("A", 18, false, "Calibri", "Noto Sans JP");
+    const expected = (1185 / 2048) * 18 * PX_PER_PT;
+    expect(width).toBeCloseTo(expected, 1);
+  });
+
+  it("混在テキストで文字ごとに異なるメトリクスを使用する", () => {
+    // A: Carlito (1185/2048), 漢: NotoSansJP (1000/1000)
+    const width = measureTextWidth("A漢", 18, false, "Calibri", "Noto Sans JP");
+    const expectedLatin = (1185 / 2048) * 18 * PX_PER_PT;
+    const expectedEa = (1000 / 1000) * 18 * PX_PER_PT;
+    expect(width).toBeCloseTo(expectedLatin + expectedEa, 1);
+  });
+
+  it("fontFamilyEa が null の場合は latin メトリクスで CJK も計測する", () => {
+    // Carlito: cjkWidth=2048, unitsPerEm=2048
+    const width = measureTextWidth("漢", 18, false, "Calibri", null);
+    const expected = (2048 / 2048) * 18 * PX_PER_PT;
+    expect(width).toBeCloseTo(expected, 1);
+  });
+});

--- a/tests/utils/text-wrap.test.ts
+++ b/tests/utils/text-wrap.test.ts
@@ -6,6 +6,7 @@ function makeRunProps(overrides: Partial<RunProperties> = {}): RunProperties {
   return {
     fontSize: 18,
     fontFamily: null,
+    fontFamilyEa: null,
     bold: false,
     italic: false,
     underline: false,


### PR DESCRIPTION
close #54

## Summary

- `RunProperties` に `fontFamilyEa` フィールドを追加し、latin フォントと East Asian フォントを別々に保持
- `measureTextWidth` で文字のコードポイントに応じて latin/ea のメトリクスを切り替え
- SVG レンダリング時にスクリプト境界（latin/CJK）で `<tspan>` を分割し、適切な `font-family` を出力
- `FontScheme` に `majorFontEa`/`minorFontEa` を追加し、テーマから ea フォントも解析

## Test plan

- [x] `measureTextWidth` に fontFamilyEa テスト追加（CJK 文字に ea メトリクス使用、latin 文字に latin メトリクス使用、混在テキスト）
- [x] `renderTextBody` に latin/ea 切り替えテスト追加（異なるフォントで tspan 分割、同じフォントで分割なし、null で分割なし）
- [x] 全既存テスト通過確認
- [x] typecheck / lint / format:check 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)