### PR TITLE
docs: README と CLAUDE.md の古い記述を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,13 +34,14 @@ CI consists of 3 jobs:
 
 Data flow: **PPTX binary → Parser (ZIP extraction + XML parsing) → Intermediate model → Renderer (SVG generation) → PNG conversion (optional)**
 
-- `src/parser/` — Builds intermediate model from PPTX via ZIP extraction (`jszip`) and XML parsing (`fast-xml-parser`)
+- `src/parser/` — Builds intermediate model from PPTX via ZIP extraction (`fflate`) and XML parsing (`fast-xml-parser`)
 - `src/model/` — TypeScript interfaces for the intermediate model (Slide, Shape, Fill, Text, Theme, Table, Chart, Image, Line, Effect, Presentation, etc.)
 - `src/renderer/` — Generates SVG strings from the intermediate model. Includes preset shape definitions in `geometry/`, plus dedicated renderers for tables, charts, and images
 - `src/color/` — Theme color resolution (schemeClr → colorMap → colorScheme) and color transformations (lumMod/tint/shade)
+- `src/font/` — Font loading (system font scanning), font mapping (proprietary → OSS alternatives), text measurement and text-to-SVG-path conversion via `opentype.js`
 - `src/png/` — SVG → PNG conversion using sharp
-- `src/data/` — Font metrics data (character width information extracted from OSS-compatible fonts)
-- `src/utils/` — EMU ↔ pixel conversion (1 inch = 914400 EMU, 96 DPI), text width measurement, and text wrapping
+- `src/data/` — Font metrics data (fallback character width information)
+- `src/utils/` — EMU ↔ pixel conversion (1 inch = 914400 EMU, 96 DPI) and text wrapping
 
 Entry point: `src/index.ts` exports `convertPptxToSvg` and `convertPptxToPng`.
 

--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ Supports conversion of static visual content in PowerPoint. Dynamic elements suc
 
 #### Charts
 
-| Feature          | Details                                                                                    |
-| ---------------- | ------------------------------------------------------------------------------------------ |
-| Supported charts | Bar chart (vertical/horizontal), line chart, pie chart, scatter plot                       |
-| Chart elements   | Title, legend (position), series (name/values/categories/color), category axis, value axis |
+| Feature          | Details                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| Supported charts | Bar chart (vertical/horizontal), line chart, pie chart, scatter plot, area chart, doughnut, bubble, radar     |
+| Chart elements   | Title, legend (position), series (name/values/categories/color), category axis, value axis                   |
 
 #### SmartArt
 
@@ -214,9 +214,9 @@ Supports conversion of static visual content in PowerPoint. Dynamic elements suc
 | -------------- | ---------------------------------------------------------------------------------------------- |
 | Fill           | Path gradient (rect/shape type)                                                                |
 | Effects        | Reflection, 3D rotation / extrusion, artistic effects                                          |
-| Charts         | Area, radar, doughnut, bubble, stock, combo, histogram, box plot, waterfall, treemap, sunburst |
+| Charts         | Stock, combo, histogram, box plot, waterfall, treemap, sunburst                                |
 | Chart details  | Data labels, axis titles / tick marks / grid lines, error bars, trendlines                     |
-| Text           | Vertical text, individual text effects (shadow/glow), text outline, text columns               |
+| Text           | Individual text effects (shadow/glow), text columns                                            |
 | Tables         | Table style template application, diagonal borders                                             |
 | Shapes         | Shape operations (Union/Subtract/Intersect/Fragment)                                           |
 | Multimedia     | Embedded video / audio                                                                         |


### PR DESCRIPTION
## Summary

- CLAUDE.md: アーキテクチャの ZIP ライブラリ記述を `jszip` → `fflate` に更新
- CLAUDE.md: `src/font/` ディレクトリ (opentype.js によるフォント処理) の説明を追加
- CLAUDE.md: `src/data/` と `src/utils/` の説明を現状に合わせて更新
- README.md: サポート済みチャートに area, doughnut, bubble, radar を追加
- README.md: 未サポート一覧から実装済みの vertical text, text outline, 4種チャートを削除

## Test plan

- [ ] CLAUDE.md の記述が実際のディレクトリ構成・依存関係と一致していることを確認
- [ ] README.md の Feature Support / Unsupported Features が実装状況と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)