### PR TITLE
fix: libreoffice-vrt の docker pull にフォールバックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Pull Docker image
-        run: docker pull ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest
+      - name: Pull or build Docker image
+        run: docker pull ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest || docker build -t ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest docker/libreoffice-vrt
 
       - name: Generate fixtures
         run: docker run --rm -v "${{ github.workspace }}":/workspace ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest python3 /workspace/vrt/libreoffice/create_fixtures.py


### PR DESCRIPTION
## Summary
- `libreoffice-vrt` ジョブの Docker イメージ取得ステップに、`vrt` ジョブと同様の `|| docker build` フォールバックを追加
- ステップ名も `Pull Docker image` → `Pull or build Docker image` に統一

## Test plan
- [ ] CI の libreoffice-vrt ジョブが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)