### PR TITLE
refactor: Vite ブラウザ互換のワークアラウンドを削除

### DIFF
--- a/src/font/opentype-helpers.ts
+++ b/src/font/opentype-helpers.ts
@@ -1,12 +1,14 @@
 /**
  * opentype.js を使ってフォントを読み込み OpentypeTextMeasurer を構築するヘルパー。
  */
+import { readFile } from "node:fs/promises";
 import type { OpentypeFont } from "./opentype-text-measurer.js";
 import { OpentypeTextMeasurer } from "./opentype-text-measurer.js";
 import type { FontMapping } from "./font-mapping.js";
 import { createFontMapping } from "./font-mapping.js";
 import type { OpentypeFullFont, TextPathFontResolver } from "./text-path-context.js";
 import { DefaultTextPathFontResolver } from "./text-path-context.js";
+import { collectFontFilePaths } from "./system-font-loader.js";
 
 /** フォントバッファの入力形式 */
 export interface FontBuffer {
@@ -228,10 +230,6 @@ export async function createOpentypeSetupFromSystem(
 ): Promise<OpentypeSetup | null> {
   const opentype = await tryLoadOpentype();
   if (!opentype) return null;
-
-  // Node.js 専用モジュールを動的インポート（ブラウザバンドル時に含まれないようにする）
-  const { collectFontFilePaths } = await import(/* @vite-ignore */ "./system-font-loader.js");
-  const { readFile } = await import(/* @vite-ignore */ "node:fs/promises");
 
   const fontFilePaths = collectFontFilePaths(additionalFontDirs);
   if (fontFilePaths.length === 0) return null;

--- a/src/font/system-font-loader.ts
+++ b/src/font/system-font-loader.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
+import { readdirSync, existsSync } from "node:fs";
+import { join, extname } from "node:path";
+import { homedir, platform } from "node:os";
 
 const FONT_EXTENSIONS = new Set([".ttf", ".otf"]);
 
@@ -8,12 +8,12 @@ let cachedPaths: string[] | null = null;
 let cachedAdditionalDirs: string[] | null = null;
 
 function getSystemFontDirs(): string[] {
-  const p = os.platform();
-  switch (p) {
+  const os = platform();
+  switch (os) {
     case "linux":
       return ["/usr/share/fonts", "/usr/local/share/fonts"];
     case "darwin":
-      return ["/System/Library/Fonts", "/Library/Fonts", path.join(os.homedir(), "Library/Fonts")];
+      return ["/System/Library/Fonts", "/Library/Fonts", join(homedir(), "Library/Fonts")];
     case "win32":
       return ["C:\\Windows\\Fonts"];
     default:
@@ -22,13 +22,13 @@ function getSystemFontDirs(): string[] {
 }
 
 function walk(dir: string, result: string[]): void {
-  if (!fs.existsSync(dir)) return;
+  if (!existsSync(dir)) return;
   try {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name);
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(fullPath, result);
-      } else if (FONT_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      } else if (FONT_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
         result.push(fullPath);
       }
     }


### PR DESCRIPTION
## Summary

デモアプリがサーバサイド変換に移行したため（#239）、PR #237 で導入した Vite ブラウザ互換のワークアラウンドが不要になった。

- `opentype-helpers.ts`: `system-font-loader` と `node:fs/promises` の動的インポート + `/* @vite-ignore */` を静的インポートに戻す
- `system-font-loader.ts`: `node:fs` / `node:path` / `node:os` のデフォルトインポートを名前付きインポートに戻す

## Test plan

- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm run typecheck` パス
- [ ] CI パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)