### PR TITLE
fix: ctrTitle/subTitle プレースホルダーのテキストカラー継承を修正

### DIFF
--- a/.changeset/fix-ctrtitle-color-inheritance.md
+++ b/.changeset/fix-ctrtitle-color-inheritance.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+ctrTitle/subTitle プレースホルダーがマスターの title/body lstStyle からテキストカラーを正しく継承するよう修正

--- a/src/text-style-resolver.test.ts
+++ b/src/text-style-resolver.test.ts
@@ -560,6 +560,75 @@ describe("applyTextStyleInheritance", () => {
     });
   });
 
+  describe("プレースホルダータイプのフォールバック", () => {
+    it("ctrTitle がマスターの title プレースホルダー lstStyle から色を継承する", () => {
+      const shape = makeShape({ placeholderType: "ctrTitle" });
+      const context = makeContext({
+        masterPlaceholderStyles: [
+          {
+            placeholderType: "title",
+            lstStyle: makeDefaultTextStyle({ color: { hex: "#FFFFFF", alpha: 1 } }),
+          },
+        ],
+        txStyles: {
+          titleStyle: makeDefaultTextStyle({ color: { hex: "#000000", alpha: 1 } }),
+        },
+      });
+
+      applyTextStyleInheritance([shape], context);
+
+      expect(shape.textBody!.paragraphs[0].runs[0].properties.color).toEqual({
+        hex: "#FFFFFF",
+        alpha: 1,
+      });
+    });
+
+    it("subTitle がマスターの body プレースホルダー lstStyle から色を継承する", () => {
+      const shape = makeShape({ placeholderType: "subTitle" });
+      const context = makeContext({
+        masterPlaceholderStyles: [
+          {
+            placeholderType: "body",
+            lstStyle: makeDefaultTextStyle({ color: { hex: "#CCCCCC", alpha: 1 } }),
+          },
+        ],
+        txStyles: {
+          bodyStyle: makeDefaultTextStyle({ color: { hex: "#000000", alpha: 1 } }),
+        },
+      });
+
+      applyTextStyleInheritance([shape], context);
+
+      expect(shape.textBody!.paragraphs[0].runs[0].properties.color).toEqual({
+        hex: "#CCCCCC",
+        alpha: 1,
+      });
+    });
+
+    it("ctrTitle の完全一致がある場合はフォールバックしない", () => {
+      const shape = makeShape({ placeholderType: "ctrTitle" });
+      const context = makeContext({
+        masterPlaceholderStyles: [
+          {
+            placeholderType: "ctrTitle",
+            lstStyle: makeDefaultTextStyle({ color: { hex: "#AAAAAA", alpha: 1 } }),
+          },
+          {
+            placeholderType: "title",
+            lstStyle: makeDefaultTextStyle({ color: { hex: "#FFFFFF", alpha: 1 } }),
+          },
+        ],
+      });
+
+      applyTextStyleInheritance([shape], context);
+
+      expect(shape.textBody!.paragraphs[0].runs[0].properties.color).toEqual({
+        hex: "#AAAAAA",
+        alpha: 1,
+      });
+    });
+  });
+
   describe("テキストボディなし", () => {
     it("textBody が null のシェイプはスキップされる", () => {
       const shape = makeShape({ textBody: null } as Partial<ShapeElement>);

--- a/src/text-style-resolver.ts
+++ b/src/text-style-resolver.ts
@@ -106,7 +106,27 @@ function findMatchingPlaceholderStyle(
 
   // type マッチにフォールバック
   const byType = styles.find((s) => s.placeholderType === placeholderType);
-  return byType?.lstStyle;
+  if (byType?.lstStyle) return byType.lstStyle;
+
+  // OOXML 仕様に基づくタイプフォールバック (ctrTitle→title, subTitle→body)
+  const fallbackType = getPlaceholderFallbackType(placeholderType);
+  if (fallbackType) {
+    const byFallback = styles.find((s) => s.placeholderType === fallbackType);
+    return byFallback?.lstStyle;
+  }
+
+  return undefined;
+}
+
+function getPlaceholderFallbackType(type: string): string | undefined {
+  switch (type) {
+    case "ctrTitle":
+      return "title";
+    case "subTitle":
+      return "body";
+    default:
+      return undefined;
+  }
 }
 
 function getTxStyleForPlaceholder(


### PR DESCRIPTION
## Summary

- `findMatchingPlaceholderStyle()` がプレースホルダータイプを完全一致でのみ検索していたため、スライドの `ctrTitle` がスライドマスターの `title` プレースホルダーの lstStyle（白色指定）にマッチせず、`txStyles.titleStyle`（黒色）が代わりに使われていた
- OOXML 仕様に基づき、`ctrTitle` → `title`、`subTitle` → `body` のフォールバックを `findMatchingPlaceholderStyle()` に追加
- ユニットテスト3件を追加（フォールバック動作、完全一致優先の確認）

## Test plan

- [x] `npm run test -- src/text-style-resolver.test.ts` でユニットテスト通過
- [x] `npm run lint && npm run format:check && npm run typecheck` 通過
- [x] `npm run render -- sample.pptx` でタイトルが白文字でレンダリングされることを確認
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)