### PR TITLE
docs: README から sharp の内部実装詳細を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ rather than pixel-perfect rendering of every PowerPoint feature.
 ## Requirements
 
 - **Node.js >= 20**
-- PNG conversion uses [sharp](https://sharp.pixelplumbing.com/) (librsvg-based)
 
 ## Installation
 
@@ -73,11 +72,11 @@ pptx-glimpse automatically scans system font directories and loads fonts using [
 
 Default system font directories:
 
-| OS      | Directories                                                      |
-| ------- | ---------------------------------------------------------------- |
-| Linux   | `/usr/share/fonts`, `/usr/local/share/fonts`                     |
-| macOS   | `/System/Library/Fonts`, `/Library/Fonts`, `~/Library/Fonts`     |
-| Windows | `C:\Windows\Fonts`                                               |
+| OS      | Directories                                                  |
+| ------- | ------------------------------------------------------------ |
+| Linux   | `/usr/share/fonts`, `/usr/local/share/fonts`                 |
+| macOS   | `/System/Library/Fonts`, `/Library/Fonts`, `~/Library/Fonts` |
+| Windows | `C:\Windows\Fonts`                                           |
 
 Use the `fontDirs` option to add custom font directories.
 


### PR DESCRIPTION
## Summary

- README の Requirements セクションから「PNG conversion uses sharp (librsvg-based)」を削除
- sharp の使用は内部実装の詳細であり、ユーザーが意識する必要がないため

## Test plan

- [ ] README の表示が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)