### PR TITLE
PRコメントにmainブランチとのテストカバレッジ比較を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,26 @@ jobs:
           path: coverage/
           retention-days: 7
 
+      - name: Checkout main branch for coverage comparison
+        if: matrix.node-version == 22 && github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: __main_branch
+
+      - name: Generate main branch coverage
+        if: matrix.node-version == 22 && github.event_name == 'pull_request'
+        working-directory: __main_branch
+        run: |
+          npm ci
+          npx vitest run --coverage --exclude 'vrt/**'
+
       - name: Coverage summary comment
         if: matrix.node-version == 22 && github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           json-summary-path: coverage/coverage-summary.json
+          json-summary-compare-path: __main_branch/coverage/coverage-summary.json
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## 概要

- PR時にmainブランチのテストカバレッジも取得し、差分を比較表示するようにした
- `davelosert/vitest-coverage-report-action@v2` の `json-summary-compare-path` パラメータを活用
- mainブランチを別ディレクトリ (`__main_branch`) にチェックアウトし、カバレッジを生成して比較

## 変更内容

- mainブランチをチェックアウトしてカバレッジを生成するステップを追加（Node 22 + PR イベント時のみ）
- カバレッジレポートアクションに `json-summary-compare-path` を追加

## テスト計画

- [ ] CIが正常に完了すること
- [ ] PRコメントにカバレッジ比較（↑↓ のトレンド表示）が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)