### PR TITLE
fix(monorepo): Changesets が root の pptx-glimpse を認識できるよう workspace に "." を追加 (#418)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ CI consists of 4 jobs:
 
 Data flow: **PPTX binary → Parser (ZIP extraction + XML parsing) → Intermediate model → Renderer (SVG generation) → PNG conversion (optional)**
 
-ソースは pnpm workspaces (`packages/*`) で分割されている。`pptx-glimpse` パッケージは `pptx-glimpse-renderer` を workspace 依存として参照する。
+ソースは pnpm workspaces (`.` + `packages/*`) で分割されている。`packages/*` 配下に renderer / cli の skeleton と `pptx-glimpse` の実装ソースが置かれており、`.` (ルート) は引き続き npm publish 対象の `pptx-glimpse` パッケージとして workspace に含めている (Changesets に root を認識させるための明示指定)。`pptx-glimpse` パッケージは `pptx-glimpse-renderer` を workspace 依存として参照する。
 
 `packages/pptx-glimpse/src/` — 公開パッケージ `pptx-glimpse` の実装（パーサー + 公開 API）
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - "."
   - "packages/*"
 
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+# "." はルートの publishable package `pptx-glimpse` を Changesets (@manypkg/get-packages) が
+# workspace member として認識するために必要。これが無いと `changeset status / version / publish`
+# が root を無視し no-op になる。root publish 経路を維持しているうちは外さないこと。
 packages:
   - "."
   - "packages/*"


### PR DESCRIPTION
close #418

## 概要

monorepo 化 (#340) のソース移動 (#417) 後、Changesets が root の publishable package である `pptx-glimpse` を workspace member として認識できず、`changeset status / version / publish` が no-op になっていた。`pnpm-workspace.yaml` の `packages` に `"."` を追加することで Changesets (内部の `@manypkg/get-packages`) がルートを workspace に含めて扱うようになり、従来の root publish 経路を維持したまま monorepo モードで Changesets が動作する。

## 背景

- root `pptx-glimpse@1.1.1` は引き続き npm publish 対象。renderer / cli / pptx-glimpse-skeleton は `"private": true` で publish 対象外 (#340 子3 で Plan A を採用済み)。
- 修正前: `@manypkg/get-packages` の検出結果に root が現れず、`pnpm exec changeset status` も "NO packages" を返していた。
- 修正後: 検出結果に `pptx-glimpse (publishable)` が含まれ、テスト用 changeset で `1.1.1 → 1.1.2` の bump を確認した。

## 変更内容

- `pnpm-workspace.yaml`: `packages` に `"."` を追加。意図を読み取れるよう、将来削除されないよう保護するコメントを併記。
- `CLAUDE.md`: Architecture 節の workspace 構成説明を `.` + `packages/*` に更新し、root を workspace の管理対象としている経緯を明記。

CI / release ワークフロー、`.changeset/config.json`、各 `package.json` には変更を加えていない。既存の publish 経路 (root の `dist/` を tsup でバンドル) はそのまま維持。

## 受け入れ条件の確認結果

- ✓ `pnpm test` でルートから全パッケージのテストが通る (51 files / 973 tests)
- ✓ `pnpm build` でルートから全パッケージがビルドできる (renderer の per-package build + root tsup)
- ✓ CI (lint / format:check / typecheck / knip) がローカルで全通過。VRT は Docker ベースで本変更の影響を受けない構造
- ✓ `npx changeset` が monorepo モードで動作し、`pptx-glimpse` の changeset を作成できる
- ✓ release ワークフローが changesets/action 経由で root を publish 対象として認識する

## ローカル検証手順

```bash
pnpm install --frozen-lockfile
pnpm test
pnpm build
pnpm lint && pnpm format:check && pnpm typecheck && pnpm knip
# 検出確認 (一時 changeset を作成)
echo '---
"pptx-glimpse": patch
---
test' > .changeset/_tmp.md
npx changeset status --verbose  # → pptx-glimpse 1.1.2 と表示
rm .changeset/_tmp.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)