### PR TITLE
refactor: ユニットテストをソースコードとコロケーション

### DIFF
--- a/src/color/color-resolver.test.ts
+++ b/src/color/color-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { ColorResolver } from "../../src/color/color-resolver.js";
-import type { ColorScheme, ColorMap } from "../../src/model/theme.js";
+import { ColorResolver } from "./color-resolver.js";
+import type { ColorScheme, ColorMap } from "../model/theme.js";
 
 const testScheme: ColorScheme = {
   dk1: "#000000",

--- a/src/data/font-metrics.test.ts
+++ b/src/data/font-metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getFontMetrics, getMetricsFallbackFont } from "../../src/data/font-metrics.js";
+import { getFontMetrics, getMetricsFallbackFont } from "./font-metrics.js";
 
 describe("getFontMetrics", () => {
   it("Calibri に対して Carlito ベースのメトリクスを返す", () => {

--- a/src/parser/chart-parser.test.ts
+++ b/src/parser/chart-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { parseChart } from "../../src/parser/chart-parser.js";
-import { ColorResolver } from "../../src/color/color-resolver.js";
+import { parseChart } from "./chart-parser.js";
+import { ColorResolver } from "../color/color-resolver.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/fill-parser.test.ts
+++ b/src/parser/fill-parser.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { parseFillFromNode } from "../../src/parser/fill-parser.js";
-import type { FillParseContext } from "../../src/parser/fill-parser.js";
-import { ColorResolver } from "../../src/color/color-resolver.js";
-import type { PptxArchive } from "../../src/parser/pptx-reader.js";
+import { parseFillFromNode } from "./fill-parser.js";
+import type { FillParseContext } from "./fill-parser.js";
+import { ColorResolver } from "../color/color-resolver.js";
+import type { PptxArchive } from "./pptx-reader.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/presentation-parser.test.ts
+++ b/src/parser/presentation-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { parsePresentation } from "../../src/parser/presentation-parser.js";
+import { parsePresentation } from "./presentation-parser.js";
 
 describe("parsePresentation", () => {
   it("parses valid presentation XML", () => {

--- a/src/parser/relationship-parser.test.ts
+++ b/src/parser/relationship-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { buildRelsPath, parseRelationships } from "../../src/parser/relationship-parser.js";
+import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
 
 describe("buildRelsPath", () => {
   it("builds rels path for slide", () => {

--- a/src/parser/slide-layout-parser.test.ts
+++ b/src/parser/slide-layout-parser.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import {
-  parseSlideLayoutBackground,
-  parseSlideLayoutElements,
-} from "../../src/parser/slide-layout-parser.js";
-import { ColorResolver } from "../../src/color/color-resolver.js";
-import type { PptxArchive } from "../../src/parser/pptx-reader.js";
-import type { ShapeElement } from "../../src/model/shape.js";
+import { parseSlideLayoutBackground, parseSlideLayoutElements } from "./slide-layout-parser.js";
+import { ColorResolver } from "../color/color-resolver.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import type { ShapeElement } from "../model/shape.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/slide-master-parser.test.ts
+++ b/src/parser/slide-master-parser.test.ts
@@ -3,10 +3,10 @@ import {
   parseSlideMasterElements,
   parseSlideMasterColorMap,
   parseSlideMasterBackground,
-} from "../../src/parser/slide-master-parser.js";
-import { ColorResolver } from "../../src/color/color-resolver.js";
-import type { PptxArchive } from "../../src/parser/pptx-reader.js";
-import type { ShapeElement } from "../../src/model/shape.js";
+} from "./slide-master-parser.js";
+import { ColorResolver } from "../color/color-resolver.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import type { ShapeElement } from "../model/shape.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/slide-parser.test.ts
+++ b/src/parser/slide-parser.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { parseSlide, parseShapeTree } from "../../src/parser/slide-parser.js";
-import { ColorResolver } from "../../src/color/color-resolver.js";
-import { parseXml } from "../../src/parser/xml-parser.js";
-import type { PptxArchive } from "../../src/parser/pptx-reader.js";
-import type { ShapeElement } from "../../src/model/shape.js";
+import { parseSlide, parseShapeTree } from "./slide-parser.js";
+import { ColorResolver } from "../color/color-resolver.js";
+import { parseXml } from "./xml-parser.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import type { ShapeElement } from "../model/shape.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/table-parser.test.ts
+++ b/src/parser/table-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { parseTable } from "../../src/parser/table-parser.js";
-import { ColorResolver } from "../../src/color/color-resolver.js";
+import { parseTable } from "./table-parser.js";
+import { ColorResolver } from "../color/color-resolver.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/theme-parser.test.ts
+++ b/src/parser/theme-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { parseTheme } from "../../src/parser/theme-parser.js";
+import { parseTheme } from "./theme-parser.js";
 
 const themeXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">

--- a/src/renderer/chart-renderer.test.ts
+++ b/src/renderer/chart-renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { renderChart } from "../../src/renderer/chart-renderer.js";
-import type { ChartElement } from "../../src/model/chart.js";
+import { renderChart } from "./chart-renderer.js";
+import type { ChartElement } from "../model/chart.js";
 
 function createChartElement(overrides: Partial<ChartElement["chart"]>): ChartElement {
   return {

--- a/src/renderer/fill-renderer.test.ts
+++ b/src/renderer/fill-renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderFillAttrs, renderOutlineAttrs } from "../../src/renderer/fill-renderer.js";
+import { renderFillAttrs, renderOutlineAttrs } from "./fill-renderer.js";
 
 describe("renderFillAttrs", () => {
   it("renders null fill as none", () => {

--- a/src/renderer/geometry/preset-geometries.test.ts
+++ b/src/renderer/geometry/preset-geometries.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getPresetGeometrySvg } from "../../src/renderer/geometry/preset-geometries.js";
+import { getPresetGeometrySvg } from "./preset-geometries.js";
 
 describe("getPresetGeometrySvg", () => {
   // --- Basic shapes ---

--- a/src/renderer/table-renderer.test.ts
+++ b/src/renderer/table-renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { renderTable } from "../../src/renderer/table-renderer.js";
-import type { TableElement } from "../../src/model/table.js";
+import { renderTable } from "./table-renderer.js";
+import type { TableElement } from "../model/table.js";
 
 function createTableElement(overrides?: Partial<TableElement["table"]>): TableElement {
   return {

--- a/src/renderer/text-renderer.test.ts
+++ b/src/renderer/text-renderer.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect } from "vitest";
-import {
-  renderTextBody,
-  formatAutoNum,
-  buildFontFamilyValue,
-} from "../../src/renderer/text-renderer.js";
-import type { TextBody, Paragraph, BulletType } from "../../src/model/text.js";
-import type { Transform } from "../../src/model/shape.js";
+import { renderTextBody, formatAutoNum, buildFontFamilyValue } from "./text-renderer.js";
+import type { TextBody, Paragraph, BulletType } from "../model/text.js";
+import type { Transform } from "../model/shape.js";
 
 function makeTransform(widthEmu: number, heightEmu: number): Transform {
   return {

--- a/src/utils/emu.test.ts
+++ b/src/utils/emu.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  emuToPixels,
-  emuToPoints,
-  rotationToDegrees,
-  hundredthPointToPoint,
-} from "../../src/utils/emu.js";
+import { emuToPixels, emuToPoints, rotationToDegrees, hundredthPointToPoint } from "./emu.js";
 
 describe("emuToPixels", () => {
   it("converts 914400 EMU (1 inch) to 96 pixels at 96 DPI", () => {

--- a/src/utils/text-measure.test.ts
+++ b/src/utils/text-measure.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { measureTextWidth, getLineHeightRatio } from "../../src/utils/text-measure.js";
+import { measureTextWidth, getLineHeightRatio } from "./text-measure.js";
 
 const PX_PER_PT = 96 / 72;
 

--- a/src/utils/text-wrap.test.ts
+++ b/src/utils/text-wrap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { wrapParagraph } from "../../src/utils/text-wrap.js";
-import type { Paragraph, RunProperties } from "../../src/model/text.js";
+import { wrapParagraph } from "./text-wrap.js";
+import type { Paragraph, RunProperties } from "../model/text.js";
 
 function makeRunProps(overrides: Partial<RunProperties> = {}): RunProperties {
   return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist", "tests", "src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    include: ["tests/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## 概要

ユニットテストファイル（19個）を `tests/` から `src/` に移動し、対応するソースファイルと同じディレクトリに配置（コロケーション）しました。

- **ユニットテスト**: `src/` 内にコロケーション（19ファイル）
- **統合テスト**: `tests/integration/` に残す
- **VRT テスト**: `tests/vrt/` に残す

## 変更内容

- `tests/{color,data,parser,renderer,utils}/*.test.ts` → `src/{color,data,parser,renderer,utils}/*.test.ts` に移動
- `preset-geometries.test.ts` は `src/renderer/geometry/` に移動（ソースファイルの場所に合わせて）
- 全テストファイルのインポートパスを更新
- `vitest.config.ts`: `include` に `src/**/*.test.ts` を追加
- `tsconfig.json`: `exclude` に `src/**/*.test.ts` を追加（型チェック対象から除外）

## テスト計画

- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run typecheck` 通過
- [x] `npm run test` — ユニットテスト 354 件全て通過
- [x] `npm run build` — テストファイルがバンドルに含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)