### PR TITLE
fix: npm publish で Trusted Publishing (OIDC) を使用

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -28,5 +31,3 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 概要

- npm publish の認証を `NPM_TOKEN` シークレットから Trusted Publishing (OIDC) に切り替え
- Trusted Publishing に必要な最新 npm へのアップグレードステップを追加
- `NODE_AUTH_TOKEN` 環境変数を削除

## 背景

https://github.com/hirokisakabe/pptx-glimpse/actions/runs/21905299744 で `ENEEDAUTH` エラーが発生していた。npmjs.com 側で Trusted Publishing の設定済みのため、ワークフロー側を対応させる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)