### PR TITLE
feat: ブラウザ向け Google Fonts 自動取得

### DIFF
--- a/src/google-fonts.test.ts
+++ b/src/google-fonts.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from "vitest";
+import type { UsedFonts } from "./font-collector.js";
+import { resolveGoogleFontNames, parseFontUrlsFromCss, fetchGoogleFonts } from "./google-fonts.js";
+
+const sampleUsedFonts: UsedFonts = {
+  theme: {
+    majorFont: "Calibri Light",
+    minorFont: "Calibri",
+    majorFontEa: "MS PGothic",
+    minorFontEa: "MS PGothic",
+    majorFontCs: "Times New Roman",
+    minorFontCs: "Arial",
+  },
+  fonts: ["Arial", "Calibri", "Calibri Light", "MS PGothic", "Times New Roman", "Yu Gothic"],
+};
+
+describe("resolveGoogleFontNames", () => {
+  it("フォントマッピングを適用して Google Fonts 名を返す", () => {
+    const result = resolveGoogleFontNames(sampleUsedFonts);
+    expect(result).toContain("Arimo"); // Arial → Arimo
+    expect(result).toContain("Carlito"); // Calibri → Carlito
+    expect(result).toContain("Tinos"); // Times New Roman → Tinos
+    expect(result).toContain("Noto Sans JP"); // MS PGothic, Yu Gothic → Noto Sans JP
+  });
+
+  it("重複を除去してソート済みで返す", () => {
+    const result = resolveGoogleFontNames(sampleUsedFonts);
+    // MS PGothic と Yu Gothic が両方 Noto Sans JP にマッピングされるが重複なし
+    const notoCount = result.filter((f) => f === "Noto Sans JP").length;
+    expect(notoCount).toBe(1);
+    // ソート済み
+    const sorted = [...result].sort();
+    expect(result).toEqual(sorted);
+  });
+
+  it("マッピングに存在しないフォントは除外される", () => {
+    const usedFonts: UsedFonts = {
+      theme: {
+        majorFont: "Unknown Font",
+        minorFont: "Another Unknown",
+        majorFontEa: null,
+        minorFontEa: null,
+        majorFontCs: null,
+        minorFontCs: null,
+      },
+      fonts: ["Unknown Font", "Another Unknown"],
+    };
+    const result = resolveGoogleFontNames(usedFonts);
+    expect(result).toEqual([]);
+  });
+
+  it("カスタムフォントマッピングを適用できる", () => {
+    const usedFonts: UsedFonts = {
+      theme: {
+        majorFont: "Custom Font",
+        minorFont: "Calibri",
+        majorFontEa: null,
+        minorFontEa: null,
+        majorFontCs: null,
+        minorFontCs: null,
+      },
+      fonts: ["Custom Font", "Calibri"],
+    };
+    const result = resolveGoogleFontNames(usedFonts, {
+      "Custom Font": "Roboto",
+    });
+    expect(result).toContain("Roboto");
+    expect(result).toContain("Carlito"); // デフォルトマッピングも維持
+  });
+});
+
+describe("parseFontUrlsFromCss", () => {
+  it("@font-face から font-family と url を抽出する", () => {
+    const css = `
+/* latin */
+@font-face {
+  font-family: 'Carlito';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/carlito/v3/3Jn9SDPw3m-pk039PDA.ttf) format('truetype');
+}
+/* latin */
+@font-face {
+  font-family: 'Arimo';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/arimo/v28/P5sfzZCDf9_T_10c.ttf) format('truetype');
+}`;
+    const result = parseFontUrlsFromCss(css);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      name: "Carlito",
+      url: "https://fonts.gstatic.com/s/carlito/v3/3Jn9SDPw3m-pk039PDA.ttf",
+    });
+    expect(result[1]).toEqual({
+      name: "Arimo",
+      url: "https://fonts.gstatic.com/s/arimo/v28/P5sfzZCDf9_T_10c.ttf",
+    });
+  });
+
+  it("空の CSS では空配列を返す", () => {
+    expect(parseFontUrlsFromCss("")).toEqual([]);
+  });
+
+  it("url のない @font-face はスキップする", () => {
+    const css = `@font-face { font-family: 'Test'; font-style: normal; }`;
+    expect(parseFontUrlsFromCss(css)).toEqual([]);
+  });
+
+  it("font-family のない @font-face はスキップする", () => {
+    const css = `@font-face { src: url(https://example.com/font.ttf); }`;
+    expect(parseFontUrlsFromCss(css)).toEqual([]);
+  });
+});
+
+describe("fetchGoogleFonts", () => {
+  const fakeCss = `
+@font-face {
+  font-family: 'Carlito';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/carlito/v3/font.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Arimo';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/arimo/v28/font.ttf) format('truetype');
+}`;
+
+  const fakeFont = new Uint8Array([0, 1, 2, 3]);
+
+  function createMockFetch(cssResponse: string, fontData: Uint8Array) {
+    return vi.fn((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("fonts.googleapis.com/css2")) {
+        return Promise.resolve(new Response(cssResponse, { status: 200 }));
+      }
+      if (urlStr.includes("fonts.gstatic.com")) {
+        return Promise.resolve(new Response(fontData, { status: 200 }));
+      }
+      return Promise.resolve(new Response("Not found", { status: 404 }));
+    }) as unknown as typeof globalThis.fetch;
+  }
+
+  it("Google Fonts からフォントバッファを取得する", async () => {
+    const mockFetch = createMockFetch(fakeCss, fakeFont);
+    const result = await fetchGoogleFonts(sampleUsedFonts, { fetch: mockFetch });
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toHaveProperty("name");
+    expect(result[0]).toHaveProperty("data");
+    expect(result[0].data).toBeInstanceOf(Uint8Array);
+  });
+
+  it("CSS API の URL に必要なフォント名が含まれる", async () => {
+    const mockFetch = createMockFetch(fakeCss, fakeFont);
+    await fetchGoogleFonts(sampleUsedFonts, { fetch: mockFetch });
+
+    const cssCall = (mockFetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const cssUrl = cssCall[0] as string;
+    expect(cssUrl).toContain("fonts.googleapis.com/css2");
+    expect(cssUrl).toContain("Arimo");
+    expect(cssUrl).toContain("Carlito");
+  });
+
+  it("マッピングに該当するフォントがない場合は空配列を返す", async () => {
+    const mockFetch = vi.fn() as unknown as typeof globalThis.fetch;
+    const usedFonts: UsedFonts = {
+      theme: {
+        majorFont: "Unknown",
+        minorFont: "Unknown2",
+        majorFontEa: null,
+        minorFontEa: null,
+        majorFontCs: null,
+        minorFontCs: null,
+      },
+      fonts: ["Unknown", "Unknown2"],
+    };
+    const result = await fetchGoogleFonts(usedFonts, { fetch: mockFetch });
+    expect(result).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("CSS API がエラーを返した場合は空配列を返す", async () => {
+    const mockFetch = vi.fn(() => {
+      return Promise.resolve(new Response("Bad Request", { status: 400 }));
+    }) as unknown as typeof globalThis.fetch;
+    const result = await fetchGoogleFonts(sampleUsedFonts, { fetch: mockFetch });
+    expect(result).toEqual([]);
+  });
+
+  it("フォントファイル取得のエラーはスキップし、他のフォントは返す", async () => {
+    let callCount = 0;
+    const mockFetch = vi.fn((url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("fonts.googleapis.com/css2")) {
+        return Promise.resolve(new Response(fakeCss, { status: 200 }));
+      }
+      callCount++;
+      if (callCount === 1) {
+        return Promise.reject(new Error("Network error"));
+      }
+      return Promise.resolve(new Response(fakeFont, { status: 200 }));
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await fetchGoogleFonts(sampleUsedFonts, { fetch: mockFetch });
+    // 1つはエラーでスキップされ、もう1つは成功する
+    expect(result).toHaveLength(1);
+  });
+
+  it("ネットワークエラー時は空配列を返す", async () => {
+    const mockFetch = vi.fn(() => {
+      return Promise.reject(new Error("Network error"));
+    }) as unknown as typeof globalThis.fetch;
+    const result = await fetchGoogleFonts(sampleUsedFonts, { fetch: mockFetch });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/google-fonts.ts
+++ b/src/google-fonts.ts
@@ -1,0 +1,130 @@
+/**
+ * Google Fonts からフォントを自動取得するユーティリティ。
+ * ブラウザ環境で resvg-wasm にフォントバッファを渡すために使用する。
+ */
+import type { UsedFonts } from "./font-collector.js";
+import type { FontMapping } from "./font-mapping.js";
+import { createFontMapping, getMappedFont } from "./font-mapping.js";
+
+/** fetchGoogleFonts のオプション */
+export interface FetchGoogleFontsOptions {
+  /** カスタムフォントマッピング（デフォルトマッピングにマージされる） */
+  fontMapping?: FontMapping;
+  /** カスタム fetch 関数（テスト用・プロキシ対応） */
+  fetch?: typeof globalThis.fetch;
+}
+
+const GOOGLE_FONTS_CSS_API = "https://fonts.googleapis.com/css2";
+
+/**
+ * UsedFonts のフォント名にマッピングを適用し、Google Fonts で取得すべきフォント名一覧を返す。
+ * 重複除去・ソート済み。
+ */
+export function resolveGoogleFontNames(usedFonts: UsedFonts, fontMapping?: FontMapping): string[] {
+  const mapping = createFontMapping(fontMapping);
+  const googleFonts = new Set<string>();
+
+  for (const font of usedFonts.fonts) {
+    const mapped = getMappedFont(font, mapping);
+    if (mapped) {
+      googleFonts.add(mapped);
+    }
+  }
+
+  return [...googleFonts].sort();
+}
+
+/**
+ * Google Fonts CSS レスポンスから @font-face の url(...) と font-family を抽出する。
+ */
+export function parseFontUrlsFromCss(css: string): Array<{ name: string; url: string }> {
+  const results: Array<{ name: string; url: string }> = [];
+  const faceRegex = /@font-face\s*\{([^}]+)\}/g;
+  let faceMatch;
+
+  while ((faceMatch = faceRegex.exec(css)) !== null) {
+    const block = faceMatch[1];
+
+    // font-family を抽出
+    const familyMatch = block.match(/font-family:\s*'([^']+)'/);
+    if (!familyMatch) continue;
+    const name = familyMatch[1];
+
+    // url(...) を抽出
+    const urlMatch = block.match(/url\(([^)]+)\)/);
+    if (!urlMatch) continue;
+    const url = urlMatch[1];
+
+    results.push({ name, url });
+  }
+
+  return results;
+}
+
+/**
+ * PPTX の使用フォント情報から Google Fonts のフォントバッファを取得する。
+ * resvg-wasm の fontBuffers オプションに渡せる形式で返す。
+ *
+ * Google Fonts に存在しないフォントはスキップされる。
+ */
+export async function fetchGoogleFonts(
+  usedFonts: UsedFonts,
+  options?: FetchGoogleFontsOptions,
+): Promise<Array<{ name: string; data: Uint8Array }>> {
+  const fetchFn = options?.fetch ?? globalThis.fetch;
+  const fontNames = resolveGoogleFontNames(usedFonts, options?.fontMapping);
+
+  if (fontNames.length === 0) return [];
+
+  // Google Fonts CSS API から CSS を取得
+  const css = await fetchGoogleFontsCss(fontNames, fetchFn);
+  if (!css) return [];
+
+  // CSS からフォント URL を抽出
+  const fontEntries = parseFontUrlsFromCss(css);
+  if (fontEntries.length === 0) return [];
+
+  // フォントファイルを並列取得
+  const results = await Promise.all(
+    fontEntries.map(async ({ name, url }) => {
+      try {
+        const res = await fetchFn(url);
+        if (!res.ok) return null;
+        const buffer = await res.arrayBuffer();
+        return { name, data: new Uint8Array(buffer) };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  const filtered: Array<{ name: string; data: Uint8Array }> = [];
+  for (const r of results) {
+    if (r !== null) filtered.push(r);
+  }
+  return filtered;
+}
+
+/**
+ * Google Fonts CSS API からフォント CSS を取得する。
+ * 未知の User-Agent を送ることで TTF 形式のレスポンスを得る。
+ */
+async function fetchGoogleFontsCss(
+  fontNames: string[],
+  fetchFn: typeof globalThis.fetch,
+): Promise<string | null> {
+  const url = new URL(GOOGLE_FONTS_CSS_API);
+  for (const name of fontNames) {
+    url.searchParams.append("family", name);
+  }
+
+  try {
+    const res = await fetchFn(url.toString(), {
+      headers: { "User-Agent": "pptx-glimpse" },
+    });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,5 @@ export { collectUsedFonts } from "./font-collector.js";
 export type { UsedFonts } from "./font-collector.js";
 export { DEFAULT_FONT_MAPPING, createFontMapping, getMappedFont } from "./font-mapping.js";
 export type { FontMapping } from "./font-mapping.js";
+export { fetchGoogleFonts, resolveGoogleFontNames, parseFontUrlsFromCss } from "./google-fonts.js";
+export type { FetchGoogleFontsOptions } from "./google-fonts.js";


### PR DESCRIPTION
close #216

## Summary

- PPTX の使用フォントから Google Fonts を自動取得するユーティリティ関数 `fetchGoogleFonts` を追加
- フォントマッピングテーブルを使って PPTX フォント名 → Google Fonts 名に変換し、CSS API 経由でフォントバッファを取得
- `resolveGoogleFontNames` / `parseFontUrlsFromCss` もエクスポートし、個別利用可能

## 使い方

```typescript
import { convertPptxToPng, fetchGoogleFonts, collectUsedFonts } from "pptx-glimpse";

// 使用フォントを収集
const usedFonts = await collectUsedFonts(pptxData);

// Google Fonts から自動取得（アプリ側でキャッシュ可能）
const fontBuffers = await fetchGoogleFonts(usedFonts);

// PNG 変換
const result = await convertPptxToPng(pptxData, { fonts: { fontBuffers } });
```

## 新規ファイル

- `src/google-fonts.ts` — Google Fonts 取得ロジック
- `src/google-fonts.test.ts` — ユニットテスト（14 テスト）

## Test plan

- [x] `npm run test -- src/google-fonts.test.ts` (14 tests passed)
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run typecheck` 通過
- [x] `npm run build` 通過
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)