### PR TITLE
docs: 仕様参照コメントを追加

### DIFF
--- a/src/color/color-resolver.ts
+++ b/src/color/color-resolver.ts
@@ -1,3 +1,10 @@
+// OOXML テーマカラー解決 (ECMA-376 §20.1.6)
+// 色の種類:
+//   srgbClr — sRGB 直接指定 (e.g. "FF0000")
+//   schemeClr — テーマカラー参照 (dk1, lt1, accent1-6, hlink, folHlink)
+//     → colorMap でキーを変換 → colorScheme から実際の色を取得
+//   sysClr — システムカラー (@_lastClr で保存された直近値を使用)
+
 import type { ColorScheme, ColorMap, ColorSchemeKey } from "../model/theme.js";
 import type { ResolvedColor } from "../model/fill.js";
 import { applyColorTransforms } from "./color-transforms.js";

--- a/src/color/color-transforms.ts
+++ b/src/color/color-transforms.ts
@@ -1,3 +1,10 @@
+// OOXML 色変換 (ECMA-376 §20.1.2.3)
+// lumMod/lumOff: HSL 色空間の輝度チャネルを変更
+// tint: 白方向にブレンド (RGB 各チャネル: c + (255 - c) * amount)
+// shade: 黒方向にブレンド (RGB 各チャネル: c * amount)
+// alpha: 不透明度 (100000 = 100%)
+// 値は 100000 分率 (e.g. 50000 = 50%)
+
 import type { ResolvedColor } from "../model/fill.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,6 +68,7 @@ function rgbToHex(r: number, g: number, b: number): string {
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 }
 
+// RGB ↔ HSL 変換: W3C CSS Color Module Level 3 §4.2.4 のアルゴリズムに準拠
 function hexToHsl(hex: string): { h: number; s: number; l: number } {
   const { r: r255, g: g255, b: b255 } = hexToRgb(hex);
   const r = r255 / 255;

--- a/src/parser/xml-parser.ts
+++ b/src/parser/xml-parser.ts
@@ -1,22 +1,26 @@
 import { XMLParser } from "fast-xml-parser";
 
+// OOXML XML で単一要素でも配列として扱う必要があるタグ。
+// fast-xml-parser は子要素が 1 つだとオブジェクト、複数だと配列を返すため、
+// スライド上に図形が 1 つだけの場合などにパース結果が不安定になる。
+// isArray で常に配列化することで、下流コードを統一的に記述できる。
 const ARRAY_TAGS = new Set([
-  "sp",
-  "pic",
-  "cxnSp",
-  "grpSp",
-  "graphicFrame",
-  "p",
-  "r",
-  "br",
-  "Relationship",
-  "sldId",
-  "gs",
-  "gridCol",
-  "tr",
-  "tc",
-  "ser",
-  "pt",
+  "sp", // 図形 (Shape)
+  "pic", // 画像 (Picture)
+  "cxnSp", // コネクタ (Connector)
+  "grpSp", // グループ (Group Shape)
+  "graphicFrame", // テーブル・チャート等のフレーム
+  "p", // テキスト段落 (Paragraph)
+  "r", // テキストラン (Run)
+  "br", // 改行 (Break)
+  "Relationship", // リレーションシップ
+  "sldId", // スライド ID
+  "gs", // グラデーションストップ (Gradient Stop)
+  "gridCol", // テーブル列定義
+  "tr", // テーブル行 (Table Row)
+  "tc", // テーブルセル (Table Cell)
+  "ser", // チャートデータ系列 (Series)
+  "pt", // チャートデータポイント (Point)
 ]);
 
 export function createXmlParser(): XMLParser {

--- a/src/renderer/geometry/preset-geometries.ts
+++ b/src/renderer/geometry/preset-geometries.ts
@@ -1,3 +1,6 @@
+// OOXML DrawingML プリセット図形 (ECMA-376 §20.1.10.56 prst)
+// adj 値は 100,000 分率で正規化 (e.g. adj=50000 → 50%)
+
 type GeometryGenerator = (w: number, h: number, adj: Record<string, number>) => string;
 
 // --- Helper functions ---
@@ -24,6 +27,7 @@ function starPolygon(w: number, h: number, points: number, innerRatio: number): 
   return `<polygon points="${coords.join(" ")}"/>`;
 }
 
+// OOXML 角度 (1/60,000 度) → ラジアン
 function ooxmlAngleToRadians(angle60k: number): number {
   return (angle60k / 60000) * (Math.PI / 180);
 }

--- a/src/renderer/svg-renderer.ts
+++ b/src/renderer/svg-renderer.ts
@@ -8,6 +8,9 @@ import { renderChart } from "./chart-renderer.js";
 import { renderTable } from "./table-renderer.js";
 import { renderFillAttrs } from "./fill-renderer.js";
 
+// SVG 1.1 (W3C) で出力。CSS クラスは使わずインライン属性のみ使用する。
+// 理由: sharp (内部で librsvg を使用) が CSS セレクタを正しく解釈しないため。
+
 export function renderSlideToSvg(slide: Slide, slideSize: SlideSize): string {
   const width = emuToPixels(slideSize.width);
   const height = emuToPixels(slideSize.height);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,10 +1,16 @@
+// OOXML 単位系 (ECMA-376 §20.1.2.1)
+// EMU (English Metric Units) は OOXML 内部の座標単位。
+// 16:9 スライド = 9,144,000 × 5,143,500 EMU = 960 × 540 px (96 DPI)
+
+/** 1 inch = 914,400 EMU */
 export const EMU_PER_INCH = 914400;
+/** 1 pt = 12,700 EMU */
 export const EMU_PER_POINT = 12700;
 export const DEFAULT_DPI = 96;
 export const DEFAULT_OUTPUT_WIDTH = 960;
 
-/** 回転角度の単位: 1/60000 度 */
+/** 回転角度の単位: 1/60,000 度 (ECMA-376 §20.1.10.3) */
 export const ROTATION_UNIT = 60000;
 
-/** フォントサイズの単位: 1/100 ポイント */
+/** フォントサイズの単位: 1/100 ポイント (ECMA-376 §21.1.2.2.25 sz 属性) */
 export const FONT_SIZE_UNIT = 100;

--- a/src/utils/text-measure.ts
+++ b/src/utils/text-measure.ts
@@ -2,14 +2,17 @@ import { type FontMetrics, getFontMetrics } from "../data/font-metrics.js";
 
 type CharCategory = "narrow" | "normal" | "wide";
 
+// フォントメトリクスが無い場合のヒューリスティック幅比率 (対 fontSize)。
+// 実測ベースの近似値。
 const WIDTH_RATIO: Record<CharCategory, number> = {
-  narrow: 0.3,
-  normal: 0.6,
-  wide: 1.0,
+  narrow: 0.3, // i, l, 1, 句読点等
+  normal: 0.6, // ラテン文字の平均的な幅
+  wide: 1.0, // CJK 文字 (全角)
 };
 
 const BOLD_FACTOR = 1.05;
 const PX_PER_PT = 96 / 72;
+// OpenType メトリクスが無いフォントの行高さフォールバック (CSS 既定値相当)
 const DEFAULT_LINE_HEIGHT_RATIO = 1.2;
 
 /**
@@ -26,12 +29,13 @@ export function getLineHeightRatio(
   return (metrics.ascender + Math.abs(metrics.descender)) / metrics.unitsPerEm;
 }
 
+// CJK 文字判定 (Unicode Standard に基づくコードポイント範囲)
 function isCjkCodePoint(codePoint: number): boolean {
   return (
-    (codePoint >= 0x3000 && codePoint <= 0x9fff) ||
-    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
-    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
-    (codePoint >= 0x20000 && codePoint <= 0x2a6df)
+    (codePoint >= 0x3000 && codePoint <= 0x9fff) || // CJK 記号・ひらがな・カタカナ・統合漢字
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) || // CJK 互換漢字
+    (codePoint >= 0xff01 && codePoint <= 0xff60) || // 全角英数・記号
+    (codePoint >= 0x20000 && codePoint <= 0x2a6df) // CJK 統合漢字拡張 B
   );
 }
 


### PR DESCRIPTION
## Summary

- ECMA-376 (OOXML)、W3C CSS Color、Unicode Standard 等の仕様参照や設計意図をコメントとして追記
- 「なぜそうしているか」が分かりにくい箇所に限定して追加

### 対象ファイル

- `src/color/color-transforms.ts` — 色変換アルゴリズム (lumMod/tint/shade) の仕様参照
- `src/color/color-resolver.ts` — テーマカラー解決フロー (schemeClr → colorMap → colorScheme)
- `src/parser/xml-parser.ts` — ARRAY_TAGS の各タグの説明と、なぜ配列化が必要かの説明
- `src/renderer/geometry/preset-geometries.ts` — プリセット図形の仕様参照と adj 値の単位説明
- `src/renderer/svg-renderer.ts` — CSS クラス不使用の理由
- `src/utils/constants.ts` — OOXML 単位系の仕様参照
- `src/utils/text-measure.ts` — CJK 判定の Unicode 範囲説明、ヒューリスティック値の根拠

## Test plan

- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run typecheck` 通過
- コメントのみの変更のため、動作への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)