### PR TITLE
feat: npm 公開の準備

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,22 @@
   "engines": {
     "node": ">=20"
   },
+  "keywords": [
+    "pptx",
+    "powerpoint",
+    "svg",
+    "png",
+    "converter"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hirokisakabe/pptx-glimpse.git"
+  },
+  "homepage": "https://github.com/hirokisakabe/pptx-glimpse",
+  "bugs": {
+    "url": "https://github.com/hirokisakabe/pptx-glimpse/issues"
+  },
+  "author": "hirokisakabe",
   "license": "MIT",
   "dependencies": {
     "fast-xml-parser": "^4.5.0",


### PR DESCRIPTION
close #45

## 概要

pptx-glimpse パッケージを npm レジストリに公開するための準備。

## 変更内容

- `package.json` にメタデータフィールドを追加
  - `keywords`: pptx, powerpoint, svg, png, converter
  - `repository`, `homepage`, `bugs`: GitHub リポジトリ情報
  - `author`: hirokisakabe
- `.github/workflows/publish.yml` を新規作成
  - `v*` タグ push 時に npm publish を自動実行
  - OIDC による provenance 対応 (`--provenance --access public`)

## 公開手順

1. この PR をマージ
2. npm で GitHub Actions を Trusted Publisher として設定
3. `git tag v0.1.0 && git push origin v0.1.0` でタグを push → 自動 publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)