### PR TITLE
test: shared-fixtures の全ファイルに E2E スモークテストを追加

### DIFF
--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -115,4 +115,121 @@ describe("Real PPTX E2E smoke tests", () => {
       expect(results[0].height).toBeGreaterThan(0);
     });
   });
+
+  describe("real-financial-report.pptx (financial report with charts)", () => {
+    it("convertPptxToSvg completes without error for all 4 slides", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
+      const results = await convertPptxToSvg(input);
+
+      expect(results).toHaveLength(4);
+      for (const result of results) {
+        expect(result.svg).toContain("<svg");
+        expect(result.svg).toContain("</svg>");
+      }
+    });
+
+    it("slides contain text elements", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
+      const results = await convertPptxToSvg(input);
+
+      for (const result of results) {
+        expect(result.svg).toMatch(/<text|<path/);
+      }
+    });
+
+    it("chart slides contain rendered chart elements", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
+      const results = await convertPptxToSvg(input);
+
+      // チャートはスライド2以降に含まれる（graphicFrame → <rect> / <path> で描画）
+      const chartSlides = results.slice(1);
+      for (const result of chartSlides) {
+        expect(result.svg).toMatch(/<rect|<path/);
+      }
+    });
+
+    it("convertPptxToPng produces valid PNG for all slides", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
+      const results = await convertPptxToPng(input);
+
+      expect(results).toHaveLength(4);
+      for (const result of results) {
+        expect(result.png[0]).toBe(0x89);
+        expect(result.png[1]).toBe(0x50);
+        expect(result.png[2]).toBe(0x4e);
+        expect(result.png[3]).toBe(0x47);
+        expect(result.width).toBeGreaterThan(0);
+        expect(result.height).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("sample.pptx (md-pptx generated, Japanese text)", () => {
+    it("convertPptxToSvg completes without error for all 6 slides", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
+      const results = await convertPptxToSvg(input);
+
+      expect(results).toHaveLength(6);
+      for (const result of results) {
+        expect(result.svg).toContain("<svg");
+        expect(result.svg).toContain("</svg>");
+      }
+    });
+
+    it("slides contain text elements including Japanese", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
+      const results = await convertPptxToSvg(input);
+
+      for (const result of results) {
+        expect(result.svg).toMatch(/<text|<path/);
+      }
+    });
+
+    it("convertPptxToPng produces valid PNG for all slides", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
+      const results = await convertPptxToPng(input);
+
+      expect(results).toHaveLength(6);
+      for (const result of results) {
+        expect(result.png[0]).toBe(0x89);
+        expect(result.png[1]).toBe(0x50);
+        expect(result.png[2]).toBe(0x4e);
+        expect(result.png[3]).toBe(0x47);
+        expect(result.width).toBeGreaterThan(0);
+        expect(result.height).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("sample-issue-387.pptx (inline text formatting)", () => {
+    it("convertPptxToSvg completes without error", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
+      const results = await convertPptxToSvg(input);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].svg).toContain("<svg");
+      expect(results[0].svg).toContain("</svg>");
+    });
+
+    it("slide contains text elements", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
+      const results = await convertPptxToSvg(input);
+      const slide = results[0].svg;
+
+      expect(slide).toMatch(/<text|<path/);
+    });
+
+    it("convertPptxToPng produces valid PNG", async () => {
+      const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
+      const results = await convertPptxToPng(input);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].png[0]).toBe(0x89);
+      expect(results[0].png[1]).toBe(0x50);
+      expect(results[0].png[2]).toBe(0x4e);
+      expect(results[0].png[3]).toBe(0x47);
+      expect(results[0].width).toBeGreaterThan(0);
+      expect(results[0].height).toBeGreaterThan(0);
+    });
+  });
 });

--- a/shared-fixtures/README.md
+++ b/shared-fixtures/README.md
@@ -1,0 +1,43 @@
+# shared-fixtures
+
+実アプリケーション（PowerPoint / Google Slides / md-pptx など）が生成した実 PPTX ファイルを格納するディレクトリ。
+
+## 用途
+
+このディレクトリのファイルは **2つのテストスイートから共有** される:
+
+| テスト | ファイル | 目的 |
+|---|---|---|
+| E2E スモークテスト | `e2e/smoke.test.ts` | エラーなく変換できること・主要要素の SVG 出力確認 |
+| スナップショット VRT | `vrt/snapshot/regression.test.ts` | レンダリング結果のリグレッション検出 |
+
+## プログラム合成フィクスチャとの違い
+
+`vrt/snapshot/fixtures/` にあるフィクスチャは `create-fixtures.ts` でプログラム的に生成される。
+このディレクトリのファイルは **手動で作成・管理される実 PPTX** であり、プログラム合成では再現しにくい以下の構造を含む:
+
+- テーマフォント参照 (`+mj-lt`, `+mn-lt`)
+- `presentation.xml` の `defaultTextStyle`
+- スライドマスターの `txStyles`
+- スタイル参照 (`sp.style` の `lnRef` / `fillRef` / `effectRef`)
+- PowerPoint バージョン固有の XML 構造
+
+## ファイル一覧
+
+| ファイル | 作成元 | スライド数 | 主な内容 |
+|---|---|---|---|
+| `real-basic-theme.pptx` | Google Slides | 2 | タイトル・コンテンツ・テーブル・画像・テーマフォント参照 |
+| `real-product-page.pptx` | 手作成 | 1 | 角丸矩形・楕円・テキストボックス |
+| `real-financial-report.pptx` | 手作成 | 4 | チャート（棒グラフ・円グラフ等）・テキスト |
+| `sample.pptx` | md-pptx 生成 | 6 | 日本語テキスト・箇条書き・テキスト装飾 |
+| `sample-issue-387.pptx` | 手作成 | 1 | インラインテキスト装飾（太字・斜体・太字斜体） |
+
+## ファイルを追加する場合
+
+1. `shared-fixtures/` に PPTX ファイルを配置する
+2. `e2e/smoke.test.ts` にスモークテストを追加する
+3. `vrt/snapshot/vrt-cases.ts` の `SHARED_FIXTURE_CASES` にエントリを追加する
+4. `npm run vrt:snapshot:update` でスナップショットを生成する
+
+ファイルサイズはリポジトリサイズへの影響を抑えるため **1ファイルあたり 500KB 以下** を目安とする。
+ライセンス上問題のない PPTX のみ追加すること（自作または OSSテンプレート）。


### PR DESCRIPTION
## 概要

- `real-financial-report.pptx` / `sample.pptx` / `sample-issue-387.pptx` の3ファイルに対する E2E スモークテストを `e2e/smoke.test.ts` に追加
- `shared-fixtures/README.md` を新規作成し、ディレクトリの用途と管理方針を文書化

## 背景

`shared-fixtures/` 内の実 PPTX ファイルはスナップショット VRT（`vrt/snapshot/regression.test.ts`）には登録済みだったが、`real-basic-theme.pptx` と `real-product-page.pptx` 以外はスモークテストが存在しなかった。

VRT はレンダリング結果の差分検出に特化しており、「エラーなく変換できるか」「主要要素が SVG 出力に含まれるか」の明示的な保証がなかった。

## 変更内容

### `e2e/smoke.test.ts`

| ファイル | 追加テスト |
|---|---|
| `real-financial-report.pptx` | 4スライド全変換・チャートスライドの要素確認・PNG 変換 |
| `sample.pptx` | 6スライド全変換・日本語テキスト含む要素確認・PNG 変換 |
| `sample-issue-387.pptx` | 1スライド変換・テキスト要素確認・PNG 変換 |

### `shared-fixtures/README.md`

- E2E スモーク / スナップショット VRT の両方から共有されていることの説明
- プログラム合成フィクスチャ（`vrt/snapshot/fixtures/`）との違い
- ファイル一覧と追加手順