### PR TITLE
perf: 遅延スライドパース - slides オプション指定時の不要スライド XML 解凍を省略

### DIFF
--- a/src/parser/pptx-reader.test.ts
+++ b/src/parser/pptx-reader.test.ts
@@ -1,7 +1,7 @@
 import { strToU8, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 
-import { LazyMediaMap, readPptx } from "./pptx-reader.js";
+import { LazyMediaMap, LazyXmlMap, readPptx } from "./pptx-reader.js";
 
 function createTestZip(entries: Record<string, Uint8Array>): Uint8Array {
   return zipSync(entries);
@@ -46,8 +46,55 @@ describe("LazyMediaMap", () => {
   });
 });
 
+describe("LazyXmlMap", () => {
+  it("returns XML string for an existing path", () => {
+    const xmlContent = "<p:presentation/>";
+    const zip = createTestZip({
+      "ppt/presentation.xml": strToU8(xmlContent),
+    });
+    const entryIndex = new Set(["ppt/presentation.xml"]);
+    const xmlMap = new LazyXmlMap(zip, entryIndex);
+
+    expect(xmlMap.get("ppt/presentation.xml")).toBe(xmlContent);
+  });
+
+  it("returns undefined for a non-existent path", () => {
+    const zip = createTestZip({
+      "ppt/presentation.xml": strToU8("<xml/>"),
+    });
+    const entryIndex = new Set<string>();
+    const xmlMap = new LazyXmlMap(zip, entryIndex);
+
+    expect(xmlMap.get("ppt/slides/slide99.xml")).toBeUndefined();
+  });
+
+  it("has() returns true for indexed paths and false otherwise", () => {
+    const zip = createTestZip({
+      "ppt/presentation.xml": strToU8("<xml/>"),
+    });
+    const entryIndex = new Set(["ppt/presentation.xml"]);
+    const xmlMap = new LazyXmlMap(zip, entryIndex);
+
+    expect(xmlMap.has("ppt/presentation.xml")).toBe(true);
+    expect(xmlMap.has("ppt/slides/slide1.xml")).toBe(false);
+  });
+
+  it("caches the result for repeated access", () => {
+    const xmlContent = "<p:presentation/>";
+    const zip = createTestZip({
+      "ppt/presentation.xml": strToU8(xmlContent),
+    });
+    const entryIndex = new Set(["ppt/presentation.xml"]);
+    const xmlMap = new LazyXmlMap(zip, entryIndex);
+
+    const first = xmlMap.get("ppt/presentation.xml");
+    const second = xmlMap.get("ppt/presentation.xml");
+    expect(first).toBe(second);
+  });
+});
+
 describe("readPptx", () => {
-  it("reads XML files and provides lazy media access", () => {
+  it("provides lazy access to XML and media files", () => {
     const xmlContent = "<p:presentation/>";
     const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
     const zip = createTestZip({
@@ -63,7 +110,7 @@ describe("readPptx", () => {
     expect(archive.media.get("ppt/media/image1.png")).toEqual(imageData);
   });
 
-  it("does not eagerly decompress media files", () => {
+  it("does not include media files in the XML accessor", () => {
     const imageData = new Uint8Array(1024).fill(0xab);
     const zip = createTestZip({
       "ppt/presentation.xml": strToU8("<xml/>"),
@@ -72,11 +119,17 @@ describe("readPptx", () => {
 
     const archive = readPptx(zip);
 
-    // files map should not contain media entries
     expect(archive.files.has("ppt/media/large-image.png")).toBe(false);
-
-    // media can still be accessed lazily
     expect(archive.media.get("ppt/media/large-image.png")).toEqual(imageData);
+  });
+
+  it("returns undefined for XML files not in the archive", () => {
+    const zip = createTestZip({
+      "ppt/presentation.xml": strToU8("<xml/>"),
+    });
+
+    const archive = readPptx(zip);
+    expect(archive.files.get("ppt/slides/slide99.xml")).toBeUndefined();
   });
 
   it("returns undefined for non-existent media", () => {

--- a/src/parser/pptx-reader.test.ts
+++ b/src/parser/pptx-reader.test.ts
@@ -89,6 +89,7 @@ describe("LazyXmlMap", () => {
 
     const first = xmlMap.get("ppt/presentation.xml");
     const second = xmlMap.get("ppt/presentation.xml");
+    // Cached string is the same object reference (not re-decoded)
     expect(first).toBe(second);
   });
 });

--- a/src/parser/pptx-reader.ts
+++ b/src/parser/pptx-reader.ts
@@ -36,38 +36,75 @@ export interface MediaAccessor {
   get(path: string): Uint8Array | undefined;
 }
 
+/**
+ * XML/RELS ファイルの遅延読み込みマップ。
+ * slides オプションで一部スライドのみ要求された場合に、
+ * 不要なスライド XML の解凍を省く。
+ */
+export class LazyXmlMap {
+  private rawInput: Uint8Array;
+  private cache = new Map<string, string>();
+  private entryIndex: Set<string>;
+
+  constructor(rawInput: Uint8Array, xmlEntryNames: Set<string>) {
+    this.rawInput = rawInput;
+    this.entryIndex = xmlEntryNames;
+  }
+
+  has(path: string): boolean {
+    return this.entryIndex.has(path);
+  }
+
+  get(path: string): string | undefined {
+    if (!this.entryIndex.has(path)) return undefined;
+
+    const cached = this.cache.get(path);
+    if (cached) return cached;
+
+    const result = unzipSync(this.rawInput, {
+      filter: (file) => file.name === path,
+    });
+    const data = result[path];
+    if (data) {
+      const str = strFromU8(data);
+      this.cache.set(path, str);
+      return str;
+    }
+    return undefined;
+  }
+}
+
+export interface XmlAccessor {
+  get(path: string): string | undefined;
+  has(path: string): boolean;
+}
+
 export interface PptxArchive {
-  files: Map<string, string>;
+  files: XmlAccessor;
   media: MediaAccessor;
 }
 
 export function readPptx(input: Buffer | Uint8Array): PptxArchive {
   const rawInput = new Uint8Array(input);
+  const xmlEntryNames = new Set<string>();
   const mediaEntryNames = new Set<string>();
-  const unzipped = unzipSync(rawInput, {
+
+  unzipSync(rawInput, {
     filter: (file) => {
       if (file.name.startsWith("ppt/media/")) {
         mediaEntryNames.add(file.name);
-        return false;
+      } else if (
+        file.name.endsWith(".xml") ||
+        file.name.endsWith(".rels") ||
+        file.name === "[Content_Types].xml"
+      ) {
+        xmlEntryNames.add(file.name);
       }
-      return true;
+      return false;
     },
   });
 
-  const files = new Map<string, string>();
-
-  for (const [relativePath, data] of Object.entries(unzipped)) {
-    if (relativePath.endsWith("/")) continue;
-
-    if (
-      relativePath.endsWith(".xml") ||
-      relativePath.endsWith(".rels") ||
-      relativePath === "[Content_Types].xml"
-    ) {
-      files.set(relativePath, strFromU8(data));
-    }
-  }
-
+  const files = new LazyXmlMap(rawInput, xmlEntryNames);
   const media = new LazyMediaMap(rawInput, mediaEntryNames);
 
   return { files, media };

--- a/src/parser/pptx-reader.ts
+++ b/src/parser/pptx-reader.ts
@@ -59,7 +59,7 @@ export class LazyXmlMap {
     if (!this.entryIndex.has(path)) return undefined;
 
     const cached = this.cache.get(path);
-    if (cached) return cached;
+    if (cached !== undefined) return cached;
 
     const result = unzipSync(this.rawInput, {
       filter: (file) => file.name === path,


### PR DESCRIPTION
close #406

## 概要

`slides` オプションで一部スライドのみ要求された場合でも、`readPptx()` 内で全 XML/RELS ファイルを一括解凍していた処理を、オンデマンド解凍に変更。

## 変更内容

### `src/parser/pptx-reader.ts`

- `LazyXmlMap` クラスを新規追加
  - `LazyMediaMap` と同構造で、ZIP から XML/RELS ファイルを遅延展開
  - `get(path)`: 初回アクセス時のみ `unzipSync` で解凍・キャッシュ
  - `has(path)`: エントリの存在確認
- `XmlAccessor` インターフェースを追加 (`get` + `has`)
- `PptxArchive.files` の型を `Map<string, string>` → `XmlAccessor` に変更
- `readPptx()` を `LazyXmlMap` を返すよう変更
  - 初回パス: 全エントリ名を収集（解凍なし）
  - 以降: `archive.files.get()` 呼び出し時のみ対象ファイルを解凍

### `src/parser/pptx-reader.test.ts`

- `LazyXmlMap` のユニットテスト4件を追加

## 効果

`slides: [1, 3]` のように一部スライドのみ変換する場合、対象外のスライド XML が解凍されない。

- 既存テスト (テスト用 `{ files: new Map() }` モック) は `Map<K,V>` が `XmlAccessor` を構造的に満たすため変更不要
- 全スライド変換時も動作に変化なし（後方互換維持）

## 動作確認

```bash
npm run test        # 921 tests 全通過
npm run typecheck   # エラーなし
npm run lint        # エラーなし
```