### PR TITLE
docs: デモサイトURLをカスタムドメインに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A lightweight JavaScript library for rendering PowerPoint (.pptx) files as SVG or PNG in Node.js. No LibreOffice required.
 
-**[Try the Demo](https://pptx-glimpse.vercel.app/)** | [npm](https://www.npmjs.com/package/pptx-glimpse)
+**[Try the Demo](https://glimpse.pptx.app/)** | [npm](https://www.npmjs.com/package/pptx-glimpse)
 
 ![pptx-glimpse demo](https://raw.githubusercontent.com/hirokisakabe/pptx-glimpse/main/docs/demo.gif)
 

--- a/demo/src/lib/constants.ts
+++ b/demo/src/lib/constants.ts
@@ -1,1 +1,1 @@
-export const SITE_URL = "https://pptx-glimpse.vercel.app";
+export const SITE_URL = "https://glimpse.pptx.app";


### PR DESCRIPTION
## 概要
- デモサイトのURLをカスタムドメインに変更
  - `https://pptx-glimpse.vercel.app` → `https://glimpse.pptx.app`

## 変更ファイル
- `README.md` — デモリンクURL
- `demo/src/lib/constants.ts` — `SITE_URL` 定数

## テストプラン
- [ ] `https://glimpse.pptx.app/` にアクセスしてデモサイトが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)