### PR TITLE
docs: README に動作環境セクションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 PPTX スライドを SVG / PNG に変換する TypeScript ライブラリ。
 
+## 動作環境
+
+- **Node.js >= 20** (ブラウザ環境では動作しません)
+- PNG 変換に [sharp](https://sharp.pixelplumbing.com/) を使用しているため、sharp がサポートするプラットフォームが必要です
+
 ## インストール
 
 ```bash


### PR DESCRIPTION
## 概要

npm に公開された `pptx-glimpse@0.1.0` を実際にインストール・実行して動作確認を行い、README に動作環境の情報を追記しました。

## 動作確認結果

以下のパターンですべて正常動作を確認:

| テスト | 結果 |
|---|---|
| ESM (`import` 構文) | OK |
| CJS (`require()` 直接) | OK |
| CJS (動的 `import()`) | OK |
| TypeScript (型チェック `tsc --noEmit`) | OK |
| TypeScript (実行 `tsx`) | OK |

## 変更内容

- README に「動作環境」セクションを追加
  - Node.js >= 20 が必要であること
  - ブラウザ環境では動作しないこと
  - sharp のプラットフォーム要件

## テストプラン

- [ ] CI が通ること
- [ ] README の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)