### PR TITLE
feat: LibreOffice VRT テストケースを拡充

### DIFF
--- a/vrt/libreoffice/libreoffice-regression.test.ts
+++ b/vrt/libreoffice/libreoffice-regression.test.ts
@@ -37,6 +37,10 @@ const LO_VRT_CASES = [
   { name: "connectors", fixture: "lo-connectors.pptx" },
   { name: "custom-geometry", fixture: "lo-custom-geometry.pptx", tolerance: 0.45 },
   { name: "slide-size-4-3", fixture: "lo-slide-size-4-3.pptx" },
+  { name: "word-wrap", fixture: "lo-word-wrap.pptx", tolerance: 0.15 },
+  { name: "background-blipfill", fixture: "lo-background-blipfill.pptx" },
+  { name: "composite", fixture: "lo-composite.pptx", tolerance: 0.15 },
+  { name: "effects", fixture: "lo-effects.pptx", tolerance: 0.2 },
 ] as const;
 
 // フィクスチャとスナップショットの両方が存在する場合のみ実行


### PR DESCRIPTION
close #69

## 概要

内部 VRT (22ケース) にあるが LibreOffice VRT (20ケース) にないテストケースを追加し、LibreOffice VRT を 24 ケースに拡充。
加えて、issue で言及されていた散布図を既存の charts フィクスチャに追加。

## 追加テストケース

| ケース名 | 内容 | 許容度 |
|---|---|---|
| word-wrap | テキスト折り返し（長文、ナロー、no-wrap、日本語、CJK混合） | 15% |
| background-blipfill | 画像ベースのスライド背景（blipFill + 半透明オーバーレイ） | 5% (デフォルト) |
| composite | 複合テスト（非矩形図形+テキスト、グラデーション+回転+半透明） | 15% |
| effects | シェイプエフェクト（ドロップシャドウ、グロー、インナーシャドウ、ソフトエッジ） | 20% |

## 既存の変更

- **charts**: 散布図（XY_SCATTER）を追加し、チャートレイアウトを 2x2 → 3+2 に変更

## 対象ファイル

- `vrt/libreoffice/generate_fixtures.py` — 4 つの新規フィクスチャ生成関数追加 + charts 関数修正
- `vrt/libreoffice/libreoffice-regression.test.ts` — LO_VRT_CASES に 4 ケース追加

## テスト結果

- ローカル: 全 400 テスト パス（LibreOffice VRT 24/24 含む）
- lint / format:check / typecheck: すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)