### PR TITLE
pnpm workspaces 骨格作成 (packages/* に 3 パッケージの雛形を配置)

### DIFF
--- a/packages/pptx-glimpse-cli/package.json
+++ b/packages/pptx-glimpse-cli/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pptx-glimpse-cli",
+  "version": "0.0.0",
+  "private": true,
+  "description": "CLI package skeleton; implementation tracked in issue #412.",
+  "type": "module",
+  "bin": {
+    "pptx-glimpse": "./dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/pptx-glimpse-cli/tsconfig.json
+++ b/packages/pptx-glimpse-cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/pptx-glimpse-cli/tsup.config.ts
+++ b/packages/pptx-glimpse-cli/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/cli.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+});

--- a/packages/pptx-glimpse-renderer/package.json
+++ b/packages/pptx-glimpse-renderer/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "pptx-glimpse-renderer",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Renderer package skeleton (private: managed as an internal package per parent issue #340 decision).",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/pptx-glimpse-renderer/tsconfig.json
+++ b/packages/pptx-glimpse-renderer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/pptx-glimpse-renderer/tsup.config.ts
+++ b/packages/pptx-glimpse-renderer/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+});

--- a/packages/pptx-glimpse/package.json
+++ b/packages/pptx-glimpse/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "pptx-glimpse",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Skeleton package; source code will move here in a follow-up issue.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/pptx-glimpse/package.json
+++ b/packages/pptx-glimpse/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "pptx-glimpse",
+  "name": "pptx-glimpse-skeleton",
   "version": "0.0.0",
   "private": true,
-  "description": "Skeleton package; source code will move here in a follow-up issue.",
+  "description": "Skeleton package; source code will move here in a follow-up issue and the name will be renamed to pptx-glimpse at that time.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/pptx-glimpse/tsconfig.json
+++ b/packages/pptx-glimpse/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/pptx-glimpse/tsup.config.ts
+++ b/packages/pptx-glimpse/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,12 @@ importers:
         specifier: ^8.19.0
         version: 8.21.0
 
+  packages/pptx-glimpse: {}
+
+  packages/pptx-glimpse-cli: {}
+
+  packages/pptx-glimpse-renderer: {}
+
 packages:
 
   '@babel/helper-string-parser@7.27.1':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "packages/*"
+
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
close #416

## 概要

親 issue #340 (モノレポ化) の子 issue 1 件目として、`pnpm-workspace.yaml` に `packages/*` を追加し、`packages/pptx-glimpse/`・`packages/pptx-glimpse-renderer/`・`packages/pptx-glimpse-cli/` の骨格 (package.json / tsconfig.json / tsup.config.ts 雛形) を配置する。

この時点ではソース移動は行わず、ルート package.json と src/ は触らないため、既存のビルド・テスト・リリース flow に影響しない。ソース移動は別の子 issue で行う。

## 変更点

- `pnpm-workspace.yaml` に `packages: ["packages/*"]` を追加 (既存の `allowBuilds` は保持)
- `packages/pptx-glimpse/` — name は一時的に `pptx-glimpse-skeleton` (ルートの `pptx-glimpse` と `pnpm --filter` で衝突しないよう骨格段階のみ仮 name 化)。ソース移動時に正式 name `pptx-glimpse` にリネーム予定
- `packages/pptx-glimpse-renderer/` — `private: true` (親 issue #340 の publish 方針コメントに従い A: 内部パッケージとして管理)
- `packages/pptx-glimpse-cli/` — `private: true` (CLI 実装は #412 で対応)
- 各パッケージに `tsconfig.json` (ルートを extends) と `tsup.config.ts` 雛形を配置
- `pnpm-lock.yaml` を 3 packages の workspace 認識に伴い再生成

## 親 issue への決定記録

renderer パッケージの publish 方針について親 #340 にコメントで A (private) を記録: https://github.com/hirokisakabe/pptx-glimpse/issues/340#issuecomment-4719008203

## ローカル検証手順

```bash
pnpm install                 # 4 workspace projects (root + 3 packages) を認識
pnpm m ls --depth -1         # 3 PRIVATE パッケージが workspace member として一覧される
pnpm --filter pptx-glimpse exec pwd            # ルートのみマッチ (1 project)
pnpm --filter pptx-glimpse-skeleton exec pwd   # packages/pptx-glimpse のみマッチ
pnpm run typecheck && pnpm run lint && pnpm run format:check
pnpm run build
pnpm run test                # 973 tests passed
```

## スコープ外

- `src/` 配下のソース移動 (別 子 issue で対応)
- CI の monorepo 対応 (子4 #?)
- ルート package.json の workspace ルート化 (子3 のソース移動時に併せて整理)
- workspace 全体の build:all / typecheck:all スクリプト (info 指摘あり、子4 のスコープ)