### PR TITLE
refactor: VRT スクリプトを vrt/ 配下に統合

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate fixtures
-        run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt python3 /workspace/scripts/vrt/generate_fixtures.py
+        run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt python3 /workspace/vrt/libreoffice/generate_fixtures.py
 
       - name: Generate LibreOffice reference images
-        run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt bash /workspace/scripts/vrt/render_references.sh
+        run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt bash /workspace/vrt/libreoffice/render_references.sh
 
       - name: Run LibreOffice VRT
         run: npx vitest run vrt/libreoffice/libreoffice-regression.test.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,26 +57,26 @@ CI は 3 ジョブ構成:
 
 ```
 vrt/
-├── compare-utils.ts               # 共通画像比較ユーティリティ
-├── internal/                      # 通常 VRT (自己比較)
-│   ├── visual-regression.test.ts  # テスト本体
-│   ├── fixtures/                  # VRT 用 PPTX フィクスチャ
-│   └── snapshots/                 # 参照スナップショット画像
-└── libreoffice/                   # LibreOffice VRT
-    └── libreoffice-regression.test.ts  # テスト本体 (fixtures/ と snapshots/ は CI で動的生成)
-
-scripts/vrt/
-├── create-fixtures.ts             # 通常 VRT フィクスチャ生成 (TypeScript)
-├── update-snapshots.ts            # 通常 VRT スナップショット更新
-├── generate_fixtures.py           # LibreOffice VRT フィクスチャ生成 (Python)
-└── render_references.sh           # LibreOffice 参照画像生成 (Docker)
+├── compare-utils.ts                          # 共通画像比較ユーティリティ
+├── internal/                                 # 通常 VRT (自己比較)
+│   ├── visual-regression.test.ts             # テスト本体
+│   ├── create-fixtures.ts                    # フィクスチャ生成スクリプト
+│   ├── update-snapshots.ts                   # スナップショット更新スクリプト
+│   ├── fixtures/                             # VRT 用 PPTX フィクスチャ
+│   └── snapshots/                            # 参照スナップショット画像
+└── libreoffice/                              # LibreOffice VRT
+    ├── libreoffice-regression.test.ts        # テスト本体
+    ├── generate_fixtures.py                  # フィクスチャ生成 (Python, Docker)
+    ├── render_references.sh                  # 参照画像生成 (Docker)
+    ├── fixtures/                             # CI で動的生成
+    └── snapshots/                            # CI で動的生成
 ```
 
 ### VRT 更新手順
 
 パーサー・レンダラー・モデルの変更で描画結果が変わる場合:
 
-1. **フィクスチャ更新** (新機能追加や既存フィクスチャの修正が必要な場合): `scripts/vrt/create-fixtures.ts` を編集し `npm run test:vrt:fixtures` を実行
+1. **フィクスチャ更新** (新機能追加や既存フィクスチャの修正が必要な場合): `vrt/internal/create-fixtures.ts` を編集し `npm run test:vrt:fixtures` を実行
 2. **スナップショット更新**: `npm run test:vrt:update` で参照画像を再生成
 3. **テスト確認**: `npm run test` で VRT テストが通ることを確認
 
@@ -84,7 +84,7 @@ scripts/vrt/
 
 新しい描画機能を追加した場合、以下の **3 箇所すべて** を更新する必要がある:
 
-1. **`scripts/vrt/create-fixtures.ts`** — 新機能をカバーするフィクスチャ (PPTX) を追加
+1. **`vrt/internal/create-fixtures.ts`** — 新機能をカバーするフィクスチャ (PPTX) を追加
 2. **`vrt/internal/visual-regression.test.ts`** — `VRT_CASES` 配列に新しいテストケースを追加
 3. **`vrt/internal/snapshots/`** — `npm run test:vrt:update` でスナップショットを再生成
 

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "render": "tsx scripts/test-render.ts",
-    "test:vrt:fixtures": "tsx scripts/vrt/create-fixtures.ts",
-    "test:vrt:update": "tsx scripts/vrt/update-snapshots.ts",
+    "test:vrt:fixtures": "tsx vrt/internal/create-fixtures.ts",
+    "test:vrt:update": "tsx vrt/internal/update-snapshots.ts",
     "vrt:lo:docker-build": "docker build -t pptx-glimpse-vrt docker/libreoffice-vrt",
-    "vrt:lo:fixtures": "docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt python3 /workspace/scripts/vrt/generate_fixtures.py",
-    "vrt:lo:reference": "docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt bash /workspace/scripts/vrt/render_references.sh",
+    "vrt:lo:fixtures": "docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt python3 /workspace/vrt/libreoffice/generate_fixtures.py",
+    "vrt:lo:reference": "docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt bash /workspace/vrt/libreoffice/render_references.sh",
     "vrt:lo:update": "npm run vrt:lo:docker-build && npm run vrt:lo:fixtures && npm run vrt:lo:reference"
   },
   "files": [

--- a/vrt/internal/create-fixtures.ts
+++ b/vrt/internal/create-fixtures.ts
@@ -1,7 +1,7 @@
 /**
  * VRT (Visual Regression Testing) 用 PPTX フィクスチャ生成スクリプト
  *
- * 使い方: npx tsx scripts/vrt/create-fixtures.ts
+ * 使い方: npx tsx vrt/internal/create-fixtures.ts
  */
 import JSZip from "jszip";
 import sharp from "sharp";
@@ -386,7 +386,7 @@ async function buildPptx(options: PptxBuildOptions): Promise<Buffer> {
   return await zip.generateAsync({ type: "nodebuffer" });
 }
 
-const FIXTURE_OUT_DIR = join(__dirname, "../../vrt/internal/fixtures");
+const FIXTURE_OUT_DIR = join(__dirname, "fixtures");
 
 function savePptx(buffer: Buffer, name: string): void {
   mkdirSync(FIXTURE_OUT_DIR, { recursive: true });

--- a/vrt/internal/update-snapshots.ts
+++ b/vrt/internal/update-snapshots.ts
@@ -4,8 +4,8 @@ import { fileURLToPath } from "url";
 import { convertPptxToPng } from "../../src/converter.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const FIXTURE_DIR = join(__dirname, "../../vrt/internal/fixtures");
-const SNAPSHOT_DIR = join(__dirname, "../../vrt/internal/snapshots");
+const FIXTURE_DIR = join(__dirname, "fixtures");
+const SNAPSHOT_DIR = join(__dirname, "snapshots");
 
 async function main(): Promise<void> {
   mkdirSync(SNAPSHOT_DIR, { recursive: true });

--- a/vrt/libreoffice/generate_fixtures.py
+++ b/vrt/libreoffice/generate_fixtures.py
@@ -3,7 +3,7 @@
 LibreOffice VRT 用の PPTX フィクスチャを python-pptx で生成する。
 
 Usage:
-    python3 scripts/vrt/generate_fixtures.py
+    python3 vrt/libreoffice/generate_fixtures.py
 """
 
 import os
@@ -25,7 +25,7 @@ def make_element(tag, **attribs):
         element.set(key, val)
     return element
 
-OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "../../vrt/libreoffice/fixtures")
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
 SLIDE_WIDTH = 9144000
 SLIDE_HEIGHT = 5143500

--- a/vrt/libreoffice/render_references.sh
+++ b/vrt/libreoffice/render_references.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Docker コンテナ内で実行されることを想定。
 #
 # Usage:
-#   bash scripts/vrt/render_references.sh
+#   bash vrt/libreoffice/render_references.sh
 
 FIXTURE_DIR="/workspace/vrt/libreoffice/fixtures"
 OUTPUT_DIR="/workspace/vrt/libreoffice/snapshots"


### PR DESCRIPTION
## Summary

- `scripts/vrt/` の 4 ファイルを `vrt/` 配下の対応するサブディレクトリに移動し、各 VRT が自己完結した構成にした
- `scripts/vrt/create-fixtures.ts` → `vrt/internal/create-fixtures.ts`
- `scripts/vrt/update-snapshots.ts` → `vrt/internal/update-snapshots.ts`
- `scripts/vrt/generate_fixtures.py` → `vrt/libreoffice/generate_fixtures.py`
- `scripts/vrt/render_references.sh` → `vrt/libreoffice/render_references.sh`
- 移動に伴い、各ファイル内の相対パス、package.json、CI 設定、CLAUDE.md を更新

## Test plan

- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm run typecheck` パス
- [x] `npm run test:vrt:fixtures` でフィクスチャ生成確認
- [x] `npm run test:vrt:update` でスナップショット更新確認
- [x] `npm run test` で全テストパス (375 passed, 20 skipped)
- [ ] CI で VRT / LibreOffice VRT が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)