### PR TITLE
docs: README と CLAUDE.md の古い記述を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ CI は 3 ジョブ構成:
 データフロー: **PPTX バイナリ → Parser (ZIP解凍+XMLパース) → 中間モデル → Renderer (SVG生成) → PNG変換 (optional)**
 
 - `src/parser/` — PPTX の ZIP 解凍 (`jszip`) と XML パース (`fast-xml-parser`) で中間モデルを構築
-- `src/model/` — 中間モデルの TypeScript インターフェース (Slide, Shape, Fill, Text, Theme, Table, Chart, Image, Line, Presentation 等)
+- `src/model/` — 中間モデルの TypeScript インターフェース (Slide, Shape, Fill, Text, Theme, Table, Chart, Image, Line, Effect, Presentation 等)
 - `src/renderer/` — 中間モデルから SVG 文字列を生成。`geometry/` にプリセット図形定義、テーブル・チャート・画像の個別レンダラーも含む
 - `src/color/` — テーマカラー解決 (schemeClr → colorMap → colorScheme) と色変換 (lumMod/tint/shade)
 - `src/png/` — sharp による SVG → PNG 変換

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Supports conversion of static visual content in PowerPoint. Dynamic elements suc
 
 | Feature        | Details                                                                                          |
 | -------------- | ------------------------------------------------------------------------------------------------ |
-| Preset shapes  | 113 types (rectangles, ellipses, arrows, flowcharts, callouts, stars, math symbols, etc.)        |
+| Preset shapes  | 123 types (rectangles, ellipses, arrows, flowcharts, callouts, stars, math symbols, etc.)        |
 | Custom shapes  | Arbitrary shape drawing using custom paths (moveTo, lnTo, cubicBezTo, close)                     |
 | Connectors     | Line connector drawing, line style / color / width settings                                      |
 | Groups         | Shape grouping, nested groups                                                                    |
@@ -50,7 +50,7 @@ Supports conversion of static visual content in PowerPoint. Dynamic elements suc
 
 | Feature        | Details                                                                                                              |
 | -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Character formatting | Font size, font family (East Asian font support), bold, italic, underline, strikethrough, font color, superscript / subscript |
+| Character formatting | Font size, font family (East Asian font support), bold, italic, underline, strikethrough, font color, superscript / subscript, hyperlinks |
 | Paragraph formatting | Horizontal alignment (left/center/right/justify), vertical anchor (top/center/bottom), line spacing, before/after paragraph spacing, indent |
 | Bullet points  | Character bullets (buChar), auto-numbering (buAutoNum, 9 types), bullet font / color / size                          |
 | Text boxes     | Word wrap (square/none), auto-fit (noAutofit/normAutofit/spAutofit), font scaling, margins                            |
@@ -132,7 +132,6 @@ Supports conversion of static visual content in PowerPoint. Dynamic elements suc
 | SmartArt         | All SmartArt features                                                                                                        |
 | Multimedia       | Embedded video / audio                                                                                                       |
 | Animations       | Object animations, slide transitions                                                                                         |
-| Links            | Hyperlinks                                                                                                                   |
 | Slide elements   | Slide notes, comments, headers / footers, slide numbers / dates                                                              |
 | Image formats    | EMF/WMF (parsed but not rendered)                                                                                            |
 | Other            | Macros / VBA, sections, zoom slides                                                                                          |


### PR DESCRIPTION
## 概要

README.md と CLAUDE.md の古くなった記述を現在のコードベースに合わせて修正。

- プリセット図形の数を 113 → 123 に更新（`preset-geometries.ts` の実際のエントリ数に合わせた）
- ハイパーリンクを「Unsupported Features」から削除し、Text の Character formatting にサポート済みとして追加
- CLAUDE.md の中間モデルリストに `Effect` を追加（`src/model/effect.ts` が存在するため）

## テストプラン

- [ ] ドキュメントのみの変更のため、動作への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)