### PR TITLE
fix: shared fixtures の VRT ミスマッチ許容値を引き下げ

### DIFF
--- a/vrt/snapshot/regression.test.ts
+++ b/vrt/snapshot/regression.test.ts
@@ -17,7 +17,7 @@ const PIXEL_THRESHOLD = 0.1;
 const MISMATCH_TOLERANCE = 0.015;
 
 const SHARED_PIXEL_THRESHOLD = 0.3;
-const SHARED_MISMATCH_TOLERANCE = 0.05;
+const SHARED_MISMATCH_TOLERANCE = 0.02;
 
 describe("Visual Regression Tests", { timeout: 60000 }, () => {
   for (const { name, fixture } of VRT_CASES) {


### PR DESCRIPTION
close #316

## Summary

- shared fixtures の `SHARED_MISMATCH_TOLERANCE` を `0.05` (5%) から `0.02` (2%) に引き下げ
- 通常の VRT ケース (`MISMATCH_TOLERANCE = 0.015`) に近い値にすることで、レンダリング変更の検出精度を向上
- #314 で発覚した、Docker イメージ不一致時にも VRT が pass してしまう問題への対策

## Test plan

- [ ] CI の VRT ジョブが pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)