### PR TITLE
fix: デモアプリビルドで @resvg/resvg-js ネイティブバイナリの解析を回避

### DIFF
--- a/src/png/native-resvg.ts
+++ b/src/png/native-resvg.ts
@@ -20,8 +20,11 @@ let nativeResvg: ResvgConstructor | null | undefined; // undefined = not yet tri
 export async function tryLoadNativeResvg(): Promise<ResvgConstructor | null> {
   if (nativeResvg !== undefined) return nativeResvg;
   try {
-    const mod = await import("@resvg/resvg-js");
-    nativeResvg = mod.Resvg as ResvgConstructor;
+    // Use a variable to prevent bundlers from statically resolving this optional import
+    const specifier = "@resvg/resvg-js";
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const mod: { Resvg: ResvgConstructor } = await import(/* @vite-ignore */ specifier);
+    nativeResvg = mod.Resvg;
     return nativeResvg;
   } catch {
     nativeResvg = null;


### PR DESCRIPTION
close #221

## 概要

- `native-resvg.ts` の `import("@resvg/resvg-js")` を変数経由 + `/* @vite-ignore */` に変更し、Vite/Rollup の静的解析によるネイティブバイナリ (`.node`) のバンドル失敗を修正

## 変更内容

`src/png/native-resvg.ts` の動的 import を以下のように修正:

- import specifier を変数に格納し、Rollup がモジュールを静的に解決しないようにする
- `/* @vite-ignore */` コメントで Vite の動的 import 警告を抑制

## Test plan

- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm run typecheck` パス
- [x] `npm run test` (VRT除外) 全742テストパス
- [x] `npm run build` 成功
- [x] デモアプリ `cd demo && npm run build` 成功（修正前は `.node` バイナリで失敗）
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)