### PR TITLE
docs: README に Demo と npm へのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # pptx-glimpse
 
+[![npm](https://img.shields.io/npm/v/pptx-glimpse)](https://www.npmjs.com/package/pptx-glimpse)
+
 A TypeScript library to render PPTX slides as SVG / PNG.
+
+[Demo](https://hirokisakabe.github.io/pptx-glimpse/) | [npm](https://www.npmjs.com/package/pptx-glimpse)
 
 ## Motivation
 


### PR DESCRIPTION
## Summary
- README のタイトル直下に npm バッジ、Demo ページと npm パッケージへのリンクを追加

## Test plan
- [ ] README のバッジとリンクが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)