### PR TITLE
fix: vitest worker OOM を回避するため converter / e2e smoke でシステムフォントスキャンを mock

### DIFF
--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -1,8 +1,22 @@
 import { readFileSync } from "fs";
 import { join } from "path";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// macOS 上では `/System/Library/Fonts` 等から数百個のフォントを parse すると
+// worker メモリが膨れ上がり OOM する。ここでは構造ベースのアサーション
+// (`<text|<path>` のいずれかが出ること、`<image>`/`<rect>` が出ること) のみを
+// 検証しているので、`DefaultTextMeasurer` フォールバックで十分。
+vi.mock("../src/font/system-font-loader.js", () => ({
+  collectFontFilePaths: vi.fn(() => []),
+  getSystemFontDirs: vi.fn(() => []),
+}));
 
 import { convertPptxToPng, convertPptxToSvg } from "../src/converter.js";
+import { clearFontCache } from "../src/font/opentype-helpers.js";
+
+beforeAll(() => {
+  clearFontCache();
+});
 
 const FIXTURE_DIR = join(import.meta.dirname, "..", "shared-fixtures");
 
@@ -84,7 +98,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
       // カード・ボタン等の角丸矩形やアイコン用の楕円
       expect(slide).toContain("<rect");
-      expect(slide).toContain("<path");
+      expect(slide).toContain("<ellipse");
     });
 
     it("convertPptxToPng produces valid PNG", async () => {

--- a/src/converter.test.ts
+++ b/src/converter.test.ts
@@ -1,7 +1,17 @@
 import JSZip from "jszip";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+// システムフォントスキャンを抑止する。macOS 上では `/System/Library/Fonts` 等から
+// 数百個のフォントが読み込まれ、parse 結果が worker メモリに蓄積して OOM を引き起こす。
+// converter のテストはフォントメトリクスに依存しない構造検証 (slide 数 / SVG 構造 / 塗り色)
+// が中心なので、`DefaultTextMeasurer` フォールバックで十分。
+vi.mock("./font/system-font-loader.js", () => ({
+  collectFontFilePaths: vi.fn(() => []),
+  getSystemFontDirs: vi.fn(() => []),
+}));
+
 import { convertPptxToPng, convertPptxToSvg } from "./converter.js";
+import { clearFontCache } from "./font/opentype-helpers.js";
 
 const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
@@ -256,6 +266,8 @@ async function createTestPptx(): Promise<Buffer> {
 let testPptx: Buffer;
 
 beforeAll(async () => {
+  // 同一 worker 内で先に動いた他テストが残したフォントキャッシュを破棄する。
+  clearFontCache();
   testPptx = await createTestPptx();
 });
 


### PR DESCRIPTION
close #396

## 目的

macOS / Node 22 のローカルで `npm run test` を全体実行すると、`src/converter.test.ts` 付近で vitest worker が `JavaScript heap out of memory` で落ちる問題を解消する。

## 原因の裏付け

issue 本文の「最有力の原因仮説」(macOS のシステムフォント 367 個 を `readFile` + `opentype.parse` した結果が worker メモリに累積) を実装で裏付けた。

| 試した実装方針 | 結果 |
| --- | --- |
| **方針 1**: `poolOptions.forks.execArgv = ['--max-old-space-size=4096']` で worker heap を 4GB に引き上げ | ❌ 解消せず。4GB に達した直後に OOM。仮説と矛盾せず、累積量が想定より大きい |
| **方針 2**: `src/converter.test.ts` で `collectFontFilePaths` を `vi.mock` で空配列に差し替え | ⚠️ converter は通るが、続く `e2e/smoke.test.ts` で OOM (worker process は再利用されるため、別 test file でフォントを実 parse すると蓄積) |
| **方針 2 (拡張)**: `e2e/smoke.test.ts` も同じ mock パターンを適用 | ✅ 解消。910 テストが OOM 無く 3.44 秒で完走 |

→ 方針 1 が単独で効かず、方針 2 (フォントスキャン抑止) で解決したことから、**OOM の主因は `createOpentypeSetupFromSystem` 内のフォント Buffer / parse 結果の保持** であることが裏付けられた。フォントを読み込まなくなった結果、heap 引き上げ (方針 1) は不要となったため `vitest.config.ts` は変更していない。

## 影響パッケージ / 変更点

- `src/converter.test.ts` — `vi.mock("./font/system-font-loader.js")` で `collectFontFilePaths` / `getSystemFontDirs` を空配列に。`beforeAll` で `clearFontCache()` 呼び出し。
- `e2e/smoke.test.ts` — 同パターンの mock を追加。`real-product-page.pptx` の roundRect / 楕円検証は元々 `<path>` (text-as-path 由来) を期待していたが、フォント mock 下では text 出力が `<text>` に変わるため、コメント通り `<ellipse>` を直接検証するアサーションに修正。

converter のテストは構造検証 (slide 数 / SVG 構造 / 塗り色) が中心で、フォント解析を必要としない。フォント mock 適用後も `DefaultTextMeasurer` フォールバックで `<text>` 要素が出力されるため、テストの意義は維持されている。フォント解決ロジックの専用カバレッジは `src/font/opentype-helpers.test.ts` などに既にあり、今回の mock の影響は受けない。

## ローカル検証

```bash
npm run lint        # ✓
npm run format:check # ✓
npm run typecheck    # ✓
npm run test         # ✓ 910/910 passed (Darwin 25.3.0 / Node v22.14.0 / vitest v3.2.4) / 3.44s
npm run build        # ✓
```

OOM 再現条件 (issue 本文記載の `npm run test` 全体実行) で解消を確認済み。