### PR TITLE
test: 未カバーモジュールのユニットテストを追加する

### DIFF
--- a/src/color/color-transforms.test.ts
+++ b/src/color/color-transforms.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest";
+import { applyColorTransforms } from "./color-transforms.js";
+
+describe("applyColorTransforms", () => {
+  it("returns unchanged color when no transforms are applied", () => {
+    const result = applyColorTransforms({ hex: "#FF0000", alpha: 1 }, {});
+    expect(result).toEqual({ hex: "#FF0000", alpha: 1 });
+  });
+
+  // --- lumMod / lumOff ---
+
+  it("applies lumMod to darken color (50%)", () => {
+    // #808080 → HSL(0, 0, 0.502) → lumMod 50% → l=0.251 → ~#404040
+    const result = applyColorTransforms(
+      { hex: "#808080", alpha: 1 },
+      { lumMod: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#404040");
+    expect(result.alpha).toBe(1);
+  });
+
+  it("applies lumMod 100% without change", () => {
+    const result = applyColorTransforms(
+      { hex: "#808080", alpha: 1 },
+      { lumMod: { "@_val": "100000" } },
+    );
+    expect(result.hex).toBe("#808080");
+  });
+
+  it("applies lumOff to brighten black", () => {
+    // #000000 → HSL(0, 0, 0) → lumOff +50% → l=0.5 → #808080
+    const result = applyColorTransforms(
+      { hex: "#000000", alpha: 1 },
+      { lumOff: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#808080");
+  });
+
+  it("applies lumMod + lumOff together", () => {
+    // #808080 → l=0.502 → lumMod 75% + lumOff 25% → l = 0.502*0.75 + 0.25 = 0.6265
+    const result = applyColorTransforms(
+      { hex: "#808080", alpha: 1 },
+      { lumMod: { "@_val": "75000" }, lumOff: { "@_val": "25000" } },
+    );
+    // 結果が元より明るくなっている
+    expect(result.hex).not.toBe("#808080");
+    expect(result.alpha).toBe(1);
+  });
+
+  it("clamps luminance to 1 when lumMod + lumOff exceeds 100%", () => {
+    const result = applyColorTransforms(
+      { hex: "#FFFFFF", alpha: 1 },
+      { lumMod: { "@_val": "200000" }, lumOff: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#ffffff");
+  });
+
+  it("clamps luminance to 0 when lumMod is 0", () => {
+    const result = applyColorTransforms({ hex: "#808080", alpha: 1 }, { lumMod: { "@_val": "0" } });
+    expect(result.hex).toBe("#000000");
+  });
+
+  // --- tint (白方向ブレンド) ---
+
+  it("applies tint 50% to red", () => {
+    // #FF0000 → tint 50% → r=255+(255-255)*0.5=255, g=0+(255-0)*0.5=128, b=0+128=128
+    const result = applyColorTransforms(
+      { hex: "#FF0000", alpha: 1 },
+      { tint: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#ff8080");
+  });
+
+  it("applies tint 100% to produce white", () => {
+    const result = applyColorTransforms(
+      { hex: "#000000", alpha: 1 },
+      { tint: { "@_val": "100000" } },
+    );
+    expect(result.hex).toBe("#ffffff");
+  });
+
+  it("applies tint 0% without change", () => {
+    const result = applyColorTransforms({ hex: "#FF0000", alpha: 1 }, { tint: { "@_val": "0" } });
+    expect(result.hex).toBe("#ff0000");
+  });
+
+  it("applies tint to white (no change)", () => {
+    const result = applyColorTransforms(
+      { hex: "#FFFFFF", alpha: 1 },
+      { tint: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#ffffff");
+  });
+
+  // --- shade (黒方向ブレンド) ---
+
+  it("applies shade 50% to red", () => {
+    // #FF0000 → shade 50% → r=255*0.5=128, g=0, b=0
+    const result = applyColorTransforms(
+      { hex: "#FF0000", alpha: 1 },
+      { shade: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#800000");
+  });
+
+  it("applies shade 0% to produce black", () => {
+    const result = applyColorTransforms({ hex: "#FFFFFF", alpha: 1 }, { shade: { "@_val": "0" } });
+    expect(result.hex).toBe("#000000");
+  });
+
+  it("applies shade 100% without change", () => {
+    const result = applyColorTransforms(
+      { hex: "#FF0000", alpha: 1 },
+      { shade: { "@_val": "100000" } },
+    );
+    expect(result.hex).toBe("#ff0000");
+  });
+
+  it("applies shade to black (no change)", () => {
+    const result = applyColorTransforms(
+      { hex: "#000000", alpha: 1 },
+      { shade: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#000000");
+  });
+
+  // --- alpha ---
+
+  it("applies alpha 50%", () => {
+    const result = applyColorTransforms(
+      { hex: "#FF0000", alpha: 1 },
+      { alpha: { "@_val": "50000" } },
+    );
+    expect(result.hex).toBe("#FF0000");
+    expect(result.alpha).toBe(0.5);
+  });
+
+  it("applies alpha 0% (fully transparent)", () => {
+    const result = applyColorTransforms({ hex: "#FF0000", alpha: 1 }, { alpha: { "@_val": "0" } });
+    expect(result.alpha).toBe(0);
+  });
+
+  it("applies alpha 100%", () => {
+    const result = applyColorTransforms(
+      { hex: "#FF0000", alpha: 1 },
+      { alpha: { "@_val": "100000" } },
+    );
+    expect(result.alpha).toBe(1);
+  });
+
+  // --- 複合変換 ---
+
+  it("applies multiple transforms in sequence", () => {
+    const result = applyColorTransforms(
+      { hex: "#4472C4", alpha: 1 },
+      {
+        lumMod: { "@_val": "75000" },
+        tint: { "@_val": "20000" },
+        alpha: { "@_val": "80000" },
+      },
+    );
+    expect(result.alpha).toBe(0.8);
+    expect(result.hex).toBeTruthy();
+  });
+
+  // --- HSL往復変換の精度 ---
+
+  it("preserves red through lumMod 100%", () => {
+    const result = applyColorTransforms(
+      { hex: "#FF0000", alpha: 1 },
+      { lumMod: { "@_val": "100000" } },
+    );
+    expect(result.hex.toLowerCase()).toBe("#ff0000");
+  });
+
+  it("preserves green through lumMod 100%", () => {
+    const result = applyColorTransforms(
+      { hex: "#00FF00", alpha: 1 },
+      { lumMod: { "@_val": "100000" } },
+    );
+    expect(result.hex.toLowerCase()).toBe("#00ff00");
+  });
+
+  it("preserves blue through lumMod 100%", () => {
+    const result = applyColorTransforms(
+      { hex: "#0000FF", alpha: 1 },
+      { lumMod: { "@_val": "100000" } },
+    );
+    expect(result.hex.toLowerCase()).toBe("#0000ff");
+  });
+
+  it("preserves white through lumMod 100%", () => {
+    const result = applyColorTransforms(
+      { hex: "#FFFFFF", alpha: 1 },
+      { lumMod: { "@_val": "100000" } },
+    );
+    expect(result.hex.toLowerCase()).toBe("#ffffff");
+  });
+
+  it("preserves black through lumMod 100%", () => {
+    const result = applyColorTransforms(
+      { hex: "#000000", alpha: 1 },
+      { lumMod: { "@_val": "100000" } },
+    );
+    expect(result.hex.toLowerCase()).toBe("#000000");
+  });
+
+  it("handles lowercase hex input", () => {
+    const result = applyColorTransforms({ hex: "#ff0000", alpha: 1 }, {});
+    expect(result.hex).toBe("#ff0000");
+  });
+});

--- a/src/parser/effect-parser.test.ts
+++ b/src/parser/effect-parser.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+import { parseEffectList } from "./effect-parser.js";
+import { ColorResolver } from "../color/color-resolver.js";
+import type { ColorScheme, ColorMap } from "../model/theme.js";
+
+const testScheme: ColorScheme = {
+  dk1: "#000000",
+  lt1: "#FFFFFF",
+  dk2: "#44546A",
+  lt2: "#E7E6E6",
+  accent1: "#4472C4",
+  accent2: "#ED7D31",
+  accent3: "#A5A5A5",
+  accent4: "#FFC000",
+  accent5: "#5B9BD5",
+  accent6: "#70AD47",
+  hlink: "#0563C1",
+  folHlink: "#954F72",
+};
+
+const testColorMap: ColorMap = {
+  bg1: "lt1",
+  tx1: "dk1",
+  bg2: "lt2",
+  tx2: "dk2",
+  accent1: "accent1",
+  accent2: "accent2",
+  accent3: "accent3",
+  accent4: "accent4",
+  accent5: "accent5",
+  accent6: "accent6",
+  hlink: "hlink",
+  folHlink: "folHlink",
+};
+
+const resolver = new ColorResolver(testScheme, testColorMap);
+
+describe("parseEffectList", () => {
+  it("returns null for null input", () => {
+    expect(parseEffectList(null, resolver)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseEffectList(undefined, resolver)).toBeNull();
+  });
+
+  it("returns null for empty object", () => {
+    expect(parseEffectList({}, resolver)).toBeNull();
+  });
+
+  // --- outerShadow ---
+
+  it("parses outerShdw with all attributes", () => {
+    const node = {
+      outerShdw: {
+        "@_blurRad": "50800",
+        "@_dist": "38100",
+        "@_dir": "2700000",
+        "@_algn": "br",
+        "@_rotWithShape": "1",
+        srgbClr: { "@_val": "000000", alpha: { "@_val": "50000" } },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+
+    expect(result).not.toBeNull();
+    expect(result!.outerShadow).toEqual({
+      blurRadius: 50800,
+      distance: 38100,
+      direction: 45, // 2700000 / 60000
+      color: { hex: "#000000", alpha: 0.5 },
+      alignment: "br",
+      rotateWithShape: true,
+    });
+    expect(result!.innerShadow).toBeNull();
+    expect(result!.glow).toBeNull();
+    expect(result!.softEdge).toBeNull();
+  });
+
+  it("parses outerShdw with default values", () => {
+    const node = {
+      outerShdw: {
+        srgbClr: { "@_val": "FF0000" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+
+    expect(result!.outerShadow).toEqual({
+      blurRadius: 0,
+      distance: 0,
+      direction: 0,
+      color: { hex: "#FF0000", alpha: 1 },
+      alignment: "b",
+      rotateWithShape: true,
+    });
+  });
+
+  it("parses outerShdw rotWithShape='0' as false", () => {
+    const node = {
+      outerShdw: {
+        "@_rotWithShape": "0",
+        srgbClr: { "@_val": "FF0000" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result!.outerShadow!.rotateWithShape).toBe(false);
+  });
+
+  it("returns null when outerShdw has no resolvable color", () => {
+    const node = {
+      outerShdw: {
+        "@_blurRad": "50800",
+      },
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result).toBeNull();
+  });
+
+  // --- innerShadow ---
+
+  it("parses innerShdw with all attributes", () => {
+    const node = {
+      innerShdw: {
+        "@_blurRad": "63500",
+        "@_dist": "38100",
+        "@_dir": "5400000",
+        srgbClr: { "@_val": "FF0000" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+
+    expect(result!.innerShadow).toEqual({
+      blurRadius: 63500,
+      distance: 38100,
+      direction: 90, // 5400000 / 60000
+      color: { hex: "#FF0000", alpha: 1 },
+    });
+  });
+
+  it("parses innerShdw with default values", () => {
+    const node = {
+      innerShdw: {
+        srgbClr: { "@_val": "0000FF" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+
+    expect(result!.innerShadow!.blurRadius).toBe(0);
+    expect(result!.innerShadow!.distance).toBe(0);
+    expect(result!.innerShadow!.direction).toBe(0);
+  });
+
+  it("parses innerShdw with schemeClr", () => {
+    const node = {
+      innerShdw: {
+        "@_blurRad": "63500",
+        "@_dist": "38100",
+        "@_dir": "5400000",
+        schemeClr: { "@_val": "accent1" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result!.innerShadow!.color).toEqual({ hex: "#4472C4", alpha: 1 });
+  });
+
+  // --- glow ---
+
+  it("parses glow with radius and color", () => {
+    const node = {
+      glow: {
+        "@_rad": "127000",
+        srgbClr: { "@_val": "00FF00" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+
+    expect(result!.glow).toEqual({
+      radius: 127000,
+      color: { hex: "#00FF00", alpha: 1 },
+    });
+  });
+
+  it("parses glow with default radius", () => {
+    const node = {
+      glow: {
+        srgbClr: { "@_val": "00FF00" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result!.glow!.radius).toBe(0);
+  });
+
+  it("returns null when glow has no resolvable color", () => {
+    const node = {
+      glow: {
+        "@_rad": "127000",
+      },
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result).toBeNull();
+  });
+
+  // --- softEdge ---
+
+  it("parses softEdge with radius", () => {
+    const node = {
+      softEdge: {
+        "@_rad": "63500",
+      },
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result!.softEdge).toEqual({ radius: 63500 });
+  });
+
+  it("parses softEdge with default radius", () => {
+    const node = {
+      softEdge: {},
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result!.softEdge!.radius).toBe(0);
+  });
+
+  // --- 複数エフェクト ---
+
+  it("parses multiple effects", () => {
+    const node = {
+      outerShdw: {
+        "@_blurRad": "50800",
+        srgbClr: { "@_val": "000000" },
+      },
+      glow: {
+        "@_rad": "127000",
+        srgbClr: { "@_val": "FF0000" },
+      },
+      softEdge: {
+        "@_rad": "63500",
+      },
+    };
+    const result = parseEffectList(node, resolver);
+
+    expect(result!.outerShadow).not.toBeNull();
+    expect(result!.glow).not.toBeNull();
+    expect(result!.softEdge).not.toBeNull();
+    expect(result!.innerShadow).toBeNull();
+  });
+
+  it("parses all four effects", () => {
+    const node = {
+      outerShdw: { srgbClr: { "@_val": "000000" } },
+      innerShdw: { srgbClr: { "@_val": "FF0000" } },
+      glow: { srgbClr: { "@_val": "00FF00" } },
+      softEdge: { "@_rad": "12700" },
+    };
+    const result = parseEffectList(node, resolver);
+
+    expect(result!.outerShadow).not.toBeNull();
+    expect(result!.innerShadow).not.toBeNull();
+    expect(result!.glow).not.toBeNull();
+    expect(result!.softEdge).not.toBeNull();
+  });
+
+  // --- direction 変換 ---
+
+  it("converts direction 21600000 to 360 degrees", () => {
+    const node = {
+      outerShdw: {
+        "@_dir": "21600000",
+        srgbClr: { "@_val": "000000" },
+      },
+    };
+    const result = parseEffectList(node, resolver);
+    expect(result!.outerShadow!.direction).toBe(360);
+  });
+});

--- a/src/parser/xml-parser.test.ts
+++ b/src/parser/xml-parser.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parseXml } from "./xml-parser.js";
+
+describe("parseXml", () => {
+  it("parses simple XML", () => {
+    const result = parseXml("<root><child>value</child></root>");
+    expect((result.root as Record<string, unknown>).child).toBe("value");
+  });
+
+  it("preserves attributes with @_ prefix", () => {
+    const result = parseXml('<shape type="rect" id="1"/>');
+    const shape = result.shape as Record<string, unknown>;
+    expect(shape["@_type"]).toBe("rect");
+    expect(shape["@_id"]).toBe("1");
+  });
+
+  it("removes namespace prefix", () => {
+    const result = parseXml('<p:sp xmlns:p="http://example.com"><p:nvSpPr/></p:sp>');
+    expect(result).toHaveProperty("sp");
+    const sp = (result.sp as Record<string, unknown>[])[0];
+    expect(sp).toHaveProperty("nvSpPr");
+  });
+});
+
+describe("ARRAY_TAGS", () => {
+  const arrayTags = [
+    "sp",
+    "pic",
+    "cxnSp",
+    "grpSp",
+    "graphicFrame",
+    "p",
+    "r",
+    "br",
+    "Relationship",
+    "sldId",
+    "gs",
+    "gridCol",
+    "tr",
+    "tc",
+    "ser",
+    "pt",
+    "gd",
+    "AlternateContent",
+  ];
+
+  it.each(arrayTags)("returns <%s> as array when single element", (tag) => {
+    const xml = `<root><${tag}>content</${tag}></root>`;
+    const result = parseXml(xml);
+    const root = result.root as Record<string, unknown>;
+    expect(Array.isArray(root[tag])).toBe(true);
+    expect(root[tag]).toHaveLength(1);
+  });
+
+  it("returns sp as array when multiple elements", () => {
+    const xml = "<spTree><sp><nvSpPr/></sp><sp><nvSpPr/></sp></spTree>";
+    const result = parseXml(xml);
+    const spTree = result.spTree as Record<string, unknown>;
+    expect(Array.isArray(spTree.sp)).toBe(true);
+    expect(spTree.sp).toHaveLength(2);
+  });
+
+  it("does not return non-array tag as array", () => {
+    const xml = "<root><single>value</single></root>";
+    const result = parseXml(xml);
+    const root = result.root as Record<string, unknown>;
+    expect(Array.isArray(root.single)).toBe(false);
+    expect(root.single).toBe("value");
+  });
+});

--- a/src/renderer/effect-renderer.test.ts
+++ b/src/renderer/effect-renderer.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderEffects } from "./effect-renderer.js";
+import type { EffectList } from "../model/effect.js";
+
+beforeEach(() => {
+  let counter = 0;
+  vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
+    return `test-uuid-${counter++}` as ReturnType<typeof crypto.randomUUID>;
+  });
+});
+
+function makeEffects(overrides: Partial<EffectList> = {}): EffectList {
+  return {
+    outerShadow: null,
+    innerShadow: null,
+    glow: null,
+    softEdge: null,
+    ...overrides,
+  };
+}
+
+describe("renderEffects", () => {
+  it("returns empty result for null effects", () => {
+    const result = renderEffects(null);
+    expect(result.filterAttr).toBe("");
+    expect(result.filterDefs).toBe("");
+  });
+
+  it("returns empty result when all effects are null", () => {
+    const result = renderEffects(makeEffects());
+    expect(result.filterAttr).toBe("");
+    expect(result.filterDefs).toBe("");
+  });
+
+  // --- softEdge ---
+
+  it("renders softEdge filter", () => {
+    const result = renderEffects(makeEffects({ softEdge: { radius: 63500 } }));
+
+    expect(result.filterAttr).toBe('filter="url(#effect-test-uuid-0)"');
+    expect(result.filterDefs).toContain('<filter id="effect-test-uuid-0"');
+    expect(result.filterDefs).toContain('<feGaussianBlur in="SourceAlpha"');
+    expect(result.filterDefs).toContain('result="softEdgeMask"');
+    expect(result.filterDefs).toContain(
+      '<feComposite in="SourceGraphic" in2="softEdgeMask" operator="in"',
+    );
+  });
+
+  // --- glow ---
+
+  it("renders glow filter", () => {
+    const result = renderEffects(
+      makeEffects({
+        glow: { radius: 127000, color: { hex: "#FF0000", alpha: 0.8 } },
+      }),
+    );
+
+    expect(result.filterDefs).toContain('<feGaussianBlur in="SourceAlpha"');
+    expect(result.filterDefs).toContain('result="glowBlur"');
+    expect(result.filterDefs).toContain('flood-color="#FF0000"');
+    expect(result.filterDefs).toContain('flood-opacity="0.8"');
+    expect(result.filterDefs).toContain('result="glowFinal"');
+    expect(result.filterDefs).toContain('<feMerge result="glowMerge">');
+    expect(result.filterDefs).toContain('<feMergeNode in="glowFinal"/>');
+    expect(result.filterDefs).toContain('<feMergeNode in="SourceGraphic"/>');
+  });
+
+  // --- outerShadow ---
+
+  it("renders outerShadow filter", () => {
+    const result = renderEffects(
+      makeEffects({
+        outerShadow: {
+          blurRadius: 50800,
+          distance: 38100,
+          direction: 45,
+          color: { hex: "#000000", alpha: 0.5 },
+          alignment: "br",
+          rotateWithShape: true,
+        },
+      }),
+    );
+
+    expect(result.filterDefs).toContain('<feGaussianBlur in="SourceAlpha"');
+    expect(result.filterDefs).toContain('result="shadowBlur"');
+    expect(result.filterDefs).toContain("<feOffset");
+    expect(result.filterDefs).toContain('result="shadowOffset"');
+    expect(result.filterDefs).toContain('flood-color="#000000"');
+    expect(result.filterDefs).toContain('flood-opacity="0.5"');
+    expect(result.filterDefs).toContain('<feMerge result="outerShadowMerge">');
+    expect(result.filterDefs).toContain('<feMergeNode in="shadowFinal"/>');
+    expect(result.filterDefs).toContain('<feMergeNode in="SourceGraphic"/>');
+  });
+
+  it("calculates outerShadow dx/dy for 0 degrees (right)", () => {
+    const result = renderEffects(
+      makeEffects({
+        outerShadow: {
+          blurRadius: 0,
+          distance: 914400, // 96px
+          direction: 0,
+          color: { hex: "#000000", alpha: 1 },
+          alignment: "b",
+          rotateWithShape: false,
+        },
+      }),
+    );
+    // 0 deg → cos(0)=1, sin(0)=0 → dx=96, dy=0
+    expect(result.filterDefs).toContain('dx="96"');
+    expect(result.filterDefs).toContain('dy="0"');
+  });
+
+  it("calculates outerShadow dx/dy for 90 degrees (down)", () => {
+    const result = renderEffects(
+      makeEffects({
+        outerShadow: {
+          blurRadius: 0,
+          distance: 914400, // 96px
+          direction: 90,
+          color: { hex: "#000000", alpha: 1 },
+          alignment: "b",
+          rotateWithShape: false,
+        },
+      }),
+    );
+    // 90 deg → cos(90)≈0, sin(90)=1 → dx≈0, dy=96
+    expect(result.filterDefs).toContain('dx="0"');
+    expect(result.filterDefs).toContain('dy="96"');
+  });
+
+  it("calculates outerShadow dx/dy for 180 degrees (left)", () => {
+    const result = renderEffects(
+      makeEffects({
+        outerShadow: {
+          blurRadius: 0,
+          distance: 914400,
+          direction: 180,
+          color: { hex: "#000000", alpha: 1 },
+          alignment: "b",
+          rotateWithShape: false,
+        },
+      }),
+    );
+    // 180 deg → cos(180)=-1, sin(180)≈0 → dx=-96, dy≈0
+    expect(result.filterDefs).toContain('dx="-96"');
+    expect(result.filterDefs).toContain('dy="0"');
+  });
+
+  // --- innerShadow ---
+
+  it("renders innerShadow filter", () => {
+    const result = renderEffects(
+      makeEffects({
+        innerShadow: {
+          blurRadius: 63500,
+          distance: 38100,
+          direction: 135,
+          color: { hex: "#FF0000", alpha: 0.75 },
+        },
+      }),
+    );
+
+    expect(result.filterDefs).toContain('<feComponentTransfer in="SourceAlpha"');
+    expect(result.filterDefs).toContain('<feFuncA type="table" tableValues="1 0"/>');
+    expect(result.filterDefs).toContain("<feGaussianBlur");
+    expect(result.filterDefs).toContain("<feOffset");
+    expect(result.filterDefs).toContain('flood-color="#FF0000"');
+    expect(result.filterDefs).toContain('flood-opacity="0.75"');
+    expect(result.filterDefs).toContain('operator="in"');
+    expect(result.filterDefs).toContain('operator="over"');
+  });
+
+  // --- filter 構造 ---
+
+  it("generates filter with correct structure", () => {
+    const result = renderEffects(makeEffects({ softEdge: { radius: 63500 } }));
+
+    expect(result.filterDefs).toContain('x="-50%"');
+    expect(result.filterDefs).toContain('y="-50%"');
+    expect(result.filterDefs).toContain('width="200%"');
+    expect(result.filterDefs).toContain('height="200%"');
+    expect(result.filterDefs).toContain('color-interpolation-filters="sRGB"');
+    expect(result.filterDefs).toContain("</filter>");
+  });
+
+  // --- 複合エフェクト ---
+
+  it("chains softEdge into glow", () => {
+    const result = renderEffects(
+      makeEffects({
+        glow: { radius: 127000, color: { hex: "#00FF00", alpha: 1 } },
+        softEdge: { radius: 63500 },
+      }),
+    );
+
+    // softEdge が先に適用される
+    expect(result.filterDefs).toContain('result="softEdgeResult"');
+    // glow は softEdgeResult を入力として使用
+    expect(result.filterDefs).toContain('in="softEdgeResult"');
+    expect(result.filterDefs).toContain('<feMergeNode in="softEdgeResult"/>');
+  });
+
+  it("renders all four effects together", () => {
+    const result = renderEffects({
+      outerShadow: {
+        blurRadius: 50800,
+        distance: 38100,
+        direction: 45,
+        color: { hex: "#000000", alpha: 0.5 },
+        alignment: "b",
+        rotateWithShape: false,
+      },
+      innerShadow: {
+        blurRadius: 63500,
+        distance: 38100,
+        direction: 135,
+        color: { hex: "#FF0000", alpha: 0.75 },
+      },
+      glow: { radius: 127000, color: { hex: "#00FF00", alpha: 1 } },
+      softEdge: { radius: 63500 },
+    });
+
+    expect(result.filterDefs).toContain("softEdgeMask");
+    expect(result.filterDefs).toContain("glowMerge");
+    expect(result.filterDefs).toContain("outerShadowMerge");
+    expect(result.filterDefs).toContain("innerShdw");
+    expect(result.filterAttr).toContain("filter=");
+  });
+});

--- a/src/renderer/image-renderer.test.ts
+++ b/src/renderer/image-renderer.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderImage } from "./image-renderer.js";
+import type { ImageElement } from "../model/image.js";
+import type { Transform } from "../model/shape.js";
+
+beforeEach(() => {
+  let counter = 0;
+  vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
+    return `test-uuid-${counter++}` as ReturnType<typeof crypto.randomUUID>;
+  });
+});
+
+function makeTransform(overrides: Partial<Transform> = {}): Transform {
+  return {
+    offsetX: 914400,
+    offsetY: 914400,
+    extentWidth: 1828800,
+    extentHeight: 1371600,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    ...overrides,
+  };
+}
+
+function makeImage(overrides: Partial<ImageElement> = {}): ImageElement {
+  return {
+    type: "image",
+    transform: makeTransform(),
+    imageData: "iVBORw0KGgo=",
+    mimeType: "image/png",
+    effects: null,
+    ...overrides,
+  };
+}
+
+describe("renderImage", () => {
+  it("renders basic image element", () => {
+    const result = renderImage(makeImage());
+
+    expect(result).toContain('<g transform="translate(96, 96)">');
+    expect(result).toContain('href="data:image/png;base64,iVBORw0KGgo="');
+    expect(result).toContain('width="192"');
+    expect(result).toContain('height="144"');
+    expect(result).toContain('preserveAspectRatio="none"');
+    expect(result).toContain("</g>");
+  });
+
+  it("renders image with JPEG mime type", () => {
+    const result = renderImage(makeImage({ mimeType: "image/jpeg", imageData: "/9j/4AAQ=" }));
+    expect(result).toContain('href="data:image/jpeg;base64,/9j/4AAQ="');
+  });
+
+  it("renders image with rotation", () => {
+    const result = renderImage(makeImage({ transform: makeTransform({ rotation: 45 }) }));
+    expect(result).toContain("rotate(45, 96, 72)");
+  });
+
+  it("renders image with flipH", () => {
+    const result = renderImage(makeImage({ transform: makeTransform({ flipH: true }) }));
+    expect(result).toContain("translate(192, 0) scale(-1, 1)");
+  });
+
+  it("does not include filter when effects is null", () => {
+    const result = renderImage(makeImage());
+    expect(result).not.toContain("<filter");
+    expect(result).not.toContain("filter=");
+  });
+
+  it("renders image with effects", () => {
+    const result = renderImage(
+      makeImage({
+        effects: {
+          outerShadow: {
+            blurRadius: 50800,
+            distance: 38100,
+            direction: 45,
+            color: { hex: "#000000", alpha: 0.5 },
+            alignment: "br",
+            rotateWithShape: false,
+          },
+          innerShadow: null,
+          glow: null,
+          softEdge: null,
+        },
+      }),
+    );
+
+    expect(result).toContain('<filter id="effect-test-uuid-0"');
+    expect(result).toContain('filter="url(#effect-test-uuid-0)"');
+  });
+});

--- a/src/renderer/shape-renderer.test.ts
+++ b/src/renderer/shape-renderer.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderShape, renderConnector } from "./shape-renderer.js";
+import type { ShapeElement, ConnectorElement, Transform } from "../model/shape.js";
+
+beforeEach(() => {
+  let counter = 0;
+  vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
+    return `test-uuid-${counter++}` as ReturnType<typeof crypto.randomUUID>;
+  });
+});
+
+function makeTransform(overrides: Partial<Transform> = {}): Transform {
+  return {
+    offsetX: 914400,
+    offsetY: 914400,
+    extentWidth: 1828800,
+    extentHeight: 914400,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    ...overrides,
+  };
+}
+
+function makeShape(overrides: Partial<ShapeElement> = {}): ShapeElement {
+  return {
+    type: "shape",
+    transform: makeTransform(),
+    geometry: { type: "preset", preset: "rect", adjustValues: {} },
+    fill: { type: "solid", color: { hex: "#FF0000", alpha: 1 } },
+    outline: {
+      width: 12700,
+      fill: { type: "solid", color: { hex: "#000000", alpha: 1 } },
+      dashStyle: "solid",
+    },
+    textBody: null,
+    effects: null,
+    ...overrides,
+  };
+}
+
+function makeConnector(overrides: Partial<ConnectorElement> = {}): ConnectorElement {
+  return {
+    type: "connector",
+    transform: makeTransform(),
+    outline: {
+      width: 12700,
+      fill: { type: "solid", color: { hex: "#000000", alpha: 1 } },
+      dashStyle: "solid",
+    },
+    effects: null,
+    ...overrides,
+  };
+}
+
+describe("renderShape", () => {
+  it("renders basic shape with fill and outline", () => {
+    const result = renderShape(makeShape());
+
+    expect(result).toContain('<g transform="translate(96, 96)">');
+    expect(result).toContain('fill="#FF0000"');
+    expect(result).toContain('stroke="#000000"');
+    expect(result).toContain("</g>");
+  });
+
+  it("renders shape with no fill", () => {
+    const result = renderShape(makeShape({ fill: { type: "none" } }));
+    expect(result).toContain('fill="none"');
+  });
+
+  it("renders shape with null fill", () => {
+    const result = renderShape(makeShape({ fill: null }));
+    expect(result).toContain('fill="none"');
+  });
+
+  it("renders shape with null outline", () => {
+    const result = renderShape(makeShape({ outline: null }));
+    expect(result).toContain('stroke="none"');
+  });
+
+  it("renders shape with rotation", () => {
+    const result = renderShape(makeShape({ transform: makeTransform({ rotation: 90 }) }));
+    expect(result).toContain("rotate(90, 96, 48)");
+  });
+
+  it("renders shape with effects", () => {
+    const result = renderShape(
+      makeShape({
+        effects: {
+          outerShadow: {
+            blurRadius: 50800,
+            distance: 38100,
+            direction: 45,
+            color: { hex: "#000000", alpha: 0.5 },
+            alignment: "br",
+            rotateWithShape: false,
+          },
+          innerShadow: null,
+          glow: null,
+          softEdge: null,
+        },
+      }),
+    );
+
+    expect(result).toContain('<filter id="effect-test-uuid-0"');
+    expect(result).toContain('filter="url(#effect-test-uuid-0)"');
+  });
+
+  it("renders shape with gradient fill", () => {
+    const result = renderShape(
+      makeShape({
+        fill: {
+          type: "gradient",
+          angle: 90,
+          gradientType: "linear",
+          stops: [
+            { position: 0, color: { hex: "#FF0000", alpha: 1 } },
+            { position: 1, color: { hex: "#0000FF", alpha: 1 } },
+          ],
+        },
+      }),
+    );
+
+    expect(result).toContain("<linearGradient");
+    expect(result).toContain("url(#grad-");
+  });
+});
+
+describe("renderConnector", () => {
+  it("renders basic connector with line element", () => {
+    const result = renderConnector(makeConnector());
+
+    expect(result).toContain('<g transform="translate(96, 96)">');
+    expect(result).toContain('<line x1="0" y1="0" x2="192" y2="96"');
+    expect(result).toContain('stroke="#000000"');
+    expect(result).toContain('fill="none"');
+    expect(result).toContain("</g>");
+  });
+
+  it("renders connector with null outline", () => {
+    const result = renderConnector(makeConnector({ outline: null }));
+    expect(result).toContain('stroke="none"');
+  });
+
+  it("renders connector with rotation", () => {
+    const result = renderConnector(makeConnector({ transform: makeTransform({ rotation: 45 }) }));
+    expect(result).toContain("rotate(45, 96, 48)");
+  });
+
+  it("renders connector with flipH", () => {
+    const result = renderConnector(makeConnector({ transform: makeTransform({ flipH: true }) }));
+    expect(result).toContain("translate(192, 0) scale(-1, 1)");
+  });
+
+  it("renders connector with effects", () => {
+    const result = renderConnector(
+      makeConnector({
+        effects: {
+          outerShadow: null,
+          innerShadow: null,
+          glow: { radius: 127000, color: { hex: "#00FF00", alpha: 1 } },
+          softEdge: null,
+        },
+      }),
+    );
+
+    expect(result).toContain("<filter");
+    expect(result).toContain("filter=");
+  });
+
+  it("renders connector with dash style", () => {
+    const result = renderConnector(
+      makeConnector({
+        outline: {
+          width: 12700,
+          fill: { type: "solid", color: { hex: "#FF0000", alpha: 1 } },
+          dashStyle: "dash",
+        },
+      }),
+    );
+
+    expect(result).toContain('stroke="#FF0000"');
+    expect(result).toContain("stroke-dasharray=");
+  });
+});

--- a/src/renderer/transform.test.ts
+++ b/src/renderer/transform.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { buildTransformAttr } from "./transform.js";
+import type { Transform } from "../model/shape.js";
+
+function makeTransform(overrides: Partial<Transform> = {}): Transform {
+  return {
+    offsetX: 0,
+    offsetY: 0,
+    extentWidth: 914400,
+    extentHeight: 914400,
+    rotation: 0,
+    flipH: false,
+    flipV: false,
+    ...overrides,
+  };
+}
+
+describe("buildTransformAttr", () => {
+  it("generates translate only when no rotation or flip", () => {
+    const t = makeTransform({ offsetX: 914400, offsetY: 914400 });
+    expect(buildTransformAttr(t)).toBe("translate(96, 96)");
+  });
+
+  it("generates translate(0, 0) for zero offsets", () => {
+    const t = makeTransform();
+    expect(buildTransformAttr(t)).toBe("translate(0, 0)");
+  });
+
+  it("generates translate + rotate", () => {
+    const t = makeTransform({
+      offsetX: 914400,
+      offsetY: 914400,
+      extentWidth: 1828800, // 192px
+      extentHeight: 914400, // 96px
+      rotation: 45,
+    });
+    expect(buildTransformAttr(t)).toBe("translate(96, 96) rotate(45, 96, 48)");
+  });
+
+  it("calculates rotate center as width/2, height/2", () => {
+    const t = makeTransform({
+      extentWidth: 1828800, // 192px
+      extentHeight: 1828800, // 192px
+      rotation: 90,
+    });
+    expect(buildTransformAttr(t)).toBe("translate(0, 0) rotate(90, 96, 96)");
+  });
+
+  it("omits rotate when rotation is 0", () => {
+    const t = makeTransform({ rotation: 0 });
+    expect(buildTransformAttr(t)).not.toContain("rotate");
+  });
+
+  it("handles negative rotation", () => {
+    const t = makeTransform({ rotation: -45 });
+    expect(buildTransformAttr(t)).toContain("rotate(-45, 48, 48)");
+  });
+
+  it("handles 360 degree rotation", () => {
+    const t = makeTransform({ rotation: 360 });
+    expect(buildTransformAttr(t)).toContain("rotate(360, 48, 48)");
+  });
+
+  // --- flipH ---
+
+  it("generates flipH transform", () => {
+    const t = makeTransform({
+      extentWidth: 1828800, // 192px
+      extentHeight: 914400, // 96px
+      flipH: true,
+    });
+    const result = buildTransformAttr(t);
+    expect(result).toContain("translate(192, 0)");
+    expect(result).toContain("scale(-1, 1)");
+  });
+
+  // --- flipV ---
+
+  it("generates flipV transform", () => {
+    const t = makeTransform({
+      extentWidth: 1828800, // 192px
+      extentHeight: 914400, // 96px
+      flipV: true,
+    });
+    const result = buildTransformAttr(t);
+    expect(result).toContain("translate(0, 96)");
+    expect(result).toContain("scale(1, -1)");
+  });
+
+  // --- flipH + flipV ---
+
+  it("generates both flips", () => {
+    const t = makeTransform({
+      extentWidth: 1828800, // 192px
+      extentHeight: 914400, // 96px
+      flipH: true,
+      flipV: true,
+    });
+    const result = buildTransformAttr(t);
+    expect(result).toContain("translate(192, 96)");
+    expect(result).toContain("scale(-1, -1)");
+  });
+
+  // --- rotate + flip ---
+
+  it("generates rotation and flipH", () => {
+    const t = makeTransform({
+      offsetX: 914400,
+      offsetY: 914400,
+      extentWidth: 1828800, // 192px
+      extentHeight: 914400, // 96px
+      rotation: 45,
+      flipH: true,
+    });
+    const result = buildTransformAttr(t);
+    expect(result).toBe("translate(96, 96) rotate(45, 96, 48) translate(192, 0) scale(-1, 1)");
+  });
+
+  it("generates rotation and flipV", () => {
+    const t = makeTransform({
+      extentWidth: 1828800,
+      extentHeight: 914400,
+      rotation: 90,
+      flipV: true,
+    });
+    const result = buildTransformAttr(t);
+    expect(result).toBe("translate(0, 0) rotate(90, 96, 48) translate(0, 96) scale(1, -1)");
+  });
+
+  it("generates rotation and both flips", () => {
+    const t = makeTransform({
+      extentWidth: 1828800,
+      extentHeight: 914400,
+      rotation: 180,
+      flipH: true,
+      flipV: true,
+    });
+    const result = buildTransformAttr(t);
+    expect(result).toBe("translate(0, 0) rotate(180, 96, 48) translate(192, 96) scale(-1, -1)");
+  });
+});


### PR DESCRIPTION
close #139

## Summary

- `src/color/color-transforms.test.ts` — lumMod/lumOff/tint/shade/alpha の色変換ロジックとHSL往復変換の精度テスト（25テスト）
- `src/renderer/transform.test.ts` — translate/rotate/flipH/flipV の組み合わせテスト（13テスト）
- `src/parser/xml-parser.test.ts` — parseXml() と ARRAY_TAGS 全18タグの配列化テスト（23テスト）
- `src/parser/effect-parser.test.ts` — outerShadow/innerShadow/glow/softEdge のパーステスト（18テスト）
- `src/renderer/effect-renderer.test.ts` — SVG フィルタ生成ロジックと dx/dy 計算テスト（12テスト）
- `src/renderer/image-renderer.test.ts` — 画像要素のSVGレンダリングテスト（6テスト）
- `src/renderer/shape-renderer.test.ts` — renderShape/renderConnector のテスト（13テスト）

合計 110 テストを追加（565テスト中）。

## Test plan

- [x] `npm run test` — 全565テストがパス
- [x] `npm run lint` — ESLint チェック通過
- [x] `npm run format:check` — Prettier チェック通過
- [x] `npm run typecheck` — TypeScript 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)