### PR TITLE
refactor: svg-renderer の defs 抽出を正規表現から構造体返却に変更

### DIFF
--- a/src/parse-render.integration.test.ts
+++ b/src/parse-render.integration.test.ts
@@ -84,7 +84,7 @@ function buildShapeXml(txBodyContent: string, spPrExtra: string = ""): string {
 function parseAndRenderShape(
   xml: string,
   rels?: Map<string, Relationship>,
-): { shape: ShapeElement; svg: string } {
+): { shape: ShapeElement; svg: string; defs: string[] } {
   const parsed = parseXml(xml);
   const elements = parseShapeTree(
     parsed.spTree as XmlNode | undefined,
@@ -96,8 +96,9 @@ function parseAndRenderShape(
   expect(elements).toHaveLength(1);
   expect(elements[0].type).toBe("shape");
   const shape = elements[0] as ShapeElement;
-  const svg = renderShape(shape);
-  return { shape, svg };
+  const result = renderShape(shape);
+  const svg = result.content;
+  return { shape, svg, defs: result.defs };
 }
 
 function extractDyValues(svg: string): number[] {
@@ -714,10 +715,12 @@ describe("parse-render integration: fill types", () => {
         </p:spPr>
       </p:sp>
     `);
-    const { svg } = parseAndRenderShape(xml);
-    expect(svg).toContain("<linearGradient");
-    expect(svg).toContain("#FF0000");
-    expect(svg).toContain("#0000FF");
+    const { svg, defs } = parseAndRenderShape(xml);
+    const allDefs = defs.join("");
+    expect(allDefs).toContain("<linearGradient");
+    expect(allDefs).toContain("#FF0000");
+    expect(allDefs).toContain("#0000FF");
+    expect(svg).toContain("url(#grad-");
   });
 });
 

--- a/src/renderer/chart-renderer.test.ts
+++ b/src/renderer/chart-renderer.test.ts
@@ -34,9 +34,9 @@ describe("renderChart", () => {
         categories: ["A", "B", "C"],
       });
 
-      const svg = renderChart(element);
+      const result = renderChart(element);
       // Should contain rect elements for the 3 bars
-      const barRects = svg.match(/<rect[^>]*fill="#4472C4"[^>]*\/>/g);
+      const barRects = result.content.match(/<rect[^>]*fill="#4472C4"[^>]*\/>/g);
       expect(barRects).not.toBeNull();
       expect(barRects!.length).toBe(3);
     });
@@ -48,8 +48,8 @@ describe("renderChart", () => {
         categories: ["Category 1"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("Category 1");
+      const result = renderChart(element);
+      expect(result.content).toContain("Category 1");
     });
 
     it("renders multiple series", () => {
@@ -62,9 +62,9 @@ describe("renderChart", () => {
         categories: ["A"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain('fill="#4472C4"');
-      expect(svg).toContain('fill="#ED7D31"');
+      const result = renderChart(element);
+      expect(result.content).toContain('fill="#4472C4"');
+      expect(result.content).toContain('fill="#ED7D31"');
     });
   });
 
@@ -76,9 +76,9 @@ describe("renderChart", () => {
         categories: ["A", "B", "C"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("<polyline");
-      expect(svg).toContain('stroke="#4472C4"');
+      const result = renderChart(element);
+      expect(result.content).toContain("<polyline");
+      expect(result.content).toContain('stroke="#4472C4"');
     });
 
     it("renders data point markers", () => {
@@ -88,8 +88,8 @@ describe("renderChart", () => {
         categories: ["A", "B"],
       });
 
-      const svg = renderChart(element);
-      const circles = svg.match(/<circle[^>]*fill="#4472C4"[^>]*\/>/g);
+      const result = renderChart(element);
+      const circles = result.content.match(/<circle[^>]*fill="#4472C4"[^>]*\/>/g);
       expect(circles).not.toBeNull();
       expect(circles!.length).toBe(2);
     });
@@ -103,8 +103,8 @@ describe("renderChart", () => {
         categories: ["A", "B"],
       });
 
-      const svg = renderChart(element);
-      const paths = svg.match(/<path[^>]*d="M[^"]*A[^"]*Z"[^>]*\/>/g);
+      const result = renderChart(element);
+      const paths = result.content.match(/<path[^>]*d="M[^"]*A[^"]*Z"[^>]*\/>/g);
       expect(paths).not.toBeNull();
       expect(paths!.length).toBe(2);
     });
@@ -116,8 +116,8 @@ describe("renderChart", () => {
         categories: ["A"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("<circle");
+      const result = renderChart(element);
+      expect(result.content).toContain("<circle");
     });
   });
 
@@ -130,8 +130,8 @@ describe("renderChart", () => {
         categories: ["A", "B"],
       });
 
-      const svg = renderChart(element);
-      const paths = svg.match(/<path[^>]*d="M[^"]*A[^"]*A[^"]*Z"[^>]*\/>/g);
+      const result = renderChart(element);
+      const paths = result.content.match(/<path[^>]*d="M[^"]*A[^"]*A[^"]*Z"[^>]*\/>/g);
       expect(paths).not.toBeNull();
       expect(paths!.length).toBe(2);
     });
@@ -144,8 +144,8 @@ describe("renderChart", () => {
         categories: ["A"],
       });
 
-      const svg = renderChart(element);
-      const circles = svg.match(/<circle[^>]*\/>/g);
+      const result = renderChart(element);
+      const circles = result.content.match(/<circle[^>]*\/>/g);
       expect(circles).not.toBeNull();
       expect(circles!.length).toBeGreaterThanOrEqual(2);
     });
@@ -157,8 +157,8 @@ describe("renderChart", () => {
         categories: ["A", "B"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("<path");
+      const result = renderChart(element);
+      expect(result.content).toContain("<path");
     });
   });
 
@@ -177,8 +177,8 @@ describe("renderChart", () => {
         categories: [],
       });
 
-      const svg = renderChart(element);
-      const circles = svg.match(/<circle[^>]*fill="#4472C4"[^>]*\/>/g);
+      const result = renderChart(element);
+      const circles = result.content.match(/<circle[^>]*fill="#4472C4"[^>]*\/>/g);
       expect(circles).not.toBeNull();
       expect(circles!.length).toBe(3);
     });
@@ -200,8 +200,8 @@ describe("renderChart", () => {
         categories: [],
       });
 
-      const svg = renderChart(element);
-      const circles = svg.match(/<circle[^>]*fill="#4472C4"[^>]*\/>/g);
+      const result = renderChart(element);
+      const circles = result.content.match(/<circle[^>]*fill="#4472C4"[^>]*\/>/g);
       expect(circles).not.toBeNull();
       expect(circles!.length).toBe(3);
     });
@@ -221,8 +221,8 @@ describe("renderChart", () => {
         categories: [],
       });
 
-      const svg = renderChart(element);
-      const circles = svg.match(/<circle[^>]*r="([^"]*)"[^>]*\/>/g);
+      const result = renderChart(element);
+      const circles = result.content.match(/<circle[^>]*r="([^"]*)"[^>]*\/>/g);
       expect(circles).not.toBeNull();
       expect(circles!.length).toBe(2);
       // Extract radii — larger bubble size should produce a larger radius
@@ -248,8 +248,8 @@ describe("renderChart", () => {
         categories: [],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain('fill-opacity="0.6"');
+      const result = renderChart(element);
+      expect(result.content).toContain('fill-opacity="0.6"');
     });
   });
 
@@ -262,15 +262,15 @@ describe("renderChart", () => {
         categories: ["A", "B", "C", "D"],
       });
 
-      const svg = renderChart(element);
+      const result = renderChart(element);
       // Grid circles (5 levels)
-      const circles = svg.match(/<circle[^>]*stroke="#D9D9D9"[^>]*\/>/g);
+      const circles = result.content.match(/<circle[^>]*stroke="#D9D9D9"[^>]*\/>/g);
       expect(circles).not.toBeNull();
       expect(circles!.length).toBe(5);
       // Data polygon
-      expect(svg).toContain("<polygon");
-      expect(svg).toContain('fill="none"');
-      expect(svg).toContain('stroke="#4472C4"');
+      expect(result.content).toContain("<polygon");
+      expect(result.content).toContain('fill="none"');
+      expect(result.content).toContain('stroke="#4472C4"');
     });
 
     it("renders filled polygon for filled radarStyle", () => {
@@ -281,9 +281,9 @@ describe("renderChart", () => {
         categories: ["A", "B", "C"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain('fill="#4472C4"');
-      expect(svg).toContain('fill-opacity="0.3"');
+      const result = renderChart(element);
+      expect(result.content).toContain('fill="#4472C4"');
+      expect(result.content).toContain('fill-opacity="0.3"');
     });
 
     it("renders markers for marker radarStyle", () => {
@@ -294,9 +294,9 @@ describe("renderChart", () => {
         categories: ["A", "B", "C"],
       });
 
-      const svg = renderChart(element);
+      const result = renderChart(element);
       // 3 data point markers
-      const markers = svg.match(/<circle[^>]*r="3"[^>]*\/>/g);
+      const markers = result.content.match(/<circle[^>]*r="3"[^>]*\/>/g);
       expect(markers).not.toBeNull();
       expect(markers!.length).toBe(3);
     });
@@ -309,9 +309,9 @@ describe("renderChart", () => {
         categories: ["Speed", "Power"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("Speed");
-      expect(svg).toContain("Power");
+      const result = renderChart(element);
+      expect(result.content).toContain("Speed");
+      expect(result.content).toContain("Power");
     });
   });
 
@@ -323,9 +323,9 @@ describe("renderChart", () => {
         categories: ["A"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("My Chart");
-      expect(svg).toContain('font-weight="bold"');
+      const result = renderChart(element);
+      expect(result.content).toContain("My Chart");
+      expect(result.content).toContain('font-weight="bold"');
     });
 
     it("escapes XML characters in title", () => {
@@ -335,8 +335,8 @@ describe("renderChart", () => {
         categories: ["A"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("A &amp; B &lt;C&gt;");
+      const result = renderChart(element);
+      expect(result.content).toContain("A &amp; B &lt;C&gt;");
     });
   });
 
@@ -351,9 +351,9 @@ describe("renderChart", () => {
         legend: { position: "b" },
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain("Series A");
-      expect(svg).toContain("Series B");
+      const result = renderChart(element);
+      expect(result.content).toContain("Series A");
+      expect(result.content).toContain("Series B");
     });
 
     it("does not render legend when not present", () => {
@@ -363,9 +363,9 @@ describe("renderChart", () => {
         legend: null,
       });
 
-      const svg = renderChart(element);
+      const result = renderChart(element);
       // Should not contain legend rect elements (aside from chart background and bar)
-      expect(svg).not.toContain("Series 1");
+      expect(result.content).not.toContain("Series 1");
     });
   });
 
@@ -376,10 +376,10 @@ describe("renderChart", () => {
         categories: [],
       });
 
-      const svg = renderChart(element);
+      const result = renderChart(element);
       // Should still return valid SVG with just the background
-      expect(svg).toContain("<g");
-      expect(svg).toContain("</g>");
+      expect(result.content).toContain("<g");
+      expect(result.content).toContain("</g>");
     });
   });
 
@@ -391,8 +391,8 @@ describe("renderChart", () => {
         categories: ["A"],
       });
 
-      const svg = renderChart(element);
-      expect(svg).toContain('fill-opacity="0.5"');
+      const result = renderChart(element);
+      expect(result.content).toContain('fill-opacity="0.5"');
     });
   });
 });

--- a/src/renderer/chart-renderer.ts
+++ b/src/renderer/chart-renderer.ts
@@ -1,5 +1,6 @@
 import type { ChartElement, ChartData, ChartSeries } from "../model/chart.js";
 import type { ResolvedColor } from "../model/fill.js";
+import type { RenderResult } from "./render-result.js";
 import { emuToPixels } from "../utils/emu.js";
 import { buildTransformAttr } from "./transform.js";
 
@@ -12,7 +13,7 @@ const DEFAULT_SERIES_COLORS: ResolvedColor[] = [
   { hex: "#70AD47", alpha: 1 },
 ];
 
-export function renderChart(element: ChartElement): string {
+export function renderChart(element: ChartElement): RenderResult {
   const { transform, chart } = element;
   const w = emuToPixels(transform.extentWidth);
   const h = emuToPixels(transform.extentHeight);
@@ -75,7 +76,7 @@ export function renderChart(element: ChartElement): string {
   }
 
   parts.push("</g>");
-  return parts.join("");
+  return { content: parts.join(""), defs: [] };
 }
 
 function renderChartTitle(title: string, chartWidth: number): string {

--- a/src/renderer/image-renderer.test.ts
+++ b/src/renderer/image-renderer.test.ts
@@ -42,33 +42,35 @@ describe("renderImage", () => {
   it("renders basic image element", () => {
     const result = renderImage(makeImage());
 
-    expect(result).toContain('<g transform="translate(96, 96)">');
-    expect(result).toContain('href="data:image/png;base64,iVBORw0KGgo="');
-    expect(result).toContain('width="192"');
-    expect(result).toContain('height="144"');
-    expect(result).toContain('preserveAspectRatio="none"');
-    expect(result).toContain("</g>");
+    expect(result.content).toContain('<g transform="translate(96, 96)">');
+    expect(result.content).toContain('href="data:image/png;base64,iVBORw0KGgo="');
+    expect(result.content).toContain('width="192"');
+    expect(result.content).toContain('height="144"');
+    expect(result.content).toContain('preserveAspectRatio="none"');
+    expect(result.content).toContain("</g>");
+    expect(result.defs).toHaveLength(0);
   });
 
   it("renders image with JPEG mime type", () => {
     const result = renderImage(makeImage({ mimeType: "image/jpeg", imageData: "/9j/4AAQ=" }));
-    expect(result).toContain('href="data:image/jpeg;base64,/9j/4AAQ="');
+    expect(result.content).toContain('href="data:image/jpeg;base64,/9j/4AAQ="');
   });
 
   it("renders image with rotation", () => {
     const result = renderImage(makeImage({ transform: makeTransform({ rotation: 45 }) }));
-    expect(result).toContain("rotate(45, 96, 72)");
+    expect(result.content).toContain("rotate(45, 96, 72)");
   });
 
   it("renders image with flipH", () => {
     const result = renderImage(makeImage({ transform: makeTransform({ flipH: true }) }));
-    expect(result).toContain("translate(192, 0) scale(-1, 1)");
+    expect(result.content).toContain("translate(192, 0) scale(-1, 1)");
   });
 
   it("does not include filter when effects is null", () => {
     const result = renderImage(makeImage());
-    expect(result).not.toContain("<filter");
-    expect(result).not.toContain("filter=");
+    expect(result.content).not.toContain("<filter");
+    expect(result.content).not.toContain("filter=");
+    expect(result.defs).toHaveLength(0);
   });
 
   it("renders image with srcRect crop", () => {
@@ -77,25 +79,25 @@ describe("renderImage", () => {
     );
 
     // clipPath def should be present
-    expect(result).toContain("<clipPath");
-    expect(result).toContain('width="192"');
-    expect(result).toContain('height="144"');
+    expect(result.content).toContain("<clipPath");
+    expect(result.content).toContain('width="192"');
+    expect(result.content).toContain('height="144"');
 
     // image should be scaled up: 192 / (1 - 0.1 - 0.1) = 240, 144 / (1 - 0.2 - 0.2) = 240
-    expect(result).toContain('width="240"');
-    expect(result).toContain('height="240"');
+    expect(result.content).toContain('width="240"');
+    expect(result.content).toContain('height="240"');
 
     // image offset: x = -0.1 * 240 = -24, y = -0.2 * 240 = -48
-    expect(result).toContain('x="-24"');
-    expect(result).toContain('y="-48"');
+    expect(result.content).toContain('x="-24"');
+    expect(result.content).toContain('y="-48"');
 
-    expect(result).toContain("clip-path=");
+    expect(result.content).toContain("clip-path=");
   });
 
   it("does not include clipPath when srcRect is null", () => {
     const result = renderImage(makeImage());
-    expect(result).not.toContain("<clipPath");
-    expect(result).not.toContain("clip-path=");
+    expect(result.content).not.toContain("<clipPath");
+    expect(result.content).not.toContain("clip-path=");
   });
 
   it("renders image with effects", () => {
@@ -117,23 +119,25 @@ describe("renderImage", () => {
       }),
     );
 
-    expect(result).toContain('<filter id="effect-test-uuid-0"');
-    expect(result).toContain('filter="url(#effect-test-uuid-0)"');
+    expect(result.defs).toHaveLength(1);
+    expect(result.defs[0]).toContain('<filter id="effect-test-uuid-0"');
+    expect(result.content).toContain('filter="url(#effect-test-uuid-0)"');
   });
 
   it("renders EMF placeholder", () => {
     const result = renderImage(makeImage({ mimeType: "image/emf" }));
-    expect(result).toContain('fill="#E0E0E0"');
-    expect(result).toContain("[EMF]");
-    expect(result).toContain("<rect");
-    expect(result).toContain("<text");
-    expect(result).not.toContain("<image");
+    expect(result.content).toContain('fill="#E0E0E0"');
+    expect(result.content).toContain("[EMF]");
+    expect(result.content).toContain("<rect");
+    expect(result.content).toContain("<text");
+    expect(result.content).not.toContain("<image");
+    expect(result.defs).toHaveLength(0);
   });
 
   it("renders WMF placeholder", () => {
     const result = renderImage(makeImage({ mimeType: "image/wmf" }));
-    expect(result).toContain("[WMF]");
-    expect(result).not.toContain("<image");
+    expect(result.content).toContain("[WMF]");
+    expect(result.content).not.toContain("<image");
   });
 
   it("renders image with blipEffects grayscale", () => {
@@ -148,9 +152,10 @@ describe("renderImage", () => {
         },
       }),
     );
-    expect(result).toContain('<filter id="blip-effect-');
-    expect(result).toContain('type="saturate" values="0"');
-    expect(result).toContain('filter="url(#blip-effect-');
+    expect(result.defs).toHaveLength(1);
+    expect(result.defs[0]).toContain('<filter id="blip-effect-');
+    expect(result.defs[0]).toContain('type="saturate" values="0"');
+    expect(result.content).toContain('filter="url(#blip-effect-');
   });
 
   it("renders image with stretch fillRect", () => {
@@ -160,11 +165,11 @@ describe("renderImage", () => {
       }),
     );
     // 192 * 0.1 = 19, 144 * 0.1 = 14
-    expect(result).toContain('x="19"');
-    expect(result).toContain('y="14"');
+    expect(result.content).toContain('x="19"');
+    expect(result.content).toContain('y="14"');
     // 192 * 0.8 = 154, 144 * 0.8 = 115
-    expect(result).toContain('width="154"');
-    expect(result).toContain('height="115"');
+    expect(result.content).toContain('width="154"');
+    expect(result.content).toContain('height="115"');
   });
 
   it("renders image with tile", () => {
@@ -173,12 +178,13 @@ describe("renderImage", () => {
         tile: { tx: 0, ty: 0, sx: 0.5, sy: 0.5, flip: "none", align: "tl" },
       }),
     );
-    expect(result).toContain("<pattern");
-    expect(result).toContain("patternUnits=");
-    expect(result).toContain('width="96"');
-    expect(result).toContain('height="72"');
-    expect(result).toContain("<rect");
-    expect(result).toContain('fill="url(#tile-');
+    expect(result.defs).toHaveLength(1);
+    expect(result.defs[0]).toContain("<pattern");
+    expect(result.defs[0]).toContain("patternUnits=");
+    expect(result.defs[0]).toContain('width="96"');
+    expect(result.defs[0]).toContain('height="72"');
+    expect(result.content).toContain("<rect");
+    expect(result.content).toContain('fill="url(#tile-');
   });
 
   it("renders tiled image with flip x", () => {
@@ -187,7 +193,7 @@ describe("renderImage", () => {
         tile: { tx: 0, ty: 0, sx: 0.5, sy: 0.5, flip: "x", align: "tl" },
       }),
     );
-    expect(result).toContain("scale(-1, 1)");
+    expect(result.defs[0]).toContain("scale(-1, 1)");
   });
 
   it("applies both blipEffects and effectLst with nested g", () => {
@@ -215,9 +221,10 @@ describe("renderImage", () => {
         },
       }),
     );
-    expect(result).toContain('<filter id="effect-');
-    expect(result).toContain('<filter id="blip-effect-');
-    expect(result).toContain('filter="url(#effect-');
-    expect(result).toContain('filter="url(#blip-effect-');
+    expect(result.defs).toHaveLength(2);
+    expect(result.defs.some((d) => d.includes('<filter id="effect-'))).toBe(true);
+    expect(result.defs.some((d) => d.includes('<filter id="blip-effect-'))).toBe(true);
+    expect(result.content).toContain('filter="url(#effect-');
+    expect(result.content).toContain('filter="url(#blip-effect-');
   });
 });

--- a/src/renderer/render-result.ts
+++ b/src/renderer/render-result.ts
@@ -1,0 +1,4 @@
+export interface RenderResult {
+  content: string;
+  defs: string[];
+}

--- a/src/renderer/shape-renderer.test.ts
+++ b/src/renderer/shape-renderer.test.ts
@@ -62,30 +62,31 @@ describe("renderShape", () => {
   it("renders basic shape with fill and outline", () => {
     const result = renderShape(makeShape());
 
-    expect(result).toContain('<g transform="translate(96, 96)">');
-    expect(result).toContain('fill="#FF0000"');
-    expect(result).toContain('stroke="#000000"');
-    expect(result).toContain("</g>");
+    expect(result.content).toContain('<g transform="translate(96, 96)">');
+    expect(result.content).toContain('fill="#FF0000"');
+    expect(result.content).toContain('stroke="#000000"');
+    expect(result.content).toContain("</g>");
+    expect(result.defs).toHaveLength(0);
   });
 
   it("renders shape with no fill", () => {
     const result = renderShape(makeShape({ fill: { type: "none" } }));
-    expect(result).toContain('fill="none"');
+    expect(result.content).toContain('fill="none"');
   });
 
   it("renders shape with null fill", () => {
     const result = renderShape(makeShape({ fill: null }));
-    expect(result).toContain('fill="none"');
+    expect(result.content).toContain('fill="none"');
   });
 
   it("renders shape with null outline", () => {
     const result = renderShape(makeShape({ outline: null }));
-    expect(result).toContain('stroke="none"');
+    expect(result.content).toContain('stroke="none"');
   });
 
   it("renders shape with rotation", () => {
     const result = renderShape(makeShape({ transform: makeTransform({ rotation: 90 }) }));
-    expect(result).toContain("rotate(90, 96, 48)");
+    expect(result.content).toContain("rotate(90, 96, 48)");
   });
 
   it("renders shape with effects", () => {
@@ -107,8 +108,10 @@ describe("renderShape", () => {
       }),
     );
 
-    expect(result).toContain('<filter id="effect-test-uuid-0"');
-    expect(result).toContain('filter="url(#effect-test-uuid-0)"');
+    expect(result.defs).toHaveLength(1);
+    expect(result.defs[0]).toContain('<filter id="effect-test-uuid-0"');
+    expect(result.content).toContain('filter="url(#effect-test-uuid-0)"');
+    expect(result.content).not.toContain("<filter");
   });
 
   it("renders shape with gradient fill", () => {
@@ -126,8 +129,10 @@ describe("renderShape", () => {
       }),
     );
 
-    expect(result).toContain("<linearGradient");
-    expect(result).toContain("url(#grad-");
+    expect(result.defs).toHaveLength(1);
+    expect(result.defs[0]).toContain("<linearGradient");
+    expect(result.content).toContain("url(#grad-");
+    expect(result.content).not.toContain("<linearGradient");
   });
 });
 
@@ -135,26 +140,27 @@ describe("renderConnector", () => {
   it("renders basic connector with line element", () => {
     const result = renderConnector(makeConnector());
 
-    expect(result).toContain('<g transform="translate(96, 96)">');
-    expect(result).toContain('<line x1="0" y1="0" x2="192" y2="96"');
-    expect(result).toContain('stroke="#000000"');
-    expect(result).toContain('fill="none"');
-    expect(result).toContain("</g>");
+    expect(result.content).toContain('<g transform="translate(96, 96)">');
+    expect(result.content).toContain('<line x1="0" y1="0" x2="192" y2="96"');
+    expect(result.content).toContain('stroke="#000000"');
+    expect(result.content).toContain('fill="none"');
+    expect(result.content).toContain("</g>");
+    expect(result.defs).toHaveLength(0);
   });
 
   it("renders connector with null outline", () => {
     const result = renderConnector(makeConnector({ outline: null }));
-    expect(result).toContain('stroke="none"');
+    expect(result.content).toContain('stroke="none"');
   });
 
   it("renders connector with rotation", () => {
     const result = renderConnector(makeConnector({ transform: makeTransform({ rotation: 45 }) }));
-    expect(result).toContain("rotate(45, 96, 48)");
+    expect(result.content).toContain("rotate(45, 96, 48)");
   });
 
   it("renders connector with flipH", () => {
     const result = renderConnector(makeConnector({ transform: makeTransform({ flipH: true }) }));
-    expect(result).toContain("translate(192, 0) scale(-1, 1)");
+    expect(result.content).toContain("translate(192, 0) scale(-1, 1)");
   });
 
   it("renders connector with effects", () => {
@@ -169,8 +175,9 @@ describe("renderConnector", () => {
       }),
     );
 
-    expect(result).toContain("<filter");
-    expect(result).toContain("filter=");
+    expect(result.defs).toHaveLength(1);
+    expect(result.defs[0]).toContain("<filter");
+    expect(result.content).toContain("filter=");
   });
 
   it("renders connector with dash style", () => {
@@ -186,7 +193,7 @@ describe("renderConnector", () => {
       }),
     );
 
-    expect(result).toContain('stroke="#FF0000"');
-    expect(result).toContain("stroke-dasharray=");
+    expect(result.content).toContain('stroke="#FF0000"');
+    expect(result.content).toContain("stroke-dasharray=");
   });
 });

--- a/src/renderer/table-renderer.test.ts
+++ b/src/renderer/table-renderer.test.ts
@@ -72,17 +72,17 @@ function createTableElement(overrides?: Partial<TableElement["table"]>): TableEl
 describe("renderTable", () => {
   it("renders a basic 2x2 table with cell backgrounds", () => {
     const element = createTableElement();
-    const defs: string[] = [];
-    const svg = renderTable(element, defs);
+    const result = renderTable(element);
 
-    expect(svg).toContain("<g transform=");
+    expect(result.content).toContain("<g transform=");
     // 4 cells, each with a rect
-    const rects = svg.match(/<rect /g);
+    const rects = result.content.match(/<rect /g);
     expect(rects).toHaveLength(4);
-    expect(svg).toContain('fill="#FF0000"');
-    expect(svg).toContain('fill="#00FF00"');
-    expect(svg).toContain('fill="#0000FF"');
-    expect(svg).toContain('fill="#FFFF00"');
+    expect(result.content).toContain('fill="#FF0000"');
+    expect(result.content).toContain('fill="#00FF00"');
+    expect(result.content).toContain('fill="#0000FF"');
+    expect(result.content).toContain('fill="#FFFF00"');
+    expect(result.defs).toHaveLength(0);
   });
 
   it("renders cell borders as lines", () => {
@@ -147,9 +147,8 @@ describe("renderTable", () => {
       },
     };
 
-    const defs: string[] = [];
-    const svg = renderTable(element, defs);
-    const lines = svg.match(/<line /g);
+    const result = renderTable(element);
+    const lines = result.content.match(/<line /g);
     expect(lines).toHaveLength(4);
   });
 
@@ -195,10 +194,9 @@ describe("renderTable", () => {
       },
     };
 
-    const defs: string[] = [];
-    const svg = renderTable(element, defs);
+    const result = renderTable(element);
     // Only 1 rect for the merged cell, hMerge cell is skipped
-    const rects = svg.match(/<rect /g);
+    const rects = result.content.match(/<rect /g);
     expect(rects).toHaveLength(1);
   });
 
@@ -276,9 +274,8 @@ describe("renderTable", () => {
       },
     };
 
-    const defs: string[] = [];
-    const svg = renderTable(element, defs);
-    expect(svg).toContain("<text");
-    expect(svg).toContain("Hello");
+    const result = renderTable(element);
+    expect(result.content).toContain("<text");
+    expect(result.content).toContain("Hello");
   });
 });

--- a/src/renderer/table-renderer.ts
+++ b/src/renderer/table-renderer.ts
@@ -1,11 +1,12 @@
 import type { TableElement } from "../model/table.js";
 import type { Transform } from "../model/shape.js";
+import type { RenderResult } from "./render-result.js";
 import { emuToPixels } from "../utils/emu.js";
 import { buildTransformAttr } from "./transform.js";
 import { renderFillAttrs, renderOutlineAttrs } from "./fill-renderer.js";
 import { renderTextBody } from "./text-renderer.js";
 
-export function renderTable(element: TableElement, defs: string[]): string {
+export function renderTable(element: TableElement): RenderResult {
   const { transform, table } = element;
   const transformAttr = buildTransformAttr(transform);
 
@@ -13,6 +14,7 @@ export function renderTable(element: TableElement, defs: string[]): string {
   const rowHeights = table.rows.map((row) => emuToPixels(row.height));
 
   const parts: string[] = [];
+  const defs: string[] = [];
   parts.push(`<g transform="${transformAttr}">`);
 
   let y = 0;
@@ -92,7 +94,7 @@ export function renderTable(element: TableElement, defs: string[]): string {
   }
 
   parts.push("</g>");
-  return parts.join("");
+  return { content: parts.join(""), defs };
 }
 
 function computeSpannedSize(sizes: number[], startIdx: number, span: number): number {


### PR DESCRIPTION
close #241

## 概要

`svg-renderer.ts` の `extractAndRemoveDefs` / `DEFS_RE` (正規表現ベースの defs 抽出) を廃止し、各レンダラーが構造体 `RenderResult { content, defs }` を返す方式に変更しました。

## 変更内容

- `src/renderer/render-result.ts` を新規追加（`RenderResult` インターフェース定義）
- `renderShape`, `renderConnector` の返り値を `string` → `RenderResult` に変更
- `renderImage` の返り値を `string` → `RenderResult` に変更
- `renderTable` の `defs` 引数を削除し、返り値を `RenderResult` に変更
- `renderChart` の返り値を `string` → `RenderResult` に変更
- `svg-renderer.ts` から `DEFS_TAGS`, `DEFS_RE`, `extractAndRemoveDefs` を削除
- `renderGroup` も `RenderResult` を返すように変更し、子要素の defs を集約
- 全テストファイルを新しいインターフェースに対応

## 期待される効果

- 型安全性の向上（正規表現の誤マッチリスクの排除）
- renderer 間のインターフェースの明確化
- 新しい `<defs>` 要素タイプ追加時に正規表現の追加が不要になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)