### PR TITLE
perf: GHA の VRT Docker ビルドにレイヤーキャッシュを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
-        run: docker build -t pptx-glimpse-vrt docker/libreoffice-vrt
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/libreoffice-vrt
+          load: true
+          tags: pptx-glimpse-vrt
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate fixtures
         run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt python3 /workspace/scripts/vrt/generate_fixtures.py


### PR DESCRIPTION
## Summary
- LibreOffice VRT ジョブの Docker ビルドに `docker/build-push-action` + GHA キャッシュバックエンドを導入
- Dockerfile/requirements.txt が未変更の場合、レイヤーキャッシュヒットでビルドをほぼスキップ可能に
- `mode=max` で中間レイヤーもキャッシュし、部分変更時も影響レイヤーのみ再ビルド

## 変更内容
- `docker/setup-buildx-action@v3` でBuildx をセットアップ
- `docker build` コマンドを `docker/build-push-action@v6` に置き換え
- `cache-from: type=gha` / `cache-to: type=gha,mode=max` でGHA キャッシュを利用

## Test plan
- [ ] CI の libreoffice-vrt ジョブが正常に通ることを確認
- [ ] 2回目以降の実行で Docker ビルドステップが高速化されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)