### PR TITLE
feat: フォントマッピングテーブル + 使用フォント収集 API

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,40 +1,15 @@
-import { readPptx } from "./parser/pptx-reader.js";
-import { parsePresentation } from "./parser/presentation-parser.js";
-import { parseTheme } from "./parser/theme-parser.js";
-import type { Theme } from "./model/theme.js";
-import {
-  parseSlideMasterColorMap,
-  parseSlideMasterBackground,
-  parseSlideMasterElements,
-  parseSlideMasterTxStyles,
-  parseSlideMasterPlaceholderStyles,
-} from "./parser/slide-master-parser.js";
-import {
-  parseSlideLayoutBackground,
-  parseSlideLayoutElements,
-  parseSlideLayoutPlaceholderStyles,
-  parseSlideLayoutShowMasterSp,
-} from "./parser/slide-layout-parser.js";
-import { parseSlide } from "./parser/slide-parser.js";
-import {
-  parseRelationships,
-  resolveRelationshipTarget,
-  buildRelsPath,
-  type Relationship,
-} from "./parser/relationship-parser.js";
-import type { FillParseContext } from "./parser/fill-parser.js";
-import { ColorResolver } from "./color/color-resolver.js";
 import { renderSlideToSvg } from "./renderer/svg-renderer.js";
 import { svgToPng } from "./png/png-converter.js";
 import { DEFAULT_OUTPUT_WIDTH } from "./utils/constants.js";
-import type { ColorMap } from "./model/theme.js";
-import type { PlaceholderStyleInfo } from "./model/text.js";
 import type { SlideElement } from "./model/shape.js";
-import { applyTextStyleInheritance } from "./text-style-resolver.js";
 import type { LogLevel } from "./warning-logger.js";
 import { initWarningLogger, flushWarnings } from "./warning-logger.js";
 import type { TextMeasurer } from "./text-measurer.js";
 import { setTextMeasurer, resetTextMeasurer } from "./text-measurer.js";
+import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
+import type { FontMapping } from "./font-mapping.js";
+import { createFontMapping } from "./font-mapping.js";
+import { setFontMapping, resetFontMapping } from "./font-mapping-context.js";
 
 export interface FontOptions {
   /** resvg-wasm に渡すフォントファイルパス (Node.js 向け) */
@@ -66,6 +41,8 @@ export interface ConvertOptions {
   textMeasurer?: TextMeasurer;
   /** PNG 変換時のフォント設定 (resvg-wasm オプション) */
   fonts?: FontOptions;
+  /** PPTX フォント名 → OSS 代替フォントのカスタムマッピング。デフォルトマッピングにマージされる */
+  fontMapping?: FontMapping;
 }
 
 export interface SlideSvg {
@@ -87,189 +64,31 @@ export async function convertPptxToSvg(
   if (options?.textMeasurer) {
     setTextMeasurer(options.textMeasurer);
   }
+  setFontMapping(createFontMapping(options?.fontMapping));
   try {
     initWarningLogger(options?.logLevel ?? "off");
 
-    const archive = await readPptx(input);
-
-    // Parse presentation.xml
-    const presentationXml = archive.files.get("ppt/presentation.xml");
-    if (!presentationXml) throw new Error("Invalid PPTX: missing ppt/presentation.xml");
-    const presInfo = parsePresentation(presentationXml);
-
-    // Parse presentation relationships
-    const presRelsXml = archive.files.get("ppt/_rels/presentation.xml.rels");
-    const presRels = presRelsXml
-      ? parseRelationships(presRelsXml)
-      : new Map<string, Relationship>();
-
-    // Parse theme
-    let theme: Theme = {
-      colorScheme: defaultColorScheme(),
-      fontScheme: {
-        majorFont: "Calibri",
-        minorFont: "Calibri",
-        majorFontEa: null,
-        minorFontEa: null,
-      },
-    };
-    for (const [, rel] of presRels) {
-      if (rel.type.includes("theme")) {
-        const themePath = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
-        const themeXml = archive.files.get(themePath);
-        if (themeXml) {
-          theme = parseTheme(themeXml);
-        }
-        break;
-      }
-    }
-
-    // Parse slide master for color map and background
-    let colorMap: ColorMap = defaultColorMap();
-    let masterPath: string | null = null;
-    for (const [, rel] of presRels) {
-      if (rel.type.includes("slideMaster")) {
-        masterPath = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
-        const masterXml = archive.files.get(masterPath);
-        if (masterXml) {
-          colorMap = parseSlideMasterColorMap(masterXml);
-        }
-        break;
-      }
-    }
-
-    const colorResolver = new ColorResolver(theme.colorScheme, colorMap);
-
-    // Parse master background and shapes (used as fallback)
-    const masterXml = masterPath ? archive.files.get(masterPath) : undefined;
-    let masterFillContext: FillParseContext | undefined;
-    if (masterPath) {
-      const masterRelsPath = buildRelsPath(masterPath);
-      const masterRelsXml = archive.files.get(masterRelsPath);
-      const masterRels = masterRelsXml
-        ? parseRelationships(masterRelsXml)
-        : new Map<string, Relationship>();
-      masterFillContext = { rels: masterRels, archive, basePath: masterPath };
-    }
-    const masterBackground = masterXml
-      ? parseSlideMasterBackground(masterXml, colorResolver, masterFillContext)
-      : null;
-    const masterElements =
-      masterPath && masterXml
-        ? parseSlideMasterElements(
-            masterXml,
-            masterPath,
-            archive,
-            colorResolver,
-            theme.fontScheme,
-            theme.fmtScheme,
-          )
-        : [];
-    const masterTxStyles = masterXml
-      ? parseSlideMasterTxStyles(masterXml, colorResolver)
-      : undefined;
-    const masterPlaceholderStyles = masterXml
-      ? parseSlideMasterPlaceholderStyles(masterXml, colorResolver)
-      : [];
-    // Resolve slide paths from relationships
-    const slidePaths: { slideNumber: number; path: string }[] = [];
-    for (let i = 0; i < presInfo.slideRIds.length; i++) {
-      const rId = presInfo.slideRIds[i];
-      const rel = presRels.get(rId);
-      if (rel) {
-        const path = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
-        slidePaths.push({ slideNumber: i + 1, path });
-      }
-    }
+    const data = await parsePptxData(input);
 
     // Filter slides if specified
     const targetSlides = options?.slides
-      ? slidePaths.filter((s) => options.slides!.includes(s.slideNumber))
-      : slidePaths;
+      ? data.slidePaths.filter((s) => options.slides!.includes(s.slideNumber))
+      : data.slidePaths;
 
     // Parse and render each slide
     const results: SlideSvg[] = [];
     for (const { slideNumber, path } of targetSlides) {
-      const slideXml = archive.files.get(path);
-      if (!slideXml) continue;
+      const parsed = parseSlideWithLayout(slideNumber, path, data);
+      if (!parsed) continue;
 
-      const slide = parseSlide(
-        slideXml,
-        path,
-        slideNumber,
-        archive,
-        colorResolver,
-        theme.fontScheme,
-        theme.fmtScheme,
-      );
-
-      // Resolve slide layout
-      let layoutElements: SlideElement[] = [];
-      let layoutPlaceholderStyles: PlaceholderStyleInfo[] = [];
-      let layoutShowMasterSp = true;
-      const slideRelsPath = buildRelsPath(path);
-      const slideRelsXml = archive.files.get(slideRelsPath);
-      if (slideRelsXml) {
-        const slideRels = parseRelationships(slideRelsXml);
-        for (const [, rel] of slideRels) {
-          if (rel.type.includes("slideLayout")) {
-            const layoutPath = resolveRelationshipTarget(path, rel.target);
-            const layoutXml = archive.files.get(layoutPath);
-            if (layoutXml) {
-              // Fallback background: slide → layout → master
-              if (!slide.background) {
-                const layoutRelsPath = buildRelsPath(layoutPath);
-                const layoutRelsXml = archive.files.get(layoutRelsPath);
-                const layoutRels = layoutRelsXml
-                  ? parseRelationships(layoutRelsXml)
-                  : new Map<string, Relationship>();
-                const layoutFillContext: FillParseContext = {
-                  rels: layoutRels,
-                  archive,
-                  basePath: layoutPath,
-                };
-                slide.background = parseSlideLayoutBackground(
-                  layoutXml,
-                  colorResolver,
-                  layoutFillContext,
-                );
-              }
-              // Parse layout shapes
-              layoutElements = parseSlideLayoutElements(
-                layoutXml,
-                layoutPath,
-                archive,
-                colorResolver,
-                theme.fontScheme,
-                theme.fmtScheme,
-              );
-              // Extract placeholder styles for text style inheritance
-              layoutPlaceholderStyles = parseSlideLayoutPlaceholderStyles(layoutXml, colorResolver);
-              layoutShowMasterSp = parseSlideLayoutShowMasterSp(layoutXml);
-            }
-            break;
-          }
-        }
-      }
-      if (!slide.background) {
-        slide.background = masterBackground;
-      }
-
-      // Apply text style inheritance chain before merging
-      applyTextStyleInheritance(slide.elements, {
-        layoutPlaceholderStyles,
-        masterPlaceholderStyles,
-        txStyles: masterTxStyles,
-        defaultTextStyle: presInfo.defaultTextStyle,
-        fontScheme: theme.fontScheme,
-      });
+      const { slide, layoutElements, layoutShowMasterSp } = parsed;
 
       // Merge shapes: master (back) → layout → slide (front)
       const effectiveMasterElements =
-        slide.showMasterSp && layoutShowMasterSp ? masterElements : [];
+        slide.showMasterSp && layoutShowMasterSp ? data.masterElements : [];
       slide.elements = mergeElements(effectiveMasterElements, layoutElements, slide.elements);
 
-      const svg = renderSlideToSvg(slide, presInfo.slideSize);
+      const svg = renderSlideToSvg(slide, data.presInfo.slideSize);
       results.push({ slideNumber, svg });
     }
 
@@ -278,6 +97,7 @@ export async function convertPptxToSvg(
     return results;
   } finally {
     resetTextMeasurer();
+    resetFontMapping();
   }
 }
 
@@ -322,38 +142,4 @@ function mergeElements(
   const filteredLayout = filterPlaceholders(layoutElements);
 
   return [...filteredMaster, ...filteredLayout, ...slideElements];
-}
-
-function defaultColorScheme() {
-  return {
-    dk1: "#000000",
-    lt1: "#FFFFFF",
-    dk2: "#44546A",
-    lt2: "#E7E6E6",
-    accent1: "#4472C4",
-    accent2: "#ED7D31",
-    accent3: "#A5A5A5",
-    accent4: "#FFC000",
-    accent5: "#5B9BD5",
-    accent6: "#70AD47",
-    hlink: "#0563C1",
-    folHlink: "#954F72",
-  };
-}
-
-function defaultColorMap() {
-  return {
-    bg1: "lt1" as const,
-    tx1: "dk1" as const,
-    bg2: "lt2" as const,
-    tx2: "dk2" as const,
-    accent1: "accent1" as const,
-    accent2: "accent2" as const,
-    accent3: "accent3" as const,
-    accent4: "accent4" as const,
-    accent5: "accent5" as const,
-    accent6: "accent6" as const,
-    hlink: "hlink" as const,
-    folHlink: "folHlink" as const,
-  };
 }

--- a/src/font-collector.test.ts
+++ b/src/font-collector.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import JSZip from "jszip";
+import { collectUsedFonts } from "./font-collector.js";
+
+const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+  <Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>
+  <Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>
+  <Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+</Types>`;
+
+const rootRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>`;
+
+const presentationXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:sldMasterIdLst>
+    <p:sldMasterId r:id="rId1"/>
+  </p:sldMasterIdLst>
+  <p:sldIdLst>
+    <p:sldId id="256" r:id="rId2"/>
+  </p:sldIdLst>
+  <p:sldSz cx="9144000" cy="5143500" type="screen16x9"/>
+</p:presentation>`;
+
+const presentationRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+</Relationships>`;
+
+const slide1Xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name=""/>
+        <p:cNvGrpSpPr/>
+        <p:nvPr/>
+      </p:nvGrpSpPr>
+      <p:grpSpPr/>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="Shape 1"/>
+          <p:cNvSpPr/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="457200" y="274638"/>
+            <a:ext cx="3048000" cy="1143000"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-US">
+                <a:latin typeface="Arial"/>
+                <a:ea typeface="MS PGothic"/>
+                <a:cs typeface="Arial"/>
+              </a:rPr>
+              <a:t>Hello</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="3" name="Shape 2"/>
+          <p:cNvSpPr/>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="4572000" y="274638"/>
+            <a:ext cx="3048000" cy="1143000"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="ja-JP">
+                <a:latin typeface="Times New Roman"/>
+                <a:ea typeface="Yu Gothic"/>
+              </a:rPr>
+              <a:t>World</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+
+const slide1Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+</Relationships>`;
+
+const slideMaster1 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+    </p:spTree>
+  </p:cSld>
+  <p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>
+</p:sldMaster>`;
+
+const slideMaster1Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>`;
+
+const slideLayout1 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="blank">
+  <p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+</p:sldLayout>`;
+
+const slideLayout1Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
+</Relationships>`;
+
+const theme1 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+  <a:themeElements>
+    <a:clrScheme name="Office">
+      <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+      <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+      <a:dk2><a:srgbClr val="44546A"/></a:dk2>
+      <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+      <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+      <a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+      <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>
+      <a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+      <a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>
+      <a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+      <a:hlink><a:srgbClr val="0563C1"/></a:hlink>
+      <a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+    </a:clrScheme>
+    <a:fontScheme name="Office">
+      <a:majorFont>
+        <a:latin typeface="Calibri Light"/>
+        <a:ea typeface="MS PGothic"/>
+        <a:cs typeface="Times New Roman"/>
+      </a:majorFont>
+      <a:minorFont>
+        <a:latin typeface="Calibri"/>
+        <a:ea typeface="MS PGothic"/>
+        <a:cs typeface="Arial"/>
+      </a:minorFont>
+    </a:fontScheme>
+    <a:fmtScheme name="Office"/>
+  </a:themeElements>
+</a:theme>`;
+
+async function createTestPptx(): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypes);
+  zip.file("_rels/.rels", rootRels);
+  zip.file("ppt/presentation.xml", presentationXml);
+  zip.file("ppt/_rels/presentation.xml.rels", presentationRels);
+  zip.file("ppt/slides/slide1.xml", slide1Xml);
+  zip.file("ppt/slides/_rels/slide1.xml.rels", slide1Rels);
+  zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
+  zip.file("ppt/slideMasters/_rels/slideMaster1.xml.rels", slideMaster1Rels);
+  zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
+  zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
+  zip.file("ppt/theme/theme1.xml", theme1);
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+let testPptx: Buffer;
+
+beforeAll(async () => {
+  testPptx = await createTestPptx();
+});
+
+describe("collectUsedFonts", () => {
+  it("テーマフォント情報を返す", async () => {
+    const result = await collectUsedFonts(testPptx);
+
+    expect(result.theme.majorFont).toBe("Calibri Light");
+    expect(result.theme.minorFont).toBe("Calibri");
+    expect(result.theme.majorFontEa).toBe("MS PGothic");
+    expect(result.theme.minorFontEa).toBe("MS PGothic");
+    expect(result.theme.majorFontCs).toBe("Times New Roman");
+    expect(result.theme.minorFontCs).toBe("Arial");
+  });
+
+  it("テキストランのフォント名を収集する", async () => {
+    const result = await collectUsedFonts(testPptx);
+
+    // テキストランで指定されたフォント
+    expect(result.fonts).toContain("Arial");
+    expect(result.fonts).toContain("MS PGothic");
+    expect(result.fonts).toContain("Times New Roman");
+    expect(result.fonts).toContain("Yu Gothic");
+  });
+
+  it("テーマフォント名も fonts 一覧に含まれる", async () => {
+    const result = await collectUsedFonts(testPptx);
+
+    expect(result.fonts).toContain("Calibri Light");
+    expect(result.fonts).toContain("Calibri");
+  });
+
+  it("フォント名は重複なしでソート済み", async () => {
+    const result = await collectUsedFonts(testPptx);
+
+    // 重複がないことを確認
+    const unique = [...new Set(result.fonts)];
+    expect(result.fonts).toEqual(unique);
+
+    // ソートされていることを確認
+    const sorted = [...result.fonts].sort();
+    expect(result.fonts).toEqual(sorted);
+  });
+});

--- a/src/font-collector.ts
+++ b/src/font-collector.ts
@@ -1,0 +1,98 @@
+/**
+ * PPTX から使用フォント名を収集する API。
+ */
+import type { SlideElement } from "./model/shape.js";
+import type { TextBody } from "./model/text.js";
+import type { FontScheme } from "./model/theme.js";
+import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
+
+/** フォント収集結果 */
+export interface UsedFonts {
+  /** テーマで定義されたフォント */
+  theme: {
+    majorFont: string;
+    minorFont: string;
+    majorFontEa: string | null;
+    minorFontEa: string | null;
+    majorFontCs: string | null;
+    minorFontCs: string | null;
+  };
+  /** テキストランやテーマで使用されているフォント名の一覧（重複なし、ソート済み） */
+  fonts: string[];
+}
+
+/**
+ * PPTX をパースして使用されているフォント名を収集する。
+ * レンダリングは行わないため軽量。
+ */
+export async function collectUsedFonts(input: Buffer | Uint8Array): Promise<UsedFonts> {
+  const data = await parsePptxData(input);
+  const fontScheme = data.theme.fontScheme;
+
+  const fonts = new Set<string>();
+
+  // テーマフォントを収集
+  collectThemeFonts(fontScheme, fonts);
+
+  // 各スライドから収集
+  for (const { slideNumber, path } of data.slidePaths) {
+    const parsed = parseSlideWithLayout(slideNumber, path, data);
+    if (!parsed) continue;
+    collectFontsFromElements(parsed.slide.elements, fonts);
+  }
+
+  // マスター要素からも収集
+  collectFontsFromElements(data.masterElements, fonts);
+
+  return {
+    theme: {
+      majorFont: fontScheme.majorFont,
+      minorFont: fontScheme.minorFont,
+      majorFontEa: fontScheme.majorFontEa,
+      minorFontEa: fontScheme.minorFontEa,
+      majorFontCs: fontScheme.majorFontCs,
+      minorFontCs: fontScheme.minorFontCs,
+    },
+    fonts: [...fonts].sort(),
+  };
+}
+
+function collectThemeFonts(fontScheme: FontScheme, fonts: Set<string>): void {
+  fonts.add(fontScheme.majorFont);
+  fonts.add(fontScheme.minorFont);
+  if (fontScheme.majorFontEa) fonts.add(fontScheme.majorFontEa);
+  if (fontScheme.minorFontEa) fonts.add(fontScheme.minorFontEa);
+  if (fontScheme.majorFontCs) fonts.add(fontScheme.majorFontCs);
+  if (fontScheme.minorFontCs) fonts.add(fontScheme.minorFontCs);
+}
+
+function collectFontsFromElements(elements: SlideElement[], fonts: Set<string>): void {
+  for (const el of elements) {
+    switch (el.type) {
+      case "shape":
+        if (el.textBody) collectFontsFromTextBody(el.textBody, fonts);
+        break;
+      case "group":
+        collectFontsFromElements(el.children, fonts);
+        break;
+      case "table":
+        for (const row of el.table.rows) {
+          for (const cell of row.cells) {
+            if (cell.textBody) collectFontsFromTextBody(cell.textBody, fonts);
+          }
+        }
+        break;
+    }
+  }
+}
+
+function collectFontsFromTextBody(textBody: TextBody, fonts: Set<string>): void {
+  for (const para of textBody.paragraphs) {
+    if (para.properties.bulletFont) fonts.add(para.properties.bulletFont);
+    for (const run of para.runs) {
+      if (run.properties.fontFamily) fonts.add(run.properties.fontFamily);
+      if (run.properties.fontFamilyEa) fonts.add(run.properties.fontFamilyEa);
+      if (run.properties.fontFamilyCs) fonts.add(run.properties.fontFamilyCs);
+    }
+  }
+}

--- a/src/font-mapping-context.ts
+++ b/src/font-mapping-context.ts
@@ -1,0 +1,27 @@
+/**
+ * レンダリング中のフォントマッピングテーブルをモジュールレベルで保持する。
+ * text-measurer.ts の setTextMeasurer/resetTextMeasurer パターンと同じ。
+ */
+import type { FontMapping } from "./font-mapping.js";
+import { DEFAULT_FONT_MAPPING, getMappedFont } from "./font-mapping.js";
+
+let currentMapping: FontMapping = { ...DEFAULT_FONT_MAPPING };
+
+export function setFontMapping(mapping: FontMapping): void {
+  currentMapping = mapping;
+}
+
+export function getFontMapping(): FontMapping {
+  return currentMapping;
+}
+
+export function resetFontMapping(): void {
+  currentMapping = { ...DEFAULT_FONT_MAPPING };
+}
+
+/**
+ * 現在のマッピングテーブルから OSS 代替フォント名を取得するショートカット。
+ */
+export function getCurrentMappedFont(fontFamily: string | null | undefined): string | null {
+  return getMappedFont(fontFamily, currentMapping);
+}

--- a/src/font-mapping.test.ts
+++ b/src/font-mapping.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_FONT_MAPPING,
+  createFontMapping,
+  getMappedFont,
+  type FontMapping,
+} from "./font-mapping.js";
+
+describe("DEFAULT_FONT_MAPPING", () => {
+  it("ラテン文字フォントのマッピングが定義されている", () => {
+    expect(DEFAULT_FONT_MAPPING["Calibri"]).toBe("Carlito");
+    expect(DEFAULT_FONT_MAPPING["Arial"]).toBe("Arimo");
+    expect(DEFAULT_FONT_MAPPING["Times New Roman"]).toBe("Tinos");
+    expect(DEFAULT_FONT_MAPPING["Courier New"]).toBe("Cousine");
+    expect(DEFAULT_FONT_MAPPING["Cambria"]).toBe("Caladea");
+  });
+
+  it("日本語ゴシック系フォントが Noto Sans JP にマッピングされている", () => {
+    expect(DEFAULT_FONT_MAPPING["メイリオ"]).toBe("Noto Sans JP");
+    expect(DEFAULT_FONT_MAPPING["Meiryo"]).toBe("Noto Sans JP");
+    expect(DEFAULT_FONT_MAPPING["游ゴシック"]).toBe("Noto Sans JP");
+    expect(DEFAULT_FONT_MAPPING["Yu Gothic"]).toBe("Noto Sans JP");
+    expect(DEFAULT_FONT_MAPPING["MS ゴシック"]).toBe("Noto Sans JP");
+    expect(DEFAULT_FONT_MAPPING["MS Gothic"]).toBe("Noto Sans JP");
+    expect(DEFAULT_FONT_MAPPING["MS Pゴシック"]).toBe("Noto Sans JP");
+    expect(DEFAULT_FONT_MAPPING["MS PGothic"]).toBe("Noto Sans JP");
+  });
+
+  it("日本語明朝系フォントが Noto Serif JP にマッピングされている", () => {
+    expect(DEFAULT_FONT_MAPPING["MS 明朝"]).toBe("Noto Serif JP");
+    expect(DEFAULT_FONT_MAPPING["MS Mincho"]).toBe("Noto Serif JP");
+    expect(DEFAULT_FONT_MAPPING["MS P明朝"]).toBe("Noto Serif JP");
+    expect(DEFAULT_FONT_MAPPING["MS PMincho"]).toBe("Noto Serif JP");
+    expect(DEFAULT_FONT_MAPPING["游明朝"]).toBe("Noto Serif JP");
+    expect(DEFAULT_FONT_MAPPING["Yu Mincho"]).toBe("Noto Serif JP");
+  });
+});
+
+describe("createFontMapping", () => {
+  it("ユーザーマッピングなしでデフォルトのコピーを返す", () => {
+    const mapping = createFontMapping();
+    expect(mapping["Calibri"]).toBe("Carlito");
+    expect(mapping["Arial"]).toBe("Arimo");
+  });
+
+  it("ユーザーマッピングでデフォルトを上書きできる", () => {
+    const mapping = createFontMapping({ Calibri: "Custom Font" });
+    expect(mapping["Calibri"]).toBe("Custom Font");
+    // 他のデフォルトは維持される
+    expect(mapping["Arial"]).toBe("Arimo");
+  });
+
+  it("ユーザーマッピングで新しいエントリを追加できる", () => {
+    const mapping = createFontMapping({ "My Custom Font": "Noto Sans" });
+    expect(mapping["My Custom Font"]).toBe("Noto Sans");
+    expect(mapping["Calibri"]).toBe("Carlito");
+  });
+});
+
+describe("getMappedFont", () => {
+  const mapping: FontMapping = {
+    Calibri: "Carlito",
+    Arial: "Arimo",
+    "MS Gothic": "Noto Sans JP",
+  };
+
+  it("完全一致でマッピングを返す", () => {
+    expect(getMappedFont("Calibri", mapping)).toBe("Carlito");
+    expect(getMappedFont("Arial", mapping)).toBe("Arimo");
+  });
+
+  it("大文字小文字を無視してマッチする", () => {
+    expect(getMappedFont("calibri", mapping)).toBe("Carlito");
+    expect(getMappedFont("ARIAL", mapping)).toBe("Arimo");
+    expect(getMappedFont("ms gothic", mapping)).toBe("Noto Sans JP");
+  });
+
+  it("マッピングに存在しないフォントは null を返す", () => {
+    expect(getMappedFont("Unknown Font", mapping)).toBeNull();
+  });
+
+  it("null または undefined は null を返す", () => {
+    expect(getMappedFont(null, mapping)).toBeNull();
+    expect(getMappedFont(undefined, mapping)).toBeNull();
+  });
+});

--- a/src/font-mapping.ts
+++ b/src/font-mapping.ts
@@ -1,0 +1,68 @@
+/**
+ * PPTX フォント名 → OSS 代替フォント (Google Fonts) のマッピング。
+ * ユーザーが拡張・上書き可能。
+ */
+
+/** フォントマッピングテーブルの型 */
+export type FontMapping = Record<string, string>;
+
+/** デフォルトのフォントマッピングテーブル */
+export const DEFAULT_FONT_MAPPING: Readonly<FontMapping> = {
+  // ラテン文字フォント
+  Calibri: "Carlito",
+  Arial: "Arimo",
+  "Times New Roman": "Tinos",
+  "Courier New": "Cousine",
+  Cambria: "Caladea",
+
+  // 日本語ゴシック系 → Noto Sans JP
+  メイリオ: "Noto Sans JP",
+  Meiryo: "Noto Sans JP",
+  游ゴシック: "Noto Sans JP",
+  "Yu Gothic": "Noto Sans JP",
+  "MS ゴシック": "Noto Sans JP",
+  "MS Gothic": "Noto Sans JP",
+  "MS Pゴシック": "Noto Sans JP",
+  "MS PGothic": "Noto Sans JP",
+
+  // 日本語明朝系 → Noto Serif JP
+  "MS 明朝": "Noto Serif JP",
+  "MS Mincho": "Noto Serif JP",
+  "MS P明朝": "Noto Serif JP",
+  "MS PMincho": "Noto Serif JP",
+  游明朝: "Noto Serif JP",
+  "Yu Mincho": "Noto Serif JP",
+};
+
+/**
+ * デフォルトマッピングとユーザーマッピングをマージしたテーブルを生成する。
+ * ユーザー指定が優先される。
+ */
+export function createFontMapping(userMapping?: FontMapping): FontMapping {
+  if (!userMapping) return { ...DEFAULT_FONT_MAPPING };
+  return { ...DEFAULT_FONT_MAPPING, ...userMapping };
+}
+
+/**
+ * マッピングテーブルから OSS 代替フォント名を取得する。
+ * 大文字小文字を区別せずにルックアップする。
+ */
+export function getMappedFont(
+  fontFamily: string | null | undefined,
+  mapping: FontMapping,
+): string | null {
+  if (!fontFamily) return null;
+
+  const direct = mapping[fontFamily];
+  if (direct !== undefined) return direct;
+
+  // 大文字小文字を無視したフォールバック
+  const lower = fontFamily.toLowerCase();
+  for (const key of Object.keys(mapping)) {
+    if (key.toLowerCase() === lower) {
+      return mapping[key];
+    }
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,7 @@ export { DefaultTextMeasurer } from "./text-measurer.js";
 export { CanvasTextMeasurer } from "./canvas-text-measurer.js";
 export { OpentypeTextMeasurer } from "./opentype-text-measurer.js";
 export type { OpentypeFont } from "./opentype-text-measurer.js";
+export { collectUsedFonts } from "./font-collector.js";
+export type { UsedFonts } from "./font-collector.js";
+export { DEFAULT_FONT_MAPPING, createFontMapping, getMappedFont } from "./font-mapping.js";
+export type { FontMapping } from "./font-mapping.js";

--- a/src/model/text.ts
+++ b/src/model/text.ts
@@ -5,6 +5,7 @@ export interface DefaultRunProperties {
   fontSize?: number;
   fontFamily?: string | null;
   fontFamilyEa?: string | null;
+  fontFamilyCs?: string | null;
   bold?: boolean;
   italic?: boolean;
   underline?: boolean;
@@ -128,6 +129,7 @@ export interface RunProperties {
   fontSize: number | null;
   fontFamily: string | null;
   fontFamilyEa: string | null;
+  fontFamilyCs: string | null;
   bold: boolean;
   italic: boolean;
   underline: boolean;

--- a/src/model/theme.ts
+++ b/src/model/theme.ts
@@ -52,4 +52,6 @@ export interface FontScheme {
   minorFont: string;
   majorFontEa: string | null;
   minorFontEa: string | null;
+  majorFontCs: string | null;
+  minorFontCs: string | null;
 }

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -1310,6 +1310,7 @@ function mergeDefaultRunProperties(
     fontSize: primary.fontSize ?? secondary.fontSize,
     fontFamily: primary.fontFamily ?? secondary.fontFamily,
     fontFamilyEa: primary.fontFamilyEa ?? secondary.fontFamilyEa,
+    fontFamilyCs: primary.fontFamilyCs ?? secondary.fontFamilyCs,
     bold: primary.bold ?? secondary.bold,
     italic: primary.italic ?? secondary.italic,
     underline: primary.underline ?? secondary.underline,
@@ -1329,6 +1330,7 @@ function parseRunProperties(
       fontSize: defaults?.fontSize ?? null,
       fontFamily: resolveThemeFont(defaults?.fontFamily ?? null, fontScheme),
       fontFamilyEa: resolveThemeFont(defaults?.fontFamilyEa ?? null, fontScheme),
+      fontFamilyCs: resolveThemeFont(defaults?.fontFamilyCs ?? null, fontScheme),
       bold: defaults?.bold ?? false,
       italic: defaults?.italic ?? false,
       underline: defaults?.underline ?? false,
@@ -1349,6 +1351,7 @@ function parseRunProperties(
 
   const latin = rPr.latin as XmlNode | undefined;
   const ea = rPr.ea as XmlNode | undefined;
+  const cs = rPr.cs as XmlNode | undefined;
 
   const fontSize = rPr["@_sz"]
     ? hundredthPointToPoint(Number(rPr["@_sz"]))
@@ -1359,6 +1362,10 @@ function parseRunProperties(
   );
   const fontFamilyEa = resolveThemeFont(
     (ea?.["@_typeface"] as string | undefined) ?? defaults?.fontFamilyEa ?? null,
+    fontScheme,
+  );
+  const fontFamilyCs = resolveThemeFont(
+    (cs?.["@_typeface"] as string | undefined) ?? defaults?.fontFamilyCs ?? null,
     fontScheme,
   );
   const bold =
@@ -1389,6 +1396,7 @@ function parseRunProperties(
     fontSize,
     fontFamily,
     fontFamilyEa,
+    fontFamilyCs,
     bold,
     italic,
     underline,

--- a/src/parser/text-style-parser.ts
+++ b/src/parser/text-style-parser.ts
@@ -27,6 +27,10 @@ export function parseDefaultRunProperties(
   if (ea?.["@_typeface"] !== undefined) {
     result.fontFamilyEa = ea["@_typeface"] as string;
   }
+  const cs = defRPr.cs as XmlNode | undefined;
+  if (cs?.["@_typeface"] !== undefined) {
+    result.fontFamilyCs = cs["@_typeface"] as string;
+  }
   if (defRPr["@_b"] !== undefined) {
     result.bold = defRPr["@_b"] === "1" || defRPr["@_b"] === "true";
   }
@@ -118,6 +122,10 @@ export function resolveThemeFont(
       return fontScheme.majorFontEa;
     case "+mn-ea":
       return fontScheme.minorFontEa;
+    case "+mj-cs":
+      return fontScheme.majorFontCs;
+    case "+mn-cs":
+      return fontScheme.minorFontCs;
     default:
       return typeface;
   }

--- a/src/parser/theme-parser.ts
+++ b/src/parser/theme-parser.ts
@@ -20,6 +20,8 @@ export function parseTheme(xml: string): Theme {
         minorFont: "Calibri",
         majorFontEa: null,
         minorFontEa: null,
+        majorFontCs: null,
+        minorFontCs: null,
       },
     };
   }
@@ -34,6 +36,8 @@ export function parseTheme(xml: string): Theme {
         minorFont: "Calibri",
         majorFontEa: null,
         minorFontEa: null,
+        majorFontCs: null,
+        minorFontCs: null,
       },
     };
   }
@@ -92,7 +96,14 @@ function extractColor(colorNode: XmlNode): string {
 
 function parseFontScheme(fontScheme: XmlNode): FontScheme {
   if (!fontScheme)
-    return { majorFont: "Calibri", minorFont: "Calibri", majorFontEa: null, minorFontEa: null };
+    return {
+      majorFont: "Calibri",
+      minorFont: "Calibri",
+      majorFontEa: null,
+      minorFontEa: null,
+      majorFontCs: null,
+      minorFontCs: null,
+    };
 
   const majorFontNode = fontScheme.majorFont as XmlNode | undefined;
   const minorFontNode = fontScheme.minorFont as XmlNode | undefined;
@@ -106,8 +117,12 @@ function parseFontScheme(fontScheme: XmlNode): FontScheme {
     ((majorFontNode?.ea as XmlNode | undefined)?.["@_typeface"] as string | undefined) ?? null;
   const minorFontEa =
     ((minorFontNode?.ea as XmlNode | undefined)?.["@_typeface"] as string | undefined) ?? null;
+  const majorFontCs =
+    ((majorFontNode?.cs as XmlNode | undefined)?.["@_typeface"] as string | undefined) ?? null;
+  const minorFontCs =
+    ((minorFontNode?.cs as XmlNode | undefined)?.["@_typeface"] as string | undefined) ?? null;
 
-  return { majorFont, minorFont, majorFontEa, minorFontEa };
+  return { majorFont, minorFont, majorFontEa, minorFontEa, majorFontCs, minorFontCs };
 }
 
 function defaultColorScheme(): ColorScheme {

--- a/src/pptx-data-parser.ts
+++ b/src/pptx-data-parser.ts
@@ -1,0 +1,276 @@
+/**
+ * PPTX の共通パース処理。
+ * converter.ts と font-collector.ts で共有する。
+ */
+import { readPptx, type PptxArchive } from "./parser/pptx-reader.js";
+import { parsePresentation, type PresentationInfo } from "./parser/presentation-parser.js";
+import { parseTheme } from "./parser/theme-parser.js";
+import type { Theme, ColorMap } from "./model/theme.js";
+import {
+  parseSlideMasterColorMap,
+  parseSlideMasterBackground,
+  parseSlideMasterElements,
+  parseSlideMasterTxStyles,
+  parseSlideMasterPlaceholderStyles,
+} from "./parser/slide-master-parser.js";
+import {
+  parseSlideLayoutBackground,
+  parseSlideLayoutElements,
+  parseSlideLayoutPlaceholderStyles,
+  parseSlideLayoutShowMasterSp,
+} from "./parser/slide-layout-parser.js";
+import { parseSlide } from "./parser/slide-parser.js";
+import type { Slide, Background } from "./model/slide.js";
+import {
+  parseRelationships,
+  resolveRelationshipTarget,
+  buildRelsPath,
+  type Relationship,
+} from "./parser/relationship-parser.js";
+import type { FillParseContext } from "./parser/fill-parser.js";
+import { ColorResolver } from "./color/color-resolver.js";
+import type { PlaceholderStyleInfo, TxStyles } from "./model/text.js";
+import type { SlideElement } from "./model/shape.js";
+import { applyTextStyleInheritance } from "./text-style-resolver.js";
+
+export interface ParsedPptxData {
+  presInfo: PresentationInfo;
+  theme: Theme;
+  colorResolver: ColorResolver;
+  masterBackground: Background | null;
+  masterElements: SlideElement[];
+  masterTxStyles: TxStyles | undefined;
+  masterPlaceholderStyles: PlaceholderStyleInfo[];
+  slidePaths: { slideNumber: number; path: string }[];
+  archive: PptxArchive;
+}
+
+export async function parsePptxData(input: Buffer | Uint8Array): Promise<ParsedPptxData> {
+  const archive = await readPptx(input);
+
+  // Parse presentation.xml
+  const presentationXml = archive.files.get("ppt/presentation.xml");
+  if (!presentationXml) throw new Error("Invalid PPTX: missing ppt/presentation.xml");
+  const presInfo = parsePresentation(presentationXml);
+
+  // Parse presentation relationships
+  const presRelsXml = archive.files.get("ppt/_rels/presentation.xml.rels");
+  const presRels = presRelsXml ? parseRelationships(presRelsXml) : new Map<string, Relationship>();
+
+  // Parse theme
+  let theme: Theme = {
+    colorScheme: defaultColorScheme(),
+    fontScheme: {
+      majorFont: "Calibri",
+      minorFont: "Calibri",
+      majorFontEa: null,
+      minorFontEa: null,
+      majorFontCs: null,
+      minorFontCs: null,
+    },
+  };
+  for (const [, rel] of presRels) {
+    if (rel.type.includes("theme")) {
+      const themePath = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
+      const themeXml = archive.files.get(themePath);
+      if (themeXml) {
+        theme = parseTheme(themeXml);
+      }
+      break;
+    }
+  }
+
+  // Parse slide master for color map and background
+  let colorMap: ColorMap = defaultColorMap();
+  let masterPath: string | null = null;
+  for (const [, rel] of presRels) {
+    if (rel.type.includes("slideMaster")) {
+      masterPath = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
+      const masterXml = archive.files.get(masterPath);
+      if (masterXml) {
+        colorMap = parseSlideMasterColorMap(masterXml);
+      }
+      break;
+    }
+  }
+
+  const colorResolver = new ColorResolver(theme.colorScheme, colorMap);
+
+  // Parse master background and shapes (used as fallback)
+  const masterXml = masterPath ? archive.files.get(masterPath) : undefined;
+  let masterFillContext: FillParseContext | undefined;
+  if (masterPath) {
+    const masterRelsPath = buildRelsPath(masterPath);
+    const masterRelsXml = archive.files.get(masterRelsPath);
+    const masterRels = masterRelsXml
+      ? parseRelationships(masterRelsXml)
+      : new Map<string, Relationship>();
+    masterFillContext = { rels: masterRels, archive, basePath: masterPath };
+  }
+  const masterBackground = masterXml
+    ? parseSlideMasterBackground(masterXml, colorResolver, masterFillContext)
+    : null;
+  const masterElements =
+    masterPath && masterXml
+      ? parseSlideMasterElements(
+          masterXml,
+          masterPath,
+          archive,
+          colorResolver,
+          theme.fontScheme,
+          theme.fmtScheme,
+        )
+      : [];
+  const masterTxStyles = masterXml ? parseSlideMasterTxStyles(masterXml, colorResolver) : undefined;
+  const masterPlaceholderStyles = masterXml
+    ? parseSlideMasterPlaceholderStyles(masterXml, colorResolver)
+    : [];
+
+  // Resolve slide paths from relationships
+  const slidePaths: { slideNumber: number; path: string }[] = [];
+  for (let i = 0; i < presInfo.slideRIds.length; i++) {
+    const rId = presInfo.slideRIds[i];
+    const rel = presRels.get(rId);
+    if (rel) {
+      const path = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
+      slidePaths.push({ slideNumber: i + 1, path });
+    }
+  }
+
+  return {
+    presInfo,
+    theme,
+    colorResolver,
+    masterBackground,
+    masterElements,
+    masterTxStyles,
+    masterPlaceholderStyles,
+    slidePaths,
+    archive,
+  };
+}
+
+export interface ParsedSlide {
+  slide: Slide;
+  layoutElements: SlideElement[];
+  layoutShowMasterSp: boolean;
+}
+
+export function parseSlideWithLayout(
+  slideNumber: number,
+  path: string,
+  data: ParsedPptxData,
+): ParsedSlide | null {
+  const slideXml = data.archive.files.get(path);
+  if (!slideXml) return null;
+
+  const slide = parseSlide(
+    slideXml,
+    path,
+    slideNumber,
+    data.archive,
+    data.colorResolver,
+    data.theme.fontScheme,
+    data.theme.fmtScheme,
+  );
+
+  // Resolve slide layout
+  let layoutElements: SlideElement[] = [];
+  let layoutPlaceholderStyles: PlaceholderStyleInfo[] = [];
+  let layoutShowMasterSp = true;
+  const slideRelsPath = buildRelsPath(path);
+  const slideRelsXml = data.archive.files.get(slideRelsPath);
+  if (slideRelsXml) {
+    const slideRels = parseRelationships(slideRelsXml);
+    for (const [, rel] of slideRels) {
+      if (rel.type.includes("slideLayout")) {
+        const layoutPath = resolveRelationshipTarget(path, rel.target);
+        const layoutXml = data.archive.files.get(layoutPath);
+        if (layoutXml) {
+          // Fallback background: slide → layout → master
+          if (!slide.background) {
+            const layoutRelsPath = buildRelsPath(layoutPath);
+            const layoutRelsXml = data.archive.files.get(layoutRelsPath);
+            const layoutRels = layoutRelsXml
+              ? parseRelationships(layoutRelsXml)
+              : new Map<string, Relationship>();
+            const layoutFillContext: FillParseContext = {
+              rels: layoutRels,
+              archive: data.archive,
+              basePath: layoutPath,
+            };
+            slide.background = parseSlideLayoutBackground(
+              layoutXml,
+              data.colorResolver,
+              layoutFillContext,
+            );
+          }
+          // Parse layout shapes
+          layoutElements = parseSlideLayoutElements(
+            layoutXml,
+            layoutPath,
+            data.archive,
+            data.colorResolver,
+            data.theme.fontScheme,
+            data.theme.fmtScheme,
+          );
+          // Extract placeholder styles for text style inheritance
+          layoutPlaceholderStyles = parseSlideLayoutPlaceholderStyles(
+            layoutXml,
+            data.colorResolver,
+          );
+          layoutShowMasterSp = parseSlideLayoutShowMasterSp(layoutXml);
+        }
+        break;
+      }
+    }
+  }
+  if (!slide.background) {
+    slide.background = data.masterBackground;
+  }
+
+  // Apply text style inheritance chain before merging
+  applyTextStyleInheritance(slide.elements, {
+    layoutPlaceholderStyles,
+    masterPlaceholderStyles: data.masterPlaceholderStyles,
+    txStyles: data.masterTxStyles,
+    defaultTextStyle: data.presInfo.defaultTextStyle,
+    fontScheme: data.theme.fontScheme,
+  });
+
+  return { slide, layoutElements, layoutShowMasterSp };
+}
+
+function defaultColorScheme() {
+  return {
+    dk1: "#000000",
+    lt1: "#FFFFFF",
+    dk2: "#44546A",
+    lt2: "#E7E6E6",
+    accent1: "#4472C4",
+    accent2: "#ED7D31",
+    accent3: "#A5A5A5",
+    accent4: "#FFC000",
+    accent5: "#5B9BD5",
+    accent6: "#70AD47",
+    hlink: "#0563C1",
+    folHlink: "#954F72",
+  };
+}
+
+function defaultColorMap() {
+  return {
+    bg1: "lt1" as const,
+    tx1: "dk1" as const,
+    bg2: "lt2" as const,
+    tx2: "dk2" as const,
+    accent1: "accent1" as const,
+    accent2: "accent2" as const,
+    accent3: "accent3" as const,
+    accent4: "accent4" as const,
+    accent5: "accent5" as const,
+    accent6: "accent6" as const,
+    hlink: "hlink" as const,
+    folHlink: "folHlink" as const,
+  };
+}

--- a/src/renderer/text-renderer.test.ts
+++ b/src/renderer/text-renderer.test.ts
@@ -858,7 +858,7 @@ describe("buildFontFamilyValue", () => {
 
   it("スペースを含むフォント名をシングルクォートで囲む", () => {
     expect(buildFontFamilyValue(["Times New Roman"])).toBe(
-      "'Times New Roman', 'Liberation Serif', serif",
+      "'Times New Roman', Tinos, 'Liberation Serif', serif",
     );
     expect(buildFontFamilyValue(["Calibri", "Noto Sans JP"])).toBe(
       "Calibri, Carlito, 'Noto Sans JP', sans-serif",
@@ -867,14 +867,16 @@ describe("buildFontFamilyValue", () => {
 
   it("serif 系フォントの汎用ファミリが serif になる", () => {
     expect(buildFontFamilyValue(["Times New Roman"])).toBe(
-      "'Times New Roman', 'Liberation Serif', serif",
+      "'Times New Roman', Tinos, 'Liberation Serif', serif",
     );
-    expect(buildFontFamilyValue(["Yu Mincho"])).toBe("'Yu Mincho', 'Noto Sans JP', serif");
-    expect(buildFontFamilyValue(["游明朝"])).toBe("游明朝, 'Noto Sans JP', serif");
+    expect(buildFontFamilyValue(["Yu Mincho"])).toBe(
+      "'Yu Mincho', 'Noto Serif JP', 'Noto Sans JP', serif",
+    );
+    expect(buildFontFamilyValue(["游明朝"])).toBe("游明朝, 'Noto Serif JP', 'Noto Sans JP', serif");
   });
 
   it("sans-serif 系フォントの汎用ファミリが sans-serif になる", () => {
-    expect(buildFontFamilyValue(["Arial"])).toBe("Arial, 'Liberation Sans', sans-serif");
+    expect(buildFontFamilyValue(["Arial"])).toBe("Arial, Arimo, 'Liberation Sans', sans-serif");
     expect(buildFontFamilyValue(["Meiryo"])).toBe("Meiryo, 'Noto Sans JP', sans-serif");
   });
 

--- a/src/renderer/text-renderer.ts
+++ b/src/renderer/text-renderer.ts
@@ -14,6 +14,7 @@ import { emuToPixels } from "../utils/emu.js";
 import { wrapParagraph } from "../utils/text-wrap.js";
 import { getMetricsFallbackFont } from "../data/font-metrics.js";
 import { getTextMeasurer } from "../text-measurer.js";
+import { getCurrentMappedFont } from "../font-mapping-context.js";
 
 const PX_PER_PT = 96 / 72;
 const DEFAULT_LINE_SPACING = 1.0;
@@ -594,6 +595,13 @@ export function buildFontFamilyValue(fonts: (string | null)[]): string | null {
     if (font && !seen.has(font)) {
       seen.add(font);
       uniqueFonts.push(font);
+
+      // マッピングテーブルから OSS 代替フォントを追加
+      const mapped = getCurrentMappedFont(font);
+      if (mapped && !seen.has(mapped)) {
+        seen.add(mapped);
+        uniqueFonts.push(mapped);
+      }
 
       // メトリクス互換 OSS フォントをフォールバックとして追加
       const fallback = getMetricsFallbackFont(font);

--- a/src/text-style-resolver.ts
+++ b/src/text-style-resolver.ts
@@ -62,6 +62,7 @@ function resolveShapeTextInheritance(shape: ShapeElement, context: TextStyleCont
           props.fontSize !== null &&
           props.fontFamily !== null &&
           props.fontFamilyEa !== null &&
+          props.fontFamilyCs !== null &&
           props.color !== null
         ) {
           break;
@@ -78,6 +79,9 @@ function resolveShapeTextInheritance(shape: ShapeElement, context: TextStyleCont
         }
         if (props.fontFamilyEa === null && defRPr.fontFamilyEa != null) {
           props.fontFamilyEa = resolveThemeFont(defRPr.fontFamilyEa, context.fontScheme);
+        }
+        if (props.fontFamilyCs === null && defRPr.fontFamilyCs != null) {
+          props.fontFamilyCs = resolveThemeFont(defRPr.fontFamilyCs, context.fontScheme);
         }
         if (props.color === null && defRPr.color !== undefined) {
           props.color = defRPr.color;


### PR DESCRIPTION
close #215

## 概要

PPTX パース時に使用されているフォント名を収集する仕組みと、プロプライエタリフォントから OSS フォントへのマッピングテーブルを実装。

## 変更内容

### フォントマッピングテーブル (`src/font-mapping.ts`)
- `DEFAULT_FONT_MAPPING`: Calibri→Carlito, Arial→Arimo, Times New Roman→Tinos 等のデフォルトマッピング
- 日本語フォント: ゴシック系→Noto Sans JP、明朝系→Noto Serif JP
- `createFontMapping(userMapping?)`: デフォルト + ユーザーマッピングをマージ
- `getMappedFont(fontFamily, mapping)`: 大文字小文字を無視したルックアップ

### 使用フォント収集 API (`src/font-collector.ts`)
- `collectUsedFonts(input)`: PPTX をパースしてテーマフォント + テキストランのフォント名を収集
- テーマの `majorFont`/`minorFont` (latin/ea/cs) とテキストランの `fontFamily`/`fontFamilyEa`/`fontFamilyCs` を網羅

### ユーザー拡張 (`ConvertOptions.fontMapping`)
- `convertPptxToSvg(input, { fontMapping: { "CustomFont": "NotoSans" } })` でカスタムマッピング指定可能
- デフォルトマッピングにマージされ、ユーザー指定が優先

### cs (Complex Script) フォント対応
- `RunProperties.fontFamilyCs`, `DefaultRunProperties.fontFamilyCs` 追加
- `FontScheme.majorFontCs`, `FontScheme.minorFontCs` 追加
- パーサー・テーマパーサー・スタイル継承で `<a:cs>` typeface をパース

### リファクタリング
- `converter.ts` のパース共通部分を `pptx-data-parser.ts` に抽出
- `font-mapping-context.ts` でレンダリング中のマッピングをモジュールレベルで管理

## テスト計画
- [x] `src/font-mapping.test.ts` — マッピングテーブルのユニットテスト
- [x] `src/font-collector.test.ts` — フォント収集 API のテスト (JSZip で PPTX を動的生成)
- [x] 既存テスト全通過 (756 tests)
- [x] typecheck, lint, format:check 通過
- [ ] VRT スナップショット更新 (`buildFontFamilyValue` のフォールバックリスト変更のため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)