### PR TITLE
feat: テキスト→パス変換（Satori方式）

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -10,7 +10,8 @@ import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 import type { FontMapping } from "./font-mapping.js";
 import { createFontMapping } from "./font-mapping.js";
 import { setFontMapping, resetFontMapping } from "./font-mapping-context.js";
-import { createOpentypeTextMeasurerFromBuffers } from "./opentype-helpers.js";
+import { createOpentypeSetupFromBuffers } from "./opentype-helpers.js";
+import { setTextPathFontResolver, resetTextPathFontResolver } from "./text-path-context.js";
 
 export interface FontOptions {
   /** resvg-wasm に渡すフォントファイルパス (Node.js 向け) */
@@ -65,12 +66,13 @@ export async function convertPptxToSvg(
   if (options?.textMeasurer) {
     setTextMeasurer(options.textMeasurer);
   } else if (options?.fonts?.fontBuffers && options.fonts.fontBuffers.length > 0) {
-    const measurer = await createOpentypeTextMeasurerFromBuffers(
+    const setup = await createOpentypeSetupFromBuffers(
       options.fonts.fontBuffers,
       options.fontMapping,
     );
-    if (measurer) {
-      setTextMeasurer(measurer);
+    if (setup) {
+      setTextMeasurer(setup.measurer);
+      setTextPathFontResolver(setup.fontResolver);
     }
   }
   setFontMapping(createFontMapping(options?.fontMapping));
@@ -106,6 +108,7 @@ export async function convertPptxToSvg(
     return results;
   } finally {
     resetTextMeasurer();
+    resetTextPathFontResolver();
     resetFontMapping();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,5 +14,10 @@ export { DEFAULT_FONT_MAPPING, createFontMapping, getMappedFont } from "./font-m
 export type { FontMapping } from "./font-mapping.js";
 export { fetchGoogleFonts, resolveGoogleFontNames, parseFontUrlsFromCss } from "./google-fonts.js";
 export type { FetchGoogleFontsOptions } from "./google-fonts.js";
-export { createOpentypeTextMeasurerFromBuffers } from "./opentype-helpers.js";
-export type { FontBuffer } from "./opentype-helpers.js";
+export {
+  createOpentypeTextMeasurerFromBuffers,
+  createOpentypeSetupFromBuffers,
+} from "./opentype-helpers.js";
+export type { FontBuffer, OpentypeSetup } from "./opentype-helpers.js";
+export type { TextPathFontResolver, OpentypeFullFont, OpentypePath } from "./text-path-context.js";
+export { DefaultTextPathFontResolver } from "./text-path-context.js";

--- a/src/renderer/text-renderer.test.ts
+++ b/src/renderer/text-renderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
   renderTextBody,
   formatAutoNum,
@@ -13,6 +13,12 @@ import type {
   BodyProperties,
 } from "../model/text.js";
 import type { Transform } from "../model/shape.js";
+import {
+  setTextPathFontResolver,
+  resetTextPathFontResolver,
+  DefaultTextPathFontResolver,
+} from "../text-path-context.js";
+import type { OpentypeFullFont } from "../text-path-context.js";
 
 function makeTransform(widthEmu: number, heightEmu: number): Transform {
   return {
@@ -1018,5 +1024,289 @@ describe("縦書きテキスト (vertical text)", () => {
     const result = renderTextBody(textBody, makeTransform(4000000, heightEmu));
     const heightPx = (heightEmu / 914400) * 96;
     expect(result).toContain(`translate(0, ${heightPx})`);
+  });
+});
+
+// ============================================================
+// テキスト→パス変換（path モード）
+// ============================================================
+
+function createMockFont(name: string): OpentypeFullFont {
+  return {
+    unitsPerEm: 1000,
+    ascender: 800,
+    descender: -200,
+    getPath: (text: string, x: number, y: number, _fontSize: number) => ({
+      toPathData: () => `M${x.toFixed(1)} ${y.toFixed(1)}L${name} ${text.length}`,
+    }),
+  };
+}
+
+function setupPathMode(fontName = "TestFont"): void {
+  const font = createMockFont(fontName);
+  const fonts = new Map([[fontName, font]]);
+  setTextPathFontResolver(new DefaultTextPathFontResolver(fonts, font));
+}
+
+describe("renderTextBody (path mode)", () => {
+  afterEach(() => {
+    resetTextPathFontResolver();
+  });
+
+  it("フォントリゾルバーが設定されている場合、<path> 要素を生成する", () => {
+    setupPathMode();
+    const textBody = makeTextBody(["Hello"]);
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain("<path");
+    expect(result).toContain('d="M');
+    expect(result).not.toContain("<text");
+    expect(result).not.toContain("<tspan");
+  });
+
+  it("テキスト色が path の fill 属性に反映される", () => {
+    setupPathMode();
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+        numCol: 1,
+        vert: "horz",
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Red Text",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                fontFamilyEa: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: { hex: "#FF0000", alpha: 1 },
+                baseline: 0,
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('fill="#FF0000"');
+  });
+
+  it("透明度が fill-opacity に反映される", () => {
+    setupPathMode();
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+        numCol: 1,
+        vert: "horz",
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Transparent",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                fontFamilyEa: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: { hex: "#0000FF", alpha: 0.5 },
+                baseline: 0,
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('fill="#0000FF"');
+    expect(result).toContain('fill-opacity="0.5"');
+  });
+
+  it("ハイパーリンクが <a> タグで包まれる", () => {
+    setupPathMode();
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+        numCol: 1,
+        vert: "horz",
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Click me",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                fontFamilyEa: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+                hyperlink: { url: "https://example.com" },
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain('<a href="https://example.com">');
+    expect(result).toContain("</a>");
+  });
+
+  it("下線が <line> 要素として描画される", () => {
+    setupPathMode();
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+        numCol: 1,
+        vert: "horz",
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Underlined",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                fontFamilyEa: null,
+                bold: false,
+                italic: false,
+                underline: true,
+                strikethrough: false,
+                color: null,
+                baseline: 0,
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain("<line");
+    expect(result).toContain("stroke=");
+  });
+
+  it("取り消し線が <line> 要素として描画される", () => {
+    setupPathMode();
+    const textBody: TextBody = {
+      bodyProperties: {
+        anchor: "t",
+        marginLeft: 91440,
+        marginRight: 91440,
+        marginTop: 45720,
+        marginBottom: 45720,
+        wrap: "square",
+        autoFit: "noAutofit",
+        fontScale: 1,
+        lnSpcReduction: 0,
+        numCol: 1,
+        vert: "horz",
+      },
+      paragraphs: [
+        {
+          runs: [
+            {
+              text: "Strikethrough",
+              properties: {
+                fontSize: 18,
+                fontFamily: null,
+                fontFamilyEa: null,
+                bold: false,
+                italic: false,
+                underline: false,
+                strikethrough: true,
+                color: null,
+                baseline: 0,
+              },
+            },
+          ],
+          properties: defaultParagraphProperties(),
+        },
+      ],
+    };
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain("<line");
+  });
+
+  it("空のテキストでは空文字列を返す", () => {
+    setupPathMode();
+    const textBody = makeTextBody([""]);
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toBe("");
+  });
+
+  it("縦書き (vert) で rotate(90) が適用される", () => {
+    setupPathMode();
+    const textBody = makeTextBody(["Vertical"], { vert: "vert" });
+    const result = renderTextBody(textBody, makeTransform(4000000, 2000000));
+    expect(result).toContain("rotate(90)");
+    expect(result).toContain("<path");
+    expect(result).not.toContain("<text");
+  });
+
+  it("縦書き (vert270) で rotate(-90) が適用される", () => {
+    setupPathMode();
+    const textBody = makeTextBody(["Vert270"], { vert: "vert270" });
+    const result = renderTextBody(textBody, makeTransform(4000000, 2000000));
+    expect(result).toContain("rotate(-90)");
+    expect(result).toContain("<path");
+  });
+
+  it("フォントリゾルバーが null の場合は tspan レンダリングにフォールバック", () => {
+    // setupPathMode() を呼ばない → fontResolver は null
+    const textBody = makeTextBody(["Fallback"]);
+    const result = renderTextBody(textBody, makeTransform(SLIDE_WIDTH, SLIDE_HEIGHT));
+    expect(result).toContain("<text");
+    expect(result).toContain("<tspan");
+    expect(result).not.toContain("<path");
   });
 });

--- a/src/text-path-context.test.ts
+++ b/src/text-path-context.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  DefaultTextPathFontResolver,
+  setTextPathFontResolver,
+  getTextPathFontResolver,
+  resetTextPathFontResolver,
+} from "./text-path-context.js";
+import type { OpentypeFullFont } from "./text-path-context.js";
+
+function createMockFont(name: string): OpentypeFullFont {
+  return {
+    unitsPerEm: 1000,
+    ascender: 800,
+    descender: -200,
+    getPath: (_text: string, _x: number, _y: number, _fontSize: number) => ({
+      toPathData: () => `M0 0 L10 10 /* ${name} */`,
+    }),
+  };
+}
+
+describe("TextPathFontResolver context", () => {
+  afterEach(() => {
+    resetTextPathFontResolver();
+  });
+
+  it("初期状態では null を返す", () => {
+    expect(getTextPathFontResolver()).toBeNull();
+  });
+
+  it("set 後に get で取得できる", () => {
+    const fonts = new Map([["Arial", createMockFont("Arial")]]);
+    const resolver = new DefaultTextPathFontResolver(fonts);
+    setTextPathFontResolver(resolver);
+    expect(getTextPathFontResolver()).toBe(resolver);
+  });
+
+  it("reset 後に null に戻る", () => {
+    const fonts = new Map([["Arial", createMockFont("Arial")]]);
+    const resolver = new DefaultTextPathFontResolver(fonts);
+    setTextPathFontResolver(resolver);
+    resetTextPathFontResolver();
+    expect(getTextPathFontResolver()).toBeNull();
+  });
+});
+
+describe("DefaultTextPathFontResolver", () => {
+  it("fontFamily でフォントを解決する", () => {
+    const arialFont = createMockFont("Arial");
+    const fonts = new Map([["Arial", arialFont]]);
+    const resolver = new DefaultTextPathFontResolver(fonts);
+    expect(resolver.resolveFont("Arial", null)).toBe(arialFont);
+  });
+
+  it("fontFamily が見つからなければ fontFamilyEa で解決する", () => {
+    const notoFont = createMockFont("Noto Sans JP");
+    const fonts = new Map([["Noto Sans JP", notoFont]]);
+    const resolver = new DefaultTextPathFontResolver(fonts);
+    expect(resolver.resolveFont("Unknown", "Noto Sans JP")).toBe(notoFont);
+  });
+
+  it("どちらも見つからなければ defaultFont にフォールバック", () => {
+    const defaultFont = createMockFont("Default");
+    const fonts = new Map<string, OpentypeFullFont>();
+    const resolver = new DefaultTextPathFontResolver(fonts, defaultFont);
+    expect(resolver.resolveFont("Unknown", "AlsoUnknown")).toBe(defaultFont);
+  });
+
+  it("どれもなければ null を返す", () => {
+    const fonts = new Map<string, OpentypeFullFont>();
+    const resolver = new DefaultTextPathFontResolver(fonts);
+    expect(resolver.resolveFont("Unknown", null)).toBeNull();
+  });
+
+  it("fontFamily が null の場合は fontFamilyEa を試みる", () => {
+    const notoFont = createMockFont("Noto Sans JP");
+    const fonts = new Map([["Noto Sans JP", notoFont]]);
+    const resolver = new DefaultTextPathFontResolver(fonts);
+    expect(resolver.resolveFont(null, "Noto Sans JP")).toBe(notoFont);
+  });
+});

--- a/src/text-path-context.ts
+++ b/src/text-path-context.ts
@@ -1,0 +1,61 @@
+/**
+ * テキスト→パス変換用のフォントリゾルバーコンテキスト。
+ * opentype.js の getPath() メソッドを持つ Font オブジェクトへのアクセスを提供する。
+ */
+
+export interface OpentypePath {
+  toPathData(decimalPlaces?: number): string;
+}
+
+export interface OpentypeFullFont {
+  unitsPerEm: number;
+  ascender: number;
+  descender: number;
+  getPath(text: string, x: number, y: number, fontSize: number): OpentypePath;
+}
+
+export interface TextPathFontResolver {
+  resolveFont(
+    fontFamily: string | null | undefined,
+    fontFamilyEa: string | null | undefined,
+  ): OpentypeFullFont | null;
+}
+
+export class DefaultTextPathFontResolver implements TextPathFontResolver {
+  private fonts: Map<string, OpentypeFullFont>;
+  private defaultFont: OpentypeFullFont | null;
+
+  constructor(fonts: Map<string, OpentypeFullFont>, defaultFont?: OpentypeFullFont) {
+    this.fonts = fonts;
+    this.defaultFont = defaultFont ?? null;
+  }
+
+  resolveFont(
+    fontFamily: string | null | undefined,
+    fontFamilyEa: string | null | undefined,
+  ): OpentypeFullFont | null {
+    if (fontFamily) {
+      const font = this.fonts.get(fontFamily);
+      if (font) return font;
+    }
+    if (fontFamilyEa) {
+      const font = this.fonts.get(fontFamilyEa);
+      if (font) return font;
+    }
+    return this.defaultFont;
+  }
+}
+
+let currentResolver: TextPathFontResolver | null = null;
+
+export function setTextPathFontResolver(resolver: TextPathFontResolver): void {
+  currentResolver = resolver;
+}
+
+export function getTextPathFontResolver(): TextPathFontResolver | null {
+  return currentResolver;
+}
+
+export function resetTextPathFontResolver(): void {
+  currentResolver = null;
+}


### PR DESCRIPTION
close #218

## Summary

- opentype.js の `getPath()` を使ってテキストを SVG `<path>` 要素に変換する機能を追加
- フォントバッファが提供されている場合のみパスレンダリングが有効になり、なければ既存の `<text>/<tspan>` にフォールバック
- 出力 SVG/PNG からフォント依存を完全に除去可能に

## 変更内容

- **`src/text-path-context.ts`** (新規): `TextPathFontResolver` インターフェース + `DefaultTextPathFontResolver` 実装 + module-level state
- **`src/opentype-helpers.ts`**: `createOpentypeSetupFromBuffers()` 追加（measurer + fontResolver を同時構築）
- **`src/converter.ts`**: `convertPptxToSvg()` で fontBuffers 提供時に TextPathFontResolver を自動セットアップ
- **`src/renderer/text-renderer.ts`**: `renderTextBodyAsPath()` 追加。既存レイアウト計算を完全再利用し、SVG 出力のみ `<path>` に変更
- **`src/index.ts`**: 新しい型・関数のエクスポート追加

## 設計ポイント

- `<text><tspan>` → `<path d="...">` への変換
- `text-anchor` → 行幅計測による x 開始位置の自前計算
- `dy` (相対位置) → `currentY` の累積管理による絶対座標
- `text-decoration` → `<line>` 要素で下線・取り消し線を描画
- CJK/Latin スクリプト分割にも対応

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run test` 通過（797 テスト、新規 18 テスト含む）
- [x] `npm run build` 成功
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)