### PR TITLE
feat: 未対応 OOXML 要素の構造化警告ログを追加

### DIFF
--- a/scripts/test-render.ts
+++ b/scripts/test-render.ts
@@ -24,7 +24,7 @@ async function main() {
   console.log(`Output dir: ${outputDir}`);
   console.log("");
 
-  const svgResults = await convertPptxToSvg(input);
+  const svgResults = await convertPptxToSvg(input, { logLevel: "warn" });
   const pngResults = await convertPptxToPng(input);
 
   for (const svg of svgResults) {

--- a/src/color/color-resolver.test.ts
+++ b/src/color/color-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { ColorResolver } from "./color-resolver.js";
+import { initWarningLogger } from "../warning-logger.js";
 import type { ColorScheme, ColorMap } from "../model/theme.js";
 
 const testScheme: ColorScheme = {
@@ -76,14 +77,16 @@ describe("ColorResolver", () => {
   });
 
   it("warns for unknown color node structure", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = resolver.resolve({ unknownClr: { "@_val": "FF0000" } });
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("ColorResolver: unknown color node structure [unknownClr]"),
+      expect.stringContaining("unknown color node structure [unknownClr]"),
     );
     expect(result).toBeNull();
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("does not warn for empty object", () => {

--- a/src/color/color-resolver.ts
+++ b/src/color/color-resolver.ts
@@ -8,8 +8,7 @@
 import type { ColorScheme, ColorMap, ColorSchemeKey } from "../model/theme.js";
 import type { ResolvedColor } from "../model/fill.js";
 import { applyColorTransforms } from "./color-transforms.js";
-
-const WARN_PREFIX = "[pptx-glimpse]";
+import { debug } from "../warning-logger.js";
 
 export class ColorResolver {
   constructor(
@@ -33,9 +32,7 @@ export class ColorResolver {
 
     const keys = Object.keys(colorNode).filter((k) => !k.startsWith("@_"));
     if (keys.length > 0) {
-      console.warn(
-        `${WARN_PREFIX} ColorResolver: unknown color node structure [${keys.join(", ")}]`,
-      );
+      debug("colorResolver.unknown", `unknown color node structure [${keys.join(", ")}]`);
     }
 
     return null;

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -29,6 +29,8 @@ import type { ColorMap } from "./model/theme.js";
 import type { PlaceholderStyleInfo } from "./model/text.js";
 import type { SlideElement } from "./model/shape.js";
 import { applyTextStyleInheritance } from "./text-style-resolver.js";
+import type { LogLevel } from "./warning-logger.js";
+import { initWarningLogger, flushWarnings } from "./warning-logger.js";
 
 export interface ConvertOptions {
   /** 変換対象のスライド番号 (1始まり)。未指定で全スライド */
@@ -37,6 +39,8 @@ export interface ConvertOptions {
   width?: number;
   /** 出力画像の高さ (ピクセル)。widthと同時指定時はwidthが優先 */
   height?: number;
+  /** 警告ログレベル。デフォルト: "off" */
+  logLevel?: LogLevel;
 }
 
 export interface SlideSvg {
@@ -55,6 +59,8 @@ export async function convertPptxToSvg(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
 ): Promise<SlideSvg[]> {
+  initWarningLogger(options?.logLevel ?? "off");
+
   const archive = await readPptx(input);
 
   // Parse presentation.xml
@@ -207,6 +213,8 @@ export async function convertPptxToSvg(
     const svg = renderSlideToSvg(slide, presInfo.slideSize);
     results.push({ slideNumber, svg });
   }
+
+  flushWarnings();
 
   return results;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export { convertPptxToPng, convertPptxToSvg } from "./converter.js";
 export type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
+export type { LogLevel, WarningSummary, WarningEntry } from "./warning-logger.js";
+export { getWarningSummary, getWarningEntries } from "./warning-logger.js";

--- a/src/parser/chart-parser.ts
+++ b/src/parser/chart-parser.ts
@@ -2,6 +2,7 @@ import type { ChartData, ChartType, ChartSeries, ChartLegend } from "../model/ch
 import type { ResolvedColor } from "../model/fill.js";
 import type { ColorResolver } from "../color/color-resolver.js";
 import { parseXml } from "./xml-parser.js";
+import { warn } from "../warning-logger.js";
 
 const ACCENT_KEYS = ["accent1", "accent2", "accent3", "accent4", "accent5", "accent6"] as const;
 
@@ -70,6 +71,25 @@ function parseChartTypeAndData(
     const barDirection = chartType === "bar" ? (chartNode.barDir?.["@_val"] ?? "col") : undefined;
 
     return { chartType, series, categories, barDirection };
+  }
+
+  // Detect unsupported chart types
+  const knownTags = new Set(CHART_TYPE_MAP.map(([tag]) => tag));
+  const chartTags = [
+    "areaChart",
+    "area3DChart",
+    "surfaceChart",
+    "surface3DChart",
+    "bubbleChart",
+    "radarChart",
+    "stockChart",
+    "ofPieChart",
+  ];
+  for (const tag of chartTags) {
+    if (!knownTags.has(tag) && plotArea[tag]) {
+      warn(`chart.${tag}`, `chart type "${tag}" not implemented`);
+      break;
+    }
   }
 
   return { chartType: null, series: [], categories: [] };

--- a/src/parser/fill-parser.test.ts
+++ b/src/parser/fill-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { parseFillFromNode } from "./fill-parser.js";
+import { initWarningLogger } from "../warning-logger.js";
 import type { FillParseContext } from "./fill-parser.js";
 import { ColorResolver } from "../color/color-resolver.js";
 import type { PptxArchive } from "./pptx-reader.js";
@@ -39,15 +40,17 @@ function createColorResolver() {
 
 describe("parseFillFromNode", () => {
   it("warns when gradFill has no gsLst", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const node = { gradFill: {} };
     const result = parseFillFromNode(node, createColorResolver());
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("GradientFill: gsLst not found, skipping gradient"),
+      expect.stringContaining("gsLst not found, skipping gradient"),
     );
     expect(result).toBeNull();
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("does not warn for valid gradient fill", () => {

--- a/src/parser/fill-parser.ts
+++ b/src/parser/fill-parser.ts
@@ -4,8 +4,7 @@ import type { ColorResolver } from "../color/color-resolver.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import type { Relationship } from "./relationship-parser.js";
 import { resolveRelationshipTarget } from "./relationship-parser.js";
-
-const WARN_PREFIX = "[pptx-glimpse]";
+import { warn, debug } from "../warning-logger.js";
 
 export interface FillParseContext {
   rels: Map<string, Relationship>;
@@ -84,7 +83,7 @@ function parseBlipFill(blipFillNode: any, context: FillParseContext): ImageFill 
 function parseGradientFill(gradNode: any, colorResolver: ColorResolver): Fill | null {
   const gsLst = gradNode.gsLst?.gs;
   if (!gsLst) {
-    console.warn(`${WARN_PREFIX} GradientFill: gsLst not found, skipping gradient`);
+    debug("gradientFill.gsLst", "GradientFill: gsLst not found, skipping gradient");
     return null;
   }
 
@@ -134,6 +133,22 @@ function parsePatternFill(pattNode: any, colorResolver: ColorResolver): PatternF
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseOutline(lnNode: any, colorResolver: ColorResolver): Outline | null {
   if (!lnNode) return null;
+
+  // Unsupported feature detection
+  if (lnNode.headEnd) {
+    const headType = lnNode.headEnd["@_type"] ?? "unknown";
+    warn("ln.headEnd", `line head arrow (type="${headType}") not implemented`);
+  }
+  if (lnNode.tailEnd) {
+    const tailType = lnNode.tailEnd["@_type"] ?? "unknown";
+    warn("ln.tailEnd", `line tail arrow (type="${tailType}") not implemented`);
+  }
+  if (lnNode.gradFill) {
+    warn("ln.gradFill", "gradient line fill not implemented");
+  }
+  if (lnNode.pattFill) {
+    warn("ln.pattFill", "pattern line fill not implemented");
+  }
 
   const width = Number(lnNode["@_w"] ?? 12700);
 

--- a/src/parser/presentation-parser.test.ts
+++ b/src/parser/presentation-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { parsePresentation } from "./presentation-parser.js";
+import { initWarningLogger } from "../warning-logger.js";
 
 describe("parsePresentation", () => {
   it("parses valid presentation XML", () => {
@@ -21,22 +22,25 @@ describe("parsePresentation", () => {
   });
 
   it("warns and returns defaults when presentation root is missing", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const xml = `<other/>`;
     const result = parsePresentation(xml);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Presentation: missing root element "presentation"'),
+      expect.stringContaining('missing root element "presentation" in XML'),
     );
     expect(result.slideSize.width).toBe(9144000);
     expect(result.slideSize.height).toBe(5143500);
     expect(result.slideRIds).toEqual([]);
 
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns and uses default size when sldSz is missing", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const xml = `
@@ -46,11 +50,12 @@ describe("parsePresentation", () => {
     `;
     const result = parsePresentation(xml);
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Presentation: sldSz missing"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("sldSz missing"));
     expect(result.slideSize.width).toBe(9144000);
     expect(result.slideSize.height).toBe(5143500);
 
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("parses defaultTextStyle with multiple levels", () => {

--- a/src/parser/presentation-parser.ts
+++ b/src/parser/presentation-parser.ts
@@ -2,6 +2,7 @@ import type { SlideSize } from "../model/presentation.js";
 import type { DefaultTextStyle } from "../model/text.js";
 import { parseXml } from "./xml-parser.js";
 import { parseListStyle } from "./text-style-parser.js";
+import { debug } from "../warning-logger.js";
 
 export interface PresentationInfo {
   slideSize: SlideSize;
@@ -9,7 +10,6 @@ export interface PresentationInfo {
   defaultTextStyle?: DefaultTextStyle;
 }
 
-const WARN_PREFIX = "[pptx-glimpse]";
 const DEFAULT_SLIDE_WIDTH = 9144000;
 const DEFAULT_SLIDE_HEIGHT = 5143500;
 
@@ -19,7 +19,7 @@ export function parsePresentation(xml: string): PresentationInfo {
   const pres = parsed.presentation;
 
   if (!pres) {
-    console.warn(`${WARN_PREFIX} Presentation: missing root element "presentation" in XML`);
+    debug("presentation.missing", `missing root element "presentation" in XML`);
     return {
       slideSize: { width: DEFAULT_SLIDE_WIDTH, height: DEFAULT_SLIDE_HEIGHT },
       slideRIds: [],
@@ -29,8 +29,9 @@ export function parsePresentation(xml: string): PresentationInfo {
   const sldSz = pres.sldSz;
   let slideSize: SlideSize;
   if (!sldSz || sldSz["@_cx"] === undefined || sldSz["@_cy"] === undefined) {
-    console.warn(
-      `${WARN_PREFIX} Presentation: sldSz missing, using default ${DEFAULT_SLIDE_WIDTH}x${DEFAULT_SLIDE_HEIGHT} EMU`,
+    debug(
+      "presentation.sldSz",
+      `sldSz missing, using default ${DEFAULT_SLIDE_WIDTH}x${DEFAULT_SLIDE_HEIGHT} EMU`,
     );
     slideSize = { width: DEFAULT_SLIDE_WIDTH, height: DEFAULT_SLIDE_HEIGHT };
   } else {
@@ -45,9 +46,7 @@ export function parsePresentation(xml: string): PresentationInfo {
     .map((s: Record<string, string>) => s["@_r:id"] ?? s["@_id"])
     .filter((id: string | undefined) => {
       if (id === undefined) {
-        console.warn(
-          `${WARN_PREFIX} Presentation: undefined slide relationship ID found, skipping`,
-        );
+        debug("presentation.slideRId", "undefined slide relationship ID found, skipping");
         return false;
       }
       return true;

--- a/src/parser/relationship-parser.test.ts
+++ b/src/parser/relationship-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
+import { initWarningLogger } from "../warning-logger.js";
 
 describe("buildRelsPath", () => {
   it("builds rels path for slide", () => {
@@ -39,18 +40,21 @@ describe("parseRelationships", () => {
   });
 
   it("warns when Relationships root is missing", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseRelationships(xml);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Relationship: missing root element "Relationships"'),
+      expect.stringContaining('missing root element "Relationships" in XML'),
     );
     expect(result.size).toBe(0);
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns and skips entries missing required attributes", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `
       <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
@@ -64,11 +68,12 @@ describe("parseRelationships", () => {
 
     expect(warnSpy).toHaveBeenCalledTimes(3);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Relationship: entry missing required attribute, skipping"),
+      expect.stringContaining("entry missing required attribute, skipping"),
     );
     expect(result.size).toBe(1);
     expect(result.get("rId1")?.target).toBe("target.xml");
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("does not warn for valid XML", () => {

--- a/src/parser/relationship-parser.ts
+++ b/src/parser/relationship-parser.ts
@@ -1,6 +1,5 @@
 import { parseXml } from "./xml-parser.js";
-
-const WARN_PREFIX = "[pptx-glimpse]";
+import { debug } from "../warning-logger.js";
 
 export interface Relationship {
   id: string;
@@ -17,7 +16,7 @@ export function parseRelationships(xml: string): Map<string, Relationship> {
   const root = parsed as any;
 
   if (!root?.Relationships) {
-    console.warn(`${WARN_PREFIX} Relationship: missing root element "Relationships" in XML`);
+    debug("relationship.missing", `missing root element "Relationships" in XML`);
     return rels;
   }
 
@@ -31,7 +30,7 @@ export function parseRelationships(xml: string): Map<string, Relationship> {
     const targetMode = rel["@_TargetMode"] as string | undefined;
 
     if (!id || !type || !target) {
-      console.warn(`${WARN_PREFIX} Relationship: entry missing required attribute, skipping`);
+      debug("relationship.attribute", "entry missing required attribute, skipping");
       continue;
     }
 

--- a/src/parser/slide-layout-parser.test.ts
+++ b/src/parser/slide-layout-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { parseSlideLayoutBackground, parseSlideLayoutElements } from "./slide-layout-parser.js";
+import { initWarningLogger } from "../warning-logger.js";
 import { ColorResolver } from "../color/color-resolver.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import type { ShapeElement } from "../model/shape.js";
@@ -173,18 +174,21 @@ describe("parseSlideLayoutElements", () => {
 
 describe("structural validation warnings", () => {
   it("warns when parseSlideLayoutBackground receives XML without sldLayout root", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseSlideLayoutBackground(xml, createColorResolver());
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('SlideLayout: missing root element "sldLayout"'),
+      expect.stringContaining('missing root element "sldLayout" in XML'),
     );
     expect(result).toBeNull();
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns when parseSlideLayoutElements receives XML without sldLayout root", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseSlideLayoutElements(
@@ -195,10 +199,11 @@ describe("structural validation warnings", () => {
     );
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('SlideLayout: missing root element "sldLayout"'),
+      expect.stringContaining('missing root element "sldLayout" in XML'),
     );
     expect(result).toHaveLength(0);
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("does not warn for valid XML", () => {

--- a/src/parser/slide-layout-parser.ts
+++ b/src/parser/slide-layout-parser.ts
@@ -10,8 +10,7 @@ import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
 import { parseListStyle } from "./text-style-parser.js";
 import type { ColorResolver } from "../color/color-resolver.js";
 import type { FontScheme } from "../model/theme.js";
-
-const WARN_PREFIX = "[pptx-glimpse]";
+import { debug } from "../warning-logger.js";
 
 export function parseSlideLayoutBackground(
   xml: string,
@@ -22,7 +21,7 @@ export function parseSlideLayoutBackground(
   const parsed = parseXml(xml) as any;
 
   if (!parsed.sldLayout) {
-    console.warn(`${WARN_PREFIX} SlideLayout: missing root element "sldLayout" in XML`);
+    debug("slideLayout.missing", `missing root element "sldLayout" in XML`);
     return null;
   }
 
@@ -47,7 +46,7 @@ export function parseSlideLayoutElements(
   const parsed = parseXml(xml) as any;
 
   if (!parsed.sldLayout) {
-    console.warn(`${WARN_PREFIX} SlideLayout: missing root element "sldLayout" in XML`);
+    debug("slideLayout.missing", `missing root element "sldLayout" in XML`);
     return [];
   }
 

--- a/src/parser/slide-master-parser.test.ts
+++ b/src/parser/slide-master-parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { initWarningLogger } from "../warning-logger.js";
 import {
   parseSlideMasterElements,
   parseSlideMasterColorMap,
@@ -295,44 +296,51 @@ describe("parseSlideMasterTxStyles", () => {
   });
 
   it("warns and returns undefined for invalid XML", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseSlideMasterTxStyles(xml);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('SlideMaster: missing root element "sldMaster"'),
+      expect.stringContaining('missing root element "sldMaster" in XML'),
     );
     expect(result).toBeUndefined();
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 });
 
 describe("structural validation warnings", () => {
   it("warns when parseSlideMasterColorMap receives XML without sldMaster root", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseSlideMasterColorMap(xml);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('SlideMaster: missing root element "sldMaster"'),
+      expect.stringContaining('missing root element "sldMaster" in XML'),
     );
     expect(result.bg1).toBe("lt1");
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns when parseSlideMasterBackground receives XML without sldMaster root", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseSlideMasterBackground(xml, createColorResolver());
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('SlideMaster: missing root element "sldMaster"'),
+      expect.stringContaining('missing root element "sldMaster" in XML'),
     );
     expect(result).toBeNull();
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns when parseSlideMasterElements receives XML without sldMaster root", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseSlideMasterElements(
@@ -343,10 +351,11 @@ describe("structural validation warnings", () => {
     );
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('SlideMaster: missing root element "sldMaster"'),
+      expect.stringContaining('missing root element "sldMaster" in XML'),
     );
     expect(result).toHaveLength(0);
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("does not warn for valid XML", () => {

--- a/src/parser/slide-master-parser.ts
+++ b/src/parser/slide-master-parser.ts
@@ -11,8 +11,7 @@ import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
 import type { ColorResolver } from "../color/color-resolver.js";
 import type { FontScheme } from "../model/theme.js";
 import { parseListStyle } from "./text-style-parser.js";
-
-const WARN_PREFIX = "[pptx-glimpse]";
+import { debug } from "../warning-logger.js";
 
 const DEFAULT_COLOR_MAP: ColorMap = {
   bg1: "lt1",
@@ -34,7 +33,7 @@ export function parseSlideMasterColorMap(xml: string): ColorMap {
   const parsed = parseXml(xml) as any;
 
   if (!parsed.sldMaster) {
-    console.warn(`${WARN_PREFIX} SlideMaster: missing root element "sldMaster" in XML`);
+    debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return { ...DEFAULT_COLOR_MAP };
   }
 
@@ -60,7 +59,7 @@ export function parseSlideMasterBackground(
   const parsed = parseXml(xml) as any;
 
   if (!parsed.sldMaster) {
-    console.warn(`${WARN_PREFIX} SlideMaster: missing root element "sldMaster" in XML`);
+    debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return null;
   }
 
@@ -85,7 +84,7 @@ export function parseSlideMasterElements(
   const parsed = parseXml(xml) as any;
 
   if (!parsed.sldMaster) {
-    console.warn(`${WARN_PREFIX} SlideMaster: missing root element "sldMaster" in XML`);
+    debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return [];
   }
 
@@ -117,7 +116,7 @@ export function parseSlideMasterTxStyles(xml: string): TxStyles | undefined {
   const parsed = parseXml(xml) as any;
 
   if (!parsed.sldMaster) {
-    console.warn(`${WARN_PREFIX} SlideMaster: missing root element "sldMaster" in XML`);
+    debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return undefined;
   }
 

--- a/src/parser/slide-parser.test.ts
+++ b/src/parser/slide-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { parseSlide, parseShapeTree, navigateOrdered } from "./slide-parser.js";
+import { initWarningLogger } from "../warning-logger.js";
 import { ColorResolver } from "../color/color-resolver.js";
 import { parseXml, parseXmlOrdered } from "./xml-parser.js";
 import type { PptxArchive } from "./pptx-reader.js";
@@ -710,6 +711,7 @@ describe("bullet parsing", () => {
 
 describe("structural validation warnings", () => {
   it("warns when parseSlide receives XML without sld root", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const xml = `<other><cSld/></other>`;
@@ -722,14 +724,16 @@ describe("structural validation warnings", () => {
     );
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Slide 3: missing root element "sld"'),
+      expect.stringContaining('missing root element "sld" in XML'),
     );
     expect(result.elements).toEqual([]);
 
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns when a shape is skipped due to parse returning null", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const xml = `
@@ -754,12 +758,14 @@ describe("structural validation warnings", () => {
     );
 
     expect(elements).toHaveLength(0);
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Slide 1: shape skipped"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("shape skipped"));
 
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns when NaN is detected in transform values", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const xml = `
@@ -797,6 +803,7 @@ describe("structural validation warnings", () => {
     );
 
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("does not warn for valid structures", () => {

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -45,8 +45,7 @@ import {
   parseDefaultRunProperties,
   resolveThemeFont,
 } from "./text-style-parser.js";
-
-const WARN_PREFIX = "[pptx-glimpse]";
+import { warn, debug } from "../warning-logger.js";
 
 const SHAPE_TAGS = new Set(["sp", "pic", "cxnSp", "grpSp", "graphicFrame"]);
 
@@ -77,7 +76,7 @@ export function parseSlide(
   const parsed = parseXml(slideXml) as any;
   const sld = parsed.sld;
   if (!sld) {
-    console.warn(`${WARN_PREFIX} Slide ${slideNumber}: missing root element "sld" in XML`);
+    debug("slide.missing", `missing root element "sld" in XML`, `Slide ${slideNumber}`);
   }
 
   const relsPath = slidePath.replace("ppt/slides/", "ppt/slides/_rels/") + ".rels";
@@ -186,7 +185,7 @@ export function parseShapeTree(
     if (shape) {
       elements.push(shape);
     } else {
-      console.warn(`${WARN_PREFIX} ${ctx}: shape skipped (parse returned null)`);
+      debug("shape.skipped", "shape skipped (parse returned null)", ctx);
     }
   }
 
@@ -196,7 +195,7 @@ export function parseShapeTree(
     if (img) {
       elements.push(img);
     } else {
-      console.warn(`${WARN_PREFIX} ${ctx}: image skipped (parse returned null)`);
+      debug("image.skipped", "image skipped (parse returned null)", ctx);
     }
   }
 
@@ -206,7 +205,7 @@ export function parseShapeTree(
     if (connector) {
       elements.push(connector);
     } else {
-      console.warn(`${WARN_PREFIX} ${ctx}: connector skipped (parse returned null)`);
+      debug("connector.skipped", "connector skipped (parse returned null)", ctx);
     }
   }
 
@@ -216,7 +215,7 @@ export function parseShapeTree(
     if (group) {
       elements.push(group);
     } else {
-      console.warn(`${WARN_PREFIX} ${ctx}: group skipped (parse returned null)`);
+      debug("group.skipped", "group skipped (parse returned null)", ctx);
     }
   }
 
@@ -226,7 +225,7 @@ export function parseShapeTree(
     if (chart) {
       elements.push(chart);
     } else {
-      console.warn(`${WARN_PREFIX} ${ctx}: graphicFrame skipped (parse returned null)`);
+      debug("graphicFrame.skipped", "graphicFrame skipped (parse returned null)", ctx);
     }
   }
 
@@ -362,7 +361,7 @@ function parseAndPushElement(
       if (shape) {
         elements.push(shape);
       } else {
-        console.warn(`${WARN_PREFIX} ${ctx}: shape skipped (parse returned null)`);
+        debug("shape.skipped", "shape skipped (parse returned null)", ctx);
       }
       break;
     }
@@ -371,7 +370,7 @@ function parseAndPushElement(
       if (img) {
         elements.push(img);
       } else {
-        console.warn(`${WARN_PREFIX} ${ctx}: image skipped (parse returned null)`);
+        debug("image.skipped", "image skipped (parse returned null)", ctx);
       }
       break;
     }
@@ -380,7 +379,7 @@ function parseAndPushElement(
       if (connector) {
         elements.push(connector);
       } else {
-        console.warn(`${WARN_PREFIX} ${ctx}: connector skipped (parse returned null)`);
+        debug("connector.skipped", "connector skipped (parse returned null)", ctx);
       }
       break;
     }
@@ -400,7 +399,7 @@ function parseAndPushElement(
       if (group) {
         elements.push(group);
       } else {
-        console.warn(`${WARN_PREFIX} ${ctx}: group skipped (parse returned null)`);
+        debug("group.skipped", "group skipped (parse returned null)", ctx);
       }
       break;
     }
@@ -416,7 +415,7 @@ function parseAndPushElement(
       if (gfResult) {
         elements.push(gfResult);
       } else {
-        console.warn(`${WARN_PREFIX} ${ctx}: graphicFrame skipped (parse returned null)`);
+        debug("graphicFrame.skipped", "graphicFrame skipped (parse returned null)", ctx);
       }
       break;
     }
@@ -436,6 +435,17 @@ function parseShape(
 
   const transform = parseTransform(spPr.xfrm);
   if (!transform) return null;
+
+  // Unsupported feature detection
+  if (sp.style) {
+    warn("sp.style", "shape style references (lnRef/fillRef/effectRef) not implemented");
+  }
+  if (spPr.scene3d) {
+    warn("spPr.scene3d", "3D scene/camera not implemented");
+  }
+  if (spPr.sp3d) {
+    warn("spPr.sp3d", "3D extrusion/bevel not implemented");
+  }
 
   const geometry = parseGeometry(spPr);
   const fill = parseFillFromNode(spPr, colorResolver, fillContext);
@@ -633,6 +643,9 @@ function parseGraphicFrame(
     );
   }
 
+  const uri = graphicData["@_uri"] ?? "unknown";
+  warn("graphicFrame.unsupported", `unsupported graphicFrame content (uri: ${uri})`);
+
   return null;
 }
 
@@ -764,23 +777,23 @@ function parseTransform(xfrm: any): Transform | null {
   let rotation = Number(xfrm["@_rot"] ?? 0);
 
   if (Number.isNaN(offsetX)) {
-    console.warn(`${WARN_PREFIX} NaN detected in transform offsetX, defaulting to 0`);
+    debug("transform.nan", "NaN detected in transform offsetX, defaulting to 0");
     offsetX = 0;
   }
   if (Number.isNaN(offsetY)) {
-    console.warn(`${WARN_PREFIX} NaN detected in transform offsetY, defaulting to 0`);
+    debug("transform.nan", "NaN detected in transform offsetY, defaulting to 0");
     offsetY = 0;
   }
   if (Number.isNaN(extentWidth)) {
-    console.warn(`${WARN_PREFIX} NaN detected in transform extentWidth, defaulting to 0`);
+    debug("transform.nan", "NaN detected in transform extentWidth, defaulting to 0");
     extentWidth = 0;
   }
   if (Number.isNaN(extentHeight)) {
-    console.warn(`${WARN_PREFIX} NaN detected in transform extentHeight, defaulting to 0`);
+    debug("transform.nan", "NaN detected in transform extentHeight, defaulting to 0");
     extentHeight = 0;
   }
   if (Number.isNaN(rotation)) {
-    console.warn(`${WARN_PREFIX} NaN detected in transform rotation, defaulting to 0`);
+    debug("transform.nan", "NaN detected in transform rotation, defaulting to 0");
     rotation = 0;
   }
 
@@ -837,6 +850,15 @@ export function parseTextBody(
   if (!txBody) return null;
 
   const bodyPr = txBody.bodyPr;
+
+  // Unsupported feature detection
+  const vert = bodyPr?.["@_vert"];
+  if (vert && vert !== "horz") {
+    warn("bodyPr@vert", `vertical text (vert="${vert}") not implemented`);
+  }
+  if (bodyPr?.["@_numCol"] && Number(bodyPr["@_numCol"]) > 1) {
+    warn("bodyPr@numCol", "multi-column text not implemented");
+  }
 
   let autoFit: BodyProperties["autoFit"] = "noAutofit";
   let fontScale = 1;
@@ -934,6 +956,14 @@ function parseParagraph(
   fontScheme?: FontScheme | null,
   lstStyle?: DefaultTextStyle,
 ): Paragraph {
+  // Unsupported feature detection
+  if (p.fld) {
+    const fldType = Array.isArray(p.fld)
+      ? (p.fld[0]?.["@_type"] ?? "unknown")
+      : (p.fld["@_type"] ?? "unknown");
+    warn("p.fld", `field code (type="${fldType}") not implemented`);
+  }
+
   const pPr = p.pPr;
   const level = Number(pPr?.["@_lvl"] ?? 0);
 
@@ -1014,6 +1044,14 @@ function parseRunProperties(
       baseline: 0,
       hyperlink: null,
     };
+  }
+
+  // Unsupported feature detection
+  if (rPr.effectLst) {
+    warn("rPr.effectLst", "text run effects not implemented");
+  }
+  if (rPr.highlight) {
+    warn("rPr.highlight", "text highlighting not implemented");
   }
 
   const fontSize = rPr["@_sz"]

--- a/src/parser/theme-parser.test.ts
+++ b/src/parser/theme-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { parseTheme } from "./theme-parser.js";
+import { initWarningLogger } from "../warning-logger.js";
 
 const themeXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
@@ -50,19 +51,22 @@ describe("parseTheme", () => {
   });
 
   it("warns and returns defaults when theme root is missing", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `<other/>`;
     const result = parseTheme(xml);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Theme: missing root element "theme"'),
+      expect.stringContaining('missing root element "theme" in XML'),
     );
     expect(result.colorScheme.dk1).toBe("#000000");
     expect(result.fontScheme.majorFont).toBe("Calibri");
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns and returns defaults when themeElements is missing", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `
       <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -71,13 +75,15 @@ describe("parseTheme", () => {
     `;
     const result = parseTheme(xml);
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Theme: themeElements not found"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("themeElements not found"));
     expect(result.colorScheme.dk1).toBe("#000000");
     expect(result.fontScheme.majorFont).toBe("Calibri");
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns when colorScheme is missing", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `
       <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -91,13 +97,15 @@ describe("parseTheme", () => {
     `;
     const result = parseTheme(xml);
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Theme: colorScheme not found"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("colorScheme not found"));
     expect(result.colorScheme.dk1).toBe("#000000");
     expect(result.fontScheme.majorFont).toBe("Arial");
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 
   it("warns when fontScheme is missing", () => {
+    initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const xml = `
       <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -121,9 +129,10 @@ describe("parseTheme", () => {
     `;
     const result = parseTheme(xml);
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Theme: fontScheme not found"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("fontScheme not found"));
     expect(result.colorScheme.dk1).toBe("#111111");
     expect(result.fontScheme.majorFont).toBe("Calibri");
     warnSpy.mockRestore();
+    initWarningLogger("off");
   });
 });

--- a/src/parser/theme-parser.ts
+++ b/src/parser/theme-parser.ts
@@ -1,14 +1,13 @@
 import type { Theme, ColorScheme, FontScheme } from "../model/theme.js";
 import { parseXml } from "./xml-parser.js";
-
-const WARN_PREFIX = "[pptx-glimpse]";
+import { debug } from "../warning-logger.js";
 
 export function parseTheme(xml: string): Theme {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const parsed = parseXml(xml) as any;
 
   if (!parsed.theme) {
-    console.warn(`${WARN_PREFIX} Theme: missing root element "theme" in XML`);
+    debug("theme.missing", `missing root element "theme" in XML`);
     return {
       colorScheme: defaultColorScheme(),
       fontScheme: {
@@ -22,7 +21,7 @@ export function parseTheme(xml: string): Theme {
 
   const themeElements = parsed.theme.themeElements;
   if (!themeElements) {
-    console.warn(`${WARN_PREFIX} Theme: themeElements not found, using defaults`);
+    debug("theme.themeElements", "themeElements not found, using defaults");
     return {
       colorScheme: defaultColorScheme(),
       fontScheme: {
@@ -35,10 +34,10 @@ export function parseTheme(xml: string): Theme {
   }
 
   if (!themeElements.clrScheme) {
-    console.warn(`${WARN_PREFIX} Theme: colorScheme not found, using defaults`);
+    debug("theme.colorScheme", "colorScheme not found, using defaults");
   }
   if (!themeElements.fontScheme) {
-    console.warn(`${WARN_PREFIX} Theme: fontScheme not found, using defaults`);
+    debug("theme.fontScheme", "fontScheme not found, using defaults");
   }
 
   const colorScheme = parseColorScheme(themeElements.clrScheme);

--- a/src/warning-logger.test.ts
+++ b/src/warning-logger.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  initWarningLogger,
+  warn,
+  debug,
+  getWarningSummary,
+  flushWarnings,
+  getWarningEntries,
+  getLogLevel,
+} from "./warning-logger.js";
+
+describe("warning-logger", () => {
+  beforeEach(() => {
+    initWarningLogger("off");
+    vi.restoreAllMocks();
+  });
+
+  describe("initWarningLogger", () => {
+    it("sets the log level", () => {
+      initWarningLogger("warn");
+      expect(getLogLevel()).toBe("warn");
+
+      initWarningLogger("debug");
+      expect(getLogLevel()).toBe("debug");
+
+      initWarningLogger("off");
+      expect(getLogLevel()).toBe("off");
+    });
+
+    it("resets entries on re-initialization", () => {
+      initWarningLogger("warn");
+      warn("sp.style", "test");
+      expect(getWarningEntries()).toHaveLength(1);
+
+      initWarningLogger("warn");
+      expect(getWarningEntries()).toHaveLength(0);
+    });
+  });
+
+  describe('level "off"', () => {
+    it("warn() is a no-op", () => {
+      initWarningLogger("off");
+      warn("sp.style", "test");
+      expect(getWarningEntries()).toHaveLength(0);
+      expect(getWarningSummary().totalCount).toBe(0);
+    });
+
+    it("debug() is a no-op", () => {
+      initWarningLogger("off");
+      debug("parse.error", "test");
+      expect(getWarningEntries()).toHaveLength(0);
+    });
+  });
+
+  describe('level "warn"', () => {
+    beforeEach(() => {
+      initWarningLogger("warn");
+    });
+
+    it("warn() records entries", () => {
+      warn("sp.style", "style references not implemented");
+      expect(getWarningEntries()).toHaveLength(1);
+      expect(getWarningEntries()[0]).toEqual({
+        feature: "sp.style",
+        message: "style references not implemented",
+      });
+    });
+
+    it("warn() records context when provided", () => {
+      warn("sp.style", "style references not implemented", "Slide 1");
+      expect(getWarningEntries()[0]).toEqual({
+        feature: "sp.style",
+        message: "style references not implemented",
+        context: "Slide 1",
+      });
+    });
+
+    it("debug() is a no-op at warn level", () => {
+      debug("parse.error", "test");
+      expect(getWarningEntries()).toHaveLength(0);
+    });
+
+    it("does not emit console.warn for individual warnings", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      warn("sp.style", "test");
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates feature counts", () => {
+      warn("sp.style", "style references not implemented", "Slide 1");
+      warn("sp.style", "style references not implemented", "Slide 2");
+      warn("sp.style", "style references not implemented", "Slide 3");
+      warn("ln.headEnd", "arrow heads not implemented");
+
+      const summary = getWarningSummary();
+      expect(summary.totalCount).toBe(4);
+      expect(summary.features).toHaveLength(2);
+      expect(summary.features[0]).toEqual({
+        feature: "sp.style",
+        message: "style references not implemented",
+        count: 3,
+      });
+      expect(summary.features[1]).toEqual({
+        feature: "ln.headEnd",
+        message: "arrow heads not implemented",
+        count: 1,
+      });
+    });
+  });
+
+  describe('level "debug"', () => {
+    beforeEach(() => {
+      initWarningLogger("debug");
+    });
+
+    it("warn() records entries and emits console.warn", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      warn("sp.style", "style references not implemented");
+      expect(getWarningEntries()).toHaveLength(1);
+      expect(spy).toHaveBeenCalledWith(
+        "[pptx-glimpse] SKIP: sp.style - style references not implemented",
+      );
+    });
+
+    it("warn() includes context in console output", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      warn("sp.style", "style references not implemented", "Slide 1");
+      expect(spy).toHaveBeenCalledWith(
+        "[pptx-glimpse] SKIP: sp.style - style references not implemented (Slide 1)",
+      );
+    });
+
+    it("debug() records entries and emits console.warn", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      debug("parse.error", "missing root element");
+      expect(getWarningEntries()).toHaveLength(1);
+      expect(spy).toHaveBeenCalledWith("[pptx-glimpse] DEBUG: parse.error - missing root element");
+    });
+  });
+
+  describe("flushWarnings", () => {
+    it("outputs summary to console.warn and resets state", () => {
+      initWarningLogger("warn");
+      warn("sp.style", "style references not implemented");
+      warn("sp.style", "style references not implemented");
+      warn("ln.headEnd", "arrow heads not implemented");
+
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const summary = flushWarnings();
+
+      expect(summary.totalCount).toBe(3);
+      expect(summary.features).toHaveLength(2);
+
+      expect(spy).toHaveBeenCalledWith("[pptx-glimpse] Summary: 2 unsupported feature(s) detected");
+      expect(spy).toHaveBeenCalledWith("  - sp.style: 2 occurrence(s)");
+      expect(spy).toHaveBeenCalledWith("  - ln.headEnd: 1 occurrence(s)");
+
+      // State is reset
+      expect(getWarningEntries()).toHaveLength(0);
+      expect(getWarningSummary().totalCount).toBe(0);
+    });
+
+    it("does not output when level is off", () => {
+      initWarningLogger("off");
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const summary = flushWarnings();
+      expect(summary.features).toHaveLength(0);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("does not output when no warnings were recorded", () => {
+      initWarningLogger("warn");
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const summary = flushWarnings();
+      expect(summary.features).toHaveLength(0);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/warning-logger.ts
+++ b/src/warning-logger.ts
@@ -1,0 +1,93 @@
+export type LogLevel = "off" | "warn" | "debug";
+
+export interface WarningEntry {
+  /** The feature key, e.g. "sp.style", "bodyPr@vert" */
+  feature: string;
+  /** Human-readable description */
+  message: string;
+  /** Location context, e.g. "Slide 1" */
+  context?: string;
+}
+
+export interface WarningSummary {
+  totalCount: number;
+  features: { feature: string; message: string; count: number }[];
+}
+
+const PREFIX = "[pptx-glimpse]";
+
+let currentLevel: LogLevel = "off";
+let entries: WarningEntry[] = [];
+const featureCounts = new Map<string, { message: string; count: number }>();
+
+export function initWarningLogger(level: LogLevel): void {
+  currentLevel = level;
+  entries = [];
+  featureCounts.clear();
+}
+
+export function warn(feature: string, message: string, context?: string): void {
+  if (currentLevel === "off") return;
+
+  entries.push({ feature, message, ...(context !== undefined && { context }) });
+
+  const existing = featureCounts.get(feature);
+  if (existing) {
+    existing.count++;
+  } else {
+    featureCounts.set(feature, { message, count: 1 });
+  }
+
+  if (currentLevel === "debug") {
+    const ctx = context ? ` (${context})` : "";
+    console.warn(`${PREFIX} SKIP: ${feature} - ${message}${ctx}`);
+  }
+}
+
+export function debug(feature: string, message: string, context?: string): void {
+  if (currentLevel !== "debug") return;
+
+  entries.push({ feature, message, ...(context !== undefined && { context }) });
+
+  const existing = featureCounts.get(feature);
+  if (existing) {
+    existing.count++;
+  } else {
+    featureCounts.set(feature, { message, count: 1 });
+  }
+
+  const ctx = context ? ` (${context})` : "";
+  console.warn(`${PREFIX} DEBUG: ${feature} - ${message}${ctx}`);
+}
+
+export function getWarningSummary(): WarningSummary {
+  const features: WarningSummary["features"] = [];
+  for (const [feature, { message, count }] of featureCounts) {
+    features.push({ feature, message, count });
+  }
+  return { totalCount: entries.length, features };
+}
+
+export function flushWarnings(): WarningSummary {
+  const summary = getWarningSummary();
+
+  if (currentLevel !== "off" && summary.features.length > 0) {
+    console.warn(`${PREFIX} Summary: ${summary.features.length} unsupported feature(s) detected`);
+    for (const { feature, count } of summary.features) {
+      console.warn(`  - ${feature}: ${count} occurrence(s)`);
+    }
+  }
+
+  entries = [];
+  featureCounts.clear();
+
+  return summary;
+}
+
+export function getWarningEntries(): readonly WarningEntry[] {
+  return entries;
+}
+
+export function getLogLevel(): LogLevel {
+  return currentLevel;
+}


### PR DESCRIPTION
closes #150

## Summary

- パーサーで認識はするが処理しない OOXML 要素を検出し、構造化された警告ログを出力する仕組みを追加
- ログレベル (`off` / `warn` / `debug`) を設定可能にし、デフォルトは `off` でライブラリ利用者に不要なログを出さない
- `npm run render` 実行時は自動的に `warn` レベルで出力し、処理完了後に未対応要素のサマリーを出力

### 主な変更点

- `src/warning-logger.ts` を新規作成（`initWarningLogger`, `warn`, `debug`, `flushWarnings` 等）
- `ConvertOptions` に `logLevel` オプションを追加
- 既存の `console.warn` を `warning-logger` の `debug()` に移行（9ファイル）
- 未対応要素の検出を追加:
  - `sp.style` (lnRef/fillRef/effectRef)
  - `bodyPr@vert` (縦書きテキスト)
  - `bodyPr@numCol` (マルチカラムテキスト)
  - `spPr.scene3d` / `spPr.sp3d` (3D効果)
  - `graphicFrame.unsupported` (未対応 graphicFrame)
  - `p.fld` (フィールドコード)
  - `rPr.effectLst` / `rPr.highlight` (テキスト効果・ハイライト)
  - `ln.headEnd` / `ln.tailEnd` (矢印)
  - `ln.gradFill` / `ln.pattFill` (グラデーション・パターン線)
  - `chart.<unsupported>` (未対応チャートタイプ)

### 出力イメージ

```
[pptx-glimpse] Summary: 3 unsupported feature(s) detected
  - sp.style: 12 occurrence(s)
  - ln.headEnd: 5 occurrence(s)
  - bodyPr@vert: 2 occurrence(s)
```

## Test plan

- [x] `warning-logger.test.ts` でロガーモジュールのユニットテスト追加
- [x] 既存テストを `initWarningLogger("debug")` 対応に更新
- [x] `npm run lint` / `npm run format:check` / `npm run typecheck` パス確認
- [x] `npm run test` (VRT除く) 全 586 テストパス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)