### PR TITLE
ci: lint/format/typecheckをmatrixから分離してCI時間を短縮

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,33 @@ on:
     branches: [main]
 
 jobs:
-  ci:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Knip
+        run: npm run knip
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Type check
+        run: npm run typecheck
+
+  test:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -25,18 +51,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Knip
-        run: npm run knip
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Format check
-        run: npm run format:check
-
-      - name: Type check
-        run: npm run typecheck
 
       - name: Test with coverage
         run: npx vitest run --coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,10 @@ npm run inspect        # Inspect PPTX internal XML (e.g., npm run inspect -- fil
 npm run dev -- file.pptx  # Live preview dev server (auto-reload on src/ changes)
 ```
 
-CI consists of 3 jobs:
+CI consists of 4 jobs:
 
-- **ci**: `lint` → `format:check` → `typecheck` → `test` with coverage (excluding VRT) → `build` → package verification (Node 20/22/24, coverage report on Node 22)
+- **lint**: `knip` → `lint` → `format:check` → `typecheck` (Node 22 only, 1回実行)
+- **test**: `test` with coverage → `build` → package verification (Node 20/22/24, coverage report on Node 22)
 - **vrt**: Snapshot VRT (Docker-based, self-comparison)
 - **libreoffice-vrt**: LibreOffice VRT (generates fixtures and reference images via Docker)
 


### PR DESCRIPTION
close #306

## 概要

lint / format:check / typecheck / knip はNode.jsバージョンに依存しないため、matrixから分離してCI時間を短縮する。

## 変更内容

- **`lint` ジョブ（新規）**: Node 22のみで knip, lint, format:check, typecheck を1回だけ実行
- **`test` ジョブ（旧 `ci`）**: マトリクス（Node 20/22/24）で test, build, verify を実行
- CLAUDE.md のCIジョブ説明を更新

## 期待される効果

- lint/format/typecheck の実行回数が 3回 → 1回 に削減
- CI全体の実行時間短縮

## 注意事項

- ジョブ名が `ci` → `lint` / `test` に変わるため、Branch Protection の Required status checks の更新が必要な場合があります

🤖 Generated with [Claude Code](https://claude.com/claude-code)