### PR TITLE
fix: GitHub Pages デモデプロイのビルドエラーを修正

### DIFF
--- a/src/opentype-helpers.ts
+++ b/src/opentype-helpers.ts
@@ -1,14 +1,12 @@
 /**
  * opentype.js を使ってフォントを読み込み OpentypeTextMeasurer を構築するヘルパー。
  */
-import { readFile } from "node:fs/promises";
 import type { OpentypeFont } from "./opentype-text-measurer.js";
 import { OpentypeTextMeasurer } from "./opentype-text-measurer.js";
 import type { FontMapping } from "./font-mapping.js";
 import { createFontMapping } from "./font-mapping.js";
 import type { OpentypeFullFont, TextPathFontResolver } from "./text-path-context.js";
 import { DefaultTextPathFontResolver } from "./text-path-context.js";
-import { collectFontFilePaths } from "./system-font-loader.js";
 
 /** フォントバッファの入力形式 */
 export interface FontBuffer {
@@ -230,6 +228,10 @@ export async function createOpentypeSetupFromSystem(
 ): Promise<OpentypeSetup | null> {
   const opentype = await tryLoadOpentype();
   if (!opentype) return null;
+
+  // Node.js 専用モジュールを動的インポート（ブラウザバンドル時に含まれないようにする）
+  const { collectFontFilePaths } = await import(/* @vite-ignore */ "./system-font-loader.js");
+  const { readFile } = await import(/* @vite-ignore */ "node:fs/promises");
 
   const fontFilePaths = collectFontFilePaths(additionalFontDirs);
   if (fontFilePaths.length === 0) return null;

--- a/src/system-font-loader.ts
+++ b/src/system-font-loader.ts
@@ -1,6 +1,6 @@
-import { readdirSync, existsSync } from "node:fs";
-import { join, extname } from "node:path";
-import { homedir, platform } from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 const FONT_EXTENSIONS = new Set([".ttf", ".otf"]);
 
@@ -8,12 +8,12 @@ let cachedPaths: string[] | null = null;
 let cachedAdditionalDirs: string[] | null = null;
 
 function getSystemFontDirs(): string[] {
-  const os = platform();
-  switch (os) {
+  const p = os.platform();
+  switch (p) {
     case "linux":
       return ["/usr/share/fonts", "/usr/local/share/fonts"];
     case "darwin":
-      return ["/System/Library/Fonts", "/Library/Fonts", join(homedir(), "Library/Fonts")];
+      return ["/System/Library/Fonts", "/Library/Fonts", path.join(os.homedir(), "Library/Fonts")];
     case "win32":
       return ["C:\\Windows\\Fonts"];
     default:
@@ -22,13 +22,13 @@ function getSystemFontDirs(): string[] {
 }
 
 function walk(dir: string, result: string[]): void {
-  if (!existsSync(dir)) return;
+  if (!fs.existsSync(dir)) return;
   try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = join(dir, entry.name);
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(fullPath, result);
-      } else if (FONT_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
+      } else if (FONT_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
         result.push(fullPath);
       }
     }


### PR DESCRIPTION
## Summary

- `system-font-loader.ts` の `node:os` からの名前付きインポート (`platform`, `homedir`) が Vite のブラウザ外部化スタブ (`__vite-browser-external`) と互換性がなく、デモの GitHub Pages デプロイが失敗していた
- `system-font-loader.ts`: 名前付きインポートをデフォルトインポート (`import os from "node:os"`) に変更し、Vite のブラウザスタブとの互換性を確保
- `opentype-helpers.ts`: Node.js 専用モジュール (`system-font-loader`, `node:fs/promises`) を静的インポートから動的インポートに変更し、ブラウザバンドル時の依存を軽減

## Test plan

- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm run typecheck` パス
- [x] `demo/` の `npm run build` が成功することを確認
- [ ] CI の Deploy Demo to GitHub Pages ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)