### PR TITLE
chore: eslint-plugin-simple-import-sort を導入

### DIFF
--- a/bench/conversion.bench.ts
+++ b/bench/conversion.bench.ts
@@ -1,11 +1,12 @@
-import { bench, describe, beforeAll } from "vitest";
 import JSZip from "jszip";
-import { convertPptxToSvg, convertPptxToPng } from "../src/converter.js";
-import { parsePptxData, parseSlideWithLayout } from "../src/pptx-data-parser.js";
-import { renderSlideToSvg } from "../src/renderer/svg-renderer.js";
-import type { Slide } from "../src/model/slide.js";
+import { beforeAll, bench, describe } from "vitest";
+
+import { convertPptxToPng, convertPptxToSvg } from "../src/converter.js";
 import type { SlideSize } from "../src/model/presentation.js";
 import type { SlideElement } from "../src/model/shape.js";
+import type { Slide } from "../src/model/slide.js";
+import { parsePptxData, parseSlideWithLayout } from "../src/pptx-data-parser.js";
+import { renderSlideToSvg } from "../src/renderer/svg-renderer.js";
 
 // ---------------------------------------------------------------------------
 // XML templates (minimal PPTX structure)

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "fs";
 import { join } from "path";
-import { describe, it, expect } from "vitest";
-import { convertPptxToSvg, convertPptxToPng } from "../src/converter.js";
+import { describe, expect, it } from "vitest";
+
+import { convertPptxToPng, convertPptxToSvg } from "../src/converter.js";
 
 const FIXTURE_DIR = join(import.meta.dirname, "..", "shared-fixtures");
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
 import prettier from "eslint-config-prettier";
 
@@ -7,6 +8,9 @@ export default tseslint.config(
   {
     files: ["src/**/*.ts", "vrt/**/*.ts", "scripts/**/*.ts", "bench/**/*.ts", "e2e/**/*.ts"],
     extends: tseslint.configs.recommendedTypeChecked,
+    plugins: {
+      "simple-import-sort": simpleImportSort,
+    },
     languageOptions: {
       parserOptions: {
         project: "./tsconfig.eslint.json",
@@ -14,6 +18,8 @@ export default tseslint.config(
       },
     },
     rules: {
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",
         { argsIgnorePattern: "^_" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pptx-glimpse",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pptx-glimpse",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.3.6",
@@ -21,6 +21,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "jszip": "^3.10.1",
         "knip": "^5.85.0",
         "pixelmatch": "^7.1.0",
@@ -3597,6 +3598,16 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "jszip": "^3.10.1",
     "knip": "^5.85.0",
     "pixelmatch": "^7.1.0",

--- a/scripts/dev-server-render.ts
+++ b/scripts/dev-server-render.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "fs";
+
 import { convertPptxToSvg } from "../src/converter.js";
 
 async function main(): Promise<void> {

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,9 +1,9 @@
+import { execFile } from "child_process";
 import { watch } from "fs";
 import { createServer } from "http";
 import { basename, resolve } from "path";
-import { execFile } from "child_process";
 import { promisify } from "util";
-import { WebSocketServer, type WebSocket } from "ws";
+import { type WebSocket, WebSocketServer } from "ws";
 
 const DEFAULT_PORT = 3000;
 const DEBOUNCE_MS = 300;

--- a/scripts/extract-font-metrics.ts
+++ b/scripts/extract-font-metrics.ts
@@ -6,9 +6,10 @@
  *   2. npx tsx scripts/extract-font-metrics.ts
  *   3. 出力された TypeScript コードを src/data/font-metrics.ts に貼り付け
  */
-import opentype from "opentype.js";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import opentype from "opentype.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/scripts/inspect-pptx.ts
+++ b/scripts/inspect-pptx.ts
@@ -1,6 +1,6 @@
+import { XMLBuilder, XMLParser } from "fast-xml-parser";
 import { readFileSync } from "fs";
 import JSZip from "jszip";
-import { XMLParser, XMLBuilder } from "fast-xml-parser";
 
 function prettyPrintXml(rawXml: string): string {
   const parser = new XMLParser({

--- a/scripts/test-render.ts
+++ b/scripts/test-render.ts
@@ -1,6 +1,7 @@
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { basename, join, resolve } from "path";
-import { convertPptxToSvg, convertPptxToPng } from "../src/converter.js";
+
+import { convertPptxToPng, convertPptxToSvg } from "../src/converter.js";
 
 async function main() {
   const filePath = process.argv[2];

--- a/src/color/color-resolver.test.ts
+++ b/src/color/color-resolver.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
-import { ColorResolver } from "./color-resolver.js";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ColorMap, ColorScheme } from "../model/theme.js";
 import { initWarningLogger } from "../warning-logger.js";
-import type { ColorScheme, ColorMap } from "../model/theme.js";
+import { ColorResolver } from "./color-resolver.js";
 
 const testScheme: ColorScheme = {
   dk1: "#000000",

--- a/src/color/color-resolver.ts
+++ b/src/color/color-resolver.ts
@@ -5,11 +5,11 @@
 //     → colorMap でキーを変換 → colorScheme から実際の色を取得
 //   sysClr — システムカラー (@_lastClr で保存された直近値を使用)
 
-import type { ColorScheme, ColorMap, ColorSchemeKey } from "../model/theme.js";
 import type { ResolvedColor } from "../model/fill.js";
+import type { ColorMap, ColorScheme, ColorSchemeKey } from "../model/theme.js";
 import type { XmlNode } from "../parser/xml-parser.js";
-import { applyColorTransforms } from "./color-transforms.js";
 import { debug } from "../warning-logger.js";
+import { applyColorTransforms } from "./color-transforms.js";
 
 export class ColorResolver {
   constructor(

--- a/src/color/color-transforms.test.ts
+++ b/src/color/color-transforms.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { applyColorTransforms } from "./color-transforms.js";
 
 describe("applyColorTransforms", () => {

--- a/src/converter.test.ts
+++ b/src/converter.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeAll } from "vitest";
 import JSZip from "jszip";
-import { convertPptxToSvg, convertPptxToPng } from "./converter.js";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { convertPptxToPng, convertPptxToSvg } from "./converter.js";
 
 const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,17 +1,17 @@
-import { renderSlideToSvg } from "./renderer/svg-renderer.js";
-import { svgToPng } from "./png/png-converter.js";
-import { DEFAULT_OUTPUT_WIDTH } from "./utils/constants.js";
-import type { SlideElement } from "./model/shape.js";
-import type { LogLevel } from "./warning-logger.js";
-import { initWarningLogger, flushWarnings } from "./warning-logger.js";
-import { setTextMeasurer, resetTextMeasurer } from "./font/text-measurer.js";
-import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 import type { FontMapping } from "./font/font-mapping.js";
 import { createFontMapping } from "./font/font-mapping.js";
-import { setFontMapping, resetFontMapping } from "./font/font-mapping-context.js";
+import { resetFontMapping, setFontMapping } from "./font/font-mapping-context.js";
 import { createOpentypeSetupFromSystem } from "./font/opentype-helpers.js";
-import { setTextPathFontResolver, resetTextPathFontResolver } from "./font/text-path-context.js";
-import { enableXmlCache, clearXmlCache } from "./parser/xml-parser.js";
+import { resetTextMeasurer, setTextMeasurer } from "./font/text-measurer.js";
+import { resetTextPathFontResolver, setTextPathFontResolver } from "./font/text-path-context.js";
+import type { SlideElement } from "./model/shape.js";
+import { clearXmlCache, enableXmlCache } from "./parser/xml-parser.js";
+import { svgToPng } from "./png/png-converter.js";
+import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
+import { renderSlideToSvg } from "./renderer/svg-renderer.js";
+import { DEFAULT_OUTPUT_WIDTH } from "./utils/constants.js";
+import type { LogLevel } from "./warning-logger.js";
+import { flushWarnings, initWarningLogger } from "./warning-logger.js";
 
 export interface ConvertOptions {
   /** 変換対象のスライド番号 (1始まり)。未指定で全スライド */

--- a/src/data/font-metrics.test.ts
+++ b/src/data/font-metrics.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { getFontMetrics, getMetricsFallbackFont } from "./font-metrics.js";
 
 describe("getFontMetrics", () => {

--- a/src/font/font-collector.test.ts
+++ b/src/font/font-collector.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeAll } from "vitest";
 import JSZip from "jszip";
+import { beforeAll, describe, expect, it } from "vitest";
+
 import { collectUsedFonts } from "./font-collector.js";
 
 const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/src/font/font-collector.ts
+++ b/src/font/font-collector.ts
@@ -4,8 +4,8 @@
 import type { SlideElement } from "../model/shape.js";
 import type { TextBody } from "../model/text.js";
 import type { FontScheme } from "../model/theme.js";
+import { clearXmlCache, enableXmlCache } from "../parser/xml-parser.js";
 import { parsePptxData, parseSlideWithLayout } from "../pptx-data-parser.js";
-import { enableXmlCache, clearXmlCache } from "../parser/xml-parser.js";
 
 /** フォント収集結果 */
 export interface UsedFonts {

--- a/src/font/font-mapping.test.ts
+++ b/src/font/font-mapping.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
-  DEFAULT_FONT_MAPPING,
   createFontMapping,
-  getMappedFont,
+  DEFAULT_FONT_MAPPING,
   type FontMapping,
+  getMappedFont,
 } from "./font-mapping.js";
 
 describe("DEFAULT_FONT_MAPPING", () => {

--- a/src/font/opentype-helpers.test.ts
+++ b/src/font/opentype-helpers.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
-  createOpentypeTextMeasurerFromBuffers,
   createOpentypeSetupFromBuffers,
+  createOpentypeTextMeasurerFromBuffers,
 } from "./opentype-helpers.js";
 import { buildTtcFromTtfs } from "./ttc-test-helper.js";
 

--- a/src/font/opentype-helpers.ts
+++ b/src/font/opentype-helpers.ts
@@ -2,14 +2,15 @@
  * opentype.js を使ってフォントを読み込み OpentypeTextMeasurer を構築するヘルパー。
  */
 import { readFile } from "node:fs/promises";
-import type { OpentypeFont } from "./opentype-text-measurer.js";
-import { OpentypeTextMeasurer } from "./opentype-text-measurer.js";
+
 import type { FontMapping } from "./font-mapping.js";
 import { createFontMapping } from "./font-mapping.js";
+import type { OpentypeFont } from "./opentype-text-measurer.js";
+import { OpentypeTextMeasurer } from "./opentype-text-measurer.js";
+import { collectFontFilePaths } from "./system-font-loader.js";
 import type { OpentypeFullFont, TextPathFontResolver } from "./text-path-context.js";
 import { DefaultTextPathFontResolver } from "./text-path-context.js";
-import { collectFontFilePaths } from "./system-font-loader.js";
-import { isTtcBuffer, extractTtcFonts } from "./ttc-parser.js";
+import { extractTtcFonts, isTtcBuffer } from "./ttc-parser.js";
 
 /** フォントバッファの入力形式 */
 export interface FontBuffer {

--- a/src/font/opentype-text-measurer.test.ts
+++ b/src/font/opentype-text-measurer.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { OpentypeTextMeasurer, type OpentypeFont } from "./opentype-text-measurer.js";
+import { describe, expect, it } from "vitest";
+
+import { type OpentypeFont, OpentypeTextMeasurer } from "./opentype-text-measurer.js";
 
 function createMockFont(opts: {
   unitsPerEm: number;

--- a/src/font/opentype-text-measurer.ts
+++ b/src/font/opentype-text-measurer.ts
@@ -1,8 +1,8 @@
-import type { TextMeasurer } from "./text-measurer.js";
 import {
-  measureTextWidth as defaultMeasureTextWidth,
   isCjkCodePoint,
+  measureTextWidth as defaultMeasureTextWidth,
 } from "../utils/text-measure.js";
+import type { TextMeasurer } from "./text-measurer.js";
 
 const PX_PER_PT = 96 / 72;
 const BOLD_FACTOR = 1.05;

--- a/src/font/system-font-loader.ts
+++ b/src/font/system-font-loader.ts
@@ -1,6 +1,6 @@
-import { readdirSync, existsSync } from "node:fs";
-import { join, extname } from "node:path";
+import { existsSync, readdirSync } from "node:fs";
 import { homedir, platform } from "node:os";
+import { extname, join } from "node:path";
 
 const FONT_EXTENSIONS = new Set([".ttf", ".otf"]);
 

--- a/src/font/text-measurer.test.ts
+++ b/src/font/text-measurer.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getAscenderRatio, getLineHeightRatio, measureTextWidth } from "../utils/text-measure.js";
 import {
   DefaultTextMeasurer,
-  setTextMeasurer,
   getTextMeasurer,
   resetTextMeasurer,
+  setTextMeasurer,
   type TextMeasurer,
 } from "./text-measurer.js";
-import { measureTextWidth, getLineHeightRatio, getAscenderRatio } from "../utils/text-measure.js";
 
 afterEach(() => {
   resetTextMeasurer();

--- a/src/font/text-measurer.ts
+++ b/src/font/text-measurer.ts
@@ -1,7 +1,7 @@
 import {
-  measureTextWidth as defaultMeasureTextWidth,
-  getLineHeightRatio as defaultGetLineHeightRatio,
   getAscenderRatio as defaultGetAscenderRatio,
+  getLineHeightRatio as defaultGetLineHeightRatio,
+  measureTextWidth as defaultMeasureTextWidth,
 } from "../utils/text-measure.js";
 
 /**

--- a/src/font/text-path-context.test.ts
+++ b/src/font/text-path-context.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { OpentypeFullFont } from "./text-path-context.js";
 import {
   DefaultTextPathFontResolver,
-  setTextPathFontResolver,
   getTextPathFontResolver,
   resetTextPathFontResolver,
+  setTextPathFontResolver,
 } from "./text-path-context.js";
-import type { OpentypeFullFont } from "./text-path-context.js";
 
 function createMockFont(name: string): OpentypeFullFont {
   return {

--- a/src/font/ttc-parser.test.ts
+++ b/src/font/ttc-parser.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { isTtcBuffer, extractTtcFonts } from "./ttc-parser.js";
+import { describe, expect, it } from "vitest";
+
+import { extractTtcFonts, isTtcBuffer } from "./ttc-parser.js";
 import { buildTtcFromTtfs } from "./ttc-test-helper.js";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
-export { convertPptxToPng, convertPptxToSvg } from "./converter.js";
 export type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
-export type { LogLevel, WarningSummary, WarningEntry } from "./warning-logger.js";
-export { getWarningSummary, getWarningEntries } from "./warning-logger.js";
-export { collectUsedFonts } from "./font/font-collector.js";
+export { convertPptxToPng, convertPptxToSvg } from "./converter.js";
 export type { UsedFonts } from "./font/font-collector.js";
-export { DEFAULT_FONT_MAPPING, createFontMapping, getMappedFont } from "./font/font-mapping.js";
+export { collectUsedFonts } from "./font/font-collector.js";
 export type { FontMapping } from "./font/font-mapping.js";
-export {
-  createOpentypeTextMeasurerFromBuffers,
-  createOpentypeSetupFromBuffers,
-} from "./font/opentype-helpers.js";
+export { createFontMapping, DEFAULT_FONT_MAPPING, getMappedFont } from "./font/font-mapping.js";
 export type { FontBuffer, OpentypeSetup } from "./font/opentype-helpers.js";
+export {
+  createOpentypeSetupFromBuffers,
+  createOpentypeTextMeasurerFromBuffers,
+} from "./font/opentype-helpers.js";
+export type { LogLevel, WarningEntry, WarningSummary } from "./warning-logger.js";
+export { getWarningEntries, getWarningSummary } from "./warning-logger.js";

--- a/src/model/chart.ts
+++ b/src/model/chart.ts
@@ -1,5 +1,5 @@
-import type { Transform } from "./shape.js";
 import type { ResolvedColor } from "./fill.js";
+import type { Transform } from "./shape.js";
 
 export interface ChartElement {
   type: "chart";

--- a/src/model/effect.ts
+++ b/src/model/effect.ts
@@ -1,5 +1,5 @@
-import type { ResolvedColor } from "./fill.js";
 import type { Emu } from "../utils/unit-types.js";
+import type { ResolvedColor } from "./fill.js";
 
 export interface EffectList {
   outerShadow: OuterShadow | null;

--- a/src/model/image.ts
+++ b/src/model/image.ts
@@ -1,6 +1,6 @@
-import type { Transform } from "./shape.js";
-import type { EffectList, BlipEffects } from "./effect.js";
 import type { Emu } from "../utils/unit-types.js";
+import type { BlipEffects, EffectList } from "./effect.js";
+import type { Transform } from "./shape.js";
 
 export interface SrcRect {
   left: number;

--- a/src/model/line.ts
+++ b/src/model/line.ts
@@ -1,5 +1,5 @@
-import type { GradientFill, SolidFill } from "./fill.js";
 import type { Emu } from "../utils/unit-types.js";
+import type { GradientFill, SolidFill } from "./fill.js";
 
 export type ArrowType = "none" | "triangle" | "stealth" | "diamond" | "oval" | "arrow";
 export type ArrowSize = "sm" | "med" | "lg";

--- a/src/model/shape.ts
+++ b/src/model/shape.ts
@@ -1,8 +1,8 @@
+import type { Emu } from "../utils/unit-types.js";
+import type { EffectList } from "./effect.js";
 import type { Fill } from "./fill.js";
 import type { Outline } from "./line.js";
 import type { Hyperlink, TextBody } from "./text.js";
-import type { EffectList } from "./effect.js";
-import type { Emu } from "../utils/unit-types.js";
 
 export interface Transform {
   offsetX: Emu;
@@ -73,6 +73,6 @@ export type SlideElement =
   | ChartElement
   | TableElement;
 
-import type { ImageElement } from "./image.js";
 import type { ChartElement } from "./chart.js";
+import type { ImageElement } from "./image.js";
 import type { TableElement } from "./table.js";

--- a/src/model/table.ts
+++ b/src/model/table.ts
@@ -1,8 +1,8 @@
+import type { Emu } from "../utils/unit-types.js";
 import type { Fill } from "./fill.js";
 import type { Outline } from "./line.js";
-import type { TextBody } from "./text.js";
 import type { Transform } from "./shape.js";
-import type { Emu } from "../utils/unit-types.js";
+import type { TextBody } from "./text.js";
 
 export interface TableElement {
   type: "table";

--- a/src/model/text.ts
+++ b/src/model/text.ts
@@ -1,5 +1,5 @@
-import type { ResolvedColor } from "./fill.js";
 import type { Emu, HundredthPt, Pt } from "../utils/unit-types.js";
+import type { ResolvedColor } from "./fill.js";
 
 /** defRPr に対応するデフォルトランプロパティ */
 export interface DefaultRunProperties {

--- a/src/model/theme.ts
+++ b/src/model/theme.ts
@@ -1,6 +1,6 @@
+import type { EffectList } from "./effect.js";
 import type { Fill } from "./fill.js";
 import type { Outline } from "./line.js";
-import type { EffectList } from "./effect.js";
 
 export interface FormatScheme {
   fillStyles: Fill[];

--- a/src/parse-render.integration.test.ts
+++ b/src/parse-render.integration.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { parseShapeTree } from "./parser/slide-parser.js";
-import { parseXml } from "./parser/xml-parser.js";
-import type { XmlNode } from "./parser/xml-parser.js";
-import type { PptxArchive } from "./parser/pptx-reader.js";
-import type { ShapeElement } from "./model/shape.js";
-import type { Relationship } from "./parser/relationship-parser.js";
+import { describe, expect, it } from "vitest";
+
 import { ColorResolver } from "./color/color-resolver.js";
+import type { ShapeElement } from "./model/shape.js";
+import type { PptxArchive } from "./parser/pptx-reader.js";
+import type { Relationship } from "./parser/relationship-parser.js";
+import { parseShapeTree } from "./parser/slide-parser.js";
+import type { XmlNode } from "./parser/xml-parser.js";
+import { parseXml } from "./parser/xml-parser.js";
 import { renderShape } from "./renderer/shape-renderer.js";
 import { renderSlideToSvg } from "./renderer/svg-renderer.js";
 

--- a/src/parser/blip-effect-parser.test.ts
+++ b/src/parser/blip-effect-parser.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
-import { parseBlipEffects } from "./blip-effect-parser.js";
+import { describe, expect, it, vi } from "vitest";
+
 import { ColorResolver } from "../color/color-resolver.js";
-import type { ColorScheme, ColorMap } from "../model/theme.js";
+import type { ColorMap, ColorScheme } from "../model/theme.js";
 import { initWarningLogger } from "../warning-logger.js";
+import { parseBlipEffects } from "./blip-effect-parser.js";
 
 const testScheme: ColorScheme = {
   dk1: "#000000",

--- a/src/parser/blip-effect-parser.ts
+++ b/src/parser/blip-effect-parser.ts
@@ -1,15 +1,15 @@
+import type { ColorResolver } from "../color/color-resolver.js";
 import type {
-  BlipEffects,
   BiLevelEffect,
+  BlipEffects,
   BlurEffect,
-  LumEffect,
   DuotoneEffect,
+  LumEffect,
 } from "../model/effect.js";
 import type { ResolvedColor } from "../model/fill.js";
-import type { ColorResolver } from "../color/color-resolver.js";
-import type { XmlNode } from "./xml-parser.js";
 import { asEmu } from "../utils/unit-types.js";
 import { warn } from "../warning-logger.js";
+import type { XmlNode } from "./xml-parser.js";
 
 const PRESET_COLORS: Record<string, string> = {
   black: "#000000",

--- a/src/parser/chart-parser.test.ts
+++ b/src/parser/chart-parser.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { parseChart } from "./chart-parser.js";
+import { describe, expect, it } from "vitest";
+
 import { ColorResolver } from "../color/color-resolver.js";
+import { parseChart } from "./chart-parser.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/chart-parser.ts
+++ b/src/parser/chart-parser.ts
@@ -1,6 +1,6 @@
-import type { ChartData, ChartType, ChartSeries, ChartLegend } from "../model/chart.js";
-import type { ResolvedColor } from "../model/fill.js";
 import type { ColorResolver } from "../color/color-resolver.js";
+import type { ChartData, ChartLegend, ChartSeries, ChartType } from "../model/chart.js";
+import type { ResolvedColor } from "../model/fill.js";
 import { parseXml, type XmlNode } from "./xml-parser.js";
 
 const ACCENT_KEYS = ["accent1", "accent2", "accent3", "accent4", "accent5", "accent6"] as const;

--- a/src/parser/custom-geometry-parser.test.ts
+++ b/src/parser/custom-geometry-parser.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { parseCustomGeometry } from "./custom-geometry-parser.js";
 
 describe("parseCustomGeometry", () => {

--- a/src/parser/custom-geometry-parser.ts
+++ b/src/parser/custom-geometry-parser.ts
@@ -1,7 +1,7 @@
 import type { CustomGeometryPath } from "../model/shape.js";
-import { evaluateGuides, resolveValue, type GuideDefinition } from "./geometry-formula.js";
-import type { XmlNode } from "./xml-parser.js";
 import { debug } from "../warning-logger.js";
+import { evaluateGuides, type GuideDefinition, resolveValue } from "./geometry-formula.js";
+import type { XmlNode } from "./xml-parser.js";
 
 /** custGeom ノードをパースして CustomGeometryPath[] を返す */
 export function parseCustomGeometry(custGeom: XmlNode): CustomGeometryPath[] | null {

--- a/src/parser/effect-parser.test.ts
+++ b/src/parser/effect-parser.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { parseEffectList } from "./effect-parser.js";
+import { describe, expect, it } from "vitest";
+
 import { ColorResolver } from "../color/color-resolver.js";
-import type { ColorScheme, ColorMap } from "../model/theme.js";
+import type { ColorMap, ColorScheme } from "../model/theme.js";
+import { parseEffectList } from "./effect-parser.js";
 
 const testScheme: ColorScheme = {
   dk1: "#000000",

--- a/src/parser/effect-parser.ts
+++ b/src/parser/effect-parser.ts
@@ -1,7 +1,7 @@
-import type { EffectList, OuterShadow, InnerShadow, Glow, SoftEdge } from "../model/effect.js";
 import type { ColorResolver } from "../color/color-resolver.js";
-import type { XmlNode } from "./xml-parser.js";
+import type { EffectList, Glow, InnerShadow, OuterShadow, SoftEdge } from "../model/effect.js";
 import { asEmu } from "../utils/unit-types.js";
+import type { XmlNode } from "./xml-parser.js";
 
 export function parseEffectList(
   effectLstNode: XmlNode,

--- a/src/parser/fill-parser.test.ts
+++ b/src/parser/fill-parser.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
-import { parseFillFromNode, parseOutline } from "./fill-parser.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { ColorResolver } from "../color/color-resolver.js";
 import { initWarningLogger } from "../warning-logger.js";
 import type { FillParseContext } from "./fill-parser.js";
-import { ColorResolver } from "../color/color-resolver.js";
+import { parseFillFromNode, parseOutline } from "./fill-parser.js";
 import type { PptxArchive } from "./pptx-reader.js";
 
 function createColorResolver() {

--- a/src/parser/fill-parser.ts
+++ b/src/parser/fill-parser.ts
@@ -1,3 +1,4 @@
+import type { ColorResolver } from "../color/color-resolver.js";
 import type {
   Fill,
   GradientFill,
@@ -8,22 +9,21 @@ import type {
   SolidFill,
 } from "../model/fill.js";
 import type {
-  Outline,
+  ArrowEndpoint,
+  ArrowSize,
+  ArrowType,
   DashStyle,
   LineCap,
   LineJoin,
-  ArrowEndpoint,
-  ArrowType,
-  ArrowSize,
+  Outline,
 } from "../model/line.js";
-import type { ColorResolver } from "../color/color-resolver.js";
+import { uint8ArrayToBase64 } from "../utils/base64.js";
+import { asEmu } from "../utils/unit-types.js";
+import { debug, warn } from "../warning-logger.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import type { Relationship } from "./relationship-parser.js";
 import { resolveRelationshipTarget } from "./relationship-parser.js";
 import type { XmlNode } from "./xml-parser.js";
-import { uint8ArrayToBase64 } from "../utils/base64.js";
-import { asEmu } from "../utils/unit-types.js";
-import { warn, debug } from "../warning-logger.js";
 
 export interface FillParseContext {
   rels: Map<string, Relationship>;

--- a/src/parser/geometry-formula.test.ts
+++ b/src/parser/geometry-formula.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { evaluateFormula, evaluateGuides, resolveValue } from "./geometry-formula.js";
 
 describe("evaluateFormula", () => {

--- a/src/parser/pptx-reader.ts
+++ b/src/parser/pptx-reader.ts
@@ -1,4 +1,4 @@
-import { unzipSync, strFromU8 } from "fflate";
+import { strFromU8, unzipSync } from "fflate";
 
 export interface PptxArchive {
   files: Map<string, string>;

--- a/src/parser/presentation-parser.test.ts
+++ b/src/parser/presentation-parser.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
-import { parsePresentation } from "./presentation-parser.js";
+import { describe, expect, it, vi } from "vitest";
+
 import { initWarningLogger } from "../warning-logger.js";
+import { parsePresentation } from "./presentation-parser.js";
 
 describe("parsePresentation", () => {
   it("parses valid presentation XML", () => {

--- a/src/parser/presentation-parser.ts
+++ b/src/parser/presentation-parser.ts
@@ -1,9 +1,9 @@
-import type { SlideSize, EmbeddedFont, Protection } from "../model/presentation.js";
+import type { EmbeddedFont, Protection, SlideSize } from "../model/presentation.js";
 import type { DefaultTextStyle } from "../model/text.js";
-import { parseXml, type XmlNode } from "./xml-parser.js";
-import { parseListStyle } from "./text-style-parser.js";
-import { debug } from "../warning-logger.js";
 import { asEmu } from "../utils/unit-types.js";
+import { debug } from "../warning-logger.js";
+import { parseListStyle } from "./text-style-parser.js";
+import { parseXml, type XmlNode } from "./xml-parser.js";
 
 export interface PresentationInfo {
   slideSize: SlideSize;

--- a/src/parser/relationship-parser.test.ts
+++ b/src/parser/relationship-parser.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
-import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
+import { describe, expect, it, vi } from "vitest";
+
 import { initWarningLogger } from "../warning-logger.js";
+import { buildRelsPath, parseRelationships } from "./relationship-parser.js";
 
 describe("buildRelsPath", () => {
   it("builds rels path for slide", () => {

--- a/src/parser/relationship-parser.ts
+++ b/src/parser/relationship-parser.ts
@@ -1,5 +1,5 @@
-import { parseXml, type XmlNode } from "./xml-parser.js";
 import { debug } from "../warning-logger.js";
+import { parseXml, type XmlNode } from "./xml-parser.js";
 
 export interface Relationship {
   id: string;

--- a/src/parser/slide-layout-parser.test.ts
+++ b/src/parser/slide-layout-parser.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import { parseSlideLayoutBackground, parseSlideLayoutElements } from "./slide-layout-parser.js";
-import { initWarningLogger } from "../warning-logger.js";
+import { describe, expect, it, vi } from "vitest";
+
 import { ColorResolver } from "../color/color-resolver.js";
-import type { PptxArchive } from "./pptx-reader.js";
 import type { ShapeElement } from "../model/shape.js";
+import { initWarningLogger } from "../warning-logger.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import { parseSlideLayoutBackground, parseSlideLayoutElements } from "./slide-layout-parser.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/slide-layout-parser.ts
+++ b/src/parser/slide-layout-parser.ts
@@ -1,16 +1,16 @@
-import type { Background } from "../model/slide.js";
-import type { SlideElement } from "../model/shape.js";
-import type { PlaceholderStyleInfo } from "../model/text.js";
-import type { PptxArchive } from "./pptx-reader.js";
-import { parseXml, parseXmlOrdered, type XmlNode } from "./xml-parser.js";
-import { parseFillFromNode } from "./fill-parser.js";
-import type { FillParseContext } from "./fill-parser.js";
-import { parseShapeTree, navigateOrdered } from "./slide-parser.js";
-import { buildRelsPath, parseRelationships, type Relationship } from "./relationship-parser.js";
-import { parseListStyle } from "./text-style-parser.js";
 import type { ColorResolver } from "../color/color-resolver.js";
+import type { SlideElement } from "../model/shape.js";
+import type { Background } from "../model/slide.js";
+import type { PlaceholderStyleInfo } from "../model/text.js";
 import type { FontScheme, FormatScheme } from "../model/theme.js";
 import { debug } from "../warning-logger.js";
+import type { FillParseContext } from "./fill-parser.js";
+import { parseFillFromNode } from "./fill-parser.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import { buildRelsPath, parseRelationships, type Relationship } from "./relationship-parser.js";
+import { navigateOrdered, parseShapeTree } from "./slide-parser.js";
+import { parseListStyle } from "./text-style-parser.js";
+import { parseXml, parseXmlOrdered, type XmlNode } from "./xml-parser.js";
 
 export function parseSlideLayoutBackground(
   xml: string,

--- a/src/parser/slide-master-parser.test.ts
+++ b/src/parser/slide-master-parser.test.ts
@@ -1,14 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import { ColorResolver } from "../color/color-resolver.js";
+import type { ShapeElement } from "../model/shape.js";
 import { initWarningLogger } from "../warning-logger.js";
+import type { PptxArchive } from "./pptx-reader.js";
 import {
-  parseSlideMasterElements,
-  parseSlideMasterColorMap,
   parseSlideMasterBackground,
+  parseSlideMasterColorMap,
+  parseSlideMasterElements,
   parseSlideMasterTxStyles,
 } from "./slide-master-parser.js";
-import { ColorResolver } from "../color/color-resolver.js";
-import type { PptxArchive } from "./pptx-reader.js";
-import type { ShapeElement } from "../model/shape.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/slide-master-parser.ts
+++ b/src/parser/slide-master-parser.ts
@@ -1,17 +1,17 @@
-import type { ColorMap, FormatScheme } from "../model/theme.js";
-import type { Background } from "../model/slide.js";
-import type { SlideElement } from "../model/shape.js";
-import type { TxStyles, PlaceholderStyleInfo } from "../model/text.js";
-import type { PptxArchive } from "./pptx-reader.js";
-import { parseXml, parseXmlOrdered, type XmlNode } from "./xml-parser.js";
-import { parseFillFromNode } from "./fill-parser.js";
-import type { FillParseContext } from "./fill-parser.js";
-import { parseShapeTree, navigateOrdered } from "./slide-parser.js";
-import { buildRelsPath, parseRelationships, type Relationship } from "./relationship-parser.js";
 import type { ColorResolver } from "../color/color-resolver.js";
+import type { SlideElement } from "../model/shape.js";
+import type { Background } from "../model/slide.js";
+import type { PlaceholderStyleInfo, TxStyles } from "../model/text.js";
+import type { ColorMap, FormatScheme } from "../model/theme.js";
 import type { FontScheme } from "../model/theme.js";
-import { parseListStyle } from "./text-style-parser.js";
 import { debug } from "../warning-logger.js";
+import type { FillParseContext } from "./fill-parser.js";
+import { parseFillFromNode } from "./fill-parser.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import { buildRelsPath, parseRelationships, type Relationship } from "./relationship-parser.js";
+import { navigateOrdered, parseShapeTree } from "./slide-parser.js";
+import { parseListStyle } from "./text-style-parser.js";
+import { parseXml, parseXmlOrdered, type XmlNode } from "./xml-parser.js";
 
 const DEFAULT_COLOR_MAP: ColorMap = {
   bg1: "lt1",

--- a/src/parser/slide-parser.test.ts
+++ b/src/parser/slide-parser.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
-import { parseSlide, parseShapeTree, parseTextBody, navigateOrdered } from "./slide-parser.js";
-import { initWarningLogger } from "../warning-logger.js";
+import { describe, expect, it, vi } from "vitest";
+
 import { ColorResolver } from "../color/color-resolver.js";
-import { parseXml, parseXmlOrdered } from "./xml-parser.js";
-import type { XmlNode } from "./xml-parser.js";
-import type { PptxArchive } from "./pptx-reader.js";
 import type { ShapeElement } from "../model/shape.js";
+import { initWarningLogger } from "../warning-logger.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import { navigateOrdered, parseShapeTree, parseSlide, parseTextBody } from "./slide-parser.js";
+import type { XmlNode } from "./xml-parser.js";
+import { parseXml, parseXmlOrdered } from "./xml-parser.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -1,58 +1,58 @@
-import type { Slide, Background } from "../model/slide.js";
-import type {
-  SlideElement,
-  ShapeElement,
-  ConnectorElement,
-  GroupElement,
-  Transform,
-  Geometry,
-} from "../model/shape.js";
-import type { ImageElement, SrcRect, StretchFillRect, TileInfo } from "../model/image.js";
+import type { ColorResolver } from "../color/color-resolver.js";
 import type { ChartElement } from "../model/chart.js";
+import type { ImageElement, SrcRect, StretchFillRect, TileInfo } from "../model/image.js";
+import type {
+  ConnectorElement,
+  Geometry,
+  GroupElement,
+  ShapeElement,
+  SlideElement,
+  Transform,
+} from "../model/shape.js";
+import type { Background, Slide } from "../model/slide.js";
 import type { TableElement } from "../model/table.js";
 import type {
-  TextBody,
-  BodyProperties,
-  Paragraph,
-  TextRun,
-  RunProperties,
-  Hyperlink,
-  TextOutline,
-  BulletType,
   AutoNumScheme,
-  DefaultTextStyle,
+  BodyProperties,
+  BulletType,
   DefaultRunProperties,
+  DefaultTextStyle,
+  Hyperlink,
+  Paragraph,
+  RunProperties,
   SpacingValue,
   TabStop,
+  TextBody,
+  TextOutline,
+  TextRun,
 } from "../model/text.js";
-import type { PptxArchive } from "./pptx-reader.js";
-import type { Relationship } from "./relationship-parser.js";
-import type { ColorResolver } from "../color/color-resolver.js";
 import type { FontScheme, FormatScheme } from "../model/theme.js";
-import { parseXml, parseXmlOrdered } from "./xml-parser.js";
-import type { XmlNode, XmlOrderedNode } from "./xml-parser.js";
-import { parseFillFromNode, parseOutline } from "./fill-parser.js";
-import type { FillParseContext } from "./fill-parser.js";
-import { parseEffectList } from "./effect-parser.js";
-import { resolveShapeStyle } from "./style-reference-resolver.js";
+import { uint8ArrayToBase64 } from "../utils/base64.js";
+import { hundredthPointToPoint } from "../utils/emu.js";
+import { asEmu, asHundredthPt } from "../utils/unit-types.js";
+import { debug, warn } from "../warning-logger.js";
 import { parseBlipEffects } from "./blip-effect-parser.js";
 import { parseChart } from "./chart-parser.js";
 import { parseCustomGeometry } from "./custom-geometry-parser.js";
-import { parseTable } from "./table-parser.js";
+import { parseEffectList } from "./effect-parser.js";
+import type { FillParseContext } from "./fill-parser.js";
+import { parseFillFromNode, parseOutline } from "./fill-parser.js";
+import type { PptxArchive } from "./pptx-reader.js";
+import type { Relationship } from "./relationship-parser.js";
 import {
+  buildRelsPath,
   parseRelationships,
   resolveRelationshipTarget,
-  buildRelsPath,
 } from "./relationship-parser.js";
-import { hundredthPointToPoint } from "../utils/emu.js";
-import { asEmu, asHundredthPt } from "../utils/unit-types.js";
+import { resolveShapeStyle } from "./style-reference-resolver.js";
+import { parseTable } from "./table-parser.js";
 import {
-  parseListStyle,
   parseDefaultRunProperties,
+  parseListStyle,
   resolveThemeFont,
 } from "./text-style-parser.js";
-import { uint8ArrayToBase64 } from "../utils/base64.js";
-import { warn, debug } from "../warning-logger.js";
+import type { XmlNode, XmlOrderedNode } from "./xml-parser.js";
+import { parseXml, parseXmlOrdered } from "./xml-parser.js";
 
 const SHAPE_TAGS = new Set(["sp", "pic", "cxnSp", "grpSp", "graphicFrame"]);
 

--- a/src/parser/style-reference-resolver.test.ts
+++ b/src/parser/style-reference-resolver.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
-import { resolveShapeStyle } from "./style-reference-resolver.js";
+import { describe, expect, it } from "vitest";
+
 import { ColorResolver } from "../color/color-resolver.js";
 import type { FormatScheme } from "../model/theme.js";
+import { resolveShapeStyle } from "./style-reference-resolver.js";
 import type { XmlNode } from "./xml-parser.js";
 
 const colorScheme = {

--- a/src/parser/style-reference-resolver.ts
+++ b/src/parser/style-reference-resolver.ts
@@ -1,9 +1,9 @@
-import type { FormatScheme } from "../model/theme.js";
+import type { ColorResolver } from "../color/color-resolver.js";
+import type { EffectList } from "../model/effect.js";
 import type { Fill } from "../model/fill.js";
 import type { ResolvedColor } from "../model/fill.js";
 import type { Outline } from "../model/line.js";
-import type { EffectList } from "../model/effect.js";
-import type { ColorResolver } from "../color/color-resolver.js";
+import type { FormatScheme } from "../model/theme.js";
 import type { XmlNode } from "./xml-parser.js";
 
 interface ResolvedStyleReference {

--- a/src/parser/table-parser.test.ts
+++ b/src/parser/table-parser.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { parseTable } from "./table-parser.js";
+import { describe, expect, it } from "vitest";
+
 import { ColorResolver } from "../color/color-resolver.js";
+import { parseTable } from "./table-parser.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/table-parser.ts
+++ b/src/parser/table-parser.ts
@@ -1,11 +1,11 @@
-import type { TableData, TableRow, TableColumn, TableCell, CellBorders } from "../model/table.js";
-import type { Outline } from "../model/line.js";
 import type { ColorResolver } from "../color/color-resolver.js";
+import type { Outline } from "../model/line.js";
+import type { CellBorders, TableCell, TableColumn, TableData, TableRow } from "../model/table.js";
 import type { FontScheme } from "../model/theme.js";
+import { asEmu } from "../utils/unit-types.js";
 import { parseFillFromNode, parseOutline } from "./fill-parser.js";
 import { parseTextBody } from "./slide-parser.js";
 import type { XmlNode } from "./xml-parser.js";
-import { asEmu } from "../utils/unit-types.js";
 
 export function parseTable(
   tblNode: XmlNode,

--- a/src/parser/text-style-parser.test.ts
+++ b/src/parser/text-style-parser.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import { ColorResolver } from "../color/color-resolver.js";
 import {
   parseDefaultRunProperties,
-  parseParagraphLevelProperties,
   parseListStyle,
+  parseParagraphLevelProperties,
 } from "./text-style-parser.js";
-import { ColorResolver } from "../color/color-resolver.js";
 
 function createColorResolver() {
   return new ColorResolver(

--- a/src/parser/text-style-parser.ts
+++ b/src/parser/text-style-parser.ts
@@ -1,10 +1,10 @@
+import type { ColorResolver } from "../color/color-resolver.js";
 import type {
-  DefaultTextStyle,
   DefaultParagraphLevelProperties,
   DefaultRunProperties,
+  DefaultTextStyle,
 } from "../model/text.js";
 import type { FontScheme } from "../model/theme.js";
-import type { ColorResolver } from "../color/color-resolver.js";
 import { hundredthPointToPoint } from "../utils/emu.js";
 import { asEmu, asHundredthPt } from "../utils/unit-types.js";
 import type { XmlNode } from "./xml-parser.js";

--- a/src/parser/theme-parser.test.ts
+++ b/src/parser/theme-parser.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
-import { parseTheme } from "./theme-parser.js";
+import { describe, expect, it, vi } from "vitest";
+
 import { initWarningLogger } from "../warning-logger.js";
+import { parseTheme } from "./theme-parser.js";
 
 const themeXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">

--- a/src/parser/theme-parser.ts
+++ b/src/parser/theme-parser.ts
@@ -1,12 +1,12 @@
-import type { Theme, ColorScheme, FontScheme, FormatScheme } from "../model/theme.js";
+import { ColorResolver } from "../color/color-resolver.js";
+import type { EffectList } from "../model/effect.js";
 import type { Fill } from "../model/fill.js";
 import type { Outline } from "../model/line.js";
-import type { EffectList } from "../model/effect.js";
-import { parseXml, parseXmlOrdered, type XmlNode, type XmlOrderedNode } from "./xml-parser.js";
-import { parseFillFromNode, parseOutline } from "./fill-parser.js";
-import { parseEffectList } from "./effect-parser.js";
-import { ColorResolver } from "../color/color-resolver.js";
+import type { ColorScheme, FontScheme, FormatScheme, Theme } from "../model/theme.js";
 import { debug } from "../warning-logger.js";
+import { parseEffectList } from "./effect-parser.js";
+import { parseFillFromNode, parseOutline } from "./fill-parser.js";
+import { parseXml, parseXmlOrdered, type XmlNode, type XmlOrderedNode } from "./xml-parser.js";
 
 export function parseTheme(xml: string): Theme {
   const parsed = parseXml(xml);

--- a/src/parser/xml-parser.test.ts
+++ b/src/parser/xml-parser.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { parseXml } from "./xml-parser.js";
 
 describe("parseXml", () => {

--- a/src/pptx-data-parser.ts
+++ b/src/pptx-data-parser.ts
@@ -2,35 +2,35 @@
  * PPTX の共通パース処理。
  * converter.ts と font-collector.ts で共有する。
  */
-import { readPptx, type PptxArchive } from "./parser/pptx-reader.js";
+import { ColorResolver } from "./color/color-resolver.js";
+import type { SlideElement } from "./model/shape.js";
+import type { Background, Slide } from "./model/slide.js";
+import type { PlaceholderStyleInfo, TxStyles } from "./model/text.js";
+import type { ColorMap, Theme } from "./model/theme.js";
+import type { FillParseContext } from "./parser/fill-parser.js";
+import { type PptxArchive, readPptx } from "./parser/pptx-reader.js";
 import { parsePresentation, type PresentationInfo } from "./parser/presentation-parser.js";
-import { parseTheme } from "./parser/theme-parser.js";
-import type { Theme, ColorMap } from "./model/theme.js";
 import {
-  parseSlideMasterColorMap,
-  parseSlideMasterBackground,
-  parseSlideMasterElements,
-  parseSlideMasterTxStyles,
-  parseSlideMasterPlaceholderStyles,
-} from "./parser/slide-master-parser.js";
+  buildRelsPath,
+  parseRelationships,
+  type Relationship,
+  resolveRelationshipTarget,
+} from "./parser/relationship-parser.js";
 import {
   parseSlideLayoutBackground,
   parseSlideLayoutElements,
   parseSlideLayoutPlaceholderStyles,
   parseSlideLayoutShowMasterSp,
 } from "./parser/slide-layout-parser.js";
-import { parseSlide } from "./parser/slide-parser.js";
-import type { Slide, Background } from "./model/slide.js";
 import {
-  parseRelationships,
-  resolveRelationshipTarget,
-  buildRelsPath,
-  type Relationship,
-} from "./parser/relationship-parser.js";
-import type { FillParseContext } from "./parser/fill-parser.js";
-import { ColorResolver } from "./color/color-resolver.js";
-import type { PlaceholderStyleInfo, TxStyles } from "./model/text.js";
-import type { SlideElement } from "./model/shape.js";
+  parseSlideMasterBackground,
+  parseSlideMasterColorMap,
+  parseSlideMasterElements,
+  parseSlideMasterPlaceholderStyles,
+  parseSlideMasterTxStyles,
+} from "./parser/slide-master-parser.js";
+import { parseSlide } from "./parser/slide-parser.js";
+import { parseTheme } from "./parser/theme-parser.js";
 import { applyTextStyleInheritance } from "./text-style-resolver.js";
 
 interface ParsedPptxData {

--- a/src/renderer/blip-effect-renderer.test.ts
+++ b/src/renderer/blip-effect-renderer.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderBlipEffects } from "./blip-effect-renderer.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { BlipEffects } from "../model/effect.js";
+import { renderBlipEffects } from "./blip-effect-renderer.js";
 
 beforeEach(() => {
   let counter = 0;

--- a/src/renderer/chart-renderer.test.ts
+++ b/src/renderer/chart-renderer.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { renderChart } from "./chart-renderer.js";
+import { describe, expect, it } from "vitest";
+
 import type { ChartElement } from "../model/chart.js";
+import { renderChart } from "./chart-renderer.js";
 
 function createChartElement(overrides: Partial<ChartElement["chart"]>): ChartElement {
   return {

--- a/src/renderer/chart-renderer.ts
+++ b/src/renderer/chart-renderer.ts
@@ -1,9 +1,9 @@
-import type { ChartElement, ChartData, ChartSeries } from "../model/chart.js";
+import type { ChartData, ChartElement, ChartSeries } from "../model/chart.js";
 import type { ResolvedColor } from "../model/fill.js";
-import type { RenderResult } from "./render-result.js";
 import { emuToPixels } from "../utils/emu.js";
-import { buildTransformAttr } from "./transform.js";
 import { debug } from "../warning-logger.js";
+import type { RenderResult } from "./render-result.js";
+import { buildTransformAttr } from "./transform.js";
 
 const DEFAULT_SERIES_COLORS: ResolvedColor[] = [
   { hex: "#4472C4", alpha: 1 },

--- a/src/renderer/effect-renderer.test.ts
+++ b/src/renderer/effect-renderer.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderEffects } from "./effect-renderer.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { EffectList } from "../model/effect.js";
+import { renderEffects } from "./effect-renderer.js";
 
 beforeEach(() => {
   let counter = 0;

--- a/src/renderer/fill-renderer.test.ts
+++ b/src/renderer/fill-renderer.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { renderFillAttrs, renderOutlineAttrs } from "./fill-renderer.js";
 
 describe("renderFillAttrs", () => {

--- a/src/renderer/fill-renderer.ts
+++ b/src/renderer/fill-renderer.ts
@@ -1,5 +1,5 @@
 import type { Fill, GradientFill, PatternFill } from "../model/fill.js";
-import type { Outline, ArrowEndpoint, ArrowSize } from "../model/line.js";
+import type { ArrowEndpoint, ArrowSize, Outline } from "../model/line.js";
 import { emuToPixels } from "../utils/emu.js";
 
 interface FillAttrs {

--- a/src/renderer/geometry/geometry-renderer.ts
+++ b/src/renderer/geometry/geometry-renderer.ts
@@ -1,4 +1,4 @@
-import type { Geometry, CustomGeometryPath } from "../../model/shape.js";
+import type { CustomGeometryPath, Geometry } from "../../model/shape.js";
 import { getPresetGeometrySvg } from "./preset-geometries.js";
 
 export function renderGeometry(geometry: Geometry, width: number, height: number): string {

--- a/src/renderer/geometry/preset-geometries.test.ts
+++ b/src/renderer/geometry/preset-geometries.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import { getPresetGeometrySvg } from "./preset-geometries.js";
 
 describe("getPresetGeometrySvg", () => {

--- a/src/renderer/image-renderer.test.ts
+++ b/src/renderer/image-renderer.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderImage } from "./image-renderer.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { ImageElement } from "../model/image.js";
 import type { Transform } from "../model/shape.js";
+import { renderImage } from "./image-renderer.js";
 
 beforeEach(() => {
   let counter = 0;

--- a/src/renderer/image-renderer.ts
+++ b/src/renderer/image-renderer.ts
@@ -1,8 +1,8 @@
 import type { ImageElement } from "../model/image.js";
-import type { RenderResult } from "./render-result.js";
-import { renderEffects } from "./effect-renderer.js";
-import { renderBlipEffects } from "./blip-effect-renderer.js";
 import { emuToPixels } from "../utils/emu.js";
+import { renderBlipEffects } from "./blip-effect-renderer.js";
+import { renderEffects } from "./effect-renderer.js";
+import type { RenderResult } from "./render-result.js";
 import { buildTransformAttr } from "./transform.js";
 
 export function renderImage(image: ImageElement): RenderResult {

--- a/src/renderer/shape-renderer.test.ts
+++ b/src/renderer/shape-renderer.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderShape, renderConnector } from "./shape-renderer.js";
-import type { ShapeElement, ConnectorElement, Transform } from "../model/shape.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ConnectorElement, ShapeElement, Transform } from "../model/shape.js";
+import { renderConnector, renderShape } from "./shape-renderer.js";
 
 beforeEach(() => {
   let counter = 0;

--- a/src/renderer/shape-renderer.ts
+++ b/src/renderer/shape-renderer.ts
@@ -1,10 +1,10 @@
-import type { ShapeElement, ConnectorElement } from "../model/shape.js";
-import type { RenderResult } from "./render-result.js";
-import { renderGeometry } from "./geometry/index.js";
-import { renderFillAttrs, renderOutlineAttrs, renderMarkers } from "./fill-renderer.js";
-import { renderTextBody, computeSpAutofitHeight } from "./text-renderer.js";
-import { renderEffects } from "./effect-renderer.js";
+import type { ConnectorElement, ShapeElement } from "../model/shape.js";
 import { emuToPixels } from "../utils/emu.js";
+import { renderEffects } from "./effect-renderer.js";
+import { renderFillAttrs, renderMarkers, renderOutlineAttrs } from "./fill-renderer.js";
+import { renderGeometry } from "./geometry/index.js";
+import type { RenderResult } from "./render-result.js";
+import { computeSpAutofitHeight, renderTextBody } from "./text-renderer.js";
 import { buildTransformAttr } from "./transform.js";
 
 export function renderShape(shape: ShapeElement): RenderResult {

--- a/src/renderer/svg-renderer.ts
+++ b/src/renderer/svg-renderer.ts
@@ -1,13 +1,13 @@
-import type { Slide } from "../model/slide.js";
 import type { SlideSize } from "../model/presentation.js";
-import type { SlideElement, GroupElement } from "../model/shape.js";
-import type { RenderResult } from "./render-result.js";
+import type { GroupElement, SlideElement } from "../model/shape.js";
+import type { Slide } from "../model/slide.js";
 import { emuToPixels } from "../utils/emu.js";
-import { renderShape, renderConnector } from "./shape-renderer.js";
-import { renderImage } from "./image-renderer.js";
 import { renderChart } from "./chart-renderer.js";
-import { renderTable } from "./table-renderer.js";
 import { renderFillAttrs } from "./fill-renderer.js";
+import { renderImage } from "./image-renderer.js";
+import type { RenderResult } from "./render-result.js";
+import { renderConnector, renderShape } from "./shape-renderer.js";
+import { renderTable } from "./table-renderer.js";
 
 // SVG 1.1 (W3C) で出力。CSS クラスは使わずインライン属性のみ使用する。
 // 理由: sharp (内部で librsvg を使用) が CSS セレクタを正しく解釈しないため。

--- a/src/renderer/table-renderer.test.ts
+++ b/src/renderer/table-renderer.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { renderTable } from "./table-renderer.js";
+import { describe, expect, it } from "vitest";
+
 import type { TableElement } from "../model/table.js";
+import { renderTable } from "./table-renderer.js";
 
 function createTableElement(overrides?: Partial<TableElement["table"]>): TableElement {
   return {

--- a/src/renderer/table-renderer.ts
+++ b/src/renderer/table-renderer.ts
@@ -1,12 +1,12 @@
-import type { TableElement } from "../model/table.js";
 import type { Transform } from "../model/shape.js";
+import type { TableElement } from "../model/table.js";
+import { emuToPixels } from "../utils/emu.js";
 import type { Emu } from "../utils/unit-types.js";
 import { asEmu } from "../utils/unit-types.js";
-import type { RenderResult } from "./render-result.js";
-import { emuToPixels } from "../utils/emu.js";
-import { buildTransformAttr } from "./transform.js";
 import { renderFillAttrs, renderOutlineAttrs } from "./fill-renderer.js";
+import type { RenderResult } from "./render-result.js";
 import { renderTextBody } from "./text-renderer.js";
+import { buildTransformAttr } from "./transform.js";
 
 export function renderTable(element: TableElement): RenderResult {
   const { transform, table } = element;

--- a/src/renderer/text-renderer.test.ts
+++ b/src/renderer/text-renderer.test.ts
@@ -1,25 +1,26 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { OpentypeFullFont } from "../font/text-path-context.js";
 import {
-  renderTextBody,
-  formatAutoNum,
+  DefaultTextPathFontResolver,
+  resetTextPathFontResolver,
+  setTextPathFontResolver,
+} from "../font/text-path-context.js";
+import type { Transform } from "../model/shape.js";
+import type {
+  BodyProperties,
+  BulletType,
+  Paragraph,
+  RunProperties,
+  SpacingValue,
+  TextBody,
+} from "../model/text.js";
+import {
   buildFontFamilyValue,
   computeSpAutofitHeight,
+  formatAutoNum,
+  renderTextBody,
 } from "./text-renderer.js";
-import type {
-  TextBody,
-  Paragraph,
-  BulletType,
-  SpacingValue,
-  BodyProperties,
-  RunProperties,
-} from "../model/text.js";
-import type { Transform } from "../model/shape.js";
-import {
-  setTextPathFontResolver,
-  resetTextPathFontResolver,
-  DefaultTextPathFontResolver,
-} from "../font/text-path-context.js";
-import type { OpentypeFullFont } from "../font/text-path-context.js";
 
 function makeTransform(widthEmu: number, heightEmu: number): Transform {
   return {

--- a/src/renderer/text-renderer.ts
+++ b/src/renderer/text-renderer.ts
@@ -1,3 +1,9 @@
+import { getMetricsFallbackFont } from "../data/font-metrics.js";
+import { getCurrentMappedFont } from "../font/font-mapping-context.js";
+import { getTextMeasurer } from "../font/text-measurer.js";
+import type { TextPathFontResolver } from "../font/text-path-context.js";
+import { getTextPathFontResolver } from "../font/text-path-context.js";
+import type { Transform } from "../model/shape.js";
 import type {
   AutoNumScheme,
   BodyProperties,
@@ -8,17 +14,11 @@ import type {
   TextBody,
   TextVerticalType,
 } from "../model/text.js";
-import type { Transform } from "../model/shape.js";
 import { EMU_PER_INCH } from "../utils/constants.js";
 import { emuToPixels } from "../utils/emu.js";
+import { wrapParagraph } from "../utils/text-wrap.js";
 import type { Emu } from "../utils/unit-types.js";
 import { asEmu } from "../utils/unit-types.js";
-import { wrapParagraph } from "../utils/text-wrap.js";
-import { getMetricsFallbackFont } from "../data/font-metrics.js";
-import { getTextMeasurer } from "../font/text-measurer.js";
-import { getCurrentMappedFont } from "../font/font-mapping-context.js";
-import type { TextPathFontResolver } from "../font/text-path-context.js";
-import { getTextPathFontResolver } from "../font/text-path-context.js";
 
 const PX_PER_PT = 96 / 72;
 const DEFAULT_LINE_SPACING = 1.0;

--- a/src/renderer/transform.test.ts
+++ b/src/renderer/transform.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { buildTransformAttr } from "./transform.js";
+import { describe, expect, it } from "vitest";
+
 import type { Transform } from "../model/shape.js";
+import { buildTransformAttr } from "./transform.js";
 
 function makeTransform(overrides: Partial<Transform> = {}): Transform {
   return {

--- a/src/text-style-resolver.test.ts
+++ b/src/text-style-resolver.test.ts
@@ -1,14 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { applyTextStyleInheritance } from "./text-style-resolver.js";
-import type { TextStyleContext } from "./text-style-resolver.js";
-import type { ShapeElement, GroupElement } from "./model/shape.js";
+import { describe, expect, it } from "vitest";
+
+import type { ResolvedColor } from "./model/fill.js";
+import type { GroupElement, ShapeElement } from "./model/shape.js";
 import type {
-  DefaultTextStyle,
   DefaultParagraphLevelProperties,
   DefaultRunProperties,
+  DefaultTextStyle,
   RunProperties,
 } from "./model/text.js";
-import type { ResolvedColor } from "./model/fill.js";
+import type { TextStyleContext } from "./text-style-resolver.js";
+import { applyTextStyleInheritance } from "./text-style-resolver.js";
 
 function makeRunProperties(overrides: Partial<RunProperties> = {}): RunProperties {
   return {

--- a/src/text-style-resolver.ts
+++ b/src/text-style-resolver.ts
@@ -1,10 +1,10 @@
+import type { ShapeElement, SlideElement } from "./model/shape.js";
 import type {
-  DefaultTextStyle,
   DefaultRunProperties,
-  TxStyles,
+  DefaultTextStyle,
   PlaceholderStyleInfo,
+  TxStyles,
 } from "./model/text.js";
-import type { SlideElement, ShapeElement } from "./model/shape.js";
 import type { FontScheme } from "./model/theme.js";
 import { resolveThemeFont } from "./parser/text-style-parser.js";
 

--- a/src/utils/emu.test.ts
+++ b/src/utils/emu.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { emuToPixels, emuToPoints, rotationToDegrees, hundredthPointToPoint } from "./emu.js";
+import { describe, expect, it } from "vitest";
+
+import { emuToPixels, emuToPoints, hundredthPointToPoint, rotationToDegrees } from "./emu.js";
 import { asEmu, asHundredthPt } from "./unit-types.js";
 
 describe("emuToPixels", () => {

--- a/src/utils/text-measure.test.ts
+++ b/src/utils/text-measure.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { measureTextWidth, getLineHeightRatio, getAscenderRatio } from "./text-measure.js";
+import { describe, expect, it } from "vitest";
+
+import { getAscenderRatio, getLineHeightRatio, measureTextWidth } from "./text-measure.js";
 
 const PX_PER_PT = 96 / 72;
 

--- a/src/utils/text-wrap.test.ts
+++ b/src/utils/text-wrap.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { wrapParagraph } from "./text-wrap.js";
+import { describe, expect, it } from "vitest";
+
 import type { Paragraph, RunProperties } from "../model/text.js";
+import { wrapParagraph } from "./text-wrap.js";
 
 function makeRunProps(overrides: Partial<RunProperties> = {}): RunProperties {
   return {

--- a/src/utils/text-wrap.ts
+++ b/src/utils/text-wrap.ts
@@ -1,5 +1,5 @@
-import type { Paragraph, RunProperties } from "../model/text.js";
 import { getTextMeasurer } from "../font/text-measurer.js";
+import type { Paragraph, RunProperties } from "../model/text.js";
 
 interface LineSegment {
   text: string;

--- a/src/warning-logger.test.ts
+++ b/src/warning-logger.test.ts
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import {
+  debug,
+  flushWarnings,
+  getLogLevel,
+  getWarningEntries,
+  getWarningSummary,
   initWarningLogger,
   warn,
-  debug,
-  getWarningSummary,
-  flushWarnings,
-  getWarningEntries,
-  getLogLevel,
 } from "./warning-logger.js";
 
 describe("warning-logger", () => {

--- a/vrt/compare-utils.ts
+++ b/vrt/compare-utils.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import pixelmatch from "pixelmatch";
 import sharp from "sharp";

--- a/vrt/libreoffice/regression.test.ts
+++ b/vrt/libreoffice/regression.test.ts
@@ -1,6 +1,7 @@
-import { readFileSync, existsSync } from "fs";
-import { join, dirname } from "path";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+
 import { convertPptxToPng } from "../../src/converter.js";
 import { compareImages } from "../compare-utils.js";
 

--- a/vrt/snapshot/create-fixtures.ts
+++ b/vrt/snapshot/create-fixtures.ts
@@ -3,11 +3,12 @@
  *
  * 使い方: npx tsx vrt/snapshot/create-fixtures.ts
  */
+import { mkdirSync, writeFileSync } from "fs";
 import JSZip from "jszip";
-import sharp from "sharp";
-import { writeFileSync, mkdirSync } from "fs";
-import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import sharp from "sharp";
+import { fileURLToPath } from "url";
+
 import { VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/vrt/snapshot/regression.test.ts
+++ b/vrt/snapshot/regression.test.ts
@@ -1,9 +1,10 @@
-import { readFileSync, existsSync } from "fs";
-import { join, dirname } from "path";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+
 import { convertPptxToPng } from "../../src/converter.js";
 import { compareImages } from "../compare-utils.js";
-import { VRT_CASES, SHARED_FIXTURE_CASES } from "./vrt-cases.js";
+import { SHARED_FIXTURE_CASES, VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = join(__dirname, "snapshots");

--- a/vrt/snapshot/update-snapshots.ts
+++ b/vrt/snapshot/update-snapshots.ts
@@ -1,6 +1,7 @@
-import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from "fs";
-import { join, dirname } from "path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+
 import { convertPptxToPng } from "../../src/converter.js";
 import { SHARED_FIXTURE_CASES } from "./vrt-cases.js";
 


### PR DESCRIPTION
## Summary

- `eslint-plugin-simple-import-sort` を devDependencies に追加
- `eslint.config.mjs` に `simple-import-sort/imports` と `simple-import-sort/exports` ルールを error レベルで設定
- 既存コード（100ファイル）の import 順を `--fix` で自動修正

## Test plan

- [x] `npm run lint` がエラーなしで通ること
- [x] `npm run format:check` が通ること
- [x] `npm run typecheck` が通ること
- [x] `npm run test` で全843テストがパスすること
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)