### PR TITLE
ci: LibreOffice VRT の Docker イメージを GHCR プレビルドに切り替えて高速化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Docker image
-        run: docker build -t pptx-glimpse-vrt docker/libreoffice-vrt
+      - name: Pull Docker image
+        run: docker pull ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest
 
       - name: Generate fixtures
-        run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt python3 /workspace/vrt/libreoffice/create_fixtures.py
+        run: docker run --rm -v "${{ github.workspace }}":/workspace ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest python3 /workspace/vrt/libreoffice/create_fixtures.py
 
       - name: Generate LibreOffice reference images
-        run: docker run --rm -v "${{ github.workspace }}":/workspace pptx-glimpse-vrt bash /workspace/vrt/libreoffice/update_snapshots.sh
+        run: docker run --rm -v "${{ github.workspace }}":/workspace ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest bash /workspace/vrt/libreoffice/update_snapshots.sh
 
       - name: Run LibreOffice VRT
         run: npx vitest run vrt/libreoffice/regression.test.ts

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,25 @@
+name: Build LibreOffice VRT Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/libreoffice-vrt/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build Docker image
+        run: docker build -t ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest docker/libreoffice-vrt
+
+      - name: Push Docker image
+        run: docker push ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest


### PR DESCRIPTION
close #160

## 概要

LibreOffice VRT ジョブのボトルネックである Docker image ビルド（毎回 ~50秒）を、GHCR プレビルドイメージで解消する。

## 変更内容

- **`.github/workflows/docker-image.yml`（新規）**: Dockerfile や requirements.txt の変更時に GHCR へイメージを自動 push するワークフロー。`workflow_dispatch` による手動トリガーも可能
- **`.github/workflows/ci.yml`**: `libreoffice-vrt` ジョブの `docker build` を `docker pull ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest` に変更

## 期待する効果

- Docker image ビルド: **~50秒 → 数秒**（pull のみ）
- libreoffice-vrt ジョブ全体: **~70-80秒 → ~30秒**

## マージ後の作業

1. GHCR パッケージの visibility を public に設定（pull に認証不要にするため）
2. `docker-image.yml` を `workflow_dispatch` で手動トリガーして初回イメージを GHCR に push

## テスト計画

- [ ] マージ後、`workflow_dispatch` で `docker-image.yml` を手動実行し、GHCR にイメージが push されることを確認
- [ ] GHCR パッケージの visibility を public に変更
- [ ] 次回 PR で `libreoffice-vrt` ジョブが正常に動作し、所要時間が短縮されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)