### PR TITLE
feat: デモアプリに Vercel Analytics を導入

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "pptx-glimpse-demo",
       "dependencies": {
+        "@vercel/analytics": "^1.6.1",
         "next": "^15.0.0",
         "pptx-glimpse": "file:..",
         "react": "^19.0.0",
@@ -694,6 +695,44 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/caniuse-lite": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.6.1",
     "next": "^15.0.0",
     "pptx-glimpse": "file:..",
     "react": "^19.0.0",

--- a/demo/src/app/layout.tsx
+++ b/demo/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -9,7 +10,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        {children}
+        <Analytics />
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- デモアプリ (`demo/`) に `@vercel/analytics` を追加
- Root Layout (`layout.tsx`) に `<Analytics />` コンポーネントを配置
- Vercel デプロイ後、ダッシュボードの Analytics タブでアクセス状況を確認可能に

## Test plan
- [ ] `demo/` ディレクトリで `npm run build` が成功すること
- [ ] Vercel にデプロイ後、Analytics タブでデータが取得されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)