### PR TITLE
perf: PPTX → SVG 変換のパフォーマンス最適化

### DIFF
--- a/bench/conversion.bench.ts
+++ b/bench/conversion.bench.ts
@@ -414,8 +414,8 @@ function createMultiSlideEntries(count: number): SlideEntry[] {
 // Parse pipeline helper (reproduces converter.ts internal logic)
 // ---------------------------------------------------------------------------
 
-async function parsePptx(input: Buffer): Promise<{ slides: Slide[]; slideSize: SlideSize }> {
-  const archive = await readPptx(input);
+function parsePptx(input: Buffer): { slides: Slide[]; slideSize: SlideSize } {
+  const archive = readPptx(input);
 
   const presentationXml = archive.files.get("ppt/presentation.xml");
   if (!presentationXml) throw new Error("Missing presentation.xml");
@@ -490,11 +490,11 @@ beforeAll(async () => {
   ]);
 
   // Pre-parse slides for renderer-only benchmarks
-  const simpleResult = await parsePptx(simplePptx);
+  const simpleResult = parsePptx(simplePptx);
   parsedSimpleSlide = simpleResult.slides[0];
   slideSize = simpleResult.slideSize;
 
-  const complexResult = await parsePptx(complexPptx);
+  const complexResult = parsePptx(complexPptx);
   parsedComplexSlide = complexResult.slides[0];
 });
 
@@ -531,12 +531,12 @@ describe("PNG conversion", () => {
 });
 
 describe("parser standalone", () => {
-  bench("parse simple slide", async () => {
-    await parsePptx(simplePptx);
+  bench("parse simple slide", () => {
+    parsePptx(simplePptx);
   });
 
-  bench("parse complex slide", async () => {
-    await parsePptx(complexPptx);
+  bench("parse complex slide", () => {
+    parsePptx(complexPptx);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.5.0",
-        "jszip": "^3.10.0",
+        "fflate": "^0.8.2",
         "opentype.js": "^1.3.4",
         "sharp": "^0.34.5"
       },
@@ -20,6 +20,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
+        "jszip": "^3.10.1",
         "pixelmatch": "^7.1.0",
         "prettier": "^3.0.0",
         "tsup": "^8.0.0",
@@ -2410,6 +2411,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -2854,6 +2856,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3041,6 +3049,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -3074,6 +3083,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-extglob": {
@@ -3113,6 +3123,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3247,6 +3258,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
@@ -3283,6 +3295,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
@@ -3564,6 +3577,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -3800,6 +3814,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -3816,6 +3831,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -3910,6 +3926,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -3928,6 +3945,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sharp": {
@@ -4055,6 +4073,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -4548,6 +4567,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "license": "MIT",
   "dependencies": {
     "fast-xml-parser": "^4.5.0",
-    "jszip": "^3.10.0",
+    "fflate": "^0.8.2",
     "opentype.js": "^1.3.4",
     "sharp": "^0.34.5"
   },
@@ -72,6 +72,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
+    "jszip": "^3.10.1",
     "pixelmatch": "^7.1.0",
     "prettier": "^3.0.0",
     "tsup": "^8.0.0",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -11,6 +11,7 @@ import { createFontMapping } from "./font/font-mapping.js";
 import { setFontMapping, resetFontMapping } from "./font/font-mapping-context.js";
 import { createOpentypeSetupFromSystem } from "./font/opentype-helpers.js";
 import { setTextPathFontResolver, resetTextPathFontResolver } from "./font/text-path-context.js";
+import { enableXmlCache, clearXmlCache } from "./parser/xml-parser.js";
 
 export interface ConvertOptions {
   /** 変換対象のスライド番号 (1始まり)。未指定で全スライド */
@@ -49,10 +50,11 @@ export async function convertPptxToSvg(
     setTextPathFontResolver(setup.fontResolver);
   }
   setFontMapping(createFontMapping(options?.fontMapping));
+  enableXmlCache();
   try {
     initWarningLogger(options?.logLevel ?? "off");
 
-    const data = await parsePptxData(input);
+    const data = parsePptxData(input);
 
     // Filter slides if specified
     const targetSlides = options?.slides
@@ -80,6 +82,7 @@ export async function convertPptxToSvg(
 
     return results;
   } finally {
+    clearXmlCache();
     resetTextMeasurer();
     resetTextPathFontResolver();
     resetFontMapping();

--- a/src/font/font-collector.test.ts
+++ b/src/font/font-collector.test.ts
@@ -193,8 +193,8 @@ beforeAll(async () => {
 });
 
 describe("collectUsedFonts", () => {
-  it("テーマフォント情報を返す", async () => {
-    const result = await collectUsedFonts(testPptx);
+  it("テーマフォント情報を返す", () => {
+    const result = collectUsedFonts(testPptx);
 
     expect(result.theme.majorFont).toBe("Calibri Light");
     expect(result.theme.minorFont).toBe("Calibri");
@@ -204,8 +204,8 @@ describe("collectUsedFonts", () => {
     expect(result.theme.minorFontCs).toBe("Arial");
   });
 
-  it("テキストランのフォント名を収集する", async () => {
-    const result = await collectUsedFonts(testPptx);
+  it("テキストランのフォント名を収集する", () => {
+    const result = collectUsedFonts(testPptx);
 
     // テキストランで指定されたフォント
     expect(result.fonts).toContain("Arial");
@@ -214,15 +214,15 @@ describe("collectUsedFonts", () => {
     expect(result.fonts).toContain("Yu Gothic");
   });
 
-  it("テーマフォント名も fonts 一覧に含まれる", async () => {
-    const result = await collectUsedFonts(testPptx);
+  it("テーマフォント名も fonts 一覧に含まれる", () => {
+    const result = collectUsedFonts(testPptx);
 
     expect(result.fonts).toContain("Calibri Light");
     expect(result.fonts).toContain("Calibri");
   });
 
-  it("フォント名は重複なしでソート済み", async () => {
-    const result = await collectUsedFonts(testPptx);
+  it("フォント名は重複なしでソート済み", () => {
+    const result = collectUsedFonts(testPptx);
 
     // 重複がないことを確認
     const unique = [...new Set(result.fonts)];

--- a/src/pptx-data-parser.ts
+++ b/src/pptx-data-parser.ts
@@ -45,8 +45,8 @@ export interface ParsedPptxData {
   archive: PptxArchive;
 }
 
-export async function parsePptxData(input: Buffer | Uint8Array): Promise<ParsedPptxData> {
-  const archive = await readPptx(input);
+export function parsePptxData(input: Buffer | Uint8Array): ParsedPptxData {
+  const archive = readPptx(input);
 
   // Parse presentation.xml
   const presentationXml = archive.files.get("ppt/presentation.xml");


### PR DESCRIPTION
close #249

## Summary

PPTX → SVG 変換パイプラインのパフォーマンスを 4 つの独立した最適化で改善。

### 最適化内容

- **XMLParser シングルトン化**: 毎回 `new XMLParser()` していたのをモジュールレベルのシングルトンに変更（ステートレスなため安全に再利用可能）
- **XML パース結果キャッシュ**: 同一 XML 文字列（マスター・レイアウト等）の重複パースを `Map` ベースのキャッシュで回避。変換開始時に `enableXmlCache()`、完了時に `clearXmlCache()` でライフサイクル管理
- **extractDefs/removeDefs 正規表現統合**: 要素ごとに 10 回の正規表現操作（5 match + 5 replace）を 1 回の統合 `replace()` に集約
- **JSZip → fflate 移行**: 同期的な `unzipSync()` で ZIP 展開を高速化。`readPptx` / `parsePptxData` / `collectUsedFonts` が同期関数に

### ベンチマーク結果

| フェーズ | Before | After | 改善率 |
|---------|--------|-------|--------|
| パーサー (simple) | 2,022 ops/s | 3,436 ops/s | **+70%** |
| パーサー (complex) | 395 ops/s | 445 ops/s | **+13%** |
| レンダラー (simple) | 305,710 ops/s | 328,994 ops/s | **+8%** |
| レンダラー (complex) | 11,160 ops/s | 13,069 ops/s | **+17%** |

※ E2E はフォント初期化（opentype.js + システムフォント検索）が 99.9% を占めるため、ローカルベンチマークでは変化なし。Vercel 環境（システムフォント少数）では ZIP 展開・XML パースが主要コストのため、実効的な改善が期待される。

### 破壊的変更

- `readPptx` が `Promise<PptxArchive>` → `PptxArchive` に変更（同期化）
- `parsePptxData` が `Promise<ParsedPptxData>` → `ParsedPptxData` に変更
- `collectUsedFonts` が `Promise<UsedFonts>` → `UsedFonts` に変更
- `jszip` が production → devDependency に移動、`fflate` を production dependency に追加

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run test` 通過（779 テスト、VRT 除く）
- [x] `npm run build` 成功
- [x] ベンチマーク実行で改善を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)