### PR TITLE
fix: スライドレイアウトのプレースホルダーテキストが表示される問題を修正

### DIFF
--- a/src/converter.test.ts
+++ b/src/converter.test.ts
@@ -512,3 +512,225 @@ describe("master placeholder text filtering", () => {
     expect(svg).toContain("MASTER_D");
   });
 });
+
+describe("layout placeholder text filtering", () => {
+  async function createPptxWithLayoutPlaceholder(): Promise<Buffer> {
+    const layoutWithPlaceholders = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="title">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name=""/>
+        <p:cNvGrpSpPr/>
+        <p:nvPr/>
+      </p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="Title 1"/>
+          <p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>
+          <p:nvPr><p:ph type="ctrTitle"/></p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="685800" y="1143000"/>
+            <a:ext cx="7772400" cy="1470025"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US" sz="4400"/>
+              <a:t>LAYOUT_TITLE_TEMPLATE</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="3" name="Subtitle 2"/>
+          <p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>
+          <p:nvPr><p:ph type="subTitle" idx="1"/></p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="1371600" y="2743200"/>
+            <a:ext cx="6400800" cy="1752600"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US" sz="2800"/>
+              <a:t>LAYOUT_SUBTITLE_TEMPLATE</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="4" name="Date Placeholder 3"/>
+          <p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>
+          <p:nvPr><p:ph type="dt" sz="half" idx="10"/></p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="457200" y="4800600"/>
+            <a:ext cx="2133600" cy="365125"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US" sz="1000"/>
+              <a:t>LAYOUT_DATE_TEMPLATE</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="5" name="Footer Placeholder 4"/>
+          <p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr>
+          <p:nvPr><p:ph type="ftr" sz="quarter" idx="11"/></p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="3124200" y="4800600"/>
+            <a:ext cx="2895600" cy="365125"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US" sz="1000"/>
+              <a:t>LAYOUT_FOOTER_TEMPLATE</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="6" name="Decorative Shape"/>
+          <p:cNvSpPr/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="0" y="0"/>
+            <a:ext cx="914400" cy="457200"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+          <a:solidFill><a:srgbClr val="0000FF"/></a:solidFill>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US" sz="1200"/>
+              <a:t>LAYOUT_DECORATIVE_TEXT</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sldLayout>`;
+
+    const simpleSlide = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name=""/>
+        <p:cNvGrpSpPr/>
+        <p:nvPr/>
+      </p:nvGrpSpPr>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="0" cy="0"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="0" cy="0"/>
+        </a:xfrm>
+      </p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="TextBox 1"/>
+          <p:cNvSpPr/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="457200" y="457200"/>
+            <a:ext cx="3048000" cy="914400"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US" sz="1800"/>
+              <a:t>SLIDE_ACTUAL_TEXT</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", contentTypes);
+    zip.file("_rels/.rels", rootRels);
+    zip.file("ppt/presentation.xml", presentationXml);
+    zip.file("ppt/_rels/presentation.xml.rels", presentationRels);
+    zip.file("ppt/slides/slide1.xml", simpleSlide);
+    zip.file("ppt/slides/_rels/slide1.xml.rels", slide1Rels);
+    zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
+    zip.file("ppt/slideMasters/_rels/slideMaster1.xml.rels", slideMaster1Rels);
+    zip.file("ppt/slideLayouts/slideLayout1.xml", layoutWithPlaceholders);
+    zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
+    zip.file("ppt/theme/theme1.xml", theme1);
+    return zip.generateAsync({ type: "nodebuffer" });
+  }
+
+  it("does not render layout placeholder text on actual slides", async () => {
+    const pptx = await createPptxWithLayoutPlaceholder();
+    const results = await convertPptxToSvg(pptx);
+    const svg = results[0].svg;
+
+    // Layout placeholder template text should NOT appear
+    expect(svg).not.toContain("LAYOUT_TITLE_TEMPLATE");
+    expect(svg).not.toContain("LAYOUT_SUBTITLE_TEMPLATE");
+    expect(svg).not.toContain("LAYOUT_DATE_TEMPLATE");
+    expect(svg).not.toContain("LAYOUT_FOOTER_TEMPLATE");
+
+    // Slide's own text should appear
+    expect(svg).toContain("SLIDE_ACTUAL_TEXT");
+  });
+
+  it("renders non-placeholder decorative shapes from layout", async () => {
+    const pptx = await createPptxWithLayoutPlaceholder();
+    const results = await convertPptxToSvg(pptx);
+    const svg = results[0].svg;
+
+    // Non-placeholder layout shapes (decorative) should still appear
+    expect(svg).toContain("LAYOUT_D");
+  });
+});

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -253,39 +253,22 @@ export async function convertPptxToPng(
   return results;
 }
 
-function collectPlaceholderTypes(elements: SlideElement[]): Set<string> {
-  const types = new Set<string>();
-  for (const el of elements) {
-    if (el.type === "shape" && el.placeholderType) {
-      types.add(el.placeholderType);
-    }
-  }
-  return types;
-}
-
-function filterByPlaceholder(elements: SlideElement[], excludeTypes: Set<string>): SlideElement[] {
-  return elements.filter((el) => {
-    if (el.type !== "shape") return true;
-    if (!el.placeholderType) return true;
-    return !excludeTypes.has(el.placeholderType);
-  });
-}
-
 function mergeElements(
   masterElements: SlideElement[],
   layoutElements: SlideElement[],
   slideElements: SlideElement[],
 ): SlideElement[] {
-  const slidePh = collectPlaceholderTypes(slideElements);
-
-  // Master placeholder shapes are always templates (position/style definitions).
+  // Placeholder shapes in master and layout are templates (position/style definitions).
   // Their text content should never appear on actual slides.
-  // Only non-placeholder master shapes (decorative elements, logos, etc.) are shown.
-  const filteredMaster = masterElements.filter((el) => {
-    if (el.type !== "shape") return true;
-    return !el.placeholderType;
-  });
-  const filteredLayout = filterByPlaceholder(layoutElements, slidePh);
+  // Only non-placeholder shapes (decorative elements, logos, etc.) are shown.
+  const filterPlaceholders = (elements: SlideElement[]) =>
+    elements.filter((el) => {
+      if (el.type !== "shape") return true;
+      return !el.placeholderType;
+    });
+
+  const filteredMaster = filterPlaceholders(masterElements);
+  const filteredLayout = filterPlaceholders(layoutElements);
 
   return [...filteredMaster, ...filteredLayout, ...slideElements];
 }


### PR DESCRIPTION
close #25

## Summary

- PR #184 ではスライドマスターのプレースホルダーテキストのフィルタリングが修正されたが、スライドレイアウトのプレースホルダーには同じ修正が適用されていなかった
- `mergeElements` でレイアウトのプレースホルダーシェイプもすべてフィルタリングするように変更
- 非プレースホルダーのレイアウトシェイプ（装飾要素等）は引き続き表示される

## 原因

`mergeElements` 関数では、レイアウトのプレースホルダーシェイプのうち、スライドでオーバーライドされているもののみをフィルタリングしていた。しかし、スライドにオーバーライドがない場合（例: スライドにタイトルプレースホルダーがない場合）、レイアウトのテンプレートテキスト（ctrTitle, subTitle, dt, ftr, sldNum 等）がそのまま表示されてしまっていた。

PowerPoint では、レイアウトのプレースホルダーシェイプはマスターと同様にあくまで位置とスタイルのテンプレートであり、スライドでオーバーライドされない限りテキスト内容は表示されない。

## 変更内容

- `src/converter.ts`: `mergeElements` のレイアウト要素フィルタリングをマスターと同じロジックに統一。不要になった `collectPlaceholderTypes` と `filterByPlaceholder` を削除
- `src/converter.test.ts`: レイアウトプレースホルダーのテキストが表示されないこと、および非プレースホルダーの装飾シェイプは表示されることを検証するテストを追加

## Test plan

- [x] 既存の全ユニットテスト通過（663 テスト）
- [x] TypeScript 型チェック通過
- [x] ESLint / Prettier チェック通過
- [x] 新規テスト: レイアウトプレースホルダーテキスト（title, subtitle, date, footer）が SVG に含まれないことを検証
- [x] 新規テスト: 非プレースホルダーのレイアウト装飾シェイプテキストは表示されることを検証
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)