### PR TITLE
docs: デモページの見出しを改善

### DIFF
--- a/demo/src/app/layout.tsx
+++ b/demo/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "pptx-glimpse Demo",
-  description: "PPTX to SVG converter — server-side demo",
+  description: "Upload a PPTX file and preview slides as SVG",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/demo/src/app/page.tsx
+++ b/demo/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <div className="app">
       <header>
         <h1>pptx-glimpse</h1>
-        <p>PPTX to SVG converter &mdash; server-side demo</p>
+        <p>Upload a PPTX file and preview slides as SVG</p>
       </header>
       <main>
         <UploadViewer />


### PR DESCRIPTION
## Summary

- デモページのサブタイトルとメタ description を「PPTX to SVG converter — server-side demo」から「Upload a PPTX file and preview slides as SVG」に変更
- 実装詳細（server-side）を含む文言から、ユーザーがデモでできることを伝える文言に改善

## Test plan

- [ ] デモページにアクセスしてヘッダーの文言が更新されていることを確認
- [ ] ページのメタ description が更新されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)