### PR TITLE
feat: スライドマスターの txStyles をパースする

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -114,7 +114,6 @@ export async function convertPptxToSvg(
     masterPath && masterXml
       ? parseSlideMasterElements(masterXml, masterPath, archive, colorResolver, theme.fontScheme)
       : [];
-
   // Resolve slide paths from relationships
   const slidePaths: { slideNumber: number; path: string }[] = [];
   for (let i = 0; i < presInfo.slideRIds.length; i++) {

--- a/src/model/presentation.ts
+++ b/src/model/presentation.ts
@@ -1,6 +1,6 @@
 import type { Slide } from "./slide.js";
 import type { Theme, ColorMap } from "./theme.js";
-import type { DefaultTextStyle } from "./text.js";
+import type { DefaultTextStyle, TxStyles } from "./text.js";
 
 export interface Presentation {
   slideSize: SlideSize;
@@ -8,6 +8,7 @@ export interface Presentation {
   theme: Theme;
   colorMap: ColorMap;
   defaultTextStyle?: DefaultTextStyle;
+  txStyles?: TxStyles;
 }
 
 export interface SlideSize {

--- a/src/model/text.ts
+++ b/src/model/text.ts
@@ -19,10 +19,17 @@ export interface DefaultParagraphLevelProperties {
   defaultRunProperties?: DefaultRunProperties;
 }
 
-/** presentation.xml の defaultTextStyle */
+/** presentation.xml の defaultTextStyle / slideMaster の titleStyle・bodyStyle・otherStyle */
 export interface DefaultTextStyle {
   defaultParagraph?: DefaultParagraphLevelProperties;
   levels: (DefaultParagraphLevelProperties | undefined)[]; // index 0 = lvl1pPr, ... index 8 = lvl9pPr
+}
+
+/** slideMaster の txStyles */
+export interface TxStyles {
+  titleStyle?: DefaultTextStyle;
+  bodyStyle?: DefaultTextStyle;
+  otherStyle?: DefaultTextStyle;
 }
 
 export interface TextBody {

--- a/src/parser/presentation-parser.ts
+++ b/src/parser/presentation-parser.ts
@@ -1,11 +1,7 @@
 import type { SlideSize } from "../model/presentation.js";
-import type {
-  DefaultTextStyle,
-  DefaultParagraphLevelProperties,
-  DefaultRunProperties,
-} from "../model/text.js";
+import type { DefaultTextStyle } from "../model/text.js";
 import { parseXml } from "./xml-parser.js";
-import { hundredthPointToPoint } from "../utils/emu.js";
+import { parseListStyle } from "./text-style-parser.js";
 
 export interface PresentationInfo {
   slideSize: SlideSize;
@@ -57,81 +53,7 @@ export function parsePresentation(xml: string): PresentationInfo {
       return true;
     });
 
-  const defaultTextStyle = parseDefaultTextStyle(pres.defaultTextStyle);
+  const defaultTextStyle = parseListStyle(pres.defaultTextStyle);
 
   return { slideSize, slideRIds, defaultTextStyle };
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function parseDefaultRunProperties(defRPr: any): DefaultRunProperties | undefined {
-  if (!defRPr) return undefined;
-
-  const result: DefaultRunProperties = {};
-
-  if (defRPr["@_sz"] !== undefined) {
-    result.fontSize = hundredthPointToPoint(Number(defRPr["@_sz"]));
-  }
-  if (defRPr.latin?.["@_typeface"] !== undefined) {
-    result.fontFamily = defRPr.latin["@_typeface"];
-  }
-  if (defRPr.ea?.["@_typeface"] !== undefined) {
-    result.fontFamilyEa = defRPr.ea["@_typeface"];
-  }
-  if (defRPr["@_b"] !== undefined) {
-    result.bold = defRPr["@_b"] === "1" || defRPr["@_b"] === "true";
-  }
-  if (defRPr["@_i"] !== undefined) {
-    result.italic = defRPr["@_i"] === "1" || defRPr["@_i"] === "true";
-  }
-  if (defRPr["@_u"] !== undefined) {
-    result.underline = defRPr["@_u"] !== "none";
-  }
-  if (defRPr["@_strike"] !== undefined) {
-    result.strikethrough = defRPr["@_strike"] !== "noStrike";
-  }
-
-  return Object.keys(result).length > 0 ? result : undefined;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function parseParagraphLevelProperties(node: any): DefaultParagraphLevelProperties | undefined {
-  if (!node) return undefined;
-
-  const result: DefaultParagraphLevelProperties = {};
-
-  if (node["@_algn"] !== undefined) {
-    result.alignment = node["@_algn"] as "l" | "ctr" | "r" | "just";
-  }
-  if (node["@_marL"] !== undefined) {
-    result.marginLeft = Number(node["@_marL"]);
-  }
-  if (node["@_indent"] !== undefined) {
-    result.indent = Number(node["@_indent"]);
-  }
-
-  const defRPr = parseDefaultRunProperties(node.defRPr);
-  if (defRPr) {
-    result.defaultRunProperties = defRPr;
-  }
-
-  return Object.keys(result).length > 0 ? result : undefined;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function parseDefaultTextStyle(node: any): DefaultTextStyle | undefined {
-  if (!node) return undefined;
-
-  const defaultParagraph = parseParagraphLevelProperties(node.defPPr);
-
-  const levels: (DefaultParagraphLevelProperties | undefined)[] = [];
-  for (let i = 1; i <= 9; i++) {
-    levels.push(parseParagraphLevelProperties(node[`lvl${i}pPr`]));
-  }
-
-  // すべてのレベルが undefined で defaultParagraph もなければ undefined を返す
-  if (!defaultParagraph && levels.every((l) => l === undefined)) {
-    return undefined;
-  }
-
-  return { defaultParagraph, levels };
 }

--- a/src/parser/slide-master-parser.test.ts
+++ b/src/parser/slide-master-parser.test.ts
@@ -3,6 +3,7 @@ import {
   parseSlideMasterElements,
   parseSlideMasterColorMap,
   parseSlideMasterBackground,
+  parseSlideMasterTxStyles,
 } from "./slide-master-parser.js";
 import { ColorResolver } from "../color/color-resolver.js";
 import type { PptxArchive } from "./pptx-reader.js";
@@ -194,6 +195,115 @@ describe("parseSlideMasterElements", () => {
     );
 
     expect(elements).toHaveLength(0);
+  });
+});
+
+describe("parseSlideMasterTxStyles", () => {
+  it("returns undefined when no txStyles", () => {
+    const xml = `
+      <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+        <p:cSld/>
+      </p:sldMaster>
+    `;
+    expect(parseSlideMasterTxStyles(xml)).toBeUndefined();
+  });
+
+  it("parses titleStyle, bodyStyle, otherStyle", () => {
+    const xml = `
+      <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld/>
+        <p:txStyles>
+          <p:titleStyle>
+            <a:lvl1pPr algn="ctr">
+              <a:defRPr sz="4400" b="1">
+                <a:latin typeface="Calibri"/>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </p:titleStyle>
+          <p:bodyStyle>
+            <a:lvl1pPr marL="342900" indent="-342900" algn="l">
+              <a:defRPr sz="3200"/>
+            </a:lvl1pPr>
+            <a:lvl2pPr marL="742950" indent="-285750" algn="l">
+              <a:defRPr sz="2800"/>
+            </a:lvl2pPr>
+          </p:bodyStyle>
+          <p:otherStyle>
+            <a:defPPr>
+              <a:defRPr sz="1800"/>
+            </a:defPPr>
+          </p:otherStyle>
+        </p:txStyles>
+      </p:sldMaster>
+    `;
+    const result = parseSlideMasterTxStyles(xml);
+
+    expect(result).toBeDefined();
+
+    // titleStyle
+    expect(result!.titleStyle).toBeDefined();
+    expect(result!.titleStyle!.levels[0]?.alignment).toBe("ctr");
+    expect(result!.titleStyle!.levels[0]?.defaultRunProperties?.fontSize).toBe(44);
+    expect(result!.titleStyle!.levels[0]?.defaultRunProperties?.bold).toBe(true);
+    expect(result!.titleStyle!.levels[0]?.defaultRunProperties?.fontFamily).toBe("Calibri");
+
+    // bodyStyle
+    expect(result!.bodyStyle).toBeDefined();
+    expect(result!.bodyStyle!.levels[0]?.marginLeft).toBe(342900);
+    expect(result!.bodyStyle!.levels[0]?.indent).toBe(-342900);
+    expect(result!.bodyStyle!.levels[0]?.defaultRunProperties?.fontSize).toBe(32);
+    expect(result!.bodyStyle!.levels[1]?.marginLeft).toBe(742950);
+    expect(result!.bodyStyle!.levels[1]?.defaultRunProperties?.fontSize).toBe(28);
+
+    // otherStyle
+    expect(result!.otherStyle).toBeDefined();
+    expect(result!.otherStyle!.defaultParagraph?.defaultRunProperties?.fontSize).toBe(18);
+  });
+
+  it("returns undefined when txStyles is empty", () => {
+    const xml = `
+      <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+        <p:cSld/>
+        <p:txStyles/>
+      </p:sldMaster>
+    `;
+    expect(parseSlideMasterTxStyles(xml)).toBeUndefined();
+  });
+
+  it("parses partial txStyles (only titleStyle)", () => {
+    const xml = `
+      <p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:cSld/>
+        <p:txStyles>
+          <p:titleStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="4400"/>
+            </a:lvl1pPr>
+          </p:titleStyle>
+        </p:txStyles>
+      </p:sldMaster>
+    `;
+    const result = parseSlideMasterTxStyles(xml);
+
+    expect(result).toBeDefined();
+    expect(result!.titleStyle).toBeDefined();
+    expect(result!.titleStyle!.levels[0]?.defaultRunProperties?.fontSize).toBe(44);
+    expect(result!.bodyStyle).toBeUndefined();
+    expect(result!.otherStyle).toBeUndefined();
+  });
+
+  it("warns and returns undefined for invalid XML", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const xml = `<other/>`;
+    const result = parseSlideMasterTxStyles(xml);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('SlideMaster: missing root element "sldMaster"'),
+    );
+    expect(result).toBeUndefined();
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/parser/slide-master-parser.ts
+++ b/src/parser/slide-master-parser.ts
@@ -1,6 +1,7 @@
 import type { ColorMap, ColorSchemeKey } from "../model/theme.js";
 import type { Background } from "../model/slide.js";
 import type { SlideElement } from "../model/shape.js";
+import type { TxStyles } from "../model/text.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import { parseXml } from "./xml-parser.js";
 import { parseFillFromNode } from "./fill-parser.js";
@@ -9,6 +10,7 @@ import { parseShapeTree } from "./slide-parser.js";
 import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
 import type { ColorResolver } from "../color/color-resolver.js";
 import type { FontScheme } from "../model/theme.js";
+import { parseListStyle } from "./text-style-parser.js";
 
 const WARN_PREFIX = "[pptx-glimpse]";
 
@@ -104,6 +106,27 @@ export function parseSlideMasterElements(
     undefined,
     fontScheme,
   );
+}
+
+export function parseSlideMasterTxStyles(xml: string): TxStyles | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const parsed = parseXml(xml) as any;
+
+  if (!parsed.sldMaster) {
+    console.warn(`${WARN_PREFIX} SlideMaster: missing root element "sldMaster" in XML`);
+    return undefined;
+  }
+
+  const txStyles = parsed.sldMaster.txStyles;
+  if (!txStyles) return undefined;
+
+  const titleStyle = parseListStyle(txStyles.titleStyle);
+  const bodyStyle = parseListStyle(txStyles.bodyStyle);
+  const otherStyle = parseListStyle(txStyles.otherStyle);
+
+  if (!titleStyle && !bodyStyle && !otherStyle) return undefined;
+
+  return { titleStyle, bodyStyle, otherStyle };
 }
 
 export function getDefaultColorMap(): ColorMap {

--- a/src/parser/text-style-parser.test.ts
+++ b/src/parser/text-style-parser.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseDefaultRunProperties,
+  parseParagraphLevelProperties,
+  parseListStyle,
+} from "./text-style-parser.js";
+
+describe("parseDefaultRunProperties", () => {
+  it("returns undefined for falsy input", () => {
+    expect(parseDefaultRunProperties(undefined)).toBeUndefined();
+    expect(parseDefaultRunProperties(null)).toBeUndefined();
+  });
+
+  it("parses fontSize from @_sz", () => {
+    const result = parseDefaultRunProperties({ "@_sz": "1800" });
+    expect(result?.fontSize).toBe(18);
+  });
+
+  it("parses fontFamily and fontFamilyEa", () => {
+    const result = parseDefaultRunProperties({
+      latin: { "@_typeface": "Arial" },
+      ea: { "@_typeface": "MS Gothic" },
+    });
+    expect(result?.fontFamily).toBe("Arial");
+    expect(result?.fontFamilyEa).toBe("MS Gothic");
+  });
+
+  it("parses bold, italic, underline, strikethrough", () => {
+    const result = parseDefaultRunProperties({
+      "@_b": "1",
+      "@_i": "true",
+      "@_u": "sng",
+      "@_strike": "sngStrike",
+    });
+    expect(result?.bold).toBe(true);
+    expect(result?.italic).toBe(true);
+    expect(result?.underline).toBe(true);
+    expect(result?.strikethrough).toBe(true);
+  });
+
+  it("parses false-like values", () => {
+    const result = parseDefaultRunProperties({
+      "@_b": "0",
+      "@_u": "none",
+      "@_strike": "noStrike",
+    });
+    expect(result?.bold).toBe(false);
+    expect(result?.underline).toBe(false);
+    expect(result?.strikethrough).toBe(false);
+  });
+
+  it("returns undefined for empty object", () => {
+    expect(parseDefaultRunProperties({})).toBeUndefined();
+  });
+});
+
+describe("parseParagraphLevelProperties", () => {
+  it("returns undefined for falsy input", () => {
+    expect(parseParagraphLevelProperties(undefined)).toBeUndefined();
+  });
+
+  it("parses alignment, marginLeft, indent", () => {
+    const result = parseParagraphLevelProperties({
+      "@_algn": "ctr",
+      "@_marL": "457200",
+      "@_indent": "-228600",
+    });
+    expect(result?.alignment).toBe("ctr");
+    expect(result?.marginLeft).toBe(457200);
+    expect(result?.indent).toBe(-228600);
+  });
+
+  it("parses nested defRPr", () => {
+    const result = parseParagraphLevelProperties({
+      "@_algn": "l",
+      defRPr: { "@_sz": "2400", "@_b": "1" },
+    });
+    expect(result?.alignment).toBe("l");
+    expect(result?.defaultRunProperties?.fontSize).toBe(24);
+    expect(result?.defaultRunProperties?.bold).toBe(true);
+  });
+
+  it("returns undefined for empty object", () => {
+    expect(parseParagraphLevelProperties({})).toBeUndefined();
+  });
+});
+
+describe("parseListStyle", () => {
+  it("returns undefined for falsy input", () => {
+    expect(parseListStyle(undefined)).toBeUndefined();
+    expect(parseListStyle(null)).toBeUndefined();
+  });
+
+  it("parses defPPr and level properties", () => {
+    const result = parseListStyle({
+      defPPr: { "@_algn": "ctr" },
+      lvl1pPr: { "@_marL": "0", defRPr: { "@_sz": "1800" } },
+      lvl2pPr: { "@_marL": "457200", defRPr: { "@_sz": "1400" } },
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.defaultParagraph?.alignment).toBe("ctr");
+    expect(result!.levels[0]?.marginLeft).toBe(0);
+    expect(result!.levels[0]?.defaultRunProperties?.fontSize).toBe(18);
+    expect(result!.levels[1]?.marginLeft).toBe(457200);
+    expect(result!.levels[1]?.defaultRunProperties?.fontSize).toBe(14);
+    for (let i = 2; i < 9; i++) {
+      expect(result!.levels[i]).toBeUndefined();
+    }
+  });
+
+  it("returns undefined when all levels are empty", () => {
+    expect(parseListStyle({})).toBeUndefined();
+  });
+
+  it("returns style with only defPPr", () => {
+    const result = parseListStyle({ defPPr: { "@_algn": "r" } });
+    expect(result).toBeDefined();
+    expect(result!.defaultParagraph?.alignment).toBe("r");
+    expect(result!.levels.every((l) => l === undefined)).toBe(true);
+  });
+
+  it("returns style with only lvl1pPr", () => {
+    const result = parseListStyle({
+      lvl1pPr: { defRPr: { "@_sz": "3200" } },
+    });
+    expect(result).toBeDefined();
+    expect(result!.defaultParagraph).toBeUndefined();
+    expect(result!.levels[0]?.defaultRunProperties?.fontSize).toBe(32);
+  });
+});

--- a/src/parser/text-style-parser.ts
+++ b/src/parser/text-style-parser.ts
@@ -1,0 +1,86 @@
+import type {
+  DefaultTextStyle,
+  DefaultParagraphLevelProperties,
+  DefaultRunProperties,
+} from "../model/text.js";
+import { hundredthPointToPoint } from "../utils/emu.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseDefaultRunProperties(defRPr: any): DefaultRunProperties | undefined {
+  if (!defRPr) return undefined;
+
+  const result: DefaultRunProperties = {};
+
+  if (defRPr["@_sz"] !== undefined) {
+    result.fontSize = hundredthPointToPoint(Number(defRPr["@_sz"]));
+  }
+  if (defRPr.latin?.["@_typeface"] !== undefined) {
+    result.fontFamily = defRPr.latin["@_typeface"];
+  }
+  if (defRPr.ea?.["@_typeface"] !== undefined) {
+    result.fontFamilyEa = defRPr.ea["@_typeface"];
+  }
+  if (defRPr["@_b"] !== undefined) {
+    result.bold = defRPr["@_b"] === "1" || defRPr["@_b"] === "true";
+  }
+  if (defRPr["@_i"] !== undefined) {
+    result.italic = defRPr["@_i"] === "1" || defRPr["@_i"] === "true";
+  }
+  if (defRPr["@_u"] !== undefined) {
+    result.underline = defRPr["@_u"] !== "none";
+  }
+  if (defRPr["@_strike"] !== undefined) {
+    result.strikethrough = defRPr["@_strike"] !== "noStrike";
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export function parseParagraphLevelProperties(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  node: any,
+): DefaultParagraphLevelProperties | undefined {
+  if (!node) return undefined;
+
+  const result: DefaultParagraphLevelProperties = {};
+
+  if (node["@_algn"] !== undefined) {
+    result.alignment = node["@_algn"] as "l" | "ctr" | "r" | "just";
+  }
+  if (node["@_marL"] !== undefined) {
+    result.marginLeft = Number(node["@_marL"]);
+  }
+  if (node["@_indent"] !== undefined) {
+    result.indent = Number(node["@_indent"]);
+  }
+
+  const defRPr = parseDefaultRunProperties(node.defRPr);
+  if (defRPr) {
+    result.defaultRunProperties = defRPr;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * defPPr + lvl1pPr〜lvl9pPr の構造を DefaultTextStyle としてパースする。
+ * presentation.xml の defaultTextStyle および slideMaster の titleStyle/bodyStyle/otherStyle で共通利用。
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseListStyle(node: any): DefaultTextStyle | undefined {
+  if (!node) return undefined;
+
+  const defaultParagraph = parseParagraphLevelProperties(node.defPPr);
+
+  const levels: (DefaultParagraphLevelProperties | undefined)[] = [];
+  for (let i = 1; i <= 9; i++) {
+    levels.push(parseParagraphLevelProperties(node[`lvl${i}pPr`]));
+  }
+
+  // すべてのレベルが undefined で defaultParagraph もなければ undefined を返す
+  if (!defaultParagraph && levels.every((l) => l === undefined)) {
+    return undefined;
+  }
+
+  return { defaultParagraph, levels };
+}


### PR DESCRIPTION
close #120

## Summary
- スライドマスターの `<p:txStyles>` 要素（`titleStyle`/`bodyStyle`/`otherStyle`）をパースする `parseSlideMasterTxStyles` を追加
- テキストスタイル解析関数（`parseDefaultRunProperties`/`parseParagraphLevelProperties`/`parseListStyle`）を `text-style-parser.ts` に抽出し、`presentation-parser.ts` と共通化
- `TxStyles` インターフェースをモデルに追加

## Test plan
- [x] `text-style-parser.test.ts` で共通解析関数の単体テスト（15件）
- [x] `slide-master-parser.test.ts` に `parseSlideMasterTxStyles` のテスト追加（5件）
- [x] `presentation-parser.test.ts` の既存テストがリファクタリング後も通ることを確認
- [x] `npm run lint && npm run format:check && npm run typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)