### PR TITLE
feat: PPTX を pom XML 形式に変換する convertPptxToPom を追加

### DIFF
--- a/.changeset/add-convert-pptx-to-pom.md
+++ b/.changeset/add-convert-pptx-to-pom.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+feat: PPTX を pom 形式 JSON に変換する `convertPptxToPom` を追加

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pptx-glimpse",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pptx-glimpse",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.3.6",
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
+        "@hirokisakabe/pom": "^4.1.1",
         "@types/node": "^25.2.2",
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^3.2.4",
@@ -1094,6 +1095,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hirokisakabe/pom": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hirokisakabe/pom/-/pom-4.1.1.tgz",
+      "integrity": "sha512-L+OfJ5X+hk3uRuf038Uz8rSWXXICPa+2Wzgm1bMVagrLjofSpJ3RWRNpYk93yo1armNW4x7H5H2/IcDWXOCt+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.3.7",
+        "image-size": "2.0.2",
+        "opentype.js": "^1.3.4",
+        "pptxgenjs": "4.0.1",
+        "yoga-layout": "3.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4173,6 +4192,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/human-id": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz",
@@ -4208,6 +4234,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {
@@ -5223,6 +5262,52 @@
         }
       }
     },
+    "node_modules/pptxgenjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-4.0.1.tgz",
+      "integrity": "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.8.1",
+        "https": "^1.0.0",
+        "image-size": "^1.2.1",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5282,6 +5367,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6569,6 +6664,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
+    "@hirokisakabe/pom": "^4.1.1",
     "@types/node": "^25.2.2",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.2.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,7 @@ export {
   createOpentypeSetupFromBuffers,
   createOpentypeTextMeasurerFromBuffers,
 } from "./font/opentype-helpers.js";
+export type { ConvertPptxToPomOptions, PomSlide } from "./pom/index.js";
+export { convertPptxToPom } from "./pom/index.js";
 export type { LogLevel, WarningEntry, WarningSummary } from "./warning-logger.js";
 export { getWarningEntries, getWarningSummary } from "./warning-logger.js";

--- a/src/pom/element-converter.ts
+++ b/src/pom/element-converter.ts
@@ -1,0 +1,645 @@
+import type { ChartElement } from "../model/chart.js";
+import type { ImageElement } from "../model/image.js";
+import type { Outline } from "../model/line.js";
+import type { ConnectorElement, GroupElement, ShapeElement, SlideElement } from "../model/shape.js";
+import type { TableElement } from "../model/table.js";
+import type { SlideScaleContext } from "./pom-converter.js";
+import { stripHash } from "./pom-converter.js";
+import type {
+  PomChartData,
+  PomChartNode,
+  PomChartType,
+  PomDashType,
+  PomImageNode,
+  PomLayerChild,
+  PomLayerNode,
+  PomLineArrow,
+  PomLineNode,
+  PomNode,
+  PomShapeNode,
+  PomTableCell,
+  PomTableNode,
+} from "./pom-types.js";
+import { convertTextBodyToNodes } from "./text-converter.js";
+
+export function convertElement(element: SlideElement, ctx: SlideScaleContext): PomNode | null {
+  switch (element.type) {
+    case "shape":
+      return convertShape(element, ctx);
+    case "image":
+      return convertImage(element);
+    case "table":
+      return convertTable(element, ctx);
+    case "chart":
+      return convertChart(element);
+    case "connector":
+      return convertConnector(element, ctx);
+    case "group":
+      return convertGroup(element, ctx);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+const POM_SUPPORTED_SHAPES = new Set([
+  "accentBorderCallout1",
+  "accentBorderCallout2",
+  "accentBorderCallout3",
+  "accentCallout1",
+  "accentCallout2",
+  "accentCallout3",
+  "actionButtonBackPrevious",
+  "actionButtonBeginning",
+  "actionButtonBlank",
+  "actionButtonDocument",
+  "actionButtonEnd",
+  "actionButtonForwardNext",
+  "actionButtonHelp",
+  "actionButtonHome",
+  "actionButtonInformation",
+  "actionButtonMovie",
+  "actionButtonReturn",
+  "actionButtonSound",
+  "arc",
+  "bentArrow",
+  "bentUpArrow",
+  "bevel",
+  "blockArc",
+  "borderCallout1",
+  "borderCallout2",
+  "borderCallout3",
+  "bracePair",
+  "bracketPair",
+  "callout1",
+  "callout2",
+  "callout3",
+  "can",
+  "chartPlus",
+  "chartStar",
+  "chartX",
+  "chevron",
+  "chord",
+  "circularArrow",
+  "cloud",
+  "cloudCallout",
+  "corner",
+  "cornerTabs",
+  "cube",
+  "curvedDownArrow",
+  "curvedLeftArrow",
+  "curvedRightArrow",
+  "curvedUpArrow",
+  "decagon",
+  "diagStripe",
+  "diamond",
+  "dodecagon",
+  "donut",
+  "doubleWave",
+  "downArrow",
+  "downArrowCallout",
+  "ellipse",
+  "ellipseRibbon",
+  "ellipseRibbon2",
+  "flowChartAlternateProcess",
+  "flowChartCollate",
+  "flowChartConnector",
+  "flowChartDecision",
+  "flowChartDelay",
+  "flowChartDisplay",
+  "flowChartDocument",
+  "flowChartExtract",
+  "flowChartInputOutput",
+  "flowChartInternalStorage",
+  "flowChartMagneticDisk",
+  "flowChartMagneticDrum",
+  "flowChartMagneticTape",
+  "flowChartManualInput",
+  "flowChartManualOperation",
+  "flowChartMerge",
+  "flowChartMultidocument",
+  "flowChartOfflineStorage",
+  "flowChartOffpageConnector",
+  "flowChartOnlineStorage",
+  "flowChartOr",
+  "flowChartPredefinedProcess",
+  "flowChartPreparation",
+  "flowChartProcess",
+  "flowChartPunchedCard",
+  "flowChartPunchedTape",
+  "flowChartSort",
+  "flowChartSummingJunction",
+  "flowChartTerminator",
+  "folderCorner",
+  "frame",
+  "funnel",
+  "gear6",
+  "gear9",
+  "halfFrame",
+  "heart",
+  "heptagon",
+  "hexagon",
+  "homePlate",
+  "horizontalScroll",
+  "irregularSeal1",
+  "irregularSeal2",
+  "leftArrow",
+  "leftArrowCallout",
+  "leftBrace",
+  "leftBracket",
+  "leftCircularArrow",
+  "leftRightArrow",
+  "leftRightArrowCallout",
+  "leftRightCircularArrow",
+  "leftRightRibbon",
+  "leftRightUpArrow",
+  "leftUpArrow",
+  "lightningBolt",
+  "line",
+  "lineInv",
+  "mathDivide",
+  "mathEqual",
+  "mathMinus",
+  "mathMultiply",
+  "mathNotEqual",
+  "mathPlus",
+  "moon",
+  "noSmoking",
+  "nonIsoscelesTrapezoid",
+  "notchedRightArrow",
+  "octagon",
+  "parallelogram",
+  "pentagon",
+  "pie",
+  "pieWedge",
+  "plaque",
+  "plaqueTabs",
+  "plus",
+  "quadArrow",
+  "quadArrowCallout",
+  "rect",
+  "ribbon",
+  "ribbon2",
+  "rightArrow",
+  "rightArrowCallout",
+  "rightBrace",
+  "rightBracket",
+  "round1Rect",
+  "round2DiagRect",
+  "round2SameRect",
+  "roundRect",
+  "rtTriangle",
+  "smileyFace",
+  "snip1Rect",
+  "snip2DiagRect",
+  "snip2SameRect",
+  "snipRoundRect",
+  "squareTabs",
+  "star10",
+  "star12",
+  "star16",
+  "star24",
+  "star32",
+  "star4",
+  "star5",
+  "star6",
+  "star7",
+  "star8",
+  "stripedRightArrow",
+  "sun",
+  "swooshArrow",
+  "teardrop",
+  "trapezoid",
+  "triangle",
+  "upArrow",
+  "upArrowCallout",
+  "upDownArrow",
+  "upDownArrowCallout",
+  "uturnArrow",
+  "verticalScroll",
+  "wave",
+  "wedgeEllipseCallout",
+  "wedgeRectCallout",
+  "wedgeRoundRectCallout",
+]);
+
+function convertShape(shape: ShapeElement, ctx: SlideScaleContext): PomNode | null {
+  // If the shape has text but no recognized geometry, convert as text node(s)
+  if (shape.textBody && shape.textBody.paragraphs.length > 0) {
+    const hasVisualShape = shape.geometry.type === "preset" && shape.geometry.preset !== "rect";
+    const hasFill = shape.fill !== null && shape.fill.type !== "none";
+    const hasOutline = shape.outline !== null && (shape.outline.width as number) > 0;
+
+    // Text-only shape (plain rect with no fill/outline) → convert as text/list nodes
+    if (!hasVisualShape && !hasFill && !hasOutline) {
+      return convertTextBodyToNodes(shape.textBody, ctx);
+    }
+  }
+
+  // Convert as pom Shape node
+  const preset = shape.geometry.type === "preset" ? shape.geometry.preset : "rect";
+  const shapeType = POM_SUPPORTED_SHAPES.has(preset) ? preset : "rect";
+
+  const node: PomShapeNode = {
+    type: "shape",
+    shapeType,
+  };
+
+  // Fill
+  if (shape.fill && shape.fill.type === "solid") {
+    node.fill = {
+      color: stripHash(shape.fill.color.hex),
+    };
+    if (shape.fill.color.alpha < 1) {
+      node.fill.transparency = Math.round((1 - shape.fill.color.alpha) * 100);
+    }
+  }
+
+  // Outline → line
+  if (shape.outline && (shape.outline.width as number) > 0) {
+    node.line = convertOutlineToLine(shape.outline, ctx);
+  }
+
+  // Shadow
+  if (shape.effects?.outerShadow) {
+    const s = shape.effects.outerShadow;
+    node.shadow = {
+      type: "outer",
+      color: stripHash(s.color.hex),
+      opacity: s.color.alpha,
+      blur: round((s.blurRadius as number) * ctx.scaleX),
+      offset: round((s.distance as number) * ctx.scaleX),
+      angle: s.direction,
+    };
+  }
+
+  // Text inside shape
+  if (shape.textBody && shape.textBody.paragraphs.length > 0) {
+    const textParts: string[] = [];
+    let firstFontPx: number | undefined;
+    let firstColor: string | undefined;
+    let firstBold: boolean | undefined;
+    let firstItalic: boolean | undefined;
+    let firstAlign: "left" | "center" | "right" | undefined;
+
+    for (const para of shape.textBody.paragraphs) {
+      const paraText = para.runs.map((r) => r.text).join("");
+      if (paraText) textParts.push(paraText);
+
+      if (firstFontPx === undefined) {
+        for (const run of para.runs) {
+          if (run.properties.fontSize !== null) {
+            firstFontPx = ptToPx(run.properties.fontSize as number);
+            break;
+          }
+        }
+      }
+      if (firstColor === undefined) {
+        for (const run of para.runs) {
+          if (run.properties.color) {
+            firstColor = stripHash(run.properties.color.hex);
+            break;
+          }
+        }
+      }
+      if (firstBold === undefined) {
+        for (const run of para.runs) {
+          if (run.properties.bold) {
+            firstBold = true;
+            break;
+          }
+        }
+      }
+      if (firstItalic === undefined) {
+        for (const run of para.runs) {
+          if (run.properties.italic) {
+            firstItalic = true;
+            break;
+          }
+        }
+      }
+      if (firstAlign === undefined) {
+        firstAlign = convertAlignment(para.properties.alignment);
+      }
+    }
+
+    if (textParts.length > 0) {
+      node.text = textParts.join("\n");
+    }
+    if (firstFontPx !== undefined) node.fontPx = firstFontPx;
+    if (firstColor !== undefined) node.color = firstColor;
+    if (firstBold) node.bold = true;
+    if (firstItalic) node.italic = true;
+    if (firstAlign && firstAlign !== "left") node.alignText = firstAlign;
+  }
+
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Image
+// ---------------------------------------------------------------------------
+
+function convertImage(image: ImageElement): PomImageNode {
+  const src = `data:${image.mimeType};base64,${image.imageData}`;
+
+  const node: PomImageNode = {
+    type: "image",
+    src,
+  };
+
+  // Crop
+  if (image.srcRect) {
+    const { left, top, right, bottom } = image.srcRect;
+    if (left > 0 || top > 0 || right > 0 || bottom > 0) {
+      node.sizing = {
+        type: "crop",
+        x: left,
+        y: top,
+      };
+    }
+  }
+
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Table
+// ---------------------------------------------------------------------------
+
+function convertTable(table: TableElement, ctx: SlideScaleContext): PomTableNode {
+  const columns = table.table.columns.map((col) => ({
+    width: round((col.width as number) * ctx.scaleX),
+  }));
+
+  const rows = table.table.rows.map((row) => {
+    const cells: PomTableCell[] = row.cells
+      .filter((cell) => !cell.hMerge && !cell.vMerge)
+      .map((cell) => {
+        const textParts: string[] = [];
+        let fontPx: number | undefined;
+        let color: string | undefined;
+        let bold: boolean | undefined;
+        let italic: boolean | undefined;
+        let alignText: "left" | "center" | "right" | undefined;
+
+        if (cell.textBody) {
+          for (const para of cell.textBody.paragraphs) {
+            const paraText = para.runs.map((r) => r.text).join("");
+            if (paraText) textParts.push(paraText);
+
+            if (fontPx === undefined) {
+              for (const run of para.runs) {
+                if (run.properties.fontSize !== null) {
+                  fontPx = ptToPx(run.properties.fontSize as number);
+                  break;
+                }
+              }
+            }
+            if (color === undefined) {
+              for (const run of para.runs) {
+                if (run.properties.color) {
+                  color = stripHash(run.properties.color.hex);
+                  break;
+                }
+              }
+            }
+            if (bold === undefined && para.runs.some((r) => r.properties.bold)) {
+              bold = true;
+            }
+            if (italic === undefined && para.runs.some((r) => r.properties.italic)) {
+              italic = true;
+            }
+            if (alignText === undefined) {
+              alignText = convertAlignment(para.properties.alignment);
+            }
+          }
+        }
+
+        const pomCell: PomTableCell = {
+          text: textParts.join("\n"),
+        };
+        if (fontPx !== undefined) pomCell.fontPx = fontPx;
+        if (color !== undefined) pomCell.color = color;
+        if (bold) pomCell.bold = true;
+        if (italic) pomCell.italic = true;
+        if (alignText && alignText !== "left") pomCell.alignText = alignText;
+        if (cell.fill && cell.fill.type === "solid") {
+          pomCell.backgroundColor = stripHash(cell.fill.color.hex);
+        }
+        if (cell.gridSpan > 1) pomCell.colspan = cell.gridSpan;
+        if (cell.rowSpan > 1) pomCell.rowspan = cell.rowSpan;
+
+        return pomCell;
+      });
+
+    return {
+      cells,
+      height: round((row.height as number) * ctx.scaleY),
+    };
+  });
+
+  return {
+    type: "table",
+    columns,
+    rows,
+  } as PomTableNode;
+}
+
+// ---------------------------------------------------------------------------
+// Chart
+// ---------------------------------------------------------------------------
+
+const POM_CHART_TYPES = new Set(["bar", "line", "pie", "area", "doughnut", "radar"]);
+
+function convertChart(chart: ChartElement): PomChartNode | null {
+  const chartType = chart.chart.chartType;
+  if (!POM_CHART_TYPES.has(chartType)) return null;
+
+  const data: PomChartData[] = chart.chart.series.map((s) => ({
+    name: s.name ?? undefined,
+    labels: chart.chart.categories,
+    values: s.values,
+  }));
+
+  const chartColors = chart.chart.series.map((s) => stripHash(s.color.hex));
+
+  const node: PomChartNode = {
+    type: "chart",
+    chartType: chartType as PomChartType,
+    data,
+  };
+
+  if (chart.chart.title) {
+    node.title = chart.chart.title;
+    node.showTitle = true;
+  }
+  if (chart.chart.legend) {
+    node.showLegend = true;
+  }
+  if (chartColors.length > 0) {
+    node.chartColors = chartColors;
+  }
+  if (chartType === "radar" && chart.chart.radarStyle) {
+    node.radarStyle = chart.chart.radarStyle;
+  }
+
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// Connector → Line
+// ---------------------------------------------------------------------------
+
+function convertConnector(connector: ConnectorElement, ctx: SlideScaleContext): PomLineNode {
+  const t = connector.transform;
+  const x = (t.offsetX as number) * ctx.scaleX;
+  const y = (t.offsetY as number) * ctx.scaleY;
+  const w = (t.extentWidth as number) * ctx.scaleX;
+  const h = (t.extentHeight as number) * ctx.scaleY;
+
+  const flipH = t.flipH;
+  const flipV = t.flipV;
+
+  const node: PomLineNode = {
+    type: "line",
+    x1: round(flipH ? x + w : x),
+    y1: round(flipV ? y + h : y),
+    x2: round(flipH ? x : x + w),
+    y2: round(flipV ? y : y + h),
+  };
+
+  if (connector.outline) {
+    const outline = connector.outline;
+    if (outline.fill && outline.fill.type === "solid") {
+      node.color = stripHash(outline.fill.color.hex);
+    }
+    if ((outline.width as number) > 0) {
+      node.lineWidth = round(emuToPoints(outline.width as number));
+    }
+    if (outline.dashStyle !== "solid") {
+      node.dashType = outline.dashStyle as PomDashType;
+    }
+    if (outline.headEnd && outline.headEnd.type !== "none") {
+      node.beginArrow = convertArrow(outline.headEnd.type);
+    }
+    if (outline.tailEnd && outline.tailEnd.type !== "none") {
+      node.endArrow = convertArrow(outline.tailEnd.type);
+    }
+  }
+
+  return node;
+}
+
+function convertArrow(arrowType: string): PomLineArrow {
+  if (
+    arrowType === "triangle" ||
+    arrowType === "stealth" ||
+    arrowType === "diamond" ||
+    arrowType === "oval" ||
+    arrowType === "arrow"
+  ) {
+    return { type: arrowType };
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Group → Layer
+// ---------------------------------------------------------------------------
+
+function convertGroup(group: GroupElement, ctx: SlideScaleContext): PomLayerNode {
+  const children: PomLayerChild[] = [];
+
+  // Group child coordinates are in the group's local coordinate system (chOff/chExt).
+  // We need to transform: (child - chOff) * (group.extent / chExt) + group.offset
+  // then apply the slide scale.
+  const chOff = group.childTransform;
+  const grp = group.transform;
+  const chExtW = chOff.extentWidth as number;
+  const chExtH = chOff.extentHeight as number;
+  const grpExtW = grp.extentWidth as number;
+  const grpExtH = grp.extentHeight as number;
+  const grpOffX = grp.offsetX as number;
+  const grpOffY = grp.offsetY as number;
+  const chOffX = chOff.offsetX as number;
+  const chOffY = chOff.offsetY as number;
+
+  for (const child of group.children) {
+    const pomNode = convertElement(child, ctx);
+    if (!pomNode) continue;
+
+    const t = child.transform;
+    // Map from group-local coords to slide coords
+    const slideX =
+      chExtW > 0
+        ? grpOffX + ((t.offsetX as number) - chOffX) * (grpExtW / chExtW)
+        : (t.offsetX as number);
+    const slideY =
+      chExtH > 0
+        ? grpOffY + ((t.offsetY as number) - chOffY) * (grpExtH / chExtH)
+        : (t.offsetY as number);
+    const slideW =
+      chExtW > 0 ? (t.extentWidth as number) * (grpExtW / chExtW) : (t.extentWidth as number);
+    const slideH =
+      chExtH > 0 ? (t.extentHeight as number) * (grpExtH / chExtH) : (t.extentHeight as number);
+
+    const x = round(slideX * ctx.scaleX);
+    const y = round(slideY * ctx.scaleY);
+    const w = round(slideW * ctx.scaleX);
+    const h = round(slideH * ctx.scaleY);
+
+    children.push({ ...pomNode, x, y, w, h } as PomLayerChild);
+  }
+
+  return {
+    type: "layer",
+    children,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function convertOutlineToLine(
+  outline: Outline,
+  _ctx: SlideScaleContext,
+): { color?: string; width?: number; dashType?: PomDashType } {
+  const result: { color?: string; width?: number; dashType?: PomDashType } = {};
+  if (outline.fill && outline.fill.type === "solid") {
+    result.color = stripHash(outline.fill.color.hex);
+  }
+  if ((outline.width as number) > 0) {
+    result.width = round(emuToPoints(outline.width as number));
+  }
+  if (outline.dashStyle !== "solid") {
+    result.dashType = outline.dashStyle as PomDashType;
+  }
+  return result;
+}
+
+function convertAlignment(alignment: "l" | "ctr" | "r" | "just"): "left" | "center" | "right" {
+  switch (alignment) {
+    case "ctr":
+      return "center";
+    case "r":
+      return "right";
+    default:
+      return "left";
+  }
+}
+
+function ptToPx(pt: number): number {
+  // 1pt = 4/3 px at 96 DPI
+  return Math.round((pt * 4) / 3);
+}
+
+function emuToPoints(emu: number): number {
+  return emu / 12700;
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/pom/index.ts
+++ b/src/pom/index.ts
@@ -1,0 +1,75 @@
+import type { SlideElement } from "../model/shape.js";
+import { clearXmlCache, enableXmlCache } from "../parser/xml-parser.js";
+import { parsePptxData, parseSlideWithLayout } from "../pptx-data-parser.js";
+import type { LogLevel } from "../warning-logger.js";
+import { flushWarnings, initWarningLogger } from "../warning-logger.js";
+import { convertSlideToPom } from "./pom-converter.js";
+import { pomLayerToXml } from "./xml-builder.js";
+
+export interface ConvertPptxToPomOptions {
+  /** 変換対象のスライド番号 (1始まり)。未指定で全スライド */
+  slides?: number[];
+  /** 警告ログレベル。デフォルト: "off" */
+  logLevel?: LogLevel;
+}
+
+export interface PomSlide {
+  slideNumber: number;
+  xml: string;
+}
+
+export function convertPptxToPom(
+  input: Buffer | Uint8Array,
+  options?: ConvertPptxToPomOptions,
+): PomSlide[] {
+  enableXmlCache();
+  try {
+    initWarningLogger(options?.logLevel ?? "off");
+
+    const data = parsePptxData(input);
+
+    const targetSlides = options?.slides
+      ? data.slidePaths.filter((s) => options.slides!.includes(s.slideNumber))
+      : data.slidePaths;
+
+    const results: PomSlide[] = [];
+    for (const { slideNumber, path } of targetSlides) {
+      const parsed = parseSlideWithLayout(slideNumber, path, data);
+      if (!parsed) continue;
+
+      const { slide, layoutElements, layoutShowMasterSp } = parsed;
+
+      // Merge shapes: master (back) → layout → slide (front)
+      const effectiveMasterElements =
+        slide.showMasterSp && layoutShowMasterSp ? data.masterElements : [];
+      slide.elements = mergeElements(effectiveMasterElements, layoutElements, slide.elements);
+
+      const node = convertSlideToPom(slide, data.presInfo.slideSize);
+      const xml = pomLayerToXml(node);
+      results.push({ slideNumber, xml });
+    }
+
+    flushWarnings();
+
+    return results;
+  } finally {
+    clearXmlCache();
+  }
+}
+
+function mergeElements(
+  masterElements: SlideElement[],
+  layoutElements: SlideElement[],
+  slideElements: SlideElement[],
+): SlideElement[] {
+  const filterPlaceholders = (elements: SlideElement[]) =>
+    elements.filter((el) => {
+      if (el.type !== "shape") return true;
+      return !el.placeholderType;
+    });
+
+  const filteredMaster = filterPlaceholders(masterElements);
+  const filteredLayout = filterPlaceholders(layoutElements);
+
+  return [...filteredMaster, ...filteredLayout, ...slideElements];
+}

--- a/src/pom/pom-converter.test.ts
+++ b/src/pom/pom-converter.test.ts
@@ -1,7 +1,19 @@
 import JSZip from "jszip";
+import path from "path";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { convertPptxToPom } from "./index.js";
+
+// Import pom's parseXml via absolute path to bypass package.json "exports" restriction
+async function loadParseXml(): Promise<(xml: string) => unknown[]> {
+  const pomParseXmlPath = path.join(
+    process.cwd(),
+    "node_modules/@hirokisakabe/pom/dist/parseXml/parseXml.js",
+  );
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const mod: { parseXml: (xml: string) => unknown[] } = await import(pomParseXmlPath);
+  return mod.parseXml;
+}
 
 // --- Minimal PPTX XML templates ---
 
@@ -175,7 +187,7 @@ describe("convertPptxToPom", () => {
       const xml = result[0].xml;
       expect(xml).toContain("<Shape");
       expect(xml).toContain('shapeType="rect"');
-      expect(xml).toContain('fill.color="4472C4"');
+      expect(xml).toContain('fill="{&quot;color&quot;:&quot;4472C4&quot;}"');
       expect(xml).toContain('bold="true"');
       expect(xml).toContain('color="FFFFFF"');
       expect(xml).toContain('alignText="center"');
@@ -256,7 +268,7 @@ describe("convertPptxToPom", () => {
       const xml = result[0].xml;
       expect(xml).toContain("<Shape");
       expect(xml).toContain('shapeType="ellipse"');
-      expect(xml).toContain('fill.color="ED7D31"');
+      expect(xml).toContain('fill="{&quot;color&quot;:&quot;ED7D31&quot;}"');
     });
   });
 
@@ -372,7 +384,7 @@ describe("convertPptxToPom", () => {
       const xml = result[0].xml;
       expect(xml).toContain("<Line");
       expect(xml).toContain('color="FF0000"');
-      expect(xml).toContain('endArrow.type="triangle"');
+      expect(xml).toContain('endArrow="{&quot;type&quot;:&quot;triangle&quot;}"');
     });
   });
 
@@ -400,6 +412,153 @@ describe("convertPptxToPom", () => {
       const result = convertPptxToPom(pptx);
       const xml = result[0].xml;
       expect(xml).toContain('backgroundColor="1A1A2E"');
+    });
+  });
+
+  describe("pom schema validation", () => {
+    let parseXml: (xml: string) => unknown[];
+
+    beforeAll(async () => {
+      parseXml = await loadParseXml();
+    });
+
+    it("shape with fill and line passes pom parseXml validation", async () => {
+      const pptx = await createPptx(
+        makeSlideXml(`
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="2" name="Rect 1"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="457200" y="274638"/><a:ext cx="3048000" cy="1143000"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+            <a:solidFill><a:srgbClr val="4472C4"/></a:solidFill>
+            <a:ln w="25400"><a:solidFill><a:srgbClr val="2F528F"/></a:solidFill></a:ln>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr anchor="ctr"/>
+            <a:lstStyle/>
+            <a:p>
+              <a:pPr algn="ctr"/>
+              <a:r>
+                <a:rPr lang="en-US" sz="2400" b="1">
+                  <a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>
+                </a:rPr>
+                <a:t>Hello World</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>`),
+      );
+      const result = convertPptxToPom(pptx);
+      expect(() => parseXml(result[0].xml)).not.toThrow();
+    });
+
+    it("text-only shape passes pom parseXml validation", async () => {
+      const pptx = await createPptx(
+        makeSlideXml(`
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="2" name="TextBox 1"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="914400" y="914400"/><a:ext cx="4572000" cy="914400"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p>
+              <a:r>
+                <a:rPr lang="en-US" sz="1800" i="1">
+                  <a:solidFill><a:srgbClr val="333333"/></a:solidFill>
+                </a:rPr>
+                <a:t>Plain text</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>`),
+      );
+      const result = convertPptxToPom(pptx);
+      expect(() => parseXml(result[0].xml)).not.toThrow();
+    });
+
+    it("connector with arrow passes pom parseXml validation", async () => {
+      const pptx = await createPptx(
+        makeSlideXml(`
+        <p:cxnSp>
+          <p:nvCxnSpPr>
+            <p:cNvPr id="5" name="Connector 1"/>
+            <p:cNvCxnSpPr/>
+            <p:nvPr/>
+          </p:nvCxnSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="914400" y="914400"/>
+              <a:ext cx="4572000" cy="0"/>
+            </a:xfrm>
+            <a:prstGeom prst="line"><a:avLst/></a:prstGeom>
+            <a:ln w="25400">
+              <a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>
+              <a:tailEnd type="triangle"/>
+            </a:ln>
+          </p:spPr>
+        </p:cxnSp>`),
+      );
+      const result = convertPptxToPom(pptx);
+      expect(() => parseXml(result[0].xml)).not.toThrow();
+    });
+
+    it("table passes pom parseXml validation", async () => {
+      const pptx = await createPptx(
+        makeSlideXml(`
+        <p:graphicFrame>
+          <p:nvGraphicFramePr>
+            <p:cNvPr id="4" name="Table 1"/>
+            <p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr>
+            <p:nvPr/>
+          </p:nvGraphicFramePr>
+          <p:xfrm><a:off x="914400" y="1828800"/><a:ext cx="7315200" cy="1828800"/></p:xfrm>
+          <a:graphic>
+            <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+              <a:tbl>
+                <a:tblGrid>
+                  <a:gridCol w="3657600"/>
+                  <a:gridCol w="3657600"/>
+                </a:tblGrid>
+                <a:tr h="914400">
+                  <a:tc>
+                    <a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US" sz="1400" b="1"/><a:t>H1</a:t></a:r></a:p></a:txBody>
+                    <a:tcPr><a:solidFill><a:srgbClr val="4472C4"/></a:solidFill></a:tcPr>
+                  </a:tc>
+                  <a:tc>
+                    <a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:rPr lang="en-US" sz="1400"/><a:t>H2</a:t></a:r></a:p></a:txBody>
+                    <a:tcPr/>
+                  </a:tc>
+                </a:tr>
+              </a:tbl>
+            </a:graphicData>
+          </a:graphic>
+        </p:graphicFrame>`),
+      );
+      const result = convertPptxToPom(pptx);
+      expect(() => parseXml(result[0].xml)).not.toThrow();
+    });
+
+    it("empty slide passes pom parseXml validation", async () => {
+      const pptx = await createPptx(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:bg>
+      <p:bgPr>
+        <a:solidFill><a:srgbClr val="1A1A2E"/></a:solidFill>
+        <a:effectLst/>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`);
+      const result = convertPptxToPom(pptx);
+      expect(() => parseXml(result[0].xml)).not.toThrow();
     });
   });
 });

--- a/src/pom/pom-converter.test.ts
+++ b/src/pom/pom-converter.test.ts
@@ -1,0 +1,405 @@
+import JSZip from "jszip";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { convertPptxToPom } from "./index.js";
+
+// --- Minimal PPTX XML templates ---
+
+const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+  <Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>
+  <Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>
+  <Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+</Types>`;
+
+const rootRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>`;
+
+const presentationXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:sldMasterIdLst>
+    <p:sldMasterId r:id="rId1"/>
+  </p:sldMasterIdLst>
+  <p:sldIdLst>
+    <p:sldId id="256" r:id="rId2"/>
+  </p:sldIdLst>
+  <p:sldSz cx="9144000" cy="5143500" type="screen16x9"/>
+</p:presentation>`;
+
+const presentationRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+</Relationships>`;
+
+const slideMaster1 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+    </p:spTree>
+  </p:cSld>
+  <p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" accent6="accent6" hlink="hlink" folHlink="folHlink"/>
+</p:sldMaster>`;
+
+const slideMaster1Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme1.xml"/>
+</Relationships>`;
+
+const slideLayout1 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="blank">
+  <p:cSld><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr/></p:spTree></p:cSld>
+</p:sldLayout>`;
+
+const slideLayout1Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>
+</Relationships>`;
+
+const theme1 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+  <a:themeElements>
+    <a:clrScheme name="Office">
+      <a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>
+      <a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>
+      <a:dk2><a:srgbClr val="44546A"/></a:dk2>
+      <a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>
+      <a:accent1><a:srgbClr val="4472C4"/></a:accent1>
+      <a:accent2><a:srgbClr val="ED7D31"/></a:accent2>
+      <a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>
+      <a:accent4><a:srgbClr val="FFC000"/></a:accent4>
+      <a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>
+      <a:accent6><a:srgbClr val="70AD47"/></a:accent6>
+      <a:hlink><a:srgbClr val="0563C1"/></a:hlink>
+      <a:folHlink><a:srgbClr val="954F72"/></a:folHlink>
+    </a:clrScheme>
+    <a:fontScheme name="Office">
+      <a:majorFont><a:latin typeface="Calibri Light"/></a:majorFont>
+      <a:minorFont><a:latin typeface="Calibri"/></a:minorFont>
+    </a:fontScheme>
+    <a:fmtScheme name="Office"/>
+  </a:themeElements>
+</a:theme>`;
+
+const slide1Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>
+</Relationships>`;
+
+async function createPptx(slideXml: string): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypes);
+  zip.file("_rels/.rels", rootRels);
+  zip.file("ppt/presentation.xml", presentationXml);
+  zip.file("ppt/_rels/presentation.xml.rels", presentationRels);
+  zip.file("ppt/slides/slide1.xml", slideXml);
+  zip.file("ppt/slides/_rels/slide1.xml.rels", slide1Rels);
+  zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
+  zip.file("ppt/slideMasters/_rels/slideMaster1.xml.rels", slideMaster1Rels);
+  zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
+  zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
+  zip.file("ppt/theme/theme1.xml", theme1);
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+function makeSlideXml(spTree: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>
+      ${spTree}
+    </p:spTree>
+  </p:cSld>
+</p:sld>`;
+}
+
+describe("convertPptxToPom", () => {
+  describe("basic structure", () => {
+    let pptx: Buffer;
+    beforeAll(async () => {
+      pptx = await createPptx(
+        makeSlideXml(`
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="2" name="Rect 1"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="457200" y="274638"/><a:ext cx="3048000" cy="1143000"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+            <a:solidFill><a:srgbClr val="4472C4"/></a:solidFill>
+            <a:ln w="25400"><a:solidFill><a:srgbClr val="2F528F"/></a:solidFill></a:ln>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr anchor="ctr"/>
+            <a:lstStyle/>
+            <a:p>
+              <a:pPr algn="ctr"/>
+              <a:r>
+                <a:rPr lang="en-US" sz="2400" b="1">
+                  <a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>
+                </a:rPr>
+                <a:t>Hello World</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>`),
+      );
+    });
+
+    it("returns one PomSlide per slide", () => {
+      const result = convertPptxToPom(pptx);
+      expect(result).toHaveLength(1);
+      expect(result[0].slideNumber).toBe(1);
+    });
+
+    it("produces XML with Layer root element and slide dimensions", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      expect(xml).toMatch(/^<Layer/);
+      expect(xml).toContain('w="1280"');
+      expect(xml).toContain('h="720"');
+    });
+
+    it("converts a shape with fill and text to pom XML", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      expect(xml).toContain("<Shape");
+      expect(xml).toContain('shapeType="rect"');
+      expect(xml).toContain('fill.color="4472C4"');
+      expect(xml).toContain('bold="true"');
+      expect(xml).toContain('color="FFFFFF"');
+      expect(xml).toContain('alignText="center"');
+      expect(xml).toContain(">Hello World</Shape>");
+    });
+
+    it("positions elements with x and y attributes", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      // 457200 / 9144000 * 1280 = 64
+      expect(xml).toContain('x="64"');
+      // 274638 / 5143500 * 720 ≈ 38.44
+      expect(xml).toContain('y="38.44"');
+    });
+
+    it("supports slide number filtering", () => {
+      const result = convertPptxToPom(pptx, { slides: [99] });
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("text-only shapes", () => {
+    let pptx: Buffer;
+    beforeAll(async () => {
+      pptx = await createPptx(
+        makeSlideXml(`
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="2" name="TextBox 1"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="914400" y="914400"/><a:ext cx="4572000" cy="914400"/></a:xfrm>
+            <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+          </p:spPr>
+          <p:txBody>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p>
+              <a:r>
+                <a:rPr lang="en-US" sz="1800" i="1">
+                  <a:solidFill><a:srgbClr val="333333"/></a:solidFill>
+                </a:rPr>
+                <a:t>Plain text box</a:t>
+              </a:r>
+            </a:p>
+          </p:txBody>
+        </p:sp>`),
+      );
+    });
+
+    it("converts a text-only shape to Text element in XML", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      expect(xml).toContain("<Text");
+      expect(xml).toContain('italic="true"');
+      expect(xml).toContain('color="333333"');
+      expect(xml).toContain('fontPx="24"'); // 18pt * 4/3
+      expect(xml).toContain(">Plain text box</Text>");
+    });
+  });
+
+  describe("ellipse shape", () => {
+    let pptx: Buffer;
+    beforeAll(async () => {
+      pptx = await createPptx(
+        makeSlideXml(`
+        <p:sp>
+          <p:nvSpPr><p:cNvPr id="2" name="Ellipse 1"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+          <p:spPr>
+            <a:xfrm><a:off x="4572000" y="274638"/><a:ext cx="2286000" cy="2286000"/></a:xfrm>
+            <a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>
+            <a:solidFill><a:srgbClr val="ED7D31"/></a:solidFill>
+          </p:spPr>
+        </p:sp>`),
+      );
+    });
+
+    it("converts ellipse with correct shapeType", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      expect(xml).toContain("<Shape");
+      expect(xml).toContain('shapeType="ellipse"');
+      expect(xml).toContain('fill.color="ED7D31"');
+    });
+  });
+
+  describe("table", () => {
+    let pptx: Buffer;
+    beforeAll(async () => {
+      pptx = await createPptx(
+        makeSlideXml(`
+        <p:graphicFrame>
+          <p:nvGraphicFramePr>
+            <p:cNvPr id="4" name="Table 1"/>
+            <p:cNvGraphicFramePr><a:graphicFrameLocks noGrp="1"/></p:cNvGraphicFramePr>
+            <p:nvPr/>
+          </p:nvGraphicFramePr>
+          <p:xfrm><a:off x="914400" y="1828800"/><a:ext cx="7315200" cy="1828800"/></p:xfrm>
+          <a:graphic>
+            <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+              <a:tbl>
+                <a:tblGrid>
+                  <a:gridCol w="3657600"/>
+                  <a:gridCol w="3657600"/>
+                </a:tblGrid>
+                <a:tr h="914400">
+                  <a:tc>
+                    <a:txBody>
+                      <a:bodyPr/>
+                      <a:lstStyle/>
+                      <a:p><a:r><a:rPr lang="en-US" sz="1400" b="1"/><a:t>Header 1</a:t></a:r></a:p>
+                    </a:txBody>
+                    <a:tcPr>
+                      <a:solidFill><a:srgbClr val="4472C4"/></a:solidFill>
+                    </a:tcPr>
+                  </a:tc>
+                  <a:tc>
+                    <a:txBody>
+                      <a:bodyPr/>
+                      <a:lstStyle/>
+                      <a:p><a:r><a:rPr lang="en-US" sz="1400" b="1"/><a:t>Header 2</a:t></a:r></a:p>
+                    </a:txBody>
+                    <a:tcPr>
+                      <a:solidFill><a:srgbClr val="4472C4"/></a:solidFill>
+                    </a:tcPr>
+                  </a:tc>
+                </a:tr>
+                <a:tr h="914400">
+                  <a:tc>
+                    <a:txBody>
+                      <a:bodyPr/>
+                      <a:lstStyle/>
+                      <a:p><a:r><a:rPr lang="en-US" sz="1400"/><a:t>Cell A</a:t></a:r></a:p>
+                    </a:txBody>
+                    <a:tcPr/>
+                  </a:tc>
+                  <a:tc>
+                    <a:txBody>
+                      <a:bodyPr/>
+                      <a:lstStyle/>
+                      <a:p><a:r><a:rPr lang="en-US" sz="1400"/><a:t>Cell B</a:t></a:r></a:p>
+                    </a:txBody>
+                    <a:tcPr/>
+                  </a:tc>
+                </a:tr>
+              </a:tbl>
+            </a:graphicData>
+          </a:graphic>
+        </p:graphicFrame>`),
+      );
+    });
+
+    it("converts a table to pom Table XML", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      expect(xml).toContain("<Table");
+      expect(xml).toContain("<TableColumn");
+      expect(xml).toContain("<TableRow");
+      expect(xml).toContain("<TableCell");
+      expect(xml).toContain('bold="true"');
+      expect(xml).toContain('backgroundColor="4472C4"');
+      expect(xml).toContain(">Header 1</TableCell>");
+      expect(xml).toContain(">Cell A</TableCell>");
+      expect(xml).toContain(">Cell B</TableCell>");
+    });
+  });
+
+  describe("connector", () => {
+    let pptx: Buffer;
+    beforeAll(async () => {
+      pptx = await createPptx(
+        makeSlideXml(`
+        <p:cxnSp>
+          <p:nvCxnSpPr>
+            <p:cNvPr id="5" name="Connector 1"/>
+            <p:cNvCxnSpPr/>
+            <p:nvPr/>
+          </p:nvCxnSpPr>
+          <p:spPr>
+            <a:xfrm>
+              <a:off x="914400" y="914400"/>
+              <a:ext cx="4572000" cy="0"/>
+            </a:xfrm>
+            <a:prstGeom prst="line"><a:avLst/></a:prstGeom>
+            <a:ln w="25400">
+              <a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>
+              <a:tailEnd type="triangle"/>
+            </a:ln>
+          </p:spPr>
+        </p:cxnSp>`),
+      );
+    });
+
+    it("converts a connector to pom Line XML", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      expect(xml).toContain("<Line");
+      expect(xml).toContain('color="FF0000"');
+      expect(xml).toContain('endArrow.type="triangle"');
+    });
+  });
+
+  describe("solid background", () => {
+    let pptx: Buffer;
+    beforeAll(async () => {
+      pptx = await createPptx(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:bg>
+      <p:bgPr>
+        <a:solidFill><a:srgbClr val="1A1A2E"/></a:solidFill>
+        <a:effectLst/>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr/>
+    </p:spTree>
+  </p:cSld>
+</p:sld>`);
+    });
+
+    it("sets backgroundColor on the Layer element", () => {
+      const result = convertPptxToPom(pptx);
+      const xml = result[0].xml;
+      expect(xml).toContain('backgroundColor="1A1A2E"');
+    });
+  });
+});

--- a/src/pom/pom-converter.ts
+++ b/src/pom/pom-converter.ts
@@ -1,0 +1,76 @@
+import type { SlideSize } from "../model/presentation.js";
+import type { SlideElement } from "../model/shape.js";
+import type { Slide } from "../model/slide.js";
+import { convertElement } from "./element-converter.js";
+import type { PomLayerChild, PomLayerNode } from "./pom-types.js";
+
+/** pom's fixed slide width in pixels */
+const POM_SLIDE_WIDTH = 1280;
+/** pom's fixed slide height in pixels */
+const POM_SLIDE_HEIGHT = 720;
+
+export interface SlideScaleContext {
+  scaleX: number;
+  scaleY: number;
+}
+
+function createScaleContext(slideSize: SlideSize): SlideScaleContext {
+  return {
+    scaleX: POM_SLIDE_WIDTH / (slideSize.width as number),
+    scaleY: POM_SLIDE_HEIGHT / (slideSize.height as number),
+  };
+}
+
+export function convertSlideToPom(slide: Slide, slideSize: SlideSize): PomLayerNode {
+  const ctx = createScaleContext(slideSize);
+
+  const children: PomLayerChild[] = [];
+  for (const element of slide.elements) {
+    const child = convertSlideElement(element, ctx);
+    if (child) {
+      children.push(child);
+    }
+  }
+
+  const layer: PomLayerNode = {
+    type: "layer",
+    w: POM_SLIDE_WIDTH,
+    h: POM_SLIDE_HEIGHT,
+    children,
+  };
+
+  if (slide.background?.fill) {
+    const bg = slide.background.fill;
+    if (bg.type === "solid") {
+      layer.backgroundColor = stripHash(bg.color.hex);
+    }
+  }
+
+  return layer;
+}
+
+function convertSlideElement(element: SlideElement, ctx: SlideScaleContext): PomLayerChild | null {
+  const pomNode = convertElement(element, ctx);
+  if (!pomNode) return null;
+
+  // Line nodes already encode absolute coordinates in x1/y1/x2/y2
+  if (pomNode.type === "line") {
+    return { ...pomNode, x: 0, y: 0 } as PomLayerChild;
+  }
+
+  const t = element.transform;
+  const x = round((t.offsetX as number) * ctx.scaleX);
+  const y = round((t.offsetY as number) * ctx.scaleY);
+  const w = round((t.extentWidth as number) * ctx.scaleX);
+  const h = round((t.extentHeight as number) * ctx.scaleY);
+
+  return { ...pomNode, x, y, w, h } as PomLayerChild;
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export function stripHash(hex: string): string {
+  return hex.startsWith("#") ? hex.slice(1) : hex;
+}

--- a/src/pom/pom-types.ts
+++ b/src/pom/pom-types.ts
@@ -1,0 +1,319 @@
+/**
+ * Self-contained pom output types.
+ * These mirror @hirokisakabe/pom's POMNode types so that pptx-glimpse
+ * does not take a runtime dependency on pom.
+ */
+
+// ---------------------------------------------------------------------------
+// Common
+// ---------------------------------------------------------------------------
+
+interface PomPadding {
+  top?: number;
+  right?: number;
+  bottom?: number;
+  left?: number;
+}
+
+interface PomBorder {
+  color?: string;
+  width?: number;
+  dashType?: PomDashType;
+}
+
+export type PomDashType =
+  | "solid"
+  | "dash"
+  | "dashDot"
+  | "lgDash"
+  | "lgDashDot"
+  | "lgDashDotDot"
+  | "sysDash"
+  | "sysDot";
+
+export interface PomShadow {
+  type?: "outer" | "inner";
+  opacity?: number;
+  blur?: number;
+  angle?: number;
+  offset?: number;
+  color?: string;
+}
+
+export interface PomFill {
+  color?: string;
+  transparency?: number;
+}
+
+export type PomAlignText = "left" | "center" | "right";
+
+export type PomAlignItems = "start" | "center" | "end" | "stretch";
+export type PomJustifyContent =
+  | "start"
+  | "center"
+  | "end"
+  | "spaceBetween"
+  | "spaceAround"
+  | "spaceEvenly";
+
+// ---------------------------------------------------------------------------
+// Base properties shared by all nodes
+// ---------------------------------------------------------------------------
+
+interface PomBaseNode {
+  w?: number | string;
+  h?: number | string;
+  minW?: number;
+  maxW?: number;
+  minH?: number;
+  maxH?: number;
+  padding?: number | PomPadding;
+  backgroundColor?: string;
+  border?: PomBorder;
+  borderRadius?: number;
+  opacity?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Text
+// ---------------------------------------------------------------------------
+
+export interface PomTextNode extends PomBaseNode {
+  type: "text";
+  text: string;
+  fontPx?: number;
+  color?: string;
+  alignText?: PomAlignText;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  highlight?: string;
+  fontFamily?: string;
+  lineSpacingMultiple?: number;
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+export interface PomLiNode {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  highlight?: string;
+  color?: string;
+  fontPx?: number;
+  fontFamily?: string;
+}
+
+export interface PomUlNode extends PomBaseNode {
+  type: "ul";
+  items: PomLiNode[];
+  fontPx?: number;
+  color?: string;
+  alignText?: PomAlignText;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  highlight?: string;
+  fontFamily?: string;
+  lineSpacingMultiple?: number;
+}
+
+export interface PomOlNode extends PomBaseNode {
+  type: "ol";
+  items: PomLiNode[];
+  fontPx?: number;
+  color?: string;
+  alignText?: PomAlignText;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  highlight?: string;
+  fontFamily?: string;
+  lineSpacingMultiple?: number;
+  numberType?: string;
+  numberStartAt?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Image
+// ---------------------------------------------------------------------------
+
+export interface PomImageNode extends PomBaseNode {
+  type: "image";
+  src: string;
+  sizing?: {
+    type: "cover" | "contain" | "crop";
+    w?: number;
+    h?: number;
+    x?: number;
+    y?: number;
+  };
+  shadow?: PomShadow;
+}
+
+// ---------------------------------------------------------------------------
+// Table
+// ---------------------------------------------------------------------------
+
+export interface PomTableCell {
+  text: string;
+  fontPx?: number;
+  color?: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  highlight?: string;
+  alignText?: PomAlignText;
+  backgroundColor?: string;
+  colspan?: number;
+  rowspan?: number;
+}
+
+export interface PomTableRow {
+  cells: PomTableCell[];
+  height?: number;
+}
+
+export interface PomTableColumn {
+  width?: number;
+}
+
+export interface PomTableNode extends PomBaseNode {
+  type: "table";
+  columns: PomTableColumn[];
+  rows: PomTableRow[];
+  defaultRowHeight?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+export interface PomShapeNode extends PomBaseNode {
+  type: "shape";
+  shapeType: string;
+  text?: string;
+  fill?: PomFill;
+  line?: {
+    color?: string;
+    width?: number;
+    dashType?: PomDashType;
+  };
+  shadow?: PomShadow;
+  fontPx?: number;
+  color?: string;
+  alignText?: PomAlignText;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strike?: boolean;
+  highlight?: string;
+  fontFamily?: string;
+  lineSpacingMultiple?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Chart
+// ---------------------------------------------------------------------------
+
+export type PomChartType = "bar" | "line" | "pie" | "area" | "doughnut" | "radar";
+
+export interface PomChartData {
+  name?: string;
+  labels: string[];
+  values: number[];
+}
+
+export interface PomChartNode extends PomBaseNode {
+  type: "chart";
+  chartType: PomChartType;
+  data: PomChartData[];
+  showLegend?: boolean;
+  showTitle?: boolean;
+  title?: string;
+  chartColors?: string[];
+  radarStyle?: "standard" | "marker" | "filled";
+}
+
+// ---------------------------------------------------------------------------
+// Line
+// ---------------------------------------------------------------------------
+
+export type PomLineArrow =
+  | boolean
+  | { type?: "none" | "diamond" | "triangle" | "arrow" | "oval" | "stealth" };
+
+export interface PomLineNode extends PomBaseNode {
+  type: "line";
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  color?: string;
+  lineWidth?: number;
+  dashType?: PomDashType;
+  beginArrow?: PomLineArrow;
+  endArrow?: PomLineArrow;
+}
+
+// ---------------------------------------------------------------------------
+// Layout containers
+// ---------------------------------------------------------------------------
+
+export interface PomBoxNode extends PomBaseNode {
+  type: "box";
+  children: PomNode;
+  shadow?: PomShadow;
+}
+
+export interface PomVStackNode extends PomBaseNode {
+  type: "vstack";
+  children: PomNode[];
+  gap?: number;
+  alignItems?: PomAlignItems;
+  justifyContent?: PomJustifyContent;
+}
+
+export interface PomHStackNode extends PomBaseNode {
+  type: "hstack";
+  children: PomNode[];
+  gap?: number;
+  alignItems?: PomAlignItems;
+  justifyContent?: PomJustifyContent;
+}
+
+export type PomLayerChild = PomNode & {
+  x: number;
+  y: number;
+};
+
+export interface PomLayerNode extends PomBaseNode {
+  type: "layer";
+  children: PomLayerChild[];
+}
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
+
+export type PomNode =
+  | PomTextNode
+  | PomUlNode
+  | PomOlNode
+  | PomImageNode
+  | PomTableNode
+  | PomBoxNode
+  | PomVStackNode
+  | PomHStackNode
+  | PomShapeNode
+  | PomChartNode
+  | PomLineNode
+  | PomLayerNode;

--- a/src/pom/text-converter.ts
+++ b/src/pom/text-converter.ts
@@ -1,0 +1,257 @@
+import type { AutoNumScheme, BulletType, Paragraph, TextBody } from "../model/text.js";
+import type { SlideScaleContext } from "./pom-converter.js";
+import { stripHash } from "./pom-converter.js";
+import type {
+  PomAlignText,
+  PomLiNode,
+  PomNode,
+  PomOlNode,
+  PomTextNode,
+  PomUlNode,
+  PomVStackNode,
+} from "./pom-types.js";
+
+/**
+ * Convert a TextBody into one or more POM nodes.
+ * - Plain text paragraphs → TextNode (or VStack of TextNodes if mixed alignment/style)
+ * - Bullet char paragraphs → UlNode
+ * - Auto-numbered paragraphs → OlNode
+ */
+export function convertTextBodyToNodes(textBody: TextBody, _ctx: SlideScaleContext): PomNode {
+  const paragraphs = textBody.paragraphs.filter(
+    (p) => p.runs.length > 0 && p.runs.some((r) => r.text.length > 0),
+  );
+
+  if (paragraphs.length === 0) {
+    return { type: "text", text: "" } as PomTextNode;
+  }
+
+  // Group consecutive paragraphs by bullet type
+  const groups = groupByBulletType(paragraphs);
+
+  if (groups.length === 1) {
+    return convertParagraphGroup(groups[0]);
+  }
+
+  // Multiple groups → VStack
+  const children: PomNode[] = groups.map(convertParagraphGroup);
+  return {
+    type: "vstack",
+    children,
+  } as PomVStackNode;
+}
+
+interface ParagraphGroup {
+  bulletType: "none" | "char" | "autoNum";
+  paragraphs: Paragraph[];
+}
+
+function groupByBulletType(paragraphs: Paragraph[]): ParagraphGroup[] {
+  const groups: ParagraphGroup[] = [];
+  let current: ParagraphGroup | null = null;
+
+  for (const para of paragraphs) {
+    const bt = getBulletCategory(para.properties.bullet);
+    if (!current || current.bulletType !== bt) {
+      current = { bulletType: bt, paragraphs: [para] };
+      groups.push(current);
+    } else {
+      current.paragraphs.push(para);
+    }
+  }
+
+  return groups;
+}
+
+function getBulletCategory(bullet: BulletType | null): "none" | "char" | "autoNum" {
+  if (!bullet) return "none";
+  return bullet.type;
+}
+
+function convertParagraphGroup(group: ParagraphGroup): PomNode {
+  switch (group.bulletType) {
+    case "char":
+      return convertToUlNode(group.paragraphs);
+    case "autoNum":
+      return convertToOlNode(group.paragraphs);
+    default:
+      return convertToTextNode(group.paragraphs);
+  }
+}
+
+function convertToTextNode(paragraphs: Paragraph[]): PomTextNode {
+  const textParts: string[] = [];
+  let fontPx: number | undefined;
+  let color: string | undefined;
+  let bold: boolean | undefined;
+  let italic: boolean | undefined;
+  let underline: boolean | undefined;
+  let strike: boolean | undefined;
+  let alignText: PomAlignText | undefined;
+  let fontFamily: string | undefined;
+  let lineSpacing: number | undefined;
+
+  for (const para of paragraphs) {
+    const paraText = para.runs.map((r) => r.text).join("");
+    textParts.push(paraText);
+
+    if (fontPx === undefined) {
+      for (const run of para.runs) {
+        if (run.properties.fontSize !== null) {
+          fontPx = ptToPx(run.properties.fontSize as number);
+          break;
+        }
+      }
+    }
+    if (color === undefined) {
+      for (const run of para.runs) {
+        if (run.properties.color) {
+          color = stripHash(run.properties.color.hex);
+          break;
+        }
+      }
+    }
+    if (bold === undefined && para.runs.some((r) => r.properties.bold)) {
+      bold = true;
+    }
+    if (italic === undefined && para.runs.some((r) => r.properties.italic)) {
+      italic = true;
+    }
+    if (underline === undefined && para.runs.some((r) => r.properties.underline)) {
+      underline = true;
+    }
+    if (strike === undefined && para.runs.some((r) => r.properties.strikethrough)) {
+      strike = true;
+    }
+    if (alignText === undefined) {
+      alignText = convertAlignment(para.properties.alignment);
+    }
+    if (fontFamily === undefined) {
+      for (const run of para.runs) {
+        if (run.properties.fontFamily) {
+          fontFamily = run.properties.fontFamily;
+          break;
+        }
+      }
+    }
+    if (lineSpacing === undefined && para.properties.lineSpacing !== null) {
+      lineSpacing = para.properties.lineSpacing;
+    }
+  }
+
+  const node: PomTextNode = {
+    type: "text",
+    text: textParts.join("\n"),
+  };
+  if (fontPx !== undefined) node.fontPx = fontPx;
+  if (color !== undefined) node.color = color;
+  if (bold) node.bold = true;
+  if (italic) node.italic = true;
+  if (underline) node.underline = true;
+  if (strike) node.strike = true;
+  if (alignText && alignText !== "left") node.alignText = alignText;
+  if (fontFamily) node.fontFamily = fontFamily;
+  if (lineSpacing !== undefined) node.lineSpacingMultiple = lineSpacing;
+
+  return node;
+}
+
+function convertToUlNode(paragraphs: Paragraph[]): PomUlNode {
+  const items: PomLiNode[] = paragraphs.map(convertParagraphToLi);
+
+  const node: PomUlNode = {
+    type: "ul",
+    items,
+  };
+
+  // Inherit common styles from first item
+  if (items.length > 0) {
+    const first = items[0];
+    if (first.fontPx !== undefined) node.fontPx = first.fontPx;
+    if (first.color !== undefined) node.color = first.color;
+    if (first.fontFamily !== undefined) node.fontFamily = first.fontFamily;
+  }
+
+  return node;
+}
+
+function convertToOlNode(paragraphs: Paragraph[]): PomOlNode {
+  const items: PomLiNode[] = paragraphs.map(convertParagraphToLi);
+
+  const node: PomOlNode = {
+    type: "ol",
+    items,
+  };
+
+  // Inherit common styles from first item
+  if (items.length > 0) {
+    const first = items[0];
+    if (first.fontPx !== undefined) node.fontPx = first.fontPx;
+    if (first.color !== undefined) node.color = first.color;
+    if (first.fontFamily !== undefined) node.fontFamily = first.fontFamily;
+  }
+
+  // Number type
+  const bullet = paragraphs[0].properties.bullet;
+  if (bullet && bullet.type === "autoNum") {
+    const numberType = convertAutoNumScheme(bullet.scheme);
+    if (numberType) node.numberType = numberType;
+    if (bullet.startAt > 1) node.numberStartAt = bullet.startAt;
+  }
+
+  return node;
+}
+
+function convertParagraphToLi(para: Paragraph): PomLiNode {
+  const text = para.runs.map((r) => r.text).join("");
+  const li: PomLiNode = { text };
+
+  for (const run of para.runs) {
+    if (run.properties.fontSize !== null && li.fontPx === undefined) {
+      li.fontPx = ptToPx(run.properties.fontSize as number);
+    }
+    if (run.properties.color && li.color === undefined) {
+      li.color = stripHash(run.properties.color.hex);
+    }
+    if (run.properties.fontFamily && li.fontFamily === undefined) {
+      li.fontFamily = run.properties.fontFamily;
+    }
+    if (run.properties.bold && li.bold === undefined) li.bold = true;
+    if (run.properties.italic && li.italic === undefined) li.italic = true;
+    if (run.properties.underline && li.underline === undefined) li.underline = true;
+    if (run.properties.strikethrough && li.strike === undefined) li.strike = true;
+  }
+
+  return li;
+}
+
+function convertAutoNumScheme(scheme: AutoNumScheme): string | undefined {
+  // Map pptx-glimpse scheme to pom numberType
+  const mapping: Record<string, string> = {
+    arabicPeriod: "arabicPeriod",
+    arabicParenR: "arabicParenR",
+    romanUcPeriod: "romanUcPeriod",
+    romanLcPeriod: "romanLcPeriod",
+    alphaUcPeriod: "alphaUcPeriod",
+    alphaLcPeriod: "alphaLcPeriod",
+    alphaLcParenR: "alphaLcParenR",
+    alphaUcParenR: "alphaUcParenR",
+    arabicPlain: "arabicPlain",
+  };
+  return mapping[scheme];
+}
+
+function convertAlignment(alignment: "l" | "ctr" | "r" | "just"): PomAlignText {
+  switch (alignment) {
+    case "ctr":
+      return "center";
+    case "r":
+      return "right";
+    default:
+      return "left";
+  }
+}
+
+function ptToPx(pt: number): number {
+  return Math.round((pt * 4) / 3);
+}

--- a/src/pom/xml-builder.ts
+++ b/src/pom/xml-builder.ts
@@ -1,0 +1,420 @@
+import type {
+  PomChartNode,
+  PomHStackNode,
+  PomImageNode,
+  PomLayerChild,
+  PomLayerNode,
+  PomLineNode,
+  PomLiNode,
+  PomNode,
+  PomOlNode,
+  PomShapeNode,
+  PomTableNode,
+  PomTextNode,
+  PomUlNode,
+  PomVStackNode,
+} from "./pom-types.js";
+
+export function pomLayerToXml(layer: PomLayerNode): string {
+  return renderLayerNode(layer, 0);
+}
+
+function renderNode(node: PomNode, indent: number): string {
+  switch (node.type) {
+    case "text":
+      return renderTextNode(node, indent);
+    case "ul":
+      return renderUlNode(node, indent);
+    case "ol":
+      return renderOlNode(node, indent);
+    case "image":
+      return renderImageNode(node, indent);
+    case "table":
+      return renderTableNode(node, indent);
+    case "shape":
+      return renderShapeNode(node, indent);
+    case "chart":
+      return renderChartNode(node, indent);
+    case "line":
+      return renderLineNode(node, indent);
+    case "layer":
+      return renderLayerNode(node, indent);
+    case "vstack":
+      return renderStackNode(node, indent);
+    case "hstack":
+      return renderStackNode(node, indent);
+    case "box":
+      return renderBoxNode(node, indent);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Text
+// ---------------------------------------------------------------------------
+
+function renderTextNode(node: PomTextNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  addTextStyleAttrs(attrs, node);
+
+  const pad = "  ".repeat(indent);
+  return `${pad}<Text${attrStr(attrs)}>${escapeXml(node.text)}</Text>`;
+}
+
+// ---------------------------------------------------------------------------
+// Lists
+// ---------------------------------------------------------------------------
+
+function renderUlNode(node: PomUlNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  addTextStyleAttrs(attrs, node);
+
+  const pad = "  ".repeat(indent);
+  const children = node.items.map((item) => renderLiNode(item, indent + 1)).join("\n");
+  return `${pad}<Ul${attrStr(attrs)}>\n${children}\n${pad}</Ul>`;
+}
+
+function renderOlNode(node: PomOlNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  addTextStyleAttrs(attrs, node);
+  if (node.numberType) attrs.push(a("numberType", node.numberType));
+  if (node.numberStartAt !== undefined) attrs.push(a("numberStartAt", node.numberStartAt));
+
+  const pad = "  ".repeat(indent);
+  const children = node.items.map((item) => renderLiNode(item, indent + 1)).join("\n");
+  return `${pad}<Ol${attrStr(attrs)}>\n${children}\n${pad}</Ol>`;
+}
+
+function renderLiNode(item: PomLiNode, indent: number): string {
+  const attrs: string[] = [];
+  if (item.bold) attrs.push(a("bold", true));
+  if (item.italic) attrs.push(a("italic", true));
+  if (item.underline) attrs.push(a("underline", true));
+  if (item.strike) attrs.push(a("strike", true));
+  if (item.highlight) attrs.push(a("highlight", item.highlight));
+  if (item.fontPx !== undefined) attrs.push(a("fontPx", item.fontPx));
+  if (item.color) attrs.push(a("color", item.color));
+  if (item.fontFamily) attrs.push(a("fontFamily", item.fontFamily));
+
+  const pad = "  ".repeat(indent);
+  return `${pad}<Li${attrStr(attrs)}>${escapeXml(item.text)}</Li>`;
+}
+
+// ---------------------------------------------------------------------------
+// Image
+// ---------------------------------------------------------------------------
+
+function renderImageNode(node: PomImageNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  attrs.push(a("src", node.src));
+
+  const pad = "  ".repeat(indent);
+  return `${pad}<Image${attrStr(attrs)} />`;
+}
+
+// ---------------------------------------------------------------------------
+// Table
+// ---------------------------------------------------------------------------
+
+function renderTableNode(node: PomTableNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  if (node.defaultRowHeight !== undefined) attrs.push(a("defaultRowHeight", node.defaultRowHeight));
+
+  const pad = "  ".repeat(indent);
+  const lines: string[] = [`${pad}<Table${attrStr(attrs)}>`];
+
+  for (const col of node.columns) {
+    const colAttrs: string[] = [];
+    if (col.width !== undefined) colAttrs.push(a("width", col.width));
+    lines.push(`${pad}  <TableColumn${attrStr(colAttrs)} />`);
+  }
+
+  for (const row of node.rows) {
+    const rowAttrs: string[] = [];
+    if (row.height !== undefined) rowAttrs.push(a("height", row.height));
+    lines.push(`${pad}  <TableRow${attrStr(rowAttrs)}>`);
+    for (const cell of row.cells) {
+      const cellAttrs: string[] = [];
+      if (cell.bold) cellAttrs.push(a("bold", true));
+      if (cell.italic) cellAttrs.push(a("italic", true));
+      if (cell.fontPx !== undefined) cellAttrs.push(a("fontPx", cell.fontPx));
+      if (cell.color) cellAttrs.push(a("color", cell.color));
+      if (cell.alignText) cellAttrs.push(a("alignText", cell.alignText));
+      if (cell.backgroundColor) cellAttrs.push(a("backgroundColor", cell.backgroundColor));
+      if (cell.colspan !== undefined && cell.colspan > 1)
+        cellAttrs.push(a("colspan", cell.colspan));
+      if (cell.rowspan !== undefined && cell.rowspan > 1)
+        cellAttrs.push(a("rowspan", cell.rowspan));
+      lines.push(`${pad}    <TableCell${attrStr(cellAttrs)}>${escapeXml(cell.text)}</TableCell>`);
+    }
+    lines.push(`${pad}  </TableRow>`);
+  }
+
+  lines.push(`${pad}</Table>`);
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+function renderShapeNode(node: PomShapeNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  attrs.push(a("shapeType", node.shapeType));
+  if (node.fill?.color) attrs.push(a("fill.color", node.fill.color));
+  if (node.fill?.transparency !== undefined)
+    attrs.push(a("fill.transparency", node.fill.transparency));
+  if (node.line?.color) attrs.push(a("line.color", node.line.color));
+  if (node.line?.width !== undefined) attrs.push(a("line.width", node.line.width));
+  if (node.line?.dashType) attrs.push(a("line.dashType", node.line.dashType));
+  addShadowAttrs(attrs, node.shadow);
+  addTextStyleAttrs(attrs, node);
+
+  const pad = "  ".repeat(indent);
+  if (node.text) {
+    return `${pad}<Shape${attrStr(attrs)}>${escapeXml(node.text)}</Shape>`;
+  }
+  return `${pad}<Shape${attrStr(attrs)} />`;
+}
+
+// ---------------------------------------------------------------------------
+// Chart
+// ---------------------------------------------------------------------------
+
+function renderChartNode(node: PomChartNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  attrs.push(a("chartType", node.chartType));
+  if (node.showTitle) attrs.push(a("showTitle", true));
+  if (node.title) attrs.push(a("title", node.title));
+  if (node.showLegend) attrs.push(a("showLegend", true));
+  if (node.chartColors && node.chartColors.length > 0) {
+    attrs.push(a("chartColors", node.chartColors.join(",")));
+  }
+  if (node.radarStyle) attrs.push(a("radarStyle", node.radarStyle));
+
+  const pad = "  ".repeat(indent);
+  const lines: string[] = [`${pad}<Chart${attrStr(attrs)}>`];
+
+  for (const series of node.data) {
+    const seriesAttrs: string[] = [];
+    if (series.name) seriesAttrs.push(a("name", series.name));
+    lines.push(`${pad}  <ChartSeries${attrStr(seriesAttrs)}>`);
+    for (let i = 0; i < series.labels.length; i++) {
+      lines.push(
+        `${pad}    <ChartDataPoint ${a("label", series.labels[i])} ${a("value", series.values[i])} />`,
+      );
+    }
+    lines.push(`${pad}  </ChartSeries>`);
+  }
+
+  lines.push(`${pad}</Chart>`);
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Line
+// ---------------------------------------------------------------------------
+
+function renderLineNode(node: PomLineNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  attrs.push(a("x1", node.x1));
+  attrs.push(a("y1", node.y1));
+  attrs.push(a("x2", node.x2));
+  attrs.push(a("y2", node.y2));
+  if (node.color) attrs.push(a("color", node.color));
+  if (node.lineWidth !== undefined) attrs.push(a("lineWidth", node.lineWidth));
+  if (node.dashType) attrs.push(a("dashType", node.dashType));
+  if (node.beginArrow !== undefined) {
+    if (typeof node.beginArrow === "boolean") {
+      attrs.push(a("beginArrow", true));
+    } else if (node.beginArrow.type) {
+      attrs.push(a("beginArrow.type", node.beginArrow.type));
+    }
+  }
+  if (node.endArrow !== undefined) {
+    if (typeof node.endArrow === "boolean") {
+      attrs.push(a("endArrow", true));
+    } else if (node.endArrow.type) {
+      attrs.push(a("endArrow.type", node.endArrow.type));
+    }
+  }
+
+  const pad = "  ".repeat(indent);
+  return `${pad}<Line${attrStr(attrs)} />`;
+}
+
+// ---------------------------------------------------------------------------
+// Layout containers
+// ---------------------------------------------------------------------------
+
+function renderLayerNode(node: PomLayerNode, indent: number): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+
+  const pad = "  ".repeat(indent);
+  if (node.children.length === 0) {
+    return `${pad}<Layer${attrStr(attrs)} />`;
+  }
+
+  const children = node.children.map((child) => renderLayerChild(child, indent + 1)).join("\n");
+  return `${pad}<Layer${attrStr(attrs)}>\n${children}\n${pad}</Layer>`;
+}
+
+function renderLayerChild(child: PomLayerChild, indent: number): string {
+  const { x, y, ...nodeRest } = child;
+  const xml = renderNode(nodeRest as PomNode, indent);
+
+  // Insert x and y attributes right after the tag name
+  const openBracket = xml.indexOf("<");
+  const firstSpace = xml.indexOf(" ", openBracket + 1);
+  const firstClose = xml.indexOf(">", openBracket + 1);
+  const firstSelfClose = xml.indexOf("/>", openBracket + 1);
+
+  const insertPos = Math.min(
+    firstSpace >= 0 ? firstSpace : Infinity,
+    firstClose >= 0 ? firstClose : Infinity,
+    firstSelfClose >= 0 ? firstSelfClose : Infinity,
+  );
+
+  if (insertPos === Infinity) return xml;
+
+  const posAttrs = ` x="${x}" y="${y}"`;
+  return xml.slice(0, insertPos) + posAttrs + xml.slice(insertPos);
+}
+
+function renderStackNode(node: PomVStackNode | PomHStackNode, indent: number): string {
+  const tagName = node.type === "vstack" ? "VStack" : "HStack";
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+  if (node.gap !== undefined) attrs.push(a("gap", node.gap));
+  if (node.alignItems) attrs.push(a("alignItems", node.alignItems));
+  if (node.justifyContent) attrs.push(a("justifyContent", node.justifyContent));
+
+  const pad = "  ".repeat(indent);
+  if (node.children.length === 0) {
+    return `${pad}<${tagName}${attrStr(attrs)} />`;
+  }
+
+  const children = node.children.map((c) => renderNode(c, indent + 1)).join("\n");
+  return `${pad}<${tagName}${attrStr(attrs)}>\n${children}\n${pad}</${tagName}>`;
+}
+
+function renderBoxNode(
+  node: { type: "box"; children: PomNode; shadow?: unknown } & BaseNodeLike,
+  indent: number,
+): string {
+  const attrs: string[] = [];
+  addBaseAttrs(attrs, node);
+
+  const pad = "  ".repeat(indent);
+  const child = renderNode(node.children, indent + 1);
+  return `${pad}<Box${attrStr(attrs)}>\n${child}\n${pad}</Box>`;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface BaseNodeLike {
+  w?: number | string;
+  h?: number | string;
+  backgroundColor?: string;
+  border?: { color?: string; width?: number; dashType?: string };
+  borderRadius?: number;
+  opacity?: number;
+  padding?: number | { top?: number; right?: number; bottom?: number; left?: number };
+}
+
+function addBaseAttrs(attrs: string[], node: BaseNodeLike): void {
+  if (node.w !== undefined) attrs.push(a("w", node.w));
+  if (node.h !== undefined) attrs.push(a("h", node.h));
+  if (node.backgroundColor) attrs.push(a("backgroundColor", node.backgroundColor));
+  if (node.border) {
+    if (node.border.color) attrs.push(a("border.color", node.border.color));
+    if (node.border.width !== undefined) attrs.push(a("border.width", node.border.width));
+    if (node.border.dashType) attrs.push(a("border.dashType", node.border.dashType));
+  }
+  if (node.borderRadius !== undefined) attrs.push(a("borderRadius", node.borderRadius));
+  if (node.opacity !== undefined && node.opacity !== 1) attrs.push(a("opacity", node.opacity));
+  if (node.padding !== undefined) {
+    if (typeof node.padding === "number") {
+      attrs.push(a("padding", node.padding));
+    }
+  }
+}
+
+function addTextStyleAttrs(
+  attrs: string[],
+  node: {
+    fontPx?: number;
+    color?: string;
+    alignText?: string;
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    strike?: boolean;
+    highlight?: string;
+    fontFamily?: string;
+    lineSpacingMultiple?: number;
+  },
+): void {
+  if (node.fontPx !== undefined) attrs.push(a("fontPx", node.fontPx));
+  if (node.color) attrs.push(a("color", node.color));
+  if (node.alignText) attrs.push(a("alignText", node.alignText));
+  if (node.bold) attrs.push(a("bold", true));
+  if (node.italic) attrs.push(a("italic", true));
+  if (node.underline) attrs.push(a("underline", true));
+  if (node.strike) attrs.push(a("strike", true));
+  if (node.highlight) attrs.push(a("highlight", node.highlight));
+  if (node.fontFamily) attrs.push(a("fontFamily", node.fontFamily));
+  if (node.lineSpacingMultiple !== undefined)
+    attrs.push(a("lineSpacingMultiple", node.lineSpacingMultiple));
+}
+
+function addShadowAttrs(
+  attrs: string[],
+  shadow?: {
+    type?: string;
+    color?: string;
+    opacity?: number;
+    blur?: number;
+    offset?: number;
+    angle?: number;
+  },
+): void {
+  if (!shadow) return;
+  if (shadow.type) attrs.push(a("shadow.type", shadow.type));
+  if (shadow.color) attrs.push(a("shadow.color", shadow.color));
+  if (shadow.opacity !== undefined) attrs.push(a("shadow.opacity", shadow.opacity));
+  if (shadow.blur !== undefined) attrs.push(a("shadow.blur", shadow.blur));
+  if (shadow.offset !== undefined) attrs.push(a("shadow.offset", shadow.offset));
+  if (shadow.angle !== undefined) attrs.push(a("shadow.angle", shadow.angle));
+}
+
+/** Build a single XML attribute string with proper escaping */
+function a(name: string, value: string | number | boolean): string {
+  return `${name}="${escapeXmlAttr(String(value))}"`;
+}
+
+function attrStr(attrs: string[]): string {
+  return attrs.length > 0 ? " " + attrs.join(" ") : "";
+}
+
+function escapeXml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeXmlAttr(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/pom/xml-builder.ts
+++ b/src/pom/xml-builder.ts
@@ -166,13 +166,9 @@ function renderShapeNode(node: PomShapeNode, indent: number): string {
   const attrs: string[] = [];
   addBaseAttrs(attrs, node);
   attrs.push(a("shapeType", node.shapeType));
-  if (node.fill?.color) attrs.push(a("fill.color", node.fill.color));
-  if (node.fill?.transparency !== undefined)
-    attrs.push(a("fill.transparency", node.fill.transparency));
-  if (node.line?.color) attrs.push(a("line.color", node.line.color));
-  if (node.line?.width !== undefined) attrs.push(a("line.width", node.line.width));
-  if (node.line?.dashType) attrs.push(a("line.dashType", node.line.dashType));
-  addShadowAttrs(attrs, node.shadow);
+  addJsonAttr(attrs, "fill", node.fill);
+  addJsonAttr(attrs, "line", node.line);
+  addJsonAttr(attrs, "shadow", node.shadow);
   addTextStyleAttrs(attrs, node);
 
   const pad = "  ".repeat(indent);
@@ -194,7 +190,7 @@ function renderChartNode(node: PomChartNode, indent: number): string {
   if (node.title) attrs.push(a("title", node.title));
   if (node.showLegend) attrs.push(a("showLegend", true));
   if (node.chartColors && node.chartColors.length > 0) {
-    attrs.push(a("chartColors", node.chartColors.join(",")));
+    attrs.push(`chartColors="${escapeXmlAttr(JSON.stringify(node.chartColors))}"`);
   }
   if (node.radarStyle) attrs.push(a("radarStyle", node.radarStyle));
 
@@ -231,20 +227,8 @@ function renderLineNode(node: PomLineNode, indent: number): string {
   if (node.color) attrs.push(a("color", node.color));
   if (node.lineWidth !== undefined) attrs.push(a("lineWidth", node.lineWidth));
   if (node.dashType) attrs.push(a("dashType", node.dashType));
-  if (node.beginArrow !== undefined) {
-    if (typeof node.beginArrow === "boolean") {
-      attrs.push(a("beginArrow", true));
-    } else if (node.beginArrow.type) {
-      attrs.push(a("beginArrow.type", node.beginArrow.type));
-    }
-  }
-  if (node.endArrow !== undefined) {
-    if (typeof node.endArrow === "boolean") {
-      attrs.push(a("endArrow", true));
-    } else if (node.endArrow.type) {
-      attrs.push(a("endArrow.type", node.endArrow.type));
-    }
-  }
+  addArrowAttr(attrs, "beginArrow", node.beginArrow);
+  addArrowAttr(attrs, "endArrow", node.endArrow);
 
   const pad = "  ".repeat(indent);
   return `${pad}<Line${attrStr(attrs)} />`;
@@ -336,11 +320,7 @@ function addBaseAttrs(attrs: string[], node: BaseNodeLike): void {
   if (node.w !== undefined) attrs.push(a("w", node.w));
   if (node.h !== undefined) attrs.push(a("h", node.h));
   if (node.backgroundColor) attrs.push(a("backgroundColor", node.backgroundColor));
-  if (node.border) {
-    if (node.border.color) attrs.push(a("border.color", node.border.color));
-    if (node.border.width !== undefined) attrs.push(a("border.width", node.border.width));
-    if (node.border.dashType) attrs.push(a("border.dashType", node.border.dashType));
-  }
+  addJsonAttr(attrs, "border", node.border);
   if (node.borderRadius !== undefined) attrs.push(a("borderRadius", node.borderRadius));
   if (node.opacity !== undefined && node.opacity !== 1) attrs.push(a("opacity", node.opacity));
   if (node.padding !== undefined) {
@@ -378,24 +358,33 @@ function addTextStyleAttrs(
     attrs.push(a("lineSpacingMultiple", node.lineSpacingMultiple));
 }
 
-function addShadowAttrs(
+/** Serialize an object value as a JSON attribute, omitting undefined fields */
+function addJsonAttr(
   attrs: string[],
-  shadow?: {
-    type?: string;
-    color?: string;
-    opacity?: number;
-    blur?: number;
-    offset?: number;
-    angle?: number;
-  },
+  name: string,
+  obj: object | undefined,
 ): void {
-  if (!shadow) return;
-  if (shadow.type) attrs.push(a("shadow.type", shadow.type));
-  if (shadow.color) attrs.push(a("shadow.color", shadow.color));
-  if (shadow.opacity !== undefined) attrs.push(a("shadow.opacity", shadow.opacity));
-  if (shadow.blur !== undefined) attrs.push(a("shadow.blur", shadow.blur));
-  if (shadow.offset !== undefined) attrs.push(a("shadow.offset", shadow.offset));
-  if (shadow.angle !== undefined) attrs.push(a("shadow.angle", shadow.angle));
+  if (!obj) return;
+  const cleaned: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) cleaned[k] = v;
+  }
+  if (Object.keys(cleaned).length === 0) return;
+  attrs.push(`${name}="${escapeXmlAttr(JSON.stringify(cleaned))}"`);
+}
+
+/** Serialize a line arrow attribute (boolean | {type}) */
+function addArrowAttr(
+  attrs: string[],
+  name: string,
+  arrow: boolean | { type?: string } | undefined,
+): void {
+  if (arrow === undefined) return;
+  if (typeof arrow === "boolean") {
+    attrs.push(a(name, true));
+  } else {
+    addJsonAttr(attrs, name, arrow as Record<string, unknown>);
+  }
 }
 
 /** Build a single XML attribute string with proper escaping */


### PR DESCRIPTION
close #282

## Summary

- PPTX ファイルを pom ライブラリの XML フォーマットに変換する `convertPptxToPom` を新しいエクスポートとして追加
- 各スライドを `<Layer>` ルート要素（1280×720 座標系）として出力し、要素を絶対座標で配置
- 対応要素: Shape, Text (箇条書き含む), Image, Table, Chart, Connector (Line), Group

## 実装詳細

### 新規ファイル (`src/pom/`)
- `pom-types.ts` — pom ノードの型定義（ランタイム依存なし）
- `pom-converter.ts` — Slide → PomLayerNode 変換（EMU→pom座標変換）
- `element-converter.ts` — 各 SlideElement → PomNode 変換
- `text-converter.ts` — TextBody → Text/Ul/Ol ノード変換
- `xml-builder.ts` — PomNode → pom XML 文字列生成
- `index.ts` — `convertPptxToPom` エントリポイント
- `pom-converter.test.ts` — E2E テスト（10ケース）

### API

```ts
import { convertPptxToPom } from "pptx-glimpse";

const slides = convertPptxToPom(pptxBuffer);
// PomSlide[] — { slideNumber: number, xml: string }
```

### 設計判断
- pom への依存はなし（型を自前で定義）
- 初期版は全要素を絶対座標（Layer）で出力（issue方針通り）
- XML 属性値は全て `escapeXmlAttr` でエスケープ
- Group 要素は `childTransform`（chOff/chExt）を考慮してローカル座標変換

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npx knip` 通過
- [x] `npm run test` 全 857 テスト通過（新規 10 テスト含む）
- [x] `npm run build` 成功
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)