### PR TITLE
feat(font): bold テキストの幅計算でボールド体フォントの実グリフ幅を参照する

### DIFF
--- a/.changeset/bold-font-glyph-width-17801418.md
+++ b/.changeset/bold-font-glyph-width-17801418.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+bold テキストの幅計算でボールド体フォント（`"${fontFamily} Bold"` / `"${fontFamily}-Bold"` の命名規則）がフォントマップに登録されている場合、固定係数 `BOLD_FACTOR (1.05)` ではなく実グリフの `advanceWidth` を使用するよう改善しました。フォントマッピング（例: `Calibri → Carlito`）経由での Bold 解決にも対応します。ボールド体フォントが未登録の場合は従来の `BOLD_FACTOR` フォールバックが引き続き動作します。

--- a/src/font/opentype-text-measurer.test.ts
+++ b/src/font/opentype-text-measurer.test.ts
@@ -50,6 +50,80 @@ describe("OpentypeTextMeasurer", () => {
     expect(boldWidth).toBeCloseTo(normalWidth * 1.05, 1);
   });
 
+  it("ボールド体フォント (${fontFamily} Bold) が存在する場合は実グリフ幅を使用する", () => {
+    const regularFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { A: 600 },
+    });
+    const boldFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { A: 720 },
+    });
+    const fonts = new Map<string, OpentypeFont>([
+      ["TestFont", regularFont],
+      ["TestFont Bold", boldFont],
+    ]);
+    const measurer = new OpentypeTextMeasurer(fonts);
+    const pxPerPt = 96 / 72;
+    const boldWidth = measurer.measureTextWidth("A", 18, true, "TestFont");
+    const expectedBoldWidth = (720 / 1000) * 18 * pxPerPt;
+    expect(boldWidth).toBeCloseTo(expectedBoldWidth, 1);
+    // BOLD_FACTOR を適用した場合の幅とは異なることを確認
+    const expectedWithFactor = (600 / 1000) * 18 * pxPerPt * 1.05;
+    expect(boldWidth).not.toBeCloseTo(expectedWithFactor, 1);
+  });
+
+  it("ボールド体フォント (${fontFamily}-Bold) が存在する場合は実グリフ幅を使用する", () => {
+    const regularFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { A: 600 },
+    });
+    const boldFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { A: 720 },
+    });
+    const fonts = new Map<string, OpentypeFont>([
+      ["TestFont", regularFont],
+      ["TestFont-Bold", boldFont],
+    ]);
+    const measurer = new OpentypeTextMeasurer(fonts);
+    const pxPerPt = 96 / 72;
+    const boldWidth = measurer.measureTextWidth("A", 18, true, "TestFont");
+    const expectedBoldWidth = (720 / 1000) * 18 * pxPerPt;
+    expect(boldWidth).toBeCloseTo(expectedBoldWidth, 1);
+  });
+
+  it("ボールド体フォントが存在しても CJK 文字には適用しない", () => {
+    const regularFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { 漢: 1000 },
+    });
+    const boldFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { 漢: 1200 },
+    });
+    const fonts = new Map<string, OpentypeFont>([
+      ["TestFont", regularFont],
+      ["TestFont Bold", boldFont],
+    ]);
+    const measurer = new OpentypeTextMeasurer(fonts);
+    const normalWidth = measurer.measureTextWidth("漢", 18, false, "TestFont");
+    const boldWidth = measurer.measureTextWidth("漢", 18, true, "TestFont");
+    expect(boldWidth).toBeCloseTo(normalWidth, 5);
+  });
+
   it("太字でも CJK 文字には BOLD_FACTOR を適用しない", () => {
     const font = createMockFont({
       unitsPerEm: 1000,

--- a/src/font/opentype-text-measurer.test.ts
+++ b/src/font/opentype-text-measurer.test.ts
@@ -277,6 +277,37 @@ describe("OpentypeTextMeasurer CJK フォールバック", () => {
   });
 });
 
+describe("OpentypeTextMeasurer ボールド体フォントのマッピング解決", () => {
+  afterEach(() => {
+    resetFontMapping();
+  });
+
+  it("フォントマッピング経由で OSS ボールド体フォントを解決する", () => {
+    const regularFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { A: 600 },
+    });
+    const boldFont = createMockFont({
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      glyphWidths: { A: 750 },
+    });
+    const fonts = new Map<string, OpentypeFont>([
+      ["Carlito", regularFont],
+      ["Carlito Bold", boldFont],
+    ]);
+    setFontMapping({ Calibri: "Carlito" });
+    const measurer = new OpentypeTextMeasurer(fonts);
+    const pxPerPt = 96 / 72;
+    const boldWidth = measurer.measureTextWidth("A", 18, true, "Calibri");
+    const expectedBoldWidth = (750 / 1000) * 18 * pxPerPt;
+    expect(boldWidth).toBeCloseTo(expectedBoldWidth, 1);
+  });
+});
+
 describe("OpentypeTextMeasurer font.notFound 警告", () => {
   afterEach(() => {
     resetFontMapping();

--- a/src/font/opentype-text-measurer.ts
+++ b/src/font/opentype-text-measurer.ts
@@ -49,6 +49,7 @@ export class OpentypeTextMeasurer implements TextMeasurer {
       return defaultMeasureTextWidth(text, fontSizePt, bold, fontFamily, fontFamilyEa);
     }
     const fontSizePx = fontSizePt * PX_PER_PT;
+    const boldLatinFont = bold ? this.resolveBoldFont(fontFamily) : null;
     let totalWidth = 0;
     for (const char of text) {
       const codePoint = char.codePointAt(0)!;
@@ -59,7 +60,13 @@ export class OpentypeTextMeasurer implements TextMeasurer {
       const glyphs = font.stringToGlyphs(char);
       let charWidth = (glyphs[0]?.advanceWidth ?? font.unitsPerEm * 0.6) * scale;
       if (bold && !isEa) {
-        charWidth *= BOLD_FACTOR;
+        if (boldLatinFont) {
+          const boldScale = fontSizePx / boldLatinFont.unitsPerEm;
+          const boldGlyphs = boldLatinFont.stringToGlyphs(char);
+          charWidth = (boldGlyphs[0]?.advanceWidth ?? boldLatinFont.unitsPerEm * 0.6) * boldScale;
+        } else {
+          charWidth *= BOLD_FACTOR;
+        }
       }
       totalWidth += charWidth;
     }
@@ -76,6 +83,20 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     const font = this.resolveFont(fontFamily) ?? this.resolveFont(fontFamilyEa) ?? this.defaultFont;
     if (!font) return 1.0;
     return font.ascender / font.unitsPerEm;
+  }
+
+  private resolveBoldFont(name: string | null | undefined): OpentypeFont | null {
+    if (!name) return null;
+    for (const boldName of [`${name} Bold`, `${name}-Bold`]) {
+      const direct = this.fonts.get(boldName);
+      if (direct) return direct;
+      const mapped = getCurrentMappedFont(boldName);
+      if (mapped) {
+        const mappedFont = this.fonts.get(mapped);
+        if (mappedFont) return mappedFont;
+      }
+    }
+    return null;
   }
 
   private resolveFont(name: string | null | undefined): OpentypeFont | null {

--- a/src/font/opentype-text-measurer.ts
+++ b/src/font/opentype-text-measurer.ts
@@ -87,13 +87,19 @@ export class OpentypeTextMeasurer implements TextMeasurer {
 
   private resolveBoldFont(name: string | null | undefined): OpentypeFont | null {
     if (!name) return null;
-    for (const boldName of [`${name} Bold`, `${name}-Bold`]) {
-      const direct = this.fonts.get(boldName);
-      if (direct) return direct;
-      const mapped = getCurrentMappedFont(boldName);
-      if (mapped) {
-        const mappedFont = this.fonts.get(mapped);
-        if (mappedFont) return mappedFont;
+    // 元の名前とフォントマッピング後の OSS 代替名の両方で Bold バリアントを探す
+    const bases = [name];
+    const mappedBase = getCurrentMappedFont(name);
+    if (mappedBase && mappedBase !== name) bases.push(mappedBase);
+    for (const base of bases) {
+      for (const boldName of [`${base} Bold`, `${base}-Bold`]) {
+        const direct = this.fonts.get(boldName);
+        if (direct) return direct;
+        const mapped = getCurrentMappedFont(boldName);
+        if (mapped) {
+          const mappedFont = this.fonts.get(mapped);
+          if (mappedFont) return mappedFont;
+        }
       }
     }
     return null;


### PR DESCRIPTION
close #422

## 概要

- `OpentypeTextMeasurer` で bold テキストの幅計算時に、ボールド体フォントがフォントマップに存在する場合は固定係数 `BOLD_FACTOR (1.05)` ではなく実グリフの `advanceWidth` を参照するよう改善
- 対応する命名規則: `"${fontFamily} Bold"` および `"${fontFamily}-Bold"`
- フォントマッピング（例: `Calibri → Carlito`）経由でも、マッピング先の Bold バリアント（例: `Carlito Bold`）を探索する
- ボールド体フォントが存在しない場合は従来の `BOLD_FACTOR` フォールバックを維持

## 変更ファイル

- `src/font/opentype-text-measurer.ts`
  - `resolveBoldFont()` メソッドを追加（`"${name} Bold"` / `"${name}-Bold"` を元名・マッピング先名の両方で探索）
  - `measureTextWidth()` で bold かつ非 CJK 文字の場合に `resolveBoldFont` の結果を優先利用

## ローカル検証

```bash
npm run test -- src/font/opentype-text-measurer.test.ts
npm run lint
npm run typecheck
```

全 20 テスト通過・lint/型チェックエラーなし。