### PR TITLE
fix: ローカルでのテスト失敗を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
             -v "${{ github.workspace }}":/workspace \
             ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest \
             bash /workspace/vrt/snapshot/docker-run.sh \
-            bash -c "npm run vrt:snapshot:fixtures && npx vitest run vrt/snapshot/regression.test.ts --exclude '**/node_modules/**'"
+            bash -c "npm run vrt:snapshot:fixtures && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/regression.test.ts"
 
       - name: Upload diff images on failure
         if: failure()
@@ -121,7 +121,7 @@ jobs:
         run: docker run --rm -v "${{ github.workspace }}":/workspace ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest bash /workspace/vrt/libreoffice/update_snapshots.sh
 
       - name: Run LibreOffice VRT
-        run: npx vitest run vrt/libreoffice/regression.test.ts --exclude '**/node_modules/**'
+        run: npx vitest run --config vitest.vrt.config.ts vrt/libreoffice/regression.test.ts
 
       - name: Upload diff images on failure
         if: failure()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,9 @@
-import { defineConfig, configDefaults } from "vitest/config";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
-    include: ["src/**/*.test.ts", "vrt/**/*.test.ts", "e2e/**/*.test.ts"],
-    exclude: [...configDefaults.exclude, "vrt/**"],
+    include: ["src/**/*.test.ts", "e2e/**/*.test.ts"],
     testTimeout: 30000,
     coverage: {
       provider: "v8",

--- a/vitest.vrt.config.ts
+++ b/vitest.vrt.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["vrt/**/*.test.ts"],
+    testTimeout: 60000,
+  },
+});


### PR DESCRIPTION
## 概要

`npm run test` がローカル環境で失敗する問題を修正しました。

### 原因

1. **VRT テストの fixture 不在**: `vitest.config.ts` の `include` に `vrt/**/*.test.ts` が含まれており、Docker で生成される fixture が存在しないローカル環境では 45 件のテストが必ず失敗していた
2. **テストタイムアウト**: `converter.test.ts` と `e2e/smoke.test.ts` はフォントスキャン + SVG/PNG 変換を行うため、デフォルトの 5 秒タイムアウトでは不足していた

### 変更内容

- `include` から `vrt/**/*.test.ts` を除外（CI では引き続きファイルパスを直接指定して実行）
- `testTimeout: 30000` を追加（converter/e2e テストのタイムアウト回避）

## テスト計画

- [x] `npm run test` がローカルで全件パス (820 passed)
- [x] `npm run lint` パス
- [x] `npm run format:check` パス
- [x] `npm run typecheck` パス
- [ ] CI が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)