### PR TITLE
chore(deps): bump fast-xml-parser from 5.3.6 to 5.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-wasm": "^2.6.2",
-        "fast-xml-parser": "^5.3.6",
+        "fast-xml-parser": "^5.7.3",
         "fflate": "^0.8.2",
         "opentype.js": "^1.3.4"
       },
@@ -3906,9 +3906,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.7.tgz",
+      "integrity": "sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==",
       "funding": [
         {
           "type": "github",
@@ -3921,9 +3921,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
-      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -3933,7 +3933,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "license": "MIT",
   "dependencies": {
     "@resvg/resvg-wasm": "^2.6.2",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": "^5.7.3",
     "fflate": "^0.8.2",
     "opentype.js": "^1.3.4"
   },


### PR DESCRIPTION
## 概要

`fast-xml-parser` を `^5.3.6` から `^5.7.3` (最新) に更新します。

- Changelog: https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/CHANGELOG.md
- Compare: https://github.com/NaturalIntelligence/fast-xml-parser/compare/v5.3.6...v5.7.3

## 変更内容

- `package.json` / `package-lock.json` のバージョン更新のみ。ソースコードへの変更はなし。

## ローカル確認

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run typecheck` ✅
- `npm run test -- src/parser/` (parser 系 285 件) ✅

`npm run test` 全体実行はローカルの vitest worker で OOM するが、`main` ブランチでも同様に再現するため本変更とは無関係。CI 側のテストに委ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)