### PR TITLE
feat: @resvg/resvg-js ネイティブ版を優先使用し WASM にフォールバック

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "jszip": "^3.10.0"
       },
       "devDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "@types/node": "^25.2.2",
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^3.2.4",
@@ -32,6 +33,18 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "peerDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
+        "opentype.js": "^1.3.4"
+      },
+      "peerDependenciesMeta": {
+        "@resvg/resvg-js": {
+          "optional": true
+        },
+        "opentype.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1368,6 +1381,234 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@resvg/resvg-wasm": {

--- a/package.json
+++ b/package.json
@@ -61,9 +61,13 @@
   "author": "hirokisakabe",
   "license": "MIT",
   "peerDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "opentype.js": "^1.3.4"
   },
   "peerDependenciesMeta": {
+    "@resvg/resvg-js": {
+      "optional": true
+    },
     "opentype.js": {
       "optional": true
     }
@@ -74,6 +78,7 @@
     "jszip": "^3.10.0"
   },
   "devDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "@types/node": "^25.2.2",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.2.4",

--- a/src/png/native-resvg.ts
+++ b/src/png/native-resvg.ts
@@ -1,0 +1,30 @@
+export interface ResvgInstance {
+  render(): RenderedImage;
+  free?(): void;
+}
+
+export interface RenderedImage {
+  asPng(): Uint8Array;
+  width: number;
+  height: number;
+  free?(): void;
+}
+
+export type ResvgConstructor = new (
+  svg: string,
+  options?: Record<string, unknown>,
+) => ResvgInstance;
+
+let nativeResvg: ResvgConstructor | null | undefined; // undefined = not yet tried
+
+export async function tryLoadNativeResvg(): Promise<ResvgConstructor | null> {
+  if (nativeResvg !== undefined) return nativeResvg;
+  try {
+    const mod = await import("@resvg/resvg-js");
+    nativeResvg = mod.Resvg as ResvgConstructor;
+    return nativeResvg;
+  } catch {
+    nativeResvg = null;
+    return null;
+  }
+}

--- a/src/png/png-converter.ts
+++ b/src/png/png-converter.ts
@@ -1,5 +1,6 @@
 import { Resvg } from "@resvg/resvg-wasm";
 import { ensureWasmInitialized } from "./wasm-init.js";
+import { tryLoadNativeResvg, type ResvgConstructor } from "./native-resvg.js";
 import type { FontOptions } from "../converter.js";
 
 export interface PngConvertOptions {
@@ -12,8 +13,23 @@ export async function svgToPng(
   svgString: string,
   options?: PngConvertOptions,
 ): Promise<{ png: Uint8Array; width: number; height: number }> {
-  await ensureWasmInitialized();
+  const NativeResvg = await tryLoadNativeResvg();
 
+  if (NativeResvg) {
+    return renderWithResvg(NativeResvg, svgString, options, true);
+  }
+
+  // WASM fallback
+  await ensureWasmInitialized();
+  return renderWithResvg(Resvg as unknown as ResvgConstructor, svgString, options, false);
+}
+
+function renderWithResvg(
+  ResvgClass: ResvgConstructor,
+  svgString: string,
+  options: PngConvertOptions | undefined,
+  defaultLoadSystemFonts: boolean,
+): { png: Uint8Array; width: number; height: number } {
   const fitTo = options?.width
     ? { mode: "width" as const, value: options.width }
     : options?.height
@@ -22,9 +38,9 @@ export async function svgToPng(
 
   const resvgOptions: Record<string, unknown> = { fitTo };
 
+  const fontOption: Record<string, unknown> = {};
   if (options?.fonts) {
     const f = options.fonts;
-    const fontOption: Record<string, unknown> = {};
     if (f.loadSystemFonts !== undefined) fontOption.loadSystemFonts = f.loadSystemFonts;
     if (f.fontFiles) fontOption.fontFiles = f.fontFiles;
     if (f.fontDirs) fontOption.fontDirs = f.fontDirs;
@@ -36,17 +52,25 @@ export async function svgToPng(
     if (f.defaultFontFamily) fontOption.defaultFontFamily = f.defaultFontFamily;
     if (f.sansSerifFamily) fontOption.sansSerifFamily = f.sansSerifFamily;
     if (f.serifFamily) fontOption.serifFamily = f.serifFamily;
+  }
+
+  // ネイティブ版: loadSystemFonts が未指定なら true をデフォルトに
+  if (fontOption.loadSystemFonts === undefined && defaultLoadSystemFonts) {
+    fontOption.loadSystemFonts = true;
+  }
+
+  if (Object.keys(fontOption).length > 0) {
     resvgOptions.font = fontOption;
   }
 
-  const resvg = new Resvg(svgString, resvgOptions);
+  const resvg = new ResvgClass(svgString, resvgOptions);
 
   const rendered = resvg.render();
   const png = rendered.asPng();
   const { width, height } = rendered;
 
-  rendered.free();
-  resvg.free();
+  rendered.free?.();
+  resvg.free?.();
 
   return { png, width, height };
 }


### PR DESCRIPTION
close #214

## 概要

Node.js 環境で `@resvg/resvg-js` (ネイティブバインディング) を動的インポートで優先使用することで、システムフォントの自動読み込みを可能にする。ネイティブ版が利用できない場合（ブラウザ等）は従来の `@resvg/resvg-wasm` にフォールバックする。

## 変更内容

- `@resvg/resvg-js` を optional peer dependency として追加
- `src/png/native-resvg.ts` を新規作成: ネイティブ版の動的インポートとキャッシュ
- `src/png/png-converter.ts` を修正: ネイティブ版を優先使用、WASM へのフォールバック
  - ネイティブ版使用時は `loadSystemFonts: true` をデフォルトに設定
  - 共通レンダリングロジックを `renderWithResvg` ヘルパーに抽出

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run test` (VRT除外) 全742テストパス（`convertPptxToPng` テスト含む）
- [x] `npm run build` 成功
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)