### PR TITLE
fix: homePlate 図形の矢印先端計算で短辺を基準にする

### DIFF
--- a/src/renderer/geometry/preset-geometries.ts
+++ b/src/renderer/geometry/preset-geometries.ts
@@ -206,7 +206,7 @@ const presetGeometries: Record<string, GeometryGenerator> = {
   },
 
   homePlate: (w, h, adj) => {
-    const offset = ((adj["adj"] ?? 50000) / 100000) * w;
+    const offset = ((adj["adj"] ?? 50000) / 100000) * Math.min(w, h);
     return `<polygon points="0,0 ${w - offset},0 ${w},${h / 2} ${w - offset},${h} 0,${h}"/>`;
   },
 


### PR DESCRIPTION
close #115

## 概要

- `homePlate` プリセットジオメトリの矢印先端（offset）の計算で、`w`（幅）を基準にしていたのを `Math.min(w, h)`（短辺）に修正
- OOXML 仕様では adj ガイドは短辺（ss = min(w, h)）に対する割合であり、同ファイル内の他の矢印系図形（`leftRightUpArrow`, `quadArrow` 等）と整合

## 修正内容

```diff
- const offset = ((adj["adj"] ?? 50000) / 100000) * w;
+ const offset = ((adj["adj"] ?? 50000) / 100000) * Math.min(w, h);
```

## テスト計画

- [x] ユニットテスト通過
- [x] VRT スナップショット更新・通過
- [x] lint / format / typecheck 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)