### PR TITLE
feat: opentype.js によるテキスト計測の自動接続

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -10,6 +10,7 @@ import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 import type { FontMapping } from "./font-mapping.js";
 import { createFontMapping } from "./font-mapping.js";
 import { setFontMapping, resetFontMapping } from "./font-mapping-context.js";
+import { createOpentypeTextMeasurerFromBuffers } from "./opentype-helpers.js";
 
 export interface FontOptions {
   /** resvg-wasm に渡すフォントファイルパス (Node.js 向け) */
@@ -63,6 +64,14 @@ export async function convertPptxToSvg(
 ): Promise<SlideSvg[]> {
   if (options?.textMeasurer) {
     setTextMeasurer(options.textMeasurer);
+  } else if (options?.fonts?.fontBuffers && options.fonts.fontBuffers.length > 0) {
+    const measurer = await createOpentypeTextMeasurerFromBuffers(
+      options.fonts.fontBuffers,
+      options.fontMapping,
+    );
+    if (measurer) {
+      setTextMeasurer(measurer);
+    }
   }
   setFontMapping(createFontMapping(options?.fontMapping));
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,5 @@ export { DEFAULT_FONT_MAPPING, createFontMapping, getMappedFont } from "./font-m
 export type { FontMapping } from "./font-mapping.js";
 export { fetchGoogleFonts, resolveGoogleFontNames, parseFontUrlsFromCss } from "./google-fonts.js";
 export type { FetchGoogleFontsOptions } from "./google-fonts.js";
+export { createOpentypeTextMeasurerFromBuffers } from "./opentype-helpers.js";
+export type { FontBuffer } from "./opentype-helpers.js";

--- a/src/opentype-helpers.test.ts
+++ b/src/opentype-helpers.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { createOpentypeTextMeasurerFromBuffers } from "./opentype-helpers.js";
+
+/**
+ * opentype.js を使って最小限の有効な TTF バッファを作成する。
+ */
+async function createTestFontBuffer(familyName: string): Promise<ArrayBuffer> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const opentype: {
+    Glyph: new (opts: Record<string, unknown>) => unknown;
+    Path: new () => {
+      moveTo(x: number, y: number): void;
+      lineTo(x: number, y: number): void;
+      close(): void;
+    };
+    Font: new (opts: Record<string, unknown>) => { toArrayBuffer(): ArrayBuffer };
+  } = await import("opentype.js");
+
+  const notdefGlyph = new opentype.Glyph({
+    name: ".notdef",
+    unicode: 0,
+    advanceWidth: 650,
+    path: new opentype.Path(),
+  });
+
+  const pathA = new opentype.Path();
+  pathA.moveTo(0, 0);
+  pathA.lineTo(300, 800);
+  pathA.lineTo(600, 0);
+  pathA.close();
+
+  const glyphA = new opentype.Glyph({
+    name: "A",
+    unicode: 65,
+    advanceWidth: 600,
+    path: pathA,
+  });
+
+  const spaceGlyph = new opentype.Glyph({
+    name: "space",
+    unicode: 32,
+    advanceWidth: 250,
+    path: new opentype.Path(),
+  });
+
+  const font = new opentype.Font({
+    familyName,
+    styleName: "Regular",
+    unitsPerEm: 1000,
+    ascender: 800,
+    descender: -200,
+    glyphs: [notdefGlyph, spaceGlyph, glyphA],
+  });
+
+  return font.toArrayBuffer();
+}
+
+describe("createOpentypeTextMeasurerFromBuffers", () => {
+  it("空配列で null を返す", async () => {
+    const result = await createOpentypeTextMeasurerFromBuffers([]);
+    expect(result).toBeNull();
+  });
+
+  it("不正バッファで null を返す", async () => {
+    const result = await createOpentypeTextMeasurerFromBuffers([
+      { name: "Invalid", data: new Uint8Array([0, 0, 0, 0]) },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("フォントバッファから OpentypeTextMeasurer を構築する", async () => {
+    const buffer = await createTestFontBuffer("TestFont");
+    const measurer = await createOpentypeTextMeasurerFromBuffers([
+      { name: "TestFont", data: buffer },
+    ]);
+    expect(measurer).not.toBeNull();
+
+    // "A" の幅を計測（advanceWidth=600, unitsPerEm=1000）
+    const width = measurer!.measureTextWidth("A", 18, false, "TestFont");
+    const expected = (600 / 1000) * 18 * (96 / 72);
+    expect(width).toBeCloseTo(expected, 1);
+  });
+
+  it("行高さを正しく計算する", async () => {
+    const buffer = await createTestFontBuffer("TestFont");
+    const measurer = await createOpentypeTextMeasurerFromBuffers([
+      { name: "TestFont", data: buffer },
+    ]);
+    expect(measurer).not.toBeNull();
+
+    // ascender=800, descender=-200 → (800+200)/1000 = 1.0
+    const ratio = measurer!.getLineHeightRatio("TestFont");
+    expect(ratio).toBeCloseTo(1.0, 5);
+  });
+
+  it("フォントマッピング逆引きで PPTX 名でも解決できる", async () => {
+    const buffer = await createTestFontBuffer("Carlito");
+    const measurer = await createOpentypeTextMeasurerFromBuffers([
+      { name: "Carlito", data: buffer },
+    ]);
+    expect(measurer).not.toBeNull();
+
+    // デフォルトマッピング: Calibri → Carlito
+    // 逆引きで "Calibri" でも Carlito のフォントが使える
+    const widthByOss = measurer!.measureTextWidth("A", 18, false, "Carlito");
+    const widthByPptx = measurer!.measureTextWidth("A", 18, false, "Calibri");
+    expect(widthByPptx).toBe(widthByOss);
+  });
+
+  it("カスタムフォントマッピングで逆引きが機能する", async () => {
+    const buffer = await createTestFontBuffer("MyFont");
+    const measurer = await createOpentypeTextMeasurerFromBuffers(
+      [{ name: "MyFont", data: buffer }],
+      { "Custom Name": "MyFont" },
+    );
+    expect(measurer).not.toBeNull();
+
+    const widthByOss = measurer!.measureTextWidth("A", 18, false, "MyFont");
+    const widthByCustom = measurer!.measureTextWidth("A", 18, false, "Custom Name");
+    expect(widthByCustom).toBe(widthByOss);
+  });
+
+  it("name なしのバッファは defaultFont として使われる", async () => {
+    const buffer = await createTestFontBuffer("Unnamed");
+    const measurer = await createOpentypeTextMeasurerFromBuffers([{ data: buffer }]);
+    expect(measurer).not.toBeNull();
+
+    // 未知のフォント名でも defaultFont が使われるため opentype ベースの計算になる
+    const width = measurer!.measureTextWidth("A", 18, false, "UnknownFont");
+    const expected = (600 / 1000) * 18 * (96 / 72);
+    expect(width).toBeCloseTo(expected, 1);
+  });
+
+  it("Uint8Array バッファでも動作する", async () => {
+    const arrayBuffer = await createTestFontBuffer("TestFont");
+    const uint8 = new Uint8Array(arrayBuffer);
+    const measurer = await createOpentypeTextMeasurerFromBuffers([
+      { name: "TestFont", data: uint8 },
+    ]);
+    expect(measurer).not.toBeNull();
+
+    const width = measurer!.measureTextWidth("A", 18, false, "TestFont");
+    expect(width).toBeGreaterThan(0);
+  });
+
+  it("複数フォントを登録できる", async () => {
+    const buffer1 = await createTestFontBuffer("Font1");
+    const buffer2 = await createTestFontBuffer("Font2");
+    const measurer = await createOpentypeTextMeasurerFromBuffers([
+      { name: "Font1", data: buffer1 },
+      { name: "Font2", data: buffer2 },
+    ]);
+    expect(measurer).not.toBeNull();
+
+    const width1 = measurer!.measureTextWidth("A", 18, false, "Font1");
+    const width2 = measurer!.measureTextWidth("A", 18, false, "Font2");
+    expect(width1).toBeGreaterThan(0);
+    expect(width2).toBeGreaterThan(0);
+  });
+});

--- a/src/opentype-helpers.ts
+++ b/src/opentype-helpers.ts
@@ -1,0 +1,115 @@
+/**
+ * opentype.js を使ってフォントバッファから OpentypeTextMeasurer を構築するヘルパー。
+ */
+import type { OpentypeFont } from "./opentype-text-measurer.js";
+import { OpentypeTextMeasurer } from "./opentype-text-measurer.js";
+import type { FontMapping } from "./font-mapping.js";
+import { createFontMapping } from "./font-mapping.js";
+
+/** フォントバッファの入力形式（ConvertOptions.fonts.fontBuffers と互換） */
+export interface FontBuffer {
+  name?: string;
+  data: ArrayBuffer | Uint8Array;
+}
+
+/**
+ * opentype.js を動的 import でロードする。
+ * opentype.js がインストールされていない場合は null を返す。
+ */
+async function tryLoadOpentype(): Promise<{
+  parse: (buffer: ArrayBuffer) => OpentypeFont;
+} | null> {
+  try {
+    // Use a variable to prevent bundlers from statically resolving this optional import
+    const specifier = "opentype.js";
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const mod: { parse: (buffer: ArrayBuffer) => OpentypeFont } = await import(
+      /* @vite-ignore */ specifier
+    );
+    return { parse: mod.parse };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * フォントマッピングの逆引きテーブルを構築する。
+ * OSS フォント名 → PPTX フォント名[] のマッピング。
+ * 例: "Carlito" → ["Calibri"]
+ */
+function buildReverseMapping(mapping: FontMapping): Map<string, string[]> {
+  const reverse = new Map<string, string[]>();
+  for (const [pptxName, ossName] of Object.entries(mapping)) {
+    const existing = reverse.get(ossName) ?? [];
+    existing.push(pptxName);
+    reverse.set(ossName, existing);
+  }
+  return reverse;
+}
+
+/**
+ * フォントバッファ配列から OpentypeTextMeasurer を構築する。
+ *
+ * 内部で opentype.js を動的 import してフォントをパースする。
+ * opentype.js が利用不可な場合は null を返す。
+ *
+ * Map には以下のキーで登録する:
+ * 1. バッファの name フィールド（例: "Carlito"）
+ * 2. フォントマッピングの逆引きで得られる PPTX 名（例: "Calibri"）
+ *
+ * これにより OpentypeTextMeasurer.resolveFont("Calibri") が
+ * Carlito のフォントデータで解決できる。
+ */
+export async function createOpentypeTextMeasurerFromBuffers(
+  fontBuffers: FontBuffer[],
+  fontMapping?: FontMapping,
+): Promise<OpentypeTextMeasurer | null> {
+  if (fontBuffers.length === 0) return null;
+
+  const opentype = await tryLoadOpentype();
+  if (!opentype) return null;
+
+  const mapping = createFontMapping(fontMapping);
+  const reverseMap = buildReverseMapping(mapping);
+  const fonts = new Map<string, OpentypeFont>();
+  let firstFont: OpentypeFont | null = null;
+
+  for (const buffer of fontBuffers) {
+    try {
+      let arrayBuffer: ArrayBuffer;
+      if (buffer.data instanceof ArrayBuffer) {
+        arrayBuffer = buffer.data;
+      } else {
+        // Uint8Array → ArrayBuffer: slice で独立した ArrayBuffer を取得
+        arrayBuffer = buffer.data.buffer.slice(
+          buffer.data.byteOffset,
+          buffer.data.byteOffset + buffer.data.byteLength,
+        ) as ArrayBuffer;
+      }
+      const font = opentype.parse(arrayBuffer);
+
+      if (!firstFont) firstFont = font;
+
+      // バッファの name があればそのキーで登録
+      if (buffer.name) {
+        fonts.set(buffer.name, font);
+
+        // 逆引きで PPTX フォント名も登録
+        const pptxNames = reverseMap.get(buffer.name);
+        if (pptxNames) {
+          for (const pptxName of pptxNames) {
+            if (!fonts.has(pptxName)) {
+              fonts.set(pptxName, font);
+            }
+          }
+        }
+      }
+    } catch {
+      // パース失敗のフォントはスキップ
+    }
+  }
+
+  if (fonts.size === 0 && !firstFont) return null;
+
+  return new OpentypeTextMeasurer(fonts, firstFont ?? undefined);
+}


### PR DESCRIPTION
closes #217

## Summary

- フォントバッファから opentype.js 経由で `OpentypeTextMeasurer` を自動構築するヘルパー関数 `createOpentypeTextMeasurerFromBuffers` を追加
- `convertPptxToSvg` に自動接続ロジックを追加: `fontBuffers` 提供時に `textMeasurer` が未指定なら自動構築
- フォントマッピングの逆引きにより、PPTX フォント名（例: Calibri）でも OSS 代替フォント（例: Carlito）で計測可能

## 詳細

### 新規ファイル
- `src/opentype-helpers.ts` — `createOpentypeTextMeasurerFromBuffers()` ヘルパー関数
- `src/opentype-helpers.test.ts` — ユニットテスト（9 テストケース）

### 変更ファイル
- `src/converter.ts` — `convertPptxToSvg` に fontBuffers からの自動 OpentypeTextMeasurer 構築ロジックを追加
- `src/index.ts` — `createOpentypeTextMeasurerFromBuffers`, `FontBuffer` を公開 export

### 後方互換性
- `ConvertOptions` インターフェース変更なし
- `fontBuffers` 未指定時は従来通り `DefaultTextMeasurer`（静的メトリクス）を使用
- opentype.js 未インストール時も `DefaultTextMeasurer` にフォールバック

## Test plan

- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm run typecheck` パス
- [x] `npm run test` パス（VRT 除く全 779 テスト）
- [x] `npm run build` 成功
- [ ] CI で全ジョブがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)