### PR TITLE
ci: npm pack によるパッケージ公開検証を CI に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify package (CJS/ESM/TypeScript)
+        run: bash scripts/test-package.sh
+
   vrt:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "vrt:lo:docker-build": "docker build -t pptx-glimpse-vrt docker/libreoffice-vrt",
     "vrt:lo:fixtures": "docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt python3 /workspace/vrt/libreoffice/generate_fixtures.py",
     "vrt:lo:reference": "docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt bash /workspace/vrt/libreoffice/render_references.sh",
-    "vrt:lo:update": "npm run vrt:lo:docker-build && npm run vrt:lo:fixtures && npm run vrt:lo:reference"
+    "vrt:lo:update": "npm run vrt:lo:docker-build && npm run vrt:lo:fixtures && npm run vrt:lo:reference",
+    "test:package": "npm run build && bash scripts/test-package.sh"
   },
   "files": [
     "dist"

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 一時ディレクトリを作成し、終了時にクリーンアップ
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "=== Package publish verification ==="
+echo "Working directory: $WORK_DIR"
+
+# npm pack でタールボールを生成
+TARBALL=$(npm pack --pack-destination "$WORK_DIR" 2>/dev/null)
+TARBALL_PATH="$WORK_DIR/$TARBALL"
+echo "Packed: $TARBALL"
+
+# テスト用ディレクトリにインストール
+TEST_DIR="$WORK_DIR/test-project"
+mkdir -p "$TEST_DIR"
+cd "$TEST_DIR"
+npm init -y > /dev/null 2>&1
+npm install "$TARBALL_PATH" > /dev/null 2>&1
+
+echo ""
+
+# --- CJS テスト ---
+echo "--- Test: CJS (require) ---"
+cat > test-cjs.cjs << 'TESTEOF'
+const pkg = require("pptx-glimpse");
+
+const assert = (condition, message) => {
+  if (!condition) {
+    console.error("FAIL:", message);
+    process.exit(1);
+  }
+};
+
+assert(typeof pkg.convertPptxToSvg === "function", "convertPptxToSvg should be a function");
+assert(typeof pkg.convertPptxToPng === "function", "convertPptxToPng should be a function");
+
+console.log("  convertPptxToSvg: function OK");
+console.log("  convertPptxToPng: function OK");
+console.log("CJS test passed!");
+TESTEOF
+node test-cjs.cjs
+
+echo ""
+
+# --- ESM テスト ---
+echo "--- Test: ESM (import) ---"
+cat > test-esm.mjs << 'TESTEOF'
+import { convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
+
+const assert = (condition, message) => {
+  if (!condition) {
+    console.error("FAIL:", message);
+    process.exit(1);
+  }
+};
+
+assert(typeof convertPptxToSvg === "function", "convertPptxToSvg should be a function");
+assert(typeof convertPptxToPng === "function", "convertPptxToPng should be a function");
+
+console.log("  convertPptxToSvg: function OK");
+console.log("  convertPptxToPng: function OK");
+console.log("ESM test passed!");
+TESTEOF
+node test-esm.mjs
+
+echo ""
+
+# --- TypeScript 型解決テスト ---
+echo "--- Test: TypeScript type resolution ---"
+npm install typescript@latest @types/node > /dev/null 2>&1
+
+# テスト用プロジェクトを ESM に設定 (pptx-glimpse は "type": "module")
+npm pkg set type=module > /dev/null 2>&1
+
+cat > tsconfig.json << 'TESTEOF'
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["test-types.ts"]
+}
+TESTEOF
+
+cat > test-types.ts << 'TESTEOF'
+import { convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
+import type { ConvertOptions, SlideImage, SlideSvg } from "pptx-glimpse";
+
+// Verify function signatures
+const _svgFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<SlideSvg[]> =
+  convertPptxToSvg;
+const _pngFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<SlideImage[]> =
+  convertPptxToPng;
+
+// Verify type structures
+const _options: ConvertOptions = { slides: [1], width: 960 };
+void _svgFn;
+void _pngFn;
+void _options;
+TESTEOF
+npx tsc --noEmit
+echo "TypeScript type resolution test passed!"
+
+echo ""
+echo "=== All package verification tests passed! ==="


### PR DESCRIPTION
## 概要

`npm pack` で生成したパッケージが CJS / ESM / TypeScript の各環境で正しくインポートできることを CI で自動検証するステップを追加。

## 変更内容

- `scripts/test-package.sh`: パッケージ検証スクリプトを新規作成
  - CJS (`require`) でのインポートテスト
  - ESM (`import`) でのインポートテスト
  - TypeScript 型解決テスト (`tsc --noEmit`)
- `.github/workflows/ci.yml`: `Build` ステップの後に検証ステップを追加（Node 20/22/24 マトリクスで実行）
- `package.json`: `test:package` スクリプトを追加（ローカル実行用）

## 検出できる問題

- `exports` フィールドのパス誤り
- CJS/ESM のデュアルパッケージ問題
- TypeScript 型定義の欠落
- `files` フィールドの漏れ

## テスト計画

- [x] ローカルで `npm run test:package` が成功することを確認
- [ ] CI の全ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)