### PR TITLE
fix: OOXML Strict 形式の SmartArt URI に対応

### DIFF
--- a/.changeset/ooxml-strict-smartart-uri.md
+++ b/.changeset/ooxml-strict-smartart-uri.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+OOXML Strict 形式のSmartArt（Diagram）URIに対応。Transitional URI（`http://schemas.openxmlformats.org/drawingml/2006/diagram`）のみを直接比較していた判定を、Strict URI（`http://purl.oclc.org/ooxml/drawingml/diagram`）にも対応した allowlist 判定に変更。

--- a/src/parser/slide-parser.test.ts
+++ b/src/parser/slide-parser.test.ts
@@ -2258,7 +2258,7 @@ describe("placeholder geometry inheritance", () => {
 });
 
 describe("OOXML Strict compatibility", () => {
-  it("recognizes SmartArt with Strict diagram URI without triggering unsupported warning", () => {
+  it("routes Strict diagram URI to SmartArt path (not unsupported warning)", () => {
     initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -2288,12 +2288,14 @@ describe("OOXML Strict compatibility", () => {
     expect(warnSpy).not.toHaveBeenCalledWith(
       expect.stringContaining("unsupported graphicFrame content"),
     );
+    // SmartArt path が実行され、archive 空のため skipped になることを確認
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("graphicFrame.skipped"));
 
     warnSpy.mockRestore();
     initWarningLogger("off");
   });
 
-  it("still recognizes SmartArt with Transitional diagram URI", () => {
+  it("routes Transitional diagram URI to SmartArt path (not unsupported warning)", () => {
     initWarningLogger("debug");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -2323,6 +2325,7 @@ describe("OOXML Strict compatibility", () => {
     expect(warnSpy).not.toHaveBeenCalledWith(
       expect.stringContaining("unsupported graphicFrame content"),
     );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("graphicFrame.skipped"));
 
     warnSpy.mockRestore();
     initWarningLogger("off");

--- a/src/parser/slide-parser.test.ts
+++ b/src/parser/slide-parser.test.ts
@@ -2256,3 +2256,75 @@ describe("placeholder geometry inheritance", () => {
     expect(shape.transform.extentWidth).toBe(7000);
   });
 });
+
+describe("OOXML Strict compatibility", () => {
+  it("recognizes SmartArt with Strict diagram URI without triggering unsupported warning", () => {
+    initWarningLogger("debug");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:graphicFrame>
+          <p:xfrm>
+            <a:off x="100" y="200"/>
+            <a:ext cx="300" cy="400"/>
+          </p:xfrm>
+          <a:graphic>
+            <a:graphicData uri="http://purl.oclc.org/ooxml/drawingml/diagram"/>
+          </a:graphic>
+        </p:graphicFrame>
+      </p:spTree>
+    `;
+    const parsed = parseXml(xml);
+    parseShapeTree(
+      parsed.spTree as XmlNode | undefined,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("unsupported graphicFrame content"),
+    );
+
+    warnSpy.mockRestore();
+    initWarningLogger("off");
+  });
+
+  it("still recognizes SmartArt with Transitional diagram URI", () => {
+    initWarningLogger("debug");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const xml = `
+      <p:spTree xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                 xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <p:graphicFrame>
+          <p:xfrm>
+            <a:off x="100" y="200"/>
+            <a:ext cx="300" cy="400"/>
+          </p:xfrm>
+          <a:graphic>
+            <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/diagram"/>
+          </a:graphic>
+        </p:graphicFrame>
+      </p:spTree>
+    `;
+    const parsed = parseXml(xml);
+    parseShapeTree(
+      parsed.spTree as XmlNode | undefined,
+      new Map(),
+      "ppt/slides/slide1.xml",
+      createEmptyArchive(),
+      createColorResolver(),
+    );
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("unsupported graphicFrame content"),
+    );
+
+    warnSpy.mockRestore();
+    initWarningLogger("off");
+  });
+});

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -57,6 +57,11 @@ import { parseXml, parseXmlOrdered } from "./xml-parser.js";
 
 const SHAPE_TAGS = new Set(["sp", "pic", "cxnSp", "grpSp", "graphicFrame"]);
 
+const SMARTART_DIAGRAM_URIS = new Set([
+  "http://schemas.openxmlformats.org/drawingml/2006/diagram",
+  "http://purl.oclc.org/ooxml/drawingml/diagram",
+]);
+
 // preserveOrder パース結果を path で辿り、指定ノードの子配列を返す。
 export function navigateOrdered(
   ordered: XmlOrderedNode[],
@@ -810,8 +815,8 @@ function parseGraphicFrame(
     return { type: "table", transform, table: tableData };
   }
 
-  // SmartArt (Diagram) — Transitional: .../drawingml/2006/diagram, Strict: .../ooxml/drawingml/diagram
-  if ((graphicData["@_uri"] as string | undefined)?.includes("diagram")) {
+  // SmartArt (Diagram) — Transitional and Strict URIs
+  if (SMARTART_DIAGRAM_URIS.has(graphicData["@_uri"] as string)) {
     return parseSmartArt(
       graphicData,
       transform,

--- a/src/parser/slide-parser.ts
+++ b/src/parser/slide-parser.ts
@@ -810,8 +810,8 @@ function parseGraphicFrame(
     return { type: "table", transform, table: tableData };
   }
 
-  // SmartArt (Diagram)
-  if (graphicData["@_uri"] === "http://schemas.openxmlformats.org/drawingml/2006/diagram") {
+  // SmartArt (Diagram) — Transitional: .../drawingml/2006/diagram, Strict: .../ooxml/drawingml/diagram
+  if ((graphicData["@_uri"] as string | undefined)?.includes("diagram")) {
     return parseSmartArt(
       graphicData,
       transform,


### PR DESCRIPTION
close #141

## 概要

OOXML Strict 形式の SmartArt（Diagram）が認識されない問題を修正します。

## 変更内容

### 問題

`src/parser/slide-parser.ts` で SmartArt の判定に Transitional URI のみをハードコードしていました。

```typescript
// 修正前
if (graphicData["@_uri"] === "http://schemas.openxmlformats.org/drawingml/2006/diagram") {
```

OOXML Strict 形式では URI が `http://purl.oclc.org/ooxml/drawingml/diagram` となるため、SmartArt が認識されず `graphicFrame.unsupported` 警告が発生していました。

### 修正

Transitional / Strict 両 URI を allowlist で管理する方式に変更しました。

```typescript
const SMARTART_DIAGRAM_URIS = new Set([
  "http://schemas.openxmlformats.org/drawingml/2006/diagram",
  "http://purl.oclc.org/ooxml/drawingml/diagram",
]);

if (SMARTART_DIAGRAM_URIS.has(graphicData["@_uri"] as string)) {
```

あわせてソースファイル全体でハードコードされた URI を検索し、他に問題箇所がないことを確認しました。

## テスト

`src/parser/slide-parser.test.ts` に「OOXML Strict compatibility」describe ブロックを追加しました。

- Strict URI (`http://purl.oclc.org/ooxml/drawingml/diagram`) で `unsupported graphicFrame content` 警告が出ないことを確認
- SmartArt パスに到達していることを `graphicFrame.skipped` の positive assertion で確認
- Transitional URI でも同様に動作することを確認

## ローカル検証

```bash
npm run test -- src/parser/slide-parser.test.ts
npm run lint
npm run typecheck
```