### PR TITLE
fix: スライドごとのカラーマップ解決と clrChange エフェクト実装

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -69,11 +69,11 @@ export async function convertPptxToSvg(
       const parsed = parseSlideWithLayout(slideNumber, path, data);
       if (!parsed) continue;
 
-      const { slide, layoutElements, layoutShowMasterSp } = parsed;
+      const { slide, layoutElements, layoutShowMasterSp, masterElements } = parsed;
 
       // Merge shapes: master (back) → layout → slide (front)
       const effectiveMasterElements =
-        slide.showMasterSp && layoutShowMasterSp ? data.masterElements : [];
+        slide.showMasterSp && layoutShowMasterSp ? masterElements : [];
       slide.elements = mergeElements(effectiveMasterElements, layoutElements, slide.elements);
 
       const svg = renderSlideToSvg(slide, data.presInfo.slideSize);

--- a/src/font/font-collector.ts
+++ b/src/font/font-collector.ts
@@ -37,15 +37,17 @@ export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
     // テーマフォントを収集
     collectThemeFonts(fontScheme, fonts);
 
-    // 各スライドから収集
+    // 各スライドから収集（スライドごとのマスター要素も含む）
+    const collectedMasters = new Set<SlideElement[]>();
     for (const { slideNumber, path } of data.slidePaths) {
       const parsed = parseSlideWithLayout(slideNumber, path, data);
       if (!parsed) continue;
       collectFontsFromElements(parsed.slide.elements, fonts);
+      if (!collectedMasters.has(parsed.masterElements)) {
+        collectedMasters.add(parsed.masterElements);
+        collectFontsFromElements(parsed.masterElements, fonts);
+      }
     }
-
-    // マスター要素からも収集
-    collectFontsFromElements(data.masterElements, fonts);
 
     return {
       theme: {

--- a/src/model/effect.ts
+++ b/src/model/effect.ts
@@ -39,6 +39,7 @@ export interface BlipEffects {
   blur: BlurEffect | null;
   lum: LumEffect | null;
   duotone: DuotoneEffect | null;
+  clrChange: ClrChangeEffect | null;
 }
 
 export interface BiLevelEffect {
@@ -58,4 +59,9 @@ export interface LumEffect {
 export interface DuotoneEffect {
   color1: ResolvedColor;
   color2: ResolvedColor;
+}
+
+export interface ClrChangeEffect {
+  clrFrom: ResolvedColor;
+  clrTo: ResolvedColor;
 }

--- a/src/parser/blip-effect-parser.test.ts
+++ b/src/parser/blip-effect-parser.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { ColorResolver } from "../color/color-resolver.js";
 import type { ColorMap, ColorScheme } from "../model/theme.js";
-import { initWarningLogger } from "../warning-logger.js";
 import { parseBlipEffects } from "./blip-effect-parser.js";
 
 const testScheme: ColorScheme = {
@@ -122,15 +121,26 @@ describe("parseBlipEffects", () => {
     expect(result).toBeNull();
   });
 
-  it("warns for clrChange and returns null if no other effects", () => {
-    initWarningLogger("debug");
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("parses clrChange with srgbClr colors", () => {
+    const result = parseBlipEffects(
+      {
+        clrChange: {
+          clrFrom: { srgbClr: { "@_val": "FFFFFF" } },
+          clrTo: { srgbClr: { "@_val": "FFFFFF", alpha: { "@_val": "0" } } },
+        },
+      },
+      resolver,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.clrChange).toEqual({
+      clrFrom: { hex: "#FFFFFF", alpha: 1 },
+      clrTo: { hex: "#FFFFFF", alpha: 0 },
+    });
+  });
+
+  it("returns null for clrChange with missing clrFrom/clrTo", () => {
     const result = parseBlipEffects({ clrChange: {} }, resolver);
     expect(result).toBeNull();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("color change effect not implemented"),
-    );
-    warnSpy.mockRestore();
   });
 
   it("parses multiple effects", () => {

--- a/src/parser/blip-effect-parser.ts
+++ b/src/parser/blip-effect-parser.ts
@@ -3,12 +3,12 @@ import type {
   BiLevelEffect,
   BlipEffects,
   BlurEffect,
+  ClrChangeEffect,
   DuotoneEffect,
   LumEffect,
 } from "../model/effect.js";
 import type { ResolvedColor } from "../model/fill.js";
 import { asEmu } from "../utils/unit-types.js";
-import { warn } from "../warning-logger.js";
 import type { XmlNode } from "./xml-parser.js";
 
 const PRESET_COLORS: Record<string, string> = {
@@ -33,16 +33,13 @@ export function parseBlipEffects(
   const blur = parseBlur(blipNode.blur as XmlNode | undefined);
   const lum = parseLum(blipNode.lum as XmlNode | undefined);
   const duotone = parseDuotone(blipNode.duotone as XmlNode | undefined, colorResolver);
+  const clrChange = parseClrChange(blipNode.clrChange as XmlNode | undefined, colorResolver);
 
-  if (blipNode.clrChange !== undefined) {
-    warn("blip.clrChange", "color change effect not implemented");
-  }
-
-  if (!grayscale && !biLevel && !blur && !lum && !duotone) {
+  if (!grayscale && !biLevel && !blur && !lum && !duotone && !clrChange) {
     return null;
   }
 
-  return { grayscale, biLevel, blur, lum, duotone };
+  return { grayscale, biLevel, blur, lum, duotone, clrChange };
 }
 
 function parseBiLevel(node: XmlNode | undefined): BiLevelEffect | null {
@@ -87,6 +84,23 @@ function parseDuotone(
 
   if (colors.length < 2) return null;
   return { color1: colors[0], color2: colors[1] };
+}
+
+function parseClrChange(
+  node: XmlNode | undefined,
+  colorResolver: ColorResolver,
+): ClrChangeEffect | null {
+  if (!node) return null;
+
+  const clrFrom = node.clrFrom as XmlNode | undefined;
+  const clrTo = node.clrTo as XmlNode | undefined;
+  if (!clrFrom || !clrTo) return null;
+
+  const from = colorResolver.resolve(clrFrom);
+  const to = colorResolver.resolve(clrTo);
+  if (!from || !to) return null;
+
+  return { clrFrom: from, clrTo: to };
 }
 
 function resolveColorNode(

--- a/src/pptx-data-parser.ts
+++ b/src/pptx-data-parser.ts
@@ -31,11 +31,22 @@ import {
 } from "./parser/slide-master-parser.js";
 import { parseSlide } from "./parser/slide-parser.js";
 import { parseTheme } from "./parser/theme-parser.js";
+import { parseXml, type XmlNode } from "./parser/xml-parser.js";
 import { applyTextStyleInheritance } from "./text-style-resolver.js";
+
+interface MasterData {
+  colorMap: ColorMap;
+  colorResolver: ColorResolver;
+  background: Background | null;
+  elements: SlideElement[];
+  txStyles: TxStyles | undefined;
+  placeholderStyles: PlaceholderStyleInfo[];
+}
 
 interface ParsedPptxData {
   presInfo: PresentationInfo;
   theme: Theme;
+  /** @deprecated Use per-slide master data instead. Kept for compatibility. */
   colorResolver: ColorResolver;
   masterBackground: Background | null;
   masterElements: SlideElement[];
@@ -43,6 +54,8 @@ interface ParsedPptxData {
   masterPlaceholderStyles: PlaceholderStyleInfo[];
   slidePaths: { slideNumber: number; path: string }[];
   archive: PptxArchive;
+  /** Cache of parsed master data keyed by master file path */
+  masterCache: Map<string, MasterData>;
 }
 
 export function parsePptxData(input: Buffer | Uint8Array): ParsedPptxData {
@@ -82,51 +95,25 @@ export function parsePptxData(input: Buffer | Uint8Array): ParsedPptxData {
     }
   }
 
-  // Parse slide master for color map and background
-  let colorMap: ColorMap = defaultColorMap();
-  let masterPath: string | null = null;
+  // Parse all slide masters and cache their data
+  const masterCache = new Map<string, MasterData>();
+  let firstMasterPath: string | null = null;
   for (const [, rel] of presRels) {
     if (rel.type.includes("slideMaster")) {
-      masterPath = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
-      const masterXml = archive.files.get(masterPath);
-      if (masterXml) {
-        colorMap = parseSlideMasterColorMap(masterXml);
-      }
-      break;
+      const mPath = resolveRelationshipTarget("ppt/presentation.xml", rel.target);
+      if (!firstMasterPath) firstMasterPath = mPath;
+      parseMasterDataCached(mPath, archive, theme, masterCache);
     }
   }
 
-  const colorResolver = new ColorResolver(theme.colorScheme, colorMap);
-
-  // Parse master background and shapes (used as fallback)
-  const masterXml = masterPath ? archive.files.get(masterPath) : undefined;
-  let masterFillContext: FillParseContext | undefined;
-  if (masterPath) {
-    const masterRelsPath = buildRelsPath(masterPath);
-    const masterRelsXml = archive.files.get(masterRelsPath);
-    const masterRels = masterRelsXml
-      ? parseRelationships(masterRelsXml)
-      : new Map<string, Relationship>();
-    masterFillContext = { rels: masterRels, archive, basePath: masterPath };
-  }
-  const masterBackground = masterXml
-    ? parseSlideMasterBackground(masterXml, colorResolver, masterFillContext)
-    : null;
-  const masterElements =
-    masterPath && masterXml
-      ? parseSlideMasterElements(
-          masterXml,
-          masterPath,
-          archive,
-          colorResolver,
-          theme.fontScheme,
-          theme.fmtScheme,
-        )
-      : [];
-  const masterTxStyles = masterXml ? parseSlideMasterTxStyles(masterXml, colorResolver) : undefined;
-  const masterPlaceholderStyles = masterXml
-    ? parseSlideMasterPlaceholderStyles(masterXml, colorResolver)
-    : [];
+  // Use first master as default (for backward compatibility)
+  const defaultMaster = firstMasterPath ? masterCache.get(firstMasterPath) : undefined;
+  const colorResolver =
+    defaultMaster?.colorResolver ?? new ColorResolver(theme.colorScheme, defaultColorMap());
+  const masterBackground = defaultMaster?.background ?? null;
+  const masterElements = defaultMaster?.elements ?? [];
+  const masterTxStyles = defaultMaster?.txStyles;
+  const masterPlaceholderStyles = defaultMaster?.placeholderStyles ?? [];
 
   // Resolve slide paths from relationships
   const slidePaths: { slideNumber: number; path: string }[] = [];
@@ -149,6 +136,7 @@ export function parsePptxData(input: Buffer | Uint8Array): ParsedPptxData {
     masterPlaceholderStyles,
     slidePaths,
     archive,
+    masterCache,
   };
 }
 
@@ -156,6 +144,7 @@ interface ParsedSlide {
   slide: Slide;
   layoutElements: SlideElement[];
   layoutShowMasterSp: boolean;
+  masterElements: SlideElement[];
 }
 
 export function parseSlideWithLayout(
@@ -166,12 +155,61 @@ export function parseSlideWithLayout(
   const slideXml = data.archive.files.get(path);
   if (!slideXml) return null;
 
+  // Resolve slide → layout → master chain to get correct ColorResolver
+  const slideRelsPath = buildRelsPath(path);
+  const slideRelsXml = data.archive.files.get(slideRelsPath);
+  const slideRels = slideRelsXml
+    ? parseRelationships(slideRelsXml)
+    : new Map<string, Relationship>();
+
+  let layoutPath: string | null = null;
+  let layoutXml: string | undefined;
+  let layoutRels = new Map<string, Relationship>();
+
+  for (const [, rel] of slideRels) {
+    if (rel.type.includes("slideLayout")) {
+      layoutPath = resolveRelationshipTarget(path, rel.target);
+      layoutXml = data.archive.files.get(layoutPath);
+      if (layoutXml) {
+        const layoutRelsPath = buildRelsPath(layoutPath);
+        const layoutRelsXml = data.archive.files.get(layoutRelsPath);
+        layoutRels = layoutRelsXml
+          ? parseRelationships(layoutRelsXml)
+          : new Map<string, Relationship>();
+      }
+      break;
+    }
+  }
+
+  // Resolve the correct slide master from layout → master chain
+  let slideMasterData: MasterData | undefined;
+  for (const [, rel] of layoutRels) {
+    if (rel.type.includes("slideMaster") && layoutPath) {
+      const masterPath = resolveRelationshipTarget(layoutPath, rel.target);
+      slideMasterData = parseMasterDataCached(
+        masterPath,
+        data.archive,
+        data.theme,
+        data.masterCache,
+      );
+      break;
+    }
+  }
+
+  // Apply clrMapOvr (color map override) from slide/layout if present
+  const slideColorResolver = resolveSlideColorResolver(
+    slideXml,
+    layoutXml,
+    slideMasterData,
+    data.theme,
+  );
+
   const slide = parseSlide(
     slideXml,
     path,
     slideNumber,
     data.archive,
-    data.colorResolver,
+    slideColorResolver,
     data.theme.fontScheme,
     data.theme.fmtScheme,
   );
@@ -180,67 +218,53 @@ export function parseSlideWithLayout(
   let layoutElements: SlideElement[] = [];
   let layoutPlaceholderStyles: PlaceholderStyleInfo[] = [];
   let layoutShowMasterSp = true;
-  const slideRelsPath = buildRelsPath(path);
-  const slideRelsXml = data.archive.files.get(slideRelsPath);
-  if (slideRelsXml) {
-    const slideRels = parseRelationships(slideRelsXml);
-    for (const [, rel] of slideRels) {
-      if (rel.type.includes("slideLayout")) {
-        const layoutPath = resolveRelationshipTarget(path, rel.target);
-        const layoutXml = data.archive.files.get(layoutPath);
-        if (layoutXml) {
-          // Fallback background: slide → layout → master
-          if (!slide.background) {
-            const layoutRelsPath = buildRelsPath(layoutPath);
-            const layoutRelsXml = data.archive.files.get(layoutRelsPath);
-            const layoutRels = layoutRelsXml
-              ? parseRelationships(layoutRelsXml)
-              : new Map<string, Relationship>();
-            const layoutFillContext: FillParseContext = {
-              rels: layoutRels,
-              archive: data.archive,
-              basePath: layoutPath,
-            };
-            slide.background = parseSlideLayoutBackground(
-              layoutXml,
-              data.colorResolver,
-              layoutFillContext,
-            );
-          }
-          // Parse layout shapes
-          layoutElements = parseSlideLayoutElements(
-            layoutXml,
-            layoutPath,
-            data.archive,
-            data.colorResolver,
-            data.theme.fontScheme,
-            data.theme.fmtScheme,
-          );
-          // Extract placeholder styles for text style inheritance
-          layoutPlaceholderStyles = parseSlideLayoutPlaceholderStyles(
-            layoutXml,
-            data.colorResolver,
-          );
-          layoutShowMasterSp = parseSlideLayoutShowMasterSp(layoutXml);
-        }
-        break;
-      }
+  if (layoutXml && layoutPath) {
+    // Fallback background: slide → layout → master
+    if (!slide.background) {
+      const layoutFillContext: FillParseContext = {
+        rels: layoutRels,
+        archive: data.archive,
+        basePath: layoutPath,
+      };
+      slide.background = parseSlideLayoutBackground(
+        layoutXml,
+        slideColorResolver,
+        layoutFillContext,
+      );
     }
+    // Parse layout shapes
+    layoutElements = parseSlideLayoutElements(
+      layoutXml,
+      layoutPath,
+      data.archive,
+      slideColorResolver,
+      data.theme.fontScheme,
+      data.theme.fmtScheme,
+    );
+    // Extract placeholder styles for text style inheritance
+    layoutPlaceholderStyles = parseSlideLayoutPlaceholderStyles(layoutXml, slideColorResolver);
+    layoutShowMasterSp = parseSlideLayoutShowMasterSp(layoutXml);
   }
   if (!slide.background) {
-    slide.background = data.masterBackground;
+    slide.background = slideMasterData?.background ?? data.masterBackground;
   }
+
+  const masterPlaceholderStyles =
+    slideMasterData?.placeholderStyles ?? data.masterPlaceholderStyles;
+  const masterTxStyles = slideMasterData?.txStyles ?? data.masterTxStyles;
 
   // Apply text style inheritance chain before merging
   applyTextStyleInheritance(slide.elements, {
     layoutPlaceholderStyles,
-    masterPlaceholderStyles: data.masterPlaceholderStyles,
-    txStyles: data.masterTxStyles,
+    masterPlaceholderStyles,
+    txStyles: masterTxStyles,
     defaultTextStyle: data.presInfo.defaultTextStyle,
     fontScheme: data.theme.fontScheme,
   });
 
-  return { slide, layoutElements, layoutShowMasterSp };
+  const masterElements = slideMasterData?.elements ?? data.masterElements;
+
+  return { slide, layoutElements, layoutShowMasterSp, masterElements };
 }
 
 function defaultColorScheme() {
@@ -260,19 +284,138 @@ function defaultColorScheme() {
   };
 }
 
-function defaultColorMap() {
+function defaultColorMap(): ColorMap {
   return {
-    bg1: "lt1" as const,
-    tx1: "dk1" as const,
-    bg2: "lt2" as const,
-    tx2: "dk2" as const,
-    accent1: "accent1" as const,
-    accent2: "accent2" as const,
-    accent3: "accent3" as const,
-    accent4: "accent4" as const,
-    accent5: "accent5" as const,
-    accent6: "accent6" as const,
-    hlink: "hlink" as const,
-    folHlink: "folHlink" as const,
+    bg1: "lt1",
+    tx1: "dk1",
+    bg2: "lt2",
+    tx2: "dk2",
+    accent1: "accent1",
+    accent2: "accent2",
+    accent3: "accent3",
+    accent4: "accent4",
+    accent5: "accent5",
+    accent6: "accent6",
+    hlink: "hlink",
+    folHlink: "folHlink",
   };
+}
+
+function parseMasterDataCached(
+  masterPath: string,
+  archive: PptxArchive,
+  theme: Theme,
+  cache: Map<string, MasterData>,
+): MasterData | undefined {
+  const cached = cache.get(masterPath);
+  if (cached) return cached;
+
+  const masterXml = archive.files.get(masterPath);
+  if (!masterXml) return undefined;
+
+  const colorMap = parseSlideMasterColorMap(masterXml);
+  const colorResolver = new ColorResolver(theme.colorScheme, colorMap);
+
+  const masterRelsPath = buildRelsPath(masterPath);
+  const masterRelsXml = archive.files.get(masterRelsPath);
+  const masterRels = masterRelsXml
+    ? parseRelationships(masterRelsXml)
+    : new Map<string, Relationship>();
+  const masterFillContext: FillParseContext = { rels: masterRels, archive, basePath: masterPath };
+
+  const background = parseSlideMasterBackground(masterXml, colorResolver, masterFillContext);
+  const elements = parseSlideMasterElements(
+    masterXml,
+    masterPath,
+    archive,
+    colorResolver,
+    theme.fontScheme,
+    theme.fmtScheme,
+  );
+  const txStyles = parseSlideMasterTxStyles(masterXml, colorResolver);
+  const placeholderStyles = parseSlideMasterPlaceholderStyles(masterXml, colorResolver);
+
+  const data: MasterData = {
+    colorMap,
+    colorResolver,
+    background,
+    elements,
+    txStyles,
+    placeholderStyles,
+  };
+  cache.set(masterPath, data);
+  return data;
+}
+
+function resolveSlideColorResolver(
+  slideXml: string,
+  layoutXml: string | undefined,
+  masterData: MasterData | undefined,
+  theme: Theme,
+): ColorResolver {
+  const baseColorMap = masterData?.colorMap ?? defaultColorMap();
+
+  // Check layout clrMapOvr first, then slide clrMapOvr
+  const layoutOverride = layoutXml ? parseClrMapOverride(layoutXml) : null;
+  const slideOverride = parseClrMapOverride(slideXml);
+
+  // Apply overrides: layout override replaces master, slide override replaces layout
+  let effectiveColorMap = baseColorMap;
+  if (layoutOverride) {
+    effectiveColorMap = { ...effectiveColorMap, ...layoutOverride };
+  }
+  if (slideOverride) {
+    effectiveColorMap = { ...effectiveColorMap, ...slideOverride };
+  }
+
+  // If no overrides, reuse master's colorResolver
+  if (!layoutOverride && !slideOverride && masterData) {
+    return masterData.colorResolver;
+  }
+
+  return new ColorResolver(theme.colorScheme, effectiveColorMap);
+}
+
+function parseClrMapOverride(xml: string): Partial<ColorMap> | null {
+  // Quick check to avoid parsing XML unnecessarily
+  if (!xml.includes("clrMapOvr")) return null;
+
+  const parsed = parseXml(xml);
+
+  // Navigate to root element (sld or sldLayout)
+  const root = (parsed.sld ?? parsed.sldLayout) as XmlNode | undefined;
+  if (!root) return null;
+
+  const clrMapOvr = root.clrMapOvr as XmlNode | undefined;
+  if (!clrMapOvr) return null;
+
+  // masterClrMapping = use master as-is (no override)
+  if (clrMapOvr.masterClrMapping !== undefined) return null;
+
+  // overrideClrMapping = individual attribute overrides
+  const override = clrMapOvr.overrideClrMapping as XmlNode | undefined;
+  if (!override) return null;
+
+  const result: Partial<ColorMap> = {};
+  const keys: (keyof ColorMap)[] = [
+    "bg1",
+    "tx1",
+    "bg2",
+    "tx2",
+    "accent1",
+    "accent2",
+    "accent3",
+    "accent4",
+    "accent5",
+    "accent6",
+    "hlink",
+    "folHlink",
+  ];
+  for (const key of keys) {
+    const val = override[`@_${key}`] as string | undefined;
+    if (val) {
+      (result as Record<string, string>)[key] = val;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
 }

--- a/src/renderer/blip-effect-renderer.test.ts
+++ b/src/renderer/blip-effect-renderer.test.ts
@@ -17,6 +17,7 @@ function makeBlipEffects(overrides: Partial<BlipEffects> = {}): BlipEffects {
     blur: null,
     lum: null,
     duotone: null,
+    clrChange: null,
     ...overrides,
   };
 }
@@ -89,6 +90,33 @@ describe("renderBlipEffects", () => {
     );
     const matches = result.filterDefs.match(/type="saturate" values="0"/g);
     expect(matches).toHaveLength(1);
+  });
+
+  it("renders clrChange filter for transparent color (alpha=0)", () => {
+    const result = renderBlipEffects(
+      makeBlipEffects({
+        clrChange: {
+          clrFrom: { hex: "#FFFFFF", alpha: 1 },
+          clrTo: { hex: "#FFFFFF", alpha: 0 },
+        },
+      }),
+    );
+    expect(result.filterDefs).toContain("feColorMatrix");
+    expect(result.filterDefs).toContain('result="clrChangeResult"');
+    expect(result.filterAttr).toContain("filter=");
+  });
+
+  it("ignores clrChange when clrTo.alpha is not 0", () => {
+    const result = renderBlipEffects(
+      makeBlipEffects({
+        clrChange: {
+          clrFrom: { hex: "#FFFFFF", alpha: 1 },
+          clrTo: { hex: "#FF0000", alpha: 1 },
+        },
+      }),
+    );
+    expect(result.filterAttr).toBe("");
+    expect(result.filterDefs).toBe("");
   });
 
   it("chains multiple effects", () => {

--- a/src/renderer/blip-effect-renderer.ts
+++ b/src/renderer/blip-effect-renderer.ts
@@ -78,6 +78,28 @@ export function renderBlipEffects(blipEffects: BlipEffects | null): BlipEffectRe
     lastResult = "duotoneResult";
   }
 
+  if (blipEffects.clrChange && blipEffects.clrChange.clrTo.alpha === 0) {
+    // "Set Transparent Color" approximation using SVG feColorMatrix.
+    // Computes alpha = scale * (R + G + B - Rf - Gf - Bf).
+    // Pixels matching clrFrom (where R+G+B ≈ Rf+Gf+Bf) get alpha near 0.
+    // This is an approximation: near-clrFrom colors become semi-transparent,
+    // and colors darker than clrFrom may also lose alpha. Works well for the
+    // common "white → transparent" case. Exact per-pixel color keying is not
+    // achievable with SVG filters alone.
+    // Only alpha=0 targets are supported; general color replacement is not.
+    const { clrFrom } = blipEffects.clrChange;
+    const [rf, gf, bf] = hexToRgbNorm(clrFrom.hex);
+    const scale = 20;
+    primitives.push(
+      `<feColorMatrix in="${lastResult}" type="matrix" values="` +
+        `1 0 0 0 0 ` +
+        `0 1 0 0 0 ` +
+        `0 0 1 0 0 ` +
+        `${round(scale)} ${round(scale)} ${round(scale)} 0 ${round(-scale * (rf + gf + bf))}" result="clrChangeResult"/>`,
+    );
+    lastResult = "clrChangeResult";
+  }
+
   if (primitives.length === 0) return { filterAttr: "", filterDefs: "" };
 
   const id = `blip-effect-${crypto.randomUUID()}`;


### PR DESCRIPTION
## Summary

- 複数のスライドマスターを持つ PPTX で、最初に見つかったマスターのカラーマップが全スライドに適用されていたバグを修正
- 各スライドの slideLayout → slideMaster チェーンを辿り、正しい colorMap で ColorResolver を構築するように変更
- `clrMapOvr`（カラーマップオーバーライド）のサポートを追加
- blip の `clrChange` エフェクト（透明色設定）を SVG フィルターで近似実装（alpha=0 のみ対応）

## 変更内容

### カラーマップ解決の修正 (`src/pptx-data-parser.ts`)

- `ParsedPptxData` に `masterCache`（スライドマスターデータのキャッシュ）を追加
- `parseMasterDataCached()`: マスターデータをパースしてキャッシュする関数を追加
- `parseSlideWithLayout()`: スライドごとに slide → layout → master チェーンを辿り、正しい `ColorResolver` を構築
- `resolveSlideColorResolver()`: slide/layout の `clrMapOvr` を考慮した ColorResolver 解決
- `parseClrMapOverride()`: `clrMapOvr` XML のパース関数
- `parseSlideWithLayout()` の戻り値に `masterElements` を追加し、スライドごとの正しいマスター要素を返すように変更

### clrChange エフェクト

- `ClrChangeEffect` インターフェースを `src/model/effect.ts` に追加
- `parseClrChange()` を `src/parser/blip-effect-parser.ts` に追加
- SVG `feColorMatrix` フィルターによる近似実装（`src/renderer/blip-effect-renderer.ts`）
  - `alpha=0` の場合のみ対応（白背景除去など）
  - 一般的な色置換は SVG フィルターでは正確に実装できないため非対応

## Test plan

- [x] 既存テスト 850 件全て通過
- [x] `blip-effect-parser.test.ts`: clrChange パーステスト追加
- [x] `blip-effect-renderer.test.ts`: clrChange レンダリングテスト追加（alpha=0 / alpha≠0）
- [x] lint / format / typecheck 全て通過
- [x] 問題の PPTX ファイルで正しくレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)