### PR TITLE
refactor: VRTテストケース定義を共通化して管理漏れを防ぐ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Visual regression tests for rendering output. When modifying the parser or rende
 vrt/
 ├── compare-utils.ts                          # Shared image comparison utilities
 ├── snapshot/                                 # Standard VRT (self-comparison, Docker-based)
+│   ├── vrt-cases.ts                          # Shared test case definitions
 │   ├── regression.test.ts                    # Test file
 │   ├── create-fixtures.ts                    # Fixture generation script
 │   ├── update-snapshots.ts                   # Snapshot update script
@@ -98,9 +99,11 @@ When changes to the parser, renderer, or model affect rendering output:
 
 When adding a new rendering feature, **all 3 of the following** must be updated:
 
-1. **`vrt/snapshot/create-fixtures.ts`** — Add fixtures (PPTX) covering the new feature
-2. **`vrt/snapshot/regression.test.ts`** — Add new test cases to the `VRT_CASES` array
+1. **`vrt/snapshot/vrt-cases.ts`** — Add a new entry to the `VRT_CASES` array
+2. **`vrt/snapshot/create-fixtures.ts`** — Add a fixture creator function and register it in `FIXTURE_CREATORS`
 3. **`vrt/snapshot/snapshots/`** — Regenerate snapshots with `npm run vrt:snapshot:update`
+
+`VRT_CASES` is the single source of truth shared by both `create-fixtures.ts` and `regression.test.ts`. If a case is added to `VRT_CASES` without a corresponding creator in `FIXTURE_CREATORS`, the fixture generation script will fail with an error.
 
 **Common mistake**: Modifying the parser or renderer but forgetting to update snapshots, causing VRT tests to fail. Always run `npm run vrt:snapshot:update` after making changes that affect rendering.
 

--- a/vrt/snapshot/create-fixtures.ts
+++ b/vrt/snapshot/create-fixtures.ts
@@ -8,6 +8,7 @@ import sharp from "sharp";
 import { writeFileSync, mkdirSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import { VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -5316,43 +5317,56 @@ async function createSpAutofitFixture(): Promise<void> {
   savePptx(buffer, "sp-autofit.pptx");
 }
 
+const FIXTURE_CREATORS: Record<string, () => Promise<void>> = {
+  "shapes.pptx": createShapesFixture,
+  "fill-and-lines.pptx": createFillAndLinesFixture,
+  "text.pptx": createTextFixture,
+  "transform.pptx": createTransformFixture,
+  "background.pptx": createBackgroundFixture,
+  "groups.pptx": createGroupsFixture,
+  "charts.pptx": createChartsFixture,
+  "connectors.pptx": createConnectorsFixture,
+  "custom-geometry.pptx": createCustomGeometryFixture,
+  "image.pptx": createImageFixture,
+  "tables.pptx": createTablesFixture,
+  "bullets.pptx": createBulletsFixture,
+  "flowchart.pptx": createFlowchartFixture,
+  "callouts-arcs.pptx": createCalloutsArcsFixture,
+  "arrows-stars.pptx": createArrowsStarsFixture,
+  "math-other.pptx": createMathOtherFixture,
+  "word-wrap.pptx": createWordWrapFixture,
+  "background-blipfill.pptx": createBackgroundBlipFillFixture,
+  "composite.pptx": createCompositeFixture,
+  "text-decoration.pptx": createTextDecorationFixture,
+  "slide-size-4-3.pptx": createSlideSize43Fixture,
+  "effects.pptx": createEffectsFixture,
+  "hyperlinks.pptx": createHyperlinksFixture,
+  "pattern-image-fill.pptx": createPatternImageFillFixture,
+  "smartart.pptx": createSmartArtFixture,
+  "theme-fonts.pptx": createThemeFontFixture,
+  "text-style-inheritance.pptx": createTextStyleInheritanceFixture,
+  "z-order-mixed.pptx": createZOrderMixedFixture,
+  "paragraph-spacing.pptx": createParagraphSpacingFixture,
+  "placeholder-overlap.pptx": createPlaceholderOverlapFixture,
+  "image-crop.pptx": createImageCropFixture,
+  "text-advanced.pptx": createTextAdvancedFixture,
+  "shrink-to-fit.pptx": createShrinkToFitFixture,
+  "sp-autofit.pptx": createSpAutofitFixture,
+};
+
 async function main(): Promise<void> {
   console.log("Creating VRT fixtures...\n");
 
-  await createShapesFixture();
-  await createFillAndLinesFixture();
-  await createTextFixture();
-  await createTransformFixture();
-  await createBackgroundFixture();
-  await createGroupsFixture();
-  await createChartsFixture();
-  await createConnectorsFixture();
-  await createCustomGeometryFixture();
-  await createImageFixture();
-  await createTablesFixture();
-  await createBulletsFixture();
-  await createFlowchartFixture();
-  await createCalloutsArcsFixture();
-  await createArrowsStarsFixture();
-  await createMathOtherFixture();
-  await createWordWrapFixture();
-  await createBackgroundBlipFillFixture();
-  await createCompositeFixture();
-  await createTextDecorationFixture();
-  await createSlideSize43Fixture();
-  await createEffectsFixture();
-  await createHyperlinksFixture();
-  await createPatternImageFillFixture();
-  await createSmartArtFixture();
-  await createThemeFontFixture();
-  await createTextStyleInheritanceFixture();
-  await createZOrderMixedFixture();
-  await createParagraphSpacingFixture();
-  await createPlaceholderOverlapFixture();
-  await createImageCropFixture();
-  await createTextAdvancedFixture();
-  await createShrinkToFitFixture();
-  await createSpAutofitFixture();
+  for (const { fixture } of VRT_CASES) {
+    const creator = FIXTURE_CREATORS[fixture];
+    if (!creator) {
+      throw new Error(
+        `No fixture creator found for "${fixture}". ` +
+          `Add a creator function to FIXTURE_CREATORS in create-fixtures.ts.`,
+      );
+    }
+    await creator();
+  }
 
   console.log("\nDone!");
 }

--- a/vrt/snapshot/regression.test.ts
+++ b/vrt/snapshot/regression.test.ts
@@ -3,6 +3,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { convertPptxToPng } from "../../src/converter.js";
 import { compareImages } from "../compare-utils.js";
+import { VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = join(__dirname, "snapshots");
@@ -11,43 +12,6 @@ const FIXTURE_DIR = join(__dirname, "fixtures");
 
 const PIXEL_THRESHOLD = 0.1;
 const MISMATCH_TOLERANCE = 0.015;
-
-const VRT_CASES = [
-  { name: "shapes", fixture: "shapes.pptx" },
-  { name: "fill-and-lines", fixture: "fill-and-lines.pptx" },
-  { name: "text", fixture: "text.pptx" },
-  { name: "transform", fixture: "transform.pptx" },
-  { name: "background", fixture: "background.pptx" },
-  { name: "groups", fixture: "groups.pptx" },
-  { name: "charts", fixture: "charts.pptx" },
-  { name: "connectors", fixture: "connectors.pptx" },
-  { name: "custom-geometry", fixture: "custom-geometry.pptx" },
-  { name: "image", fixture: "image.pptx" },
-  { name: "tables", fixture: "tables.pptx" },
-  { name: "bullets", fixture: "bullets.pptx" },
-  { name: "flowchart", fixture: "flowchart.pptx" },
-  { name: "callouts-arcs", fixture: "callouts-arcs.pptx" },
-  { name: "arrows-stars", fixture: "arrows-stars.pptx" },
-  { name: "math-other", fixture: "math-other.pptx" },
-  { name: "word-wrap", fixture: "word-wrap.pptx" },
-  { name: "background-blipfill", fixture: "background-blipfill.pptx" },
-  { name: "composite", fixture: "composite.pptx" },
-  { name: "text-decoration", fixture: "text-decoration.pptx" },
-  { name: "slide-size-4-3", fixture: "slide-size-4-3.pptx" },
-  { name: "effects", fixture: "effects.pptx" },
-  { name: "hyperlinks", fixture: "hyperlinks.pptx" },
-  { name: "pattern-image-fill", fixture: "pattern-image-fill.pptx" },
-  { name: "smartart", fixture: "smartart.pptx" },
-  { name: "theme-fonts", fixture: "theme-fonts.pptx" },
-  { name: "text-style-inheritance", fixture: "text-style-inheritance.pptx" },
-  { name: "z-order-mixed", fixture: "z-order-mixed.pptx" },
-  { name: "paragraph-spacing", fixture: "paragraph-spacing.pptx" },
-  { name: "placeholder-overlap", fixture: "placeholder-overlap.pptx" },
-  { name: "image-crop", fixture: "image-crop.pptx" },
-  { name: "text-advanced", fixture: "text-advanced.pptx" },
-  { name: "shrink-to-fit", fixture: "shrink-to-fit.pptx" },
-  { name: "sp-autofit", fixture: "sp-autofit.pptx" },
-] as const;
 
 describe("Visual Regression Tests", { timeout: 60000 }, () => {
   for (const { name, fixture } of VRT_CASES) {

--- a/vrt/snapshot/vrt-cases.ts
+++ b/vrt/snapshot/vrt-cases.ts
@@ -1,0 +1,44 @@
+/**
+ * VRT テストケース定義（共通）
+ *
+ * create-fixtures.ts と regression.test.ts の両方から参照される。
+ * 新しいフィクスチャを追加する際はここに追記すること。
+ */
+export const VRT_CASES = [
+  { name: "shapes", fixture: "shapes.pptx" },
+  { name: "fill-and-lines", fixture: "fill-and-lines.pptx" },
+  { name: "text", fixture: "text.pptx" },
+  { name: "transform", fixture: "transform.pptx" },
+  { name: "background", fixture: "background.pptx" },
+  { name: "groups", fixture: "groups.pptx" },
+  { name: "charts", fixture: "charts.pptx" },
+  { name: "connectors", fixture: "connectors.pptx" },
+  { name: "custom-geometry", fixture: "custom-geometry.pptx" },
+  { name: "image", fixture: "image.pptx" },
+  { name: "tables", fixture: "tables.pptx" },
+  { name: "bullets", fixture: "bullets.pptx" },
+  { name: "flowchart", fixture: "flowchart.pptx" },
+  { name: "callouts-arcs", fixture: "callouts-arcs.pptx" },
+  { name: "arrows-stars", fixture: "arrows-stars.pptx" },
+  { name: "math-other", fixture: "math-other.pptx" },
+  { name: "word-wrap", fixture: "word-wrap.pptx" },
+  { name: "background-blipfill", fixture: "background-blipfill.pptx" },
+  { name: "composite", fixture: "composite.pptx" },
+  { name: "text-decoration", fixture: "text-decoration.pptx" },
+  { name: "slide-size-4-3", fixture: "slide-size-4-3.pptx" },
+  { name: "effects", fixture: "effects.pptx" },
+  { name: "hyperlinks", fixture: "hyperlinks.pptx" },
+  { name: "pattern-image-fill", fixture: "pattern-image-fill.pptx" },
+  { name: "smartart", fixture: "smartart.pptx" },
+  { name: "theme-fonts", fixture: "theme-fonts.pptx" },
+  { name: "text-style-inheritance", fixture: "text-style-inheritance.pptx" },
+  { name: "z-order-mixed", fixture: "z-order-mixed.pptx" },
+  { name: "paragraph-spacing", fixture: "paragraph-spacing.pptx" },
+  { name: "placeholder-overlap", fixture: "placeholder-overlap.pptx" },
+  { name: "image-crop", fixture: "image-crop.pptx" },
+  { name: "text-advanced", fixture: "text-advanced.pptx" },
+  { name: "shrink-to-fit", fixture: "shrink-to-fit.pptx" },
+  { name: "sp-autofit", fixture: "sp-autofit.pptx" },
+] as const;
+
+export type VrtCase = (typeof VRT_CASES)[number];


### PR DESCRIPTION
close #188

## Summary

- `vrt/snapshot/vrt-cases.ts` を新規作成し、`VRT_CASES` 配列を一元管理するようにした
- `regression.test.ts` と `create-fixtures.ts` の両方から共通定義を参照する構成に変更
- `create-fixtures.ts` に `FIXTURE_CREATORS` マップを追加し、`VRT_CASES` に追加されたケースに対応する生成関数がない場合はエラーで検出できるようにした
- `CLAUDE.md` のドキュメントを更新

## Test plan

- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm run typecheck` パス
- [x] `npm run test` パス（VRT テストは fixture 未生成のためスキップ相当）
- [ ] CI（vrt ジョブ）でスナップショット VRT がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)