### PR TITLE
feat: presentation.xml の defaultTextStyle をパースする

### DIFF
--- a/src/model/presentation.ts
+++ b/src/model/presentation.ts
@@ -1,11 +1,13 @@
 import type { Slide } from "./slide.js";
 import type { Theme, ColorMap } from "./theme.js";
+import type { DefaultTextStyle } from "./text.js";
 
 export interface Presentation {
   slideSize: SlideSize;
   slides: Slide[];
   theme: Theme;
   colorMap: ColorMap;
+  defaultTextStyle?: DefaultTextStyle;
 }
 
 export interface SlideSize {

--- a/src/model/text.ts
+++ b/src/model/text.ts
@@ -1,5 +1,30 @@
 import type { ResolvedColor } from "./fill.js";
 
+/** defRPr に対応するデフォルトランプロパティ */
+export interface DefaultRunProperties {
+  fontSize?: number;
+  fontFamily?: string | null;
+  fontFamilyEa?: string | null;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+}
+
+/** defaultTextStyle の各レベルに対応するデフォルト段落プロパティ */
+export interface DefaultParagraphLevelProperties {
+  alignment?: "l" | "ctr" | "r" | "just";
+  marginLeft?: number;
+  indent?: number;
+  defaultRunProperties?: DefaultRunProperties;
+}
+
+/** presentation.xml の defaultTextStyle */
+export interface DefaultTextStyle {
+  defaultParagraph?: DefaultParagraphLevelProperties;
+  levels: (DefaultParagraphLevelProperties | undefined)[]; // index 0 = lvl1pPr, ... index 8 = lvl9pPr
+}
+
 export interface TextBody {
   paragraphs: Paragraph[];
   bodyProperties: BodyProperties;

--- a/src/parser/presentation-parser.test.ts
+++ b/src/parser/presentation-parser.test.ts
@@ -53,6 +53,103 @@ describe("parsePresentation", () => {
     warnSpy.mockRestore();
   });
 
+  it("parses defaultTextStyle with multiple levels", () => {
+    const xml = `
+      <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <p:sldSz cx="9144000" cy="5143500"/>
+        <p:sldIdLst>
+          <p:sldId id="256" r:id="rId2"/>
+        </p:sldIdLst>
+        <p:defaultTextStyle>
+          <a:defPPr>
+            <a:defRPr lang="en-US"/>
+          </a:defPPr>
+          <a:lvl1pPr marL="0" algn="l">
+            <a:defRPr sz="1800" b="1">
+              <a:latin typeface="Calibri"/>
+              <a:ea typeface="MS Gothic"/>
+            </a:defRPr>
+          </a:lvl1pPr>
+          <a:lvl2pPr marL="457200" algn="l" indent="-228600">
+            <a:defRPr sz="1400"/>
+          </a:lvl2pPr>
+        </p:defaultTextStyle>
+      </p:presentation>
+    `;
+    const result = parsePresentation(xml);
+
+    expect(result.defaultTextStyle).toBeDefined();
+    expect(result.defaultTextStyle!.defaultParagraph).toBeUndefined();
+
+    // lvl1pPr
+    const lvl1 = result.defaultTextStyle!.levels[0];
+    expect(lvl1).toBeDefined();
+    expect(lvl1!.marginLeft).toBe(0);
+    expect(lvl1!.alignment).toBe("l");
+    expect(lvl1!.defaultRunProperties).toBeDefined();
+    expect(lvl1!.defaultRunProperties!.fontSize).toBe(18);
+    expect(lvl1!.defaultRunProperties!.bold).toBe(true);
+    expect(lvl1!.defaultRunProperties!.fontFamily).toBe("Calibri");
+    expect(lvl1!.defaultRunProperties!.fontFamilyEa).toBe("MS Gothic");
+
+    // lvl2pPr
+    const lvl2 = result.defaultTextStyle!.levels[1];
+    expect(lvl2).toBeDefined();
+    expect(lvl2!.marginLeft).toBe(457200);
+    expect(lvl2!.indent).toBe(-228600);
+    expect(lvl2!.defaultRunProperties!.fontSize).toBe(14);
+
+    // lvl3pPr ~ lvl9pPr are undefined
+    for (let i = 2; i < 9; i++) {
+      expect(result.defaultTextStyle!.levels[i]).toBeUndefined();
+    }
+  });
+
+  it("parses defaultTextStyle with defPPr containing defRPr", () => {
+    const xml = `
+      <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <p:sldSz cx="9144000" cy="5143500"/>
+        <p:sldIdLst>
+          <p:sldId id="256" r:id="rId2"/>
+        </p:sldIdLst>
+        <p:defaultTextStyle>
+          <a:defPPr algn="ctr">
+            <a:defRPr sz="2400" i="1" u="sng" strike="sngStrike"/>
+          </a:defPPr>
+        </p:defaultTextStyle>
+      </p:presentation>
+    `;
+    const result = parsePresentation(xml);
+
+    expect(result.defaultTextStyle).toBeDefined();
+    const defPPr = result.defaultTextStyle!.defaultParagraph;
+    expect(defPPr).toBeDefined();
+    expect(defPPr!.alignment).toBe("ctr");
+    expect(defPPr!.defaultRunProperties!.fontSize).toBe(24);
+    expect(defPPr!.defaultRunProperties!.italic).toBe(true);
+    expect(defPPr!.defaultRunProperties!.underline).toBe(true);
+    expect(defPPr!.defaultRunProperties!.strikethrough).toBe(true);
+  });
+
+  it("returns undefined defaultTextStyle when element is missing", () => {
+    const xml = `
+      <p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <p:sldSz cx="9144000" cy="5143500"/>
+        <p:sldIdLst>
+          <p:sldId id="256" r:id="rId2"/>
+        </p:sldIdLst>
+      </p:presentation>
+    `;
+    const result = parsePresentation(xml);
+
+    expect(result.defaultTextStyle).toBeUndefined();
+  });
+
   it("does not warn for valid XML", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/src/parser/presentation-parser.ts
+++ b/src/parser/presentation-parser.ts
@@ -1,9 +1,16 @@
 import type { SlideSize } from "../model/presentation.js";
+import type {
+  DefaultTextStyle,
+  DefaultParagraphLevelProperties,
+  DefaultRunProperties,
+} from "../model/text.js";
 import { parseXml } from "./xml-parser.js";
+import { hundredthPointToPoint } from "../utils/emu.js";
 
 export interface PresentationInfo {
   slideSize: SlideSize;
   slideRIds: string[];
+  defaultTextStyle?: DefaultTextStyle;
 }
 
 const WARN_PREFIX = "[pptx-glimpse]";
@@ -50,5 +57,81 @@ export function parsePresentation(xml: string): PresentationInfo {
       return true;
     });
 
-  return { slideSize, slideRIds };
+  const defaultTextStyle = parseDefaultTextStyle(pres.defaultTextStyle);
+
+  return { slideSize, slideRIds, defaultTextStyle };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseDefaultRunProperties(defRPr: any): DefaultRunProperties | undefined {
+  if (!defRPr) return undefined;
+
+  const result: DefaultRunProperties = {};
+
+  if (defRPr["@_sz"] !== undefined) {
+    result.fontSize = hundredthPointToPoint(Number(defRPr["@_sz"]));
+  }
+  if (defRPr.latin?.["@_typeface"] !== undefined) {
+    result.fontFamily = defRPr.latin["@_typeface"];
+  }
+  if (defRPr.ea?.["@_typeface"] !== undefined) {
+    result.fontFamilyEa = defRPr.ea["@_typeface"];
+  }
+  if (defRPr["@_b"] !== undefined) {
+    result.bold = defRPr["@_b"] === "1" || defRPr["@_b"] === "true";
+  }
+  if (defRPr["@_i"] !== undefined) {
+    result.italic = defRPr["@_i"] === "1" || defRPr["@_i"] === "true";
+  }
+  if (defRPr["@_u"] !== undefined) {
+    result.underline = defRPr["@_u"] !== "none";
+  }
+  if (defRPr["@_strike"] !== undefined) {
+    result.strikethrough = defRPr["@_strike"] !== "noStrike";
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseParagraphLevelProperties(node: any): DefaultParagraphLevelProperties | undefined {
+  if (!node) return undefined;
+
+  const result: DefaultParagraphLevelProperties = {};
+
+  if (node["@_algn"] !== undefined) {
+    result.alignment = node["@_algn"] as "l" | "ctr" | "r" | "just";
+  }
+  if (node["@_marL"] !== undefined) {
+    result.marginLeft = Number(node["@_marL"]);
+  }
+  if (node["@_indent"] !== undefined) {
+    result.indent = Number(node["@_indent"]);
+  }
+
+  const defRPr = parseDefaultRunProperties(node.defRPr);
+  if (defRPr) {
+    result.defaultRunProperties = defRPr;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseDefaultTextStyle(node: any): DefaultTextStyle | undefined {
+  if (!node) return undefined;
+
+  const defaultParagraph = parseParagraphLevelProperties(node.defPPr);
+
+  const levels: (DefaultParagraphLevelProperties | undefined)[] = [];
+  for (let i = 1; i <= 9; i++) {
+    levels.push(parseParagraphLevelProperties(node[`lvl${i}pPr`]));
+  }
+
+  // すべてのレベルが undefined で defaultParagraph もなければ undefined を返す
+  if (!defaultParagraph && levels.every((l) => l === undefined)) {
+    return undefined;
+  }
+
+  return { defaultParagraph, levels };
 }


### PR DESCRIPTION
close #119

## 概要

`presentation.xml` の `<p:defaultTextStyle>` 要素をパースし、各レベル（`defPPr`, `lvl1pPr` 〜 `lvl9pPr`）のデフォルト段落プロパティ（`defRPr` 含む）を取得・保持する機能を追加。

テキストスタイル継承チェーンの最下層フォールバックとして必要。

## 変更内容

- **`src/model/text.ts`** — `DefaultRunProperties`, `DefaultParagraphLevelProperties`, `DefaultTextStyle` インターフェースを追加
- **`src/model/presentation.ts`** — `Presentation` に `defaultTextStyle` オプショナルフィールドを追加
- **`src/parser/presentation-parser.ts`** — `defaultTextStyle` のパース処理を追加（`PresentationInfo` にも反映）
- **`src/parser/presentation-parser.test.ts`** — パースのユニットテストを3件追加

## パース対象プロパティ

### 段落レベル (`defPPr`, `lvl1pPr` 〜 `lvl9pPr`)
- `alignment` (`@algn`)
- `marginLeft` (`@marL`)
- `indent` (`@indent`)

### デフォルトランプロパティ (`defRPr`)
- `fontSize` (`@sz`)
- `fontFamily` (`latin/@typeface`)
- `fontFamilyEa` (`ea/@typeface`)
- `bold` (`@b`)
- `italic` (`@i`)
- `underline` (`@u`)
- `strikethrough` (`@strike`)

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint && npm run format:check` 通過
- [x] `npm run test -- src/parser/presentation-parser.test.ts` 通過（7件全パス）
- [x] VRT 除外の全テスト通過（403件全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)