### PR TITLE
feat: package.json に packageManager フィールドを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "files": [
     "dist"
   ],
+  "packageManager": "npm@10.9.6",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
close #307

## 概要
- `package.json` に `packageManager: "npm@10.9.6"` フィールドを追加
- Corepack 経由で npm バージョンを固定し、CI・ローカル環境でのバージョン不一致を防止

## テスト計画
- [ ] CI の lint / test / typecheck が通ること
- [ ] `npm ci` が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)