### PR TITLE
LibreOffice VRT の tolerance を実測値ベースで厳格化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,10 @@ npm run test                   # Run tests (including LibreOffice VRT)
 #### Tolerance
 
 - `PIXEL_THRESHOLD = 0.3` (per-pixel color difference tolerance)
-- `MISMATCH_TOLERANCE = 0.05` (allows up to 5% pixel mismatch)
+- Each test case has an explicit `tolerance` set to its measured mismatch rate in CI × 1.2, rounded up to 0.1pt (minimum 0.3%). Measured values are printed as `[lo-vrt]` log lines during test runs — use the CI job logs to recalibrate when LibreOffice or runner fonts change
+- `MISMATCH_TOLERANCE = 0.02` is the fallback for newly added cases before calibration
 
-Since LibreOffice ≠ PowerPoint, differences in font rendering and anti-aliasing are tolerated. The goal is to detect obvious rendering omissions and structural errors.
+Since LibreOffice ≠ PowerPoint, differences in font rendering and anti-aliasing are tolerated. The goal is to detect rendering regressions, omissions, and structural errors.
 
 #### Without Docker
 

--- a/vrt/libreoffice/regression.test.ts
+++ b/vrt/libreoffice/regression.test.ts
@@ -78,6 +78,13 @@ describeOrSkip("LibreOffice Visual Regression Tests", { timeout: 60000 }, () => 
             resizeRef: true,
           });
 
+          // tolerance 調整用に実測値を常に出力する
+          console.log(
+            `[lo-vrt] ${name} slide${result.slideNumber}: ` +
+              `${(comparison.mismatchPercentage * 100).toFixed(3)}% ` +
+              `(tolerance ${(tolerance * 100).toFixed(1)}%)`,
+          );
+
           expect(
             comparison.passed,
             `${name} slide ${result.slideNumber}: ` +

--- a/vrt/libreoffice/regression.test.ts
+++ b/vrt/libreoffice/regression.test.ts
@@ -13,37 +13,39 @@ const FIXTURE_DIR = join(__dirname, "fixtures");
 // LibreOffice と pptx-glimpse の比較は高い許容度が必要
 // フォントレンダリングやアンチエイリアスの差異を許容する
 const PIXEL_THRESHOLD = 0.3;
+// 新規ケース用のフォールバック。CI で実測値を確認したら個別の tolerance を設定すること
 const MISMATCH_TOLERANCE = 0.02;
 
-// tolerance: テストケース固有の許容度（省略時はデフォルト値 2% を使用）
-// 実測値の約2倍をマージンとして設定（環境差の揺れを吸収しつつ回帰検出できる範囲）
+// tolerance: CI 上の実測 mismatch 率 × 1.2 を 0.1pt 単位で切り上げ（下限 0.3%）
+// 実測値はテスト実行時の [lo-vrt] ログで確認できる。
+// LibreOffice や CI ランナーのフォント更新で実測値が変わったら、同じ方針で再設定する
 const LO_VRT_CASES = [
-  { name: "basic-shapes", fixture: "basic-shapes.pptx" },
-  { name: "text-formatting", fixture: "text-formatting.pptx" },
-  { name: "fill-and-lines", fixture: "fill-and-lines.pptx" },
-  { name: "gradient-fills", fixture: "gradient-fills.pptx" },
-  { name: "dash-lines", fixture: "dash-lines.pptx", tolerance: 0.03 },
-  { name: "text-decoration", fixture: "text-decoration.pptx" },
-  { name: "tables", fixture: "tables.pptx" },
-  { name: "bullets", fixture: "bullets.pptx" },
-  { name: "transforms", fixture: "transforms.pptx", tolerance: 0.07 },
-  { name: "groups", fixture: "groups.pptx" },
-  { name: "slide-background", fixture: "slide-background.pptx" },
-  { name: "flowchart-shapes", fixture: "flowchart-shapes.pptx", tolerance: 0.04 },
-  { name: "arrows-stars", fixture: "arrows-stars.pptx", tolerance: 0.16 },
-  { name: "callouts-arcs", fixture: "callouts-arcs.pptx", tolerance: 0.17 },
-  { name: "math-other", fixture: "math-other.pptx", tolerance: 0.1 },
-  { name: "image", fixture: "image.pptx" },
-  { name: "charts", fixture: "charts.pptx", tolerance: 0.15 },
+  { name: "basic-shapes", fixture: "basic-shapes.pptx", tolerance: 0.008 },
+  { name: "text-formatting", fixture: "text-formatting.pptx", tolerance: 0.018 },
+  { name: "fill-and-lines", fixture: "fill-and-lines.pptx", tolerance: 0.003 },
+  { name: "gradient-fills", fixture: "gradient-fills.pptx", tolerance: 0.003 },
+  { name: "dash-lines", fixture: "dash-lines.pptx", tolerance: 0.018 },
+  { name: "text-decoration", fixture: "text-decoration.pptx", tolerance: 0.013 },
+  { name: "tables", fixture: "tables.pptx", tolerance: 0.008 },
+  { name: "bullets", fixture: "bullets.pptx", tolerance: 0.01 },
+  { name: "transforms", fixture: "transforms.pptx", tolerance: 0.057 },
+  { name: "groups", fixture: "groups.pptx", tolerance: 0.003 },
+  { name: "slide-background", fixture: "slide-background.pptx", tolerance: 0.005 },
+  { name: "flowchart-shapes", fixture: "flowchart-shapes.pptx", tolerance: 0.025 },
+  { name: "arrows-stars", fixture: "arrows-stars.pptx", tolerance: 0.159 },
+  { name: "callouts-arcs", fixture: "callouts-arcs.pptx", tolerance: 0.168 },
+  { name: "math-other", fixture: "math-other.pptx", tolerance: 0.093 },
+  { name: "image", fixture: "image.pptx", tolerance: 0.003 },
+  { name: "charts", fixture: "charts.pptx", tolerance: 0.145 },
   { name: "chart-legend-position", fixture: "chart-legend-position.pptx", tolerance: 0.15 },
-  { name: "connectors", fixture: "connectors.pptx" },
-  { name: "custom-geometry", fixture: "custom-geometry.pptx" },
-  { name: "slide-size-4-3", fixture: "slide-size-4-3.pptx" },
-  { name: "word-wrap", fixture: "word-wrap.pptx", tolerance: 0.03 },
-  { name: "background-blipfill", fixture: "background-blipfill.pptx" },
-  { name: "composite", fixture: "composite.pptx", tolerance: 0.03 },
-  { name: "effects", fixture: "effects.pptx" },
-  { name: "hyperlinks", fixture: "hyperlinks.pptx" },
+  { name: "connectors", fixture: "connectors.pptx", tolerance: 0.003 },
+  { name: "custom-geometry", fixture: "custom-geometry.pptx", tolerance: 0.003 },
+  { name: "slide-size-4-3", fixture: "slide-size-4-3.pptx", tolerance: 0.004 },
+  { name: "word-wrap", fixture: "word-wrap.pptx", tolerance: 0.031 },
+  { name: "background-blipfill", fixture: "background-blipfill.pptx", tolerance: 0.006 },
+  { name: "composite", fixture: "composite.pptx", tolerance: 0.011 },
+  { name: "effects", fixture: "effects.pptx", tolerance: 0.004 },
+  { name: "hyperlinks", fixture: "hyperlinks.pptx", tolerance: 0.009 },
 ] as const;
 
 // フィクスチャとスナップショットの両方が存在する場合のみ実行


### PR DESCRIPTION
## 概要

LibreOffice VRT の tolerance を CI 上の実測値ベースで厳格化し、回帰検出力を高める。

## 変更内容

- 各ケースの実測 mismatch 率を常に `[lo-vrt]` ログとして出力するよう変更(今後の再調整用)
- 全 26 ケースに明示的な `tolerance` を設定: **CI 実測値 × 1.2 を 0.1pt 単位で切り上げ(下限 0.3%)**
  - 従来は「実測値の約2倍」ポリシー(デフォルト 2% + 個別設定)
- `MISMATCH_TOLERANCE = 0.02` は新規ケース追加時のフォールバックとして残す
- CLAUDE.md の tolerance 記述を更新(旧記述は 5% のままで実態と乖離していた)

## 根拠

- CI で2回実行した実測値が全ケースで完全に一致しており、レンダリングは決定的。揺れが生じるのは LibreOffice や CI ランナーのフォントが更新された時のみで、その際は `[lo-vrt]` ログから同じ方針で再設定する
- 代表例: image 2%→0.3%, groups 2%→0.3%, basic-shapes 2%→0.8%, transforms 7%→5.7%, charts 15%→14.5%, callouts-arcs 17%→16.8%

## 確認

- [x] CI green (libreoffice-vrt 含む全ジョブ成功)

🤖 Generated with [Claude Code](https://claude.com/claude-code)