### PR TITLE
docs: プロジェクト説明文をデモページと統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/pptx-glimpse)](https://www.npmjs.com/package/pptx-glimpse)
 
-A Node.js library to render PPTX as SVG / PNG.
+A lightweight JavaScript library for rendering PowerPoint (.pptx) files as SVG or PNG in Node.js. No LibreOffice required.
 
 [Demo](https://pptx-glimpse.vercel.app/) | [npm](https://www.npmjs.com/package/pptx-glimpse)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pptx-glimpse",
   "version": "0.2.2",
-  "description": "A Node.js library to render PPTX as SVG / PNG.",
+  "description": "A lightweight JavaScript library for rendering PowerPoint (.pptx) files as SVG or PNG in Node.js. No LibreOffice required.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- `package.json` と `README.md` のプロジェクト説明文を、デモページと同じ表現に統一
- 変更後: "A lightweight JavaScript library for rendering PowerPoint (.pptx) files as SVG or PNG in Node.js. No LibreOffice required."

## Test plan
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)