### PR TITLE
fix: CI の VRT ジョブで Dockerfile 変更時にローカルビルドを強制する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Pull or build Docker image
-        run: docker pull ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest || docker build -t ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest docker/snapshot-vrt
+        run: |
+          git fetch origin main --depth=1
+          if git diff --name-only origin/main -- docker/snapshot-vrt/ | grep -q .; then
+            echo "docker/snapshot-vrt changed, forcing local build"
+            docker build -t ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest docker/snapshot-vrt
+          else
+            docker pull ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest || \
+              docker build -t ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest docker/snapshot-vrt
+          fi
 
       - name: Generate VRT fixtures and run VRT
         run: |
@@ -129,7 +137,15 @@ jobs:
         run: npm ci
 
       - name: Pull or build Docker image
-        run: docker pull ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest || docker build -t ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest docker/libreoffice-vrt
+        run: |
+          git fetch origin main --depth=1
+          if git diff --name-only origin/main -- docker/libreoffice-vrt/ | grep -q .; then
+            echo "docker/libreoffice-vrt changed, forcing local build"
+            docker build -t ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest docker/libreoffice-vrt
+          else
+            docker pull ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest || \
+              docker build -t ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest docker/libreoffice-vrt
+          fi
 
       - name: Generate fixtures
         run: docker run --rm -v "${{ github.workspace }}":/workspace ghcr.io/hirokisakabe/pptx-glimpse-vrt:latest python3 /workspace/vrt/libreoffice/create_fixtures.py


### PR DESCRIPTION
close #315

## Summary
- VRT ジョブの `Pull or build Docker image` ステップで、`docker/snapshot-vrt/` や `docker/libreoffice-vrt/` 配下に変更がある場合は `docker pull` をスキップしてローカルビルドを強制するように変更
- `git fetch origin main --depth=1` で main ブランチを取得し、`git diff --name-only origin/main` で変更を検知

## Test plan
- [ ] CI の VRT ジョブが正常に動作することを確認
- [ ] Dockerfile を変更した PR で、ローカルビルドが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)