### PR TITLE
fix: SVG font-family にメトリクス互換フォントのフォールバックを追加

### DIFF
--- a/src/data/font-metrics.ts
+++ b/src/data/font-metrics.ts
@@ -218,6 +218,17 @@ const fontNameMap: Record<string, string> = {
 };
 
 /**
+ * メトリクスキー → 実際の OSS フォント名。
+ * SVG の font-family フォールバックに使用する。
+ */
+const metricsKeyToFontName: Record<string, string> = {
+  Carlito: "Carlito",
+  LiberationSans: "Liberation Sans",
+  LiberationSerif: "Liberation Serif",
+  NotoSansJP: "Noto Sans JP",
+};
+
+/**
  * フォント名からメトリクスデータを取得する。
  * マッピングに存在しないフォントの場合は null を返す。
  */
@@ -228,4 +239,18 @@ export function getFontMetrics(fontFamily: string | null | undefined): FontMetri
   if (!key) return null;
 
   return metricsData[key] ?? null;
+}
+
+/**
+ * PPTX フォント名に対応するメトリクス互換 OSS フォント名を返す。
+ * SVG の font-family フォールバックリストに追加することで、
+ * 計測と描画のフォント一致度を上げる。
+ */
+export function getMetricsFallbackFont(fontFamily: string | null | undefined): string | null {
+  if (!fontFamily) return null;
+
+  const key = fontNameMap[fontFamily] ?? fontNameMap[fontFamily.toLowerCase()];
+  if (!key) return null;
+
+  return metricsKeyToFontName[key] ?? null;
 }

--- a/src/renderer/text-renderer.ts
+++ b/src/renderer/text-renderer.ts
@@ -8,6 +8,7 @@ import type {
 import type { Transform } from "../model/shape.js";
 import { emuToPixels } from "../utils/emu.js";
 import { wrapParagraph } from "../utils/text-wrap.js";
+import { getMetricsFallbackFont } from "../data/font-metrics.js";
 
 const PX_PER_PT = 96 / 72;
 const DEFAULT_LINE_SPACING = 1.2;
@@ -451,6 +452,13 @@ export function buildFontFamilyValue(fonts: (string | null)[]): string | null {
     if (font && !seen.has(font)) {
       seen.add(font);
       uniqueFonts.push(font);
+
+      // メトリクス互換 OSS フォントをフォールバックとして追加
+      const fallback = getMetricsFallbackFont(font);
+      if (fallback && !seen.has(fallback)) {
+        seen.add(fallback);
+        uniqueFonts.push(fallback);
+      }
     }
   }
 

--- a/tests/data/font-metrics.test.ts
+++ b/tests/data/font-metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getFontMetrics } from "../../src/data/font-metrics.js";
+import { getFontMetrics, getMetricsFallbackFont } from "../../src/data/font-metrics.js";
 
 describe("getFontMetrics", () => {
   it("Calibri に対して Carlito ベースのメトリクスを返す", () => {
@@ -69,5 +69,51 @@ describe("getFontMetrics", () => {
     const arial = getFontMetrics("Arial")!;
     expect(arial.ascender).toBeGreaterThan(0);
     expect(arial.descender).toBeLessThan(0);
+  });
+});
+
+describe("getMetricsFallbackFont", () => {
+  it("Calibri に対して Carlito を返す", () => {
+    expect(getMetricsFallbackFont("Calibri")).toBe("Carlito");
+  });
+
+  it("Arial に対して Liberation Sans を返す", () => {
+    expect(getMetricsFallbackFont("Arial")).toBe("Liberation Sans");
+  });
+
+  it("Helvetica に対して Liberation Sans を返す", () => {
+    expect(getMetricsFallbackFont("Helvetica")).toBe("Liberation Sans");
+  });
+
+  it("Times New Roman に対して Liberation Serif を返す", () => {
+    expect(getMetricsFallbackFont("Times New Roman")).toBe("Liberation Serif");
+  });
+
+  it("Meiryo に対して Noto Sans JP を返す", () => {
+    expect(getMetricsFallbackFont("Meiryo")).toBe("Noto Sans JP");
+  });
+
+  it("Yu Gothic に対して Noto Sans JP を返す", () => {
+    expect(getMetricsFallbackFont("Yu Gothic")).toBe("Noto Sans JP");
+  });
+
+  it("Noto Sans JP に対して Noto Sans JP を返す", () => {
+    expect(getMetricsFallbackFont("Noto Sans JP")).toBe("Noto Sans JP");
+  });
+
+  it("大文字小文字を無視してマッチングする", () => {
+    expect(getMetricsFallbackFont("calibri")).toBe("Carlito");
+  });
+
+  it("未知のフォントに対して null を返す", () => {
+    expect(getMetricsFallbackFont("NonExistentFont")).toBeNull();
+  });
+
+  it("null に対して null を返す", () => {
+    expect(getMetricsFallbackFont(null)).toBeNull();
+  });
+
+  it("undefined に対して null を返す", () => {
+    expect(getMetricsFallbackFont(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
close #55

## Summary

- SVG の `font-family` にメトリクス計測で使用している OSS 互換フォント名をフォールバックとして追加
- `getMetricsFallbackFont` 関数を `font-metrics.ts` に追加し、PPTX フォント名から対応する OSS フォント名を取得可能に
- `buildFontFamilyValue` で各フォント名の直後にフォールバックフォントを自動挿入

### 変更前
```
font-family="Calibri, sans-serif"
font-family="Meiryo, Calibri, sans-serif"
```

### 変更後
```
font-family="Calibri, Carlito, sans-serif"
font-family="Meiryo, 'Noto Sans JP', Calibri, Carlito, sans-serif"
```

## Test plan
- [x] `getMetricsFallbackFont` のユニットテスト追加（11 ケース）
- [x] `buildFontFamilyValue` のテスト期待値更新 + 新規テスト 2 ケース追加
- [x] latin/ea フォント切り替えテストの期待値更新
- [x] `npm run lint` / `npm run format:check` / `npm run typecheck` / `npm run test` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)