### PR TITLE
fix: pnpm 移行時に削除された npm@11 アップグレードステップを復元

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,13 @@ jobs:
       - run: pnpm run build
       - run: pnpm exec vitest run --exclude 'vrt/**'
 
+      # Workaround: Node 22 にバンドルされた npm@10 は OIDC Trusted Publishing に未対応のため npm@11 へアップグレード。
+      # npm install -g が Node 22 の npm バグで失敗するため npx 経由で取得してインストールする。
+      # https://github.com/npm/cli/issues/9151
+      # https://github.com/nodejs/node/issues/62425
+      - name: Upgrade npm for Trusted Publishing
+        run: npx -y npm@11 install -g npm@11
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## 概要

pnpm 移行時 (#419) に release action が失敗するようになったため修正。

## 原因

コミット `ae3e60f` での pnpm 移行時に「Upgrade npm for Trusted Publishing」ステップをまとめて削除してしまったことが原因。

Node 22 にバンドルされた npm@10 は OIDC Trusted Publishing に未対応で、`pnpm exec changeset publish` が内部で npm を呼び出して publish する際に E404 エラーが発生する。

```
npm error 404 Not Found - PUT https://registry.npmjs.org/pptx-glimpse - Not found
npm error 404  'pptx-glimpse@0.11.2' is not in this registry.
```

## 修正内容

以前のワークアラウンドを復元。`npx -y npm@11 install -g npm@11` で npm@11 にアップグレードしてから publish する。

`npm install -g` 自体が Node 22 バンドルの npm バグで失敗するため、npx 経由で npm@11 を取得してからインストールする二段階方式が必要（[npm/cli#9151](https://github.com/npm/cli/issues/9151)、[nodejs/node#62425](https://github.com/nodejs/node/issues/62425)）。

## 関連

- 元の修正: `2ce283e` (fix: npm@11 にアップグレードして Trusted Publishing の OIDC 対応を修正)
- 削除されたコミット: `ae3e60f` (ci: update GitHub Actions workflows for pnpm)