### PR TITLE
feat(converter): skipSystemFonts オプションを ConvertOptions に追加

### DIFF
--- a/.changeset/skip-system-fonts-option.md
+++ b/.changeset/skip-system-fonts-option.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+`ConvertOptions` に `skipSystemFonts?: boolean` オプションを追加。`true` を指定すると OS のシステムフォントディレクトリをスキャンせず、`fontDirs` で指定したディレクトリのみを使用する。コンテナ・サーバレス環境や起動時間を短縮したい CLI ツールでの利用を想定。

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const results = await convertPptxToPng(pptx, {
   height: 1080, // Output height in pixels (width takes priority if both set)
   logLevel: "warn", // Warning log level: "off" | "warn" | "debug"
   fontDirs: ["/custom/fonts"], // Additional font directories to search
+  skipSystemFonts: true, // Skip OS system font directories; use fontDirs only
   fontMapping: {
     "Custom Corp Font": "Noto Sans", // Custom font name mapping
   },
@@ -154,7 +155,7 @@ Default system font directories:
 | macOS   | `/System/Library/Fonts`, `/Library/Fonts`, `~/Library/Fonts` |
 | Windows | `C:\Windows\Fonts`                                           |
 
-Use the `fontDirs` option to add custom font directories.
+Use the `fontDirs` option to add custom font directories. To skip system font scanning entirely and use only `fontDirs` (useful in containers, serverless environments, or when you want to bundle specific fonts to reduce startup time), set `skipSystemFonts: true`.
 
 ### Font Mapping
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -27,6 +27,8 @@ export interface ConvertOptions {
   fontDirs?: string[];
   /** PPTX フォント名 → OSS 代替フォントのカスタムマッピング。デフォルトマッピングにマージされる */
   fontMapping?: FontMapping;
+  /** true のとき OS のシステムフォントをスキャンせず fontDirs のみを使用する */
+  skipSystemFonts?: boolean;
 }
 
 export interface SlideSvg {
@@ -45,7 +47,11 @@ export async function convertPptxToSvg(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
 ): Promise<SlideSvg[]> {
-  const setup = await createOpentypeSetupFromSystem(options?.fontDirs, options?.fontMapping);
+  const setup = await createOpentypeSetupFromSystem(
+    options?.fontDirs,
+    options?.fontMapping,
+    options?.skipSystemFonts,
+  );
   if (setup) {
     setTextMeasurer(setup.measurer);
     setTextPathFontResolver(setup.fontResolver);

--- a/src/font/opentype-helpers.test.ts
+++ b/src/font/opentype-helpers.test.ts
@@ -331,4 +331,25 @@ describe("createOpentypeSetupFromSystem キャッシュ", () => {
     await createOpentypeSetupFromSystem();
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it("skipSystemFonts が異なる場合はキャッシュを無効化する", async () => {
+    await setupTestFont();
+    await mockCollectFontFilePaths();
+
+    const setup1 = await createOpentypeSetupFromSystem(undefined, undefined, false);
+    const setup2 = await createOpentypeSetupFromSystem(undefined, undefined, true);
+    expect(setup1).not.toBeNull();
+    expect(setup2).not.toBeNull();
+    // skipSystemFonts が異なるのでキャッシュキーが変わり別オブジェクト
+    expect(setup1).not.toBe(setup2);
+  });
+
+  it("skipSystemFonts が collectFontFilePaths に正しく伝播する", async () => {
+    await setupTestFont();
+    const systemFontLoader = await import("./system-font-loader.js");
+    const spy = vi.spyOn(systemFontLoader, "collectFontFilePaths").mockReturnValue([testFontPath!]);
+
+    await createOpentypeSetupFromSystem(undefined, undefined, true);
+    expect(spy).toHaveBeenCalledWith(undefined, true);
+  });
 });

--- a/src/font/opentype-helpers.ts
+++ b/src/font/opentype-helpers.ts
@@ -218,12 +218,16 @@ function collectFontNames(font: OpentypeFontWithNames): Set<string> {
 /**
  * キャッシュキーを生成する。fontDirs と fontMapping の組み合わせで一意に識別する。
  */
-function buildCacheKey(additionalFontDirs?: string[], fontMapping?: FontMapping): string {
+function buildCacheKey(
+  additionalFontDirs?: string[],
+  fontMapping?: FontMapping,
+  skipSystemFonts = false,
+): string {
   const dirsKey = additionalFontDirs ? [...additionalFontDirs].sort().join("\0") : "";
   const mappingKey = fontMapping
     ? JSON.stringify(fontMapping, Object.keys(fontMapping).sort())
     : "";
-  return `${dirsKey}\n${mappingKey}`;
+  return `${dirsKey}\n${mappingKey}\n${skipSystemFonts}`;
 }
 
 /** パース済み Font オブジェクトのキャッシュ */
@@ -253,8 +257,9 @@ export function clearFontCache(): void {
 export async function createOpentypeSetupFromSystem(
   additionalFontDirs?: string[],
   fontMapping?: FontMapping,
+  skipSystemFonts = false,
 ): Promise<OpentypeSetup | null> {
-  const key = buildCacheKey(additionalFontDirs, fontMapping);
+  const key = buildCacheKey(additionalFontDirs, fontMapping, skipSystemFonts);
   if (cachedSetup && cachedSetupKey === key) {
     return cachedSetup;
   }
@@ -262,7 +267,7 @@ export async function createOpentypeSetupFromSystem(
   const opentype = await tryLoadOpentype();
   if (!opentype) return null;
 
-  const fontFilePaths = collectFontFilePaths(additionalFontDirs);
+  const fontFilePaths = collectFontFilePaths(additionalFontDirs, skipSystemFonts);
   if (fontFilePaths.length === 0) return null;
 
   const mapping = createFontMapping(fontMapping);

--- a/src/font/system-font-loader.test.ts
+++ b/src/font/system-font-loader.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { collectFontFilePaths } from "./system-font-loader.js";

--- a/src/font/system-font-loader.test.ts
+++ b/src/font/system-font-loader.test.ts
@@ -1,0 +1,45 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { collectFontFilePaths } from "./system-font-loader.js";
+
+function makeTempFontDir(): { dir: string; fontPath: string } {
+  const dir = join(tmpdir(), `pptx-glimpse-loader-test-${Date.now()}-${Math.random()}`);
+  mkdirSync(dir, { recursive: true });
+  const fontPath = join(dir, "bundled.ttf");
+  writeFileSync(fontPath, "");
+  return { dir, fontPath };
+}
+
+describe("collectFontFilePaths skipSystemFonts", () => {
+  it("skipSystemFonts=true のとき additionalDirs のファイルのみ返す", () => {
+    const { dir, fontPath } = makeTempFontDir();
+    const result = collectFontFilePaths([dir], true);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(fontPath);
+  });
+
+  it("skipSystemFonts=true かつ fontDirs 未指定のとき空配列を返す", () => {
+    // ユニークキーにするため空配列でも別インスタンス的に扱われる
+    // (キャッシュは dirsKey+skipSystemFonts で管理されるため問題なし)
+    const result = collectFontFilePaths([], true);
+    expect(result).toEqual([]);
+  });
+
+  it("skipSystemFonts=false のとき additionalDirs のファイルが含まれる", () => {
+    const { dir, fontPath } = makeTempFontDir();
+    const result = collectFontFilePaths([dir], false);
+    expect(result).toContain(fontPath);
+  });
+
+  it("skipSystemFonts=false は skipSystemFonts=true と同数以上のファイルを返す", () => {
+    const { dir } = makeTempFontDir();
+    const skipSystem = collectFontFilePaths([dir], true);
+    // 別の dir を使わないと skipSystem のキャッシュが当たってしまうため
+    // 同じ dir で false を呼ぶ (dirsKey は同じだが skipSystemFonts が異なるためキャッシュミス)
+    const withSystem = collectFontFilePaths([dir], false);
+    expect(withSystem.length).toBeGreaterThanOrEqual(skipSystem.length);
+  });
+});

--- a/src/font/system-font-loader.test.ts
+++ b/src/font/system-font-loader.test.ts
@@ -1,18 +1,27 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { collectFontFilePaths } from "./system-font-loader.js";
+
+const tempDirs: string[] = [];
 
 function makeTempFontDir(): { dir: string; fontPath: string } {
   const dir = join(tmpdir(), `pptx-glimpse-loader-test-${Date.now()}-${Math.random()}`);
   mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
   const fontPath = join(dir, "bundled.ttf");
   writeFileSync(fontPath, "");
   return { dir, fontPath };
 }
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("collectFontFilePaths skipSystemFonts", () => {
   it("skipSystemFonts=true のとき additionalDirs のファイルのみ返す", () => {
@@ -23,8 +32,6 @@ describe("collectFontFilePaths skipSystemFonts", () => {
   });
 
   it("skipSystemFonts=true かつ fontDirs 未指定のとき空配列を返す", () => {
-    // ユニークキーにするため空配列でも別インスタンス的に扱われる
-    // (キャッシュは dirsKey+skipSystemFonts で管理されるため問題なし)
     const result = collectFontFilePaths([], true);
     expect(result).toEqual([]);
   });
@@ -38,7 +45,6 @@ describe("collectFontFilePaths skipSystemFonts", () => {
   it("skipSystemFonts=false は skipSystemFonts=true と同数以上のファイルを返す", () => {
     const { dir } = makeTempFontDir();
     const skipSystem = collectFontFilePaths([dir], true);
-    // 別の dir を使わないと skipSystem のキャッシュが当たってしまうため
     // 同じ dir で false を呼ぶ (dirsKey は同じだが skipSystemFonts が異なるためキャッシュミス)
     const withSystem = collectFontFilePaths([dir], false);
     expect(withSystem.length).toBeGreaterThanOrEqual(skipSystem.length);

--- a/src/font/system-font-loader.ts
+++ b/src/font/system-font-loader.ts
@@ -25,6 +25,7 @@ const CJK_TTC_PATTERNS = [
 
 let cachedPaths: string[] | null = null;
 let cachedAdditionalDirs: string[] | null = null;
+let cachedSkipSystemFonts: boolean | null = null;
 
 function getSystemFontDirs(): string[] {
   const os = platform();
@@ -68,18 +69,21 @@ function walk(dir: string, result: string[]): void {
  * OS のシステムフォントディレクトリ + 追加ディレクトリから
  * .ttf / .otf ファイルパスを収集する。
  *
+ * skipSystemFonts が true の場合、システムフォントディレクトリをスキャンせず
+ * additionalDirs のみを対象とする。
+ *
  * 結果はモジュールレベルでキャッシュされ、同一引数での再呼び出しは即座に返る。
  */
-export function collectFontFilePaths(additionalDirs?: string[]): string[] {
+export function collectFontFilePaths(additionalDirs?: string[], skipSystemFonts = false): string[] {
   const dirs = additionalDirs ?? [];
   const dirsKey = dirs.join("\0");
   const cachedKey = cachedAdditionalDirs?.join("\0") ?? null;
 
-  if (cachedPaths !== null && dirsKey === cachedKey) {
+  if (cachedPaths !== null && dirsKey === cachedKey && cachedSkipSystemFonts === skipSystemFonts) {
     return cachedPaths;
   }
 
-  const allDirs = [...getSystemFontDirs(), ...dirs];
+  const allDirs = skipSystemFonts ? dirs : [...getSystemFontDirs(), ...dirs];
   const result: string[] = [];
   for (const dir of allDirs) {
     walk(dir, result);
@@ -87,5 +91,6 @@ export function collectFontFilePaths(additionalDirs?: string[]): string[] {
 
   cachedPaths = result;
   cachedAdditionalDirs = dirs;
+  cachedSkipSystemFonts = skipSystemFonts;
   return result;
 }


### PR DESCRIPTION
close #402

## 概要

`ConvertOptions` に `skipSystemFonts?: boolean` オプションを追加しました。`true` を指定すると OS のシステムフォントディレクトリをスキャンせず、`fontDirs` で指定したディレクトリのみを使用します。

## 背景

macOS の `/System/Library/Fonts` は 566MB あり、opentype.js でパースすると JavaScript ヒープが 4GB+ に達して OOM クラッシュする問題があります。CLI ツール等でバンドルフォントのみを使いたいケースに対応します。

## 変更ファイル

- `src/converter.ts` — `ConvertOptions` に `skipSystemFonts?: boolean` を追加し、`createOpentypeSetupFromSystem` へ伝播
- `src/font/system-font-loader.ts` — `collectFontFilePaths` に `skipSystemFonts` 引数を追加、キャッシュキーにも反映
- `src/font/opentype-helpers.ts` — `createOpentypeSetupFromSystem` / `buildCacheKey` に `skipSystemFonts` を追加
- `src/font/system-font-loader.test.ts` — 新規テストファイル（skipSystemFonts の動作検証）
- `src/font/opentype-helpers.test.ts` — `skipSystemFonts` のキャッシュ分岐・伝播テストを追加
- `README.md` — Options / Fonts セクションに `skipSystemFonts` の説明を追加
- `.changeset/skip-system-fonts-option.md` — minor バンプ用 changeset

## ローカル検証手順

```bash
npm run test
npm run typecheck
npm run lint
```

## 使用例

```ts
const slides = await convertPptxToSvg(buf, {
  fontDirs: ["/path/to/bundled/fonts"],
  skipSystemFonts: true,
});
```
