### PR TITLE
chore: TypeScript を 5.9.3 にアップグレード

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "prettier": "^3.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.21.0",
-        "typescript": "^5.5.0",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.55.0",
         "vitest": "^3.0.0",
         "ws": "^8.19.0"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prettier": "^3.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.5.0",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.55.0",
     "vitest": "^3.0.0",
     "ws": "^8.19.0"


### PR DESCRIPTION
## Summary
- TypeScript を `^5.5.0` → `^5.9.3` にアップグレード
- typecheck / lint / test / build すべて問題なく通ることを確認済み

## Test plan
- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] `npm run format:check` 成功
- [x] `npm run test` 全843テスト パス
- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)