### PR TITLE
fix: スライド端で図形がはみ出す問題を修正

### DIFF
--- a/.changeset/fix-shape-overflow.md
+++ b/.changeset/fix-shape-overflow.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+SVG ルート要素に overflow="hidden" を追加し、スライド端で図形がはみ出す問題を修正

--- a/src/parse-render.integration.test.ts
+++ b/src/parse-render.integration.test.ts
@@ -815,6 +815,22 @@ describe("parse-render integration: shape-level hyperlink", () => {
 });
 
 // ---------------------------------------------------------------------------
+// SVG ルート要素の overflow 属性
+// ---------------------------------------------------------------------------
+
+describe("parse-render integration: SVG overflow", () => {
+  it("renderSlideToSvg の SVG ルート要素に overflow='hidden' が含まれる", () => {
+    const slide = {
+      elements: [],
+      background: null,
+    };
+    const slideSize = { width: 9144000, height: 5143500 };
+    const svg = renderSlideToSvg(slide, slideSize);
+    expect(svg).toContain('overflow="hidden"');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // テキストアウトライン (rPr.ln)
 // ---------------------------------------------------------------------------
 

--- a/src/renderer/svg-renderer.ts
+++ b/src/renderer/svg-renderer.ts
@@ -20,7 +20,7 @@ export function renderSlideToSvg(slide: Slide, slideSize: SlideSize): string {
   const defs: string[] = [];
 
   parts.push(
-    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">`,
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" overflow="hidden">`,
   );
 
   // Background


### PR DESCRIPTION
close #332

## 概要

SVG ルート要素に `overflow="hidden"` を追加し、スライド右端に配置された図形がビューポート外にはみ出して描画される問題を修正しました。

## 変更内容

- `src/renderer/svg-renderer.ts`: SVG ルート `<svg>` 要素に `overflow="hidden"` 属性を追加
- `src/parse-render.integration.test.ts`: `overflow="hidden"` の存在を検証するテストを追加
- `.changeset/fix-shape-overflow.md`: changeset 追加

## テスト計画

- [x] 既存テスト全パス（860 tests）
- [x] lint / format / typecheck パス
- [x] VRT スナップショット確認（PNG 出力に差分なし）
- [ ] CI パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)