### PR TITLE
fix: main ブランチカバレッジのキャッシュ化で npm ci 重複を削減

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,26 +63,34 @@ jobs:
           path: coverage/
           retention-days: 7
 
-      - name: Checkout main branch for coverage comparison
-        if: matrix.node-version == 22 && github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+      - name: Cache main branch coverage
+        if: matrix.node-version == 22 && github.event_name == 'push'
+        uses: actions/cache/save@v4
         with:
-          ref: main
-          path: __main_branch
+          path: coverage/coverage-summary.json
+          key: coverage-main-${{ github.sha }}
 
-      - name: Generate main branch coverage
+      - name: Restore main branch coverage
+        id: restore-main-coverage
         if: matrix.node-version == 22 && github.event_name == 'pull_request'
-        working-directory: __main_branch
-        run: |
-          npm ci
-          npx vitest run --coverage --exclude 'vrt/**'
+        uses: actions/cache/restore@v4
+        with:
+          path: __main_coverage/coverage-summary.json
+          key: coverage-main-
+          restore-keys: coverage-main-
 
-      - name: Coverage summary comment
-        if: matrix.node-version == 22 && github.event_name == 'pull_request'
+      - name: Coverage summary comment (with comparison)
+        if: matrix.node-version == 22 && github.event_name == 'pull_request' && steps.restore-main-coverage.outputs.cache-matched-key != ''
         uses: davelosert/vitest-coverage-report-action@v2
         with:
           json-summary-path: coverage/coverage-summary.json
-          json-summary-compare-path: __main_branch/coverage/coverage-summary.json
+          json-summary-compare-path: __main_coverage/coverage-summary.json
+
+      - name: Coverage summary comment (without comparison)
+        if: matrix.node-version == 22 && github.event_name == 'pull_request' && steps.restore-main-coverage.outputs.cache-matched-key == ''
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
close #305

## 概要

PR のカバレッジ比較時に main ブランチを再チェックアウトして `npm ci` + テスト実行していた処理を、`actions/cache` によるキャッシュ方式に変更。

## 変更内容

- **main push 時**: `coverage-summary.json` を `actions/cache/save` でキャッシュ（キー: `coverage-main-{SHA}`）
- **PR 時**: `actions/cache/restore` でキャッシュを復元し、カバレッジ比較に使用
- キャッシュが存在しない場合（初回など）は比較なしでカバレッジレポートのみ表示

## 期待される効果

- CI 実行時間の短縮（main ブランチの `npm ci` + テスト実行が不要に）

## Test plan

- [ ] main ブランチへの push で `coverage-main-{SHA}` キャッシュが保存されることを確認
- [ ] PR 作成時にキャッシュが復元され、カバレッジ比較コメントが投稿されることを確認
- [ ] キャッシュが存在しない場合、比較なしのカバレッジレポートが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)