### PR TITLE
revert: GHA の VRT Docker ビルドのレイヤーキャッシュを取り消し

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,17 +70,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: docker/libreoffice-vrt
-          load: true
-          tags: pptx-glimpse-vrt
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: docker build -t pptx-glimpse-vrt docker/libreoffice-vrt
 
       - name: Generate fixtures
         run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt python3 /workspace/scripts/vrt/generate_fixtures.py


### PR DESCRIPTION
close #84

## Summary
- PR #84 で導入した `docker/build-push-action` + GHA キャッシュバックエンドをリバート
- キャッシュマニフェストは読み込まれるがレイヤーが `CACHED` にならず毎回フルビルドしていた
- buildx の `docker-container` ドライバ + `load: true` による Docker daemon への転送(32秒)と GHA キャッシュ書き込み(36.6秒)のオーバーヘッドにより、旧方式(65秒)より遅くなっていた(109秒)
- 元の `docker build` コマンドに戻す

## Test plan
- [ ] CI の libreoffice-vrt ジョブが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)