### PR TITLE
docs: Translate CLAUDE.md to English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,119 +2,119 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## プロジェクト概要
+## Project Overview
 
-pptx-glimpse は PPTX スライドを SVG / PNG に変換する TypeScript ライブラリ。
-入力は `Buffer | Uint8Array`、出力は SVG 文字列または PNG Buffer。
+pptx-glimpse is a TypeScript library that converts PPTX slides to SVG / PNG.
+Input: `Buffer | Uint8Array`, Output: SVG string or PNG Buffer.
 
-## コマンド
+## Commands
 
 ```bash
-npm run build          # tsup でビルド (CJS + ESM + .d.ts)
-npm run test           # vitest で全テスト実行
-npm run test -- src/utils/emu.test.ts  # 単一テストファイル実行
-npm run test:watch     # テストのウォッチモード
-npm run lint           # ESLint チェック
-npm run lint:fix       # ESLint 自動修正
-npm run format         # Prettier 整形
-npm run format:check   # Prettier チェック
-npm run typecheck      # tsc --noEmit で型チェック
-npm run render         # tsx scripts/test-render.ts でテストレンダリング
+npm run build          # Build with tsup (CJS + ESM + .d.ts)
+npm run test           # Run all tests with vitest
+npm run test -- src/utils/emu.test.ts  # Run a single test file
+npm run test:watch     # Watch mode for tests
+npm run lint           # ESLint check
+npm run lint:fix       # ESLint auto-fix
+npm run format         # Prettier formatting
+npm run format:check   # Prettier check
+npm run typecheck      # Type check with tsc --noEmit
+npm run render         # Test rendering with tsx scripts/test-render.ts
 ```
 
-CI は 3 ジョブ構成:
+CI consists of 3 jobs:
 
-- **ci**: `lint` → `format:check` → `typecheck` → `test` (VRT 除外) → `build` (Node 20/22/24)
-- **vrt**: 通常 VRT (自己比較)
-- **libreoffice-vrt**: LibreOffice VRT (Docker でフィクスチャ・参照画像を生成して実行)
+- **ci**: `lint` → `format:check` → `typecheck` → `test` (excluding VRT) → `build` (Node 20/22/24)
+- **vrt**: Standard VRT (self-comparison)
+- **libreoffice-vrt**: LibreOffice VRT (generates fixtures and reference images via Docker)
 
-## アーキテクチャ
+## Architecture
 
-データフロー: **PPTX バイナリ → Parser (ZIP解凍+XMLパース) → 中間モデル → Renderer (SVG生成) → PNG変換 (optional)**
+Data flow: **PPTX binary → Parser (ZIP extraction + XML parsing) → Intermediate model → Renderer (SVG generation) → PNG conversion (optional)**
 
-- `src/parser/` — PPTX の ZIP 解凍 (`jszip`) と XML パース (`fast-xml-parser`) で中間モデルを構築
-- `src/model/` — 中間モデルの TypeScript インターフェース (Slide, Shape, Fill, Text, Theme, Table, Chart, Image, Line, Effect, Presentation 等)
-- `src/renderer/` — 中間モデルから SVG 文字列を生成。`geometry/` にプリセット図形定義、テーブル・チャート・画像の個別レンダラーも含む
-- `src/color/` — テーマカラー解決 (schemeClr → colorMap → colorScheme) と色変換 (lumMod/tint/shade)
-- `src/png/` — sharp による SVG → PNG 変換
-- `src/data/` — フォントメトリクスデータ (OSS 互換フォントから抽出した文字幅情報)
-- `src/utils/` — EMU↔ピクセル変換 (1 inch = 914400 EMU, 96 DPI)、テキスト幅計測・テキスト折り返し
+- `src/parser/` — Builds intermediate model from PPTX via ZIP extraction (`jszip`) and XML parsing (`fast-xml-parser`)
+- `src/model/` — TypeScript interfaces for the intermediate model (Slide, Shape, Fill, Text, Theme, Table, Chart, Image, Line, Effect, Presentation, etc.)
+- `src/renderer/` — Generates SVG strings from the intermediate model. Includes preset shape definitions in `geometry/`, plus dedicated renderers for tables, charts, and images
+- `src/color/` — Theme color resolution (schemeClr → colorMap → colorScheme) and color transformations (lumMod/tint/shade)
+- `src/png/` — SVG → PNG conversion using sharp
+- `src/data/` — Font metrics data (character width information extracted from OSS-compatible fonts)
+- `src/utils/` — EMU ↔ pixel conversion (1 inch = 914400 EMU, 96 DPI), text width measurement, and text wrapping
 
-エントリポイント: `src/index.ts` が `convertPptxToSvg` と `convertPptxToPng` をエクスポート。
+Entry point: `src/index.ts` exports `convertPptxToSvg` and `convertPptxToPng`.
 
-## 技術制約
+## Technical Constraints
 
-- **SVG はインライン属性のみ使用** — CSS クラスは使わない。sharp (librsvg) が CSS を正しく解釈しないため
-- **fast-xml-parser の `isArray` 設定が必須** — `sp`, `pic`, `p`, `r` 等のタグは単一要素でも配列として返す必要がある (`xml-parser.ts` の `ARRAY_TAGS`)
-- **EMU 単位** — PPTX 内部座標は EMU (English Metric Units)。`emuToPixels()` で変換。16:9 スライドは 9144000×5143500 EMU = 960×540 px
-- **背景フォールバック** — スライド → スライドレイアウト → スライドマスターの順で背景を探索
+- **SVG uses inline attributes only** — No CSS classes. sharp (librsvg) does not correctly interpret CSS
+- **`isArray` configuration in fast-xml-parser is required** — Tags such as `sp`, `pic`, `p`, `r` must be returned as arrays even for single elements (`ARRAY_TAGS` in `xml-parser.ts`)
+- **EMU units** — PPTX internal coordinates use EMU (English Metric Units). Convert with `emuToPixels()`. A 16:9 slide is 9144000×5143500 EMU = 960×540 px
+- **Background fallback** — Backgrounds are resolved in order: slide → slide layout → slide master
 
 ## VRT (Visual Regression Testing)
 
-描画結果の視覚的回帰テスト。パーサーやレンダラーを変更した場合、**必ず VRT の更新が必要か確認すること**。
+Visual regression tests for rendering output. When modifying the parser or renderer, **always check whether VRT updates are needed**.
 
-### ディレクトリ構成
+### Directory Structure
 
 ```
 vrt/
-├── compare-utils.ts                          # 共通画像比較ユーティリティ
-├── internal/                                 # 通常 VRT (自己比較)
-│   ├── regression.test.ts                    # テスト本体
-│   ├── create-fixtures.ts                    # フィクスチャ生成スクリプト
-│   ├── update-snapshots.ts                   # スナップショット更新スクリプト
-│   ├── fixtures/                             # VRT 用 PPTX フィクスチャ (CI で動的生成)
-│   └── snapshots/                            # 参照スナップショット画像
+├── compare-utils.ts                          # Shared image comparison utilities
+├── internal/                                 # Standard VRT (self-comparison)
+│   ├── regression.test.ts                    # Test file
+│   ├── create-fixtures.ts                    # Fixture generation script
+│   ├── update-snapshots.ts                   # Snapshot update script
+│   ├── fixtures/                             # VRT PPTX fixtures (dynamically generated in CI)
+│   └── snapshots/                            # Reference snapshot images
 └── libreoffice/                              # LibreOffice VRT
-    ├── regression.test.ts                    # テスト本体
-    ├── create_fixtures.py                    # フィクスチャ生成 (Python, Docker)
-    ├── update_snapshots.sh                   # スナップショット更新 (Docker)
-    ├── fixtures/                             # CI で動的生成
-    └── snapshots/                            # CI で動的生成
+    ├── regression.test.ts                    # Test file
+    ├── create_fixtures.py                    # Fixture generation (Python, Docker)
+    ├── update_snapshots.sh                   # Snapshot update (Docker)
+    ├── fixtures/                             # Dynamically generated in CI
+    └── snapshots/                            # Dynamically generated in CI
 ```
 
-### VRT 更新手順
+### VRT Update Procedure
 
-パーサー・レンダラー・モデルの変更で描画結果が変わる場合:
+When changes to the parser, renderer, or model affect rendering output:
 
-1. **フィクスチャ更新** (新機能追加や既存フィクスチャの修正が必要な場合): `vrt/internal/create-fixtures.ts` を編集し `npm run vrt:internal:fixtures` を実行
-2. **スナップショット更新**: `npm run vrt:internal:update` で参照画像を再生成
-3. **テスト確認**: `npm run test` で VRT テストが通ることを確認
+1. **Update fixtures** (if adding new features or modifying existing fixtures): Edit `vrt/internal/create-fixtures.ts` and run `npm run vrt:internal:fixtures`
+2. **Update snapshots**: Regenerate reference images with `npm run vrt:internal:update`
+3. **Verify tests**: Confirm VRT tests pass with `npm run test`
 
-### 同期が必要な 3 箇所
+### 3 Locations That Must Stay in Sync
 
-新しい描画機能を追加した場合、以下の **3 箇所すべて** を更新する必要がある:
+When adding a new rendering feature, **all 3 of the following** must be updated:
 
-1. **`vrt/internal/create-fixtures.ts`** — 新機能をカバーするフィクスチャ (PPTX) を追加
-2. **`vrt/internal/regression.test.ts`** — `VRT_CASES` 配列に新しいテストケースを追加
-3. **`vrt/internal/snapshots/`** — `npm run vrt:internal:update` でスナップショットを再生成
+1. **`vrt/internal/create-fixtures.ts`** — Add fixtures (PPTX) covering the new feature
+2. **`vrt/internal/regression.test.ts`** — Add new test cases to the `VRT_CASES` array
+3. **`vrt/internal/snapshots/`** — Regenerate snapshots with `npm run vrt:internal:update`
 
-**よくあるミス**: パーサーやレンダラーを修正したのにスナップショットを更新し忘れて VRT テストが失敗する。描画に影響する変更を行ったら、必ず `npm run vrt:internal:update` を実行すること。
+**Common mistake**: Modifying the parser or renderer but forgetting to update snapshots, causing VRT tests to fail. Always run `npm run vrt:internal:update` after making changes that affect rendering.
 
-### LibreOffice VRT (Docker ベース)
+### LibreOffice VRT (Docker-based)
 
-python-pptx で生成した PPTX を LibreOffice でレンダリングし、pptx-glimpse の出力と比較する。Docker で環境を統一。
+Renders PPTX files generated with python-pptx using LibreOffice and compares them against pptx-glimpse output. Docker ensures a consistent environment.
 
-#### セットアップ
+#### Setup
 
 ```bash
-npm run vrt:lo:docker-build   # Docker イメージのビルド
-npm run vrt:lo:update          # フィクスチャ生成 + 参照画像生成 (Docker 必須)
-npm run test                   # テスト実行 (LibreOffice VRT 含む)
+npm run vrt:lo:docker-build   # Build the Docker image
+npm run vrt:lo:update          # Generate fixtures + reference images (Docker required)
+npm run test                   # Run tests (including LibreOffice VRT)
 ```
 
-#### 許容度
+#### Tolerance
 
-- `PIXEL_THRESHOLD = 0.3` (ピクセル単位の色差許容度)
-- `MISMATCH_TOLERANCE = 0.05` (5% のピクセル不一致を許容)
+- `PIXEL_THRESHOLD = 0.3` (per-pixel color difference tolerance)
+- `MISMATCH_TOLERANCE = 0.05` (allows up to 5% pixel mismatch)
 
-LibreOffice ≠ PowerPoint のため、フォントレンダリングやアンチエイリアスの差異は許容する。明らかな描画漏れ・構造的な間違いを検知する目的。
+Since LibreOffice ≠ PowerPoint, differences in font rendering and anti-aliasing are tolerated. The goal is to detect obvious rendering omissions and structural errors.
 
-#### Docker なしの場合
+#### Without Docker
 
-Docker がない環境では LibreOffice VRT テストは自動的にスキップされる。`npm run test` は問題なく通る。
+LibreOffice VRT tests are automatically skipped in environments without Docker. `npm run test` will pass without issues.
 
-## コーディング規約
+## Coding Conventions
 
-- Prettier: ダブルクォート、セミコロンあり、末尾カンマ、printWidth 100
-- ESLint: `_` プレフィックスの未使用変数は許可
-- ESM (`"type": "module"`) — インポートには `.js` 拡張子が必要
+- Prettier: double quotes, semicolons, trailing commas, printWidth 100
+- ESLint: unused variables with `_` prefix are allowed
+- ESM (`"type": "module"`) — imports require `.js` extension


### PR DESCRIPTION
## 概要
- CLAUDE.md の全セクション（見出し、説明文、コードブロック内コメント）を日本語から英語に翻訳

## テストプラン
- [ ] CLAUDE.md の内容が正確に英語化されていることを確認
- [ ] コマンドやコードブロックの実行可能な部分が変更されていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)