### PR TITLE
docs: @pptx-glimpse/document の責務境界を記録

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ Data flow: **PPTX binary → Parser (ZIP extraction + XML parsing) → Intermedi
 
 ソースは pnpm workspaces (`.` + `packages/*`) で分割されている。`packages/*` 配下に renderer / cli の skeleton と `pptx-glimpse` の実装ソースが置かれており、`.` (ルート) は引き続き npm publish 対象の `pptx-glimpse` パッケージとして workspace に含めている (Changesets に root を認識させるための明示指定)。`pptx-glimpse` パッケージは `pptx-glimpse-renderer` を workspace 依存として参照する。
 
+`@pptx-glimpse/document` / CleanDoc / writer / editor-core / pom 連携に関わる issue に着手する前に、責務境界と依存方向の決定記録である `docs/document-boundaries.md` を必ず読むこと。`document` は `core` / `editor-core` / renderer / pom を知らない下位基盤として扱う。
+
 `packages/pptx-glimpse/src/` — 公開パッケージ `pptx-glimpse` の実装（パーサー + 公開 API）
 
 - `parser/` — Builds intermediate model from PPTX via ZIP extraction (`fflate`) and XML parsing (`fast-xml-parser`)

--- a/docs/document-boundaries.md
+++ b/docs/document-boundaries.md
@@ -10,6 +10,11 @@ decision from
 will eventually depend on `@pptx-glimpse/document`, and pptx-glimpse will not
 depend on pom.**
 
+Package names with the `@pptx-glimpse/*` scope describe the intended long-term
+package boundaries. The current repository still contains unscoped packages such
+as `pptx-glimpse` and `pptx-glimpse-renderer`; this RFC uses the scoped names to
+describe the target architecture.
+
 ## Dependency direction
 
 `@pptx-glimpse/document` is the lower-level OOXML / CleanDoc foundation. Higher
@@ -25,7 +30,9 @@ editing workflows, or pom's authoring DSL.
 
 @pptx-glimpse/core
   -> @pptx-glimpse/document
-  -> OOXML package parts / CleanDoc types / writer primitives
+
+@pptx-glimpse/document
+  -> OOXML package parts
 ```
 
 `@pptx-glimpse/document` must not depend on:

--- a/docs/document-boundaries.md
+++ b/docs/document-boundaries.md
@@ -1,0 +1,153 @@
+# `@pptx-glimpse/document` responsibility boundaries
+
+Status: RFC decision for [#449](https://github.com/hirokisakabe/pptx-glimpse/issues/449)
+Date: 2026-06-20
+
+This note records the package boundary decision that should feed into
+[#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445). It assumes the
+decision from
+[hirokisakabe/pom#895](https://github.com/hirokisakabe/pom/issues/895): **pom
+will eventually depend on `@pptx-glimpse/document`, and pptx-glimpse will not
+depend on pom.**
+
+## Dependency direction
+
+`@pptx-glimpse/document` is the lower-level OOXML / CleanDoc foundation. Higher
+packages may consume it, but it must not know product-level APIs, preview APIs,
+editing workflows, or pom's authoring DSL.
+
+```text
+@hirokisakabe/pom
+  -> @pptx-glimpse/document
+
+@pptx-glimpse/editor-core
+  -> @pptx-glimpse/document
+
+@pptx-glimpse/core
+  -> @pptx-glimpse/document
+  -> OOXML package parts / CleanDoc types / writer primitives
+```
+
+`@pptx-glimpse/document` must not depend on:
+
+- `@pptx-glimpse/core`
+- `@pptx-glimpse/editor-core`
+- `@pptx-glimpse/renderer`
+- `@hirokisakabe/pom`
+- browser UI packages or demo application code
+
+The dependency contract is one-way:
+
+```text
+authoring / preview / editor layers
+  -> document
+  -> OOXML file structure
+```
+
+There should be no reverse dependency from `document` into authoring, preview, or
+editor-specific concepts.
+
+## What `document` owns
+
+`@pptx-glimpse/document` owns the PPTX document domain model and the mechanics
+needed to read, write, validate, and preserve that domain model:
+
+- CleanDoc schema and TypeScript types.
+- Presentation package structure: slides, layouts, masters, themes, media,
+  relationships, and content types.
+- Reader-side conversion from OOXML package parts into CleanDoc.
+- Writer-side conversion from CleanDoc back into OOXML package parts.
+- Stable IDs and relationship references that allow round-trip editing.
+- Normalized units and value types where CleanDoc intentionally hides OOXML
+  encoding details.
+- Source-level values plus the metadata required to recover or preserve OOXML
+  constructs that CleanDoc does not model directly.
+- Raw OOXML escape hatch for vendor extensions, uncommon DrawingML constructs,
+  `mc:AlternateContent`, and other lossless-tax cases.
+- Validation and diagnostics that are about document correctness, not rendering
+  fidelity or UI behavior.
+
+The package may expose utilities that compute effective document values when
+those values are part of the document semantics, for example resolving a slide's
+master/layout inheritance into a document-level view. Those utilities should not
+encode renderer fallbacks, font substitution policy, browser behavior, or pom
+authoring conveniences.
+
+## What `document` does not own
+
+`@pptx-glimpse/document` does not own higher-level workflows:
+
+- SVG/PNG rendering APIs.
+- Renderer-specific intermediate model shapes.
+- Font discovery, font fallback, font subsetting, or text-to-path conversion.
+- Browser editor commands, selection state, undo history, collaboration state, or
+  UI interaction models.
+- pom's Flexbox-like authoring DSL, layout primitives, or AI-first document
+  authoring shortcuts.
+- `convertPptxToPom` lossy authoring conversion policy.
+- CLI, demo, VRT harnesses, or publish-time package bundling behavior.
+
+Those concerns belong in `core`, `editor-core`, renderer packages, pom, or
+application-level packages that depend on `document`.
+
+## Package roles
+
+| Package                     | Role                                               | Depends on `document`?           | `document` may depend on it? |
+| --------------------------- | -------------------------------------------------- | -------------------------------- | ---------------------------- |
+| `@pptx-glimpse/document`    | CleanDoc, OOXML reader/writer, document validation | n/a                              | n/a                          |
+| `@pptx-glimpse/core`        | Public preview/conversion API and orchestration    | Yes                              | No                           |
+| `@pptx-glimpse/editor-core` | Headless editing commands and state machine        | Yes                              | No                           |
+| `@pptx-glimpse/renderer`    | Render-oriented model and SVG/PNG generation       | Possibly via an adapter consumer | No                           |
+| `@hirokisakabe/pom`         | Authoring DSL and generation workflow              | Yes, eventually                  | No                           |
+
+## Renderer model and CleanDoc
+
+The existing renderer model should **not** be merged directly into CleanDoc.
+
+The renderer model is a computed, display-oriented view optimized for SVG/PNG
+generation. It can contain resolved values, fallback decisions, pixel-oriented
+measurements, rendering warnings, and simplifications that are useful for
+preview output but too lossy or too presentation-specific to be the canonical
+document model.
+
+CleanDoc should instead be the source/semantic model. Rendering should use an
+adapter:
+
+```text
+OOXML package
+  -> CleanDoc
+  -> computed render view / renderer adapter
+  -> SVG / PNG
+```
+
+This lets `document` preserve enough structure for writer/editor/round-trip
+work, while `renderer` keeps a purpose-built shape for visual output.
+
+Short term, the current parser-to-renderer path can continue to exist. The
+migration path is:
+
+1. Introduce CleanDoc types in `@pptx-glimpse/document`.
+2. Add a reader path that builds CleanDoc from OOXML.
+3. Add an adapter from CleanDoc to the current renderer model.
+4. Gradually move parser semantics that are not renderer-specific into
+   `document`.
+5. Keep renderer-only fallbacks and visual diagnostics outside `document`.
+
+## Conclusion
+
+Adopt `@pptx-glimpse/document` as a lower-level foundation. `core`,
+`editor-core`, and pom may depend on it; `document` must not depend on them.
+
+The package boundary should be:
+
+- `document`: canonical PPTX/CleanDoc data model, OOXML read/write mechanics,
+  preservation hooks, validation.
+- `core`: public conversion orchestration and compatibility API.
+- `editor-core`: editing commands and headless editor state built on CleanDoc.
+- renderer: computed display model and SVG/PNG output.
+- pom: authoring DSL that may emit or consume CleanDoc but is never known by
+  pptx-glimpse packages.
+
+For #445, this means CleanDoc should be designed as the canonical
+`@pptx-glimpse/document` model, with a generated computed render view rather than
+an in-place replacement of the existing renderer model.

--- a/docs/document-boundaries.md
+++ b/docs/document-boundaries.md
@@ -1,7 +1,7 @@
 # `@pptx-glimpse/document` responsibility boundaries
 
-Status: RFC decision for [#449](https://github.com/hirokisakabe/pptx-glimpse/issues/449)
-Date: 2026-06-20
+- Status: RFC decision for [#449](https://github.com/hirokisakabe/pptx-glimpse/issues/449)
+- Date: 2026-06-20
 
 This note records the package boundary decision that should feed into
 [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445). It assumes the
@@ -21,6 +21,11 @@ describe the target architecture.
 packages may consume it, but it must not know product-level APIs, preview APIs,
 editing workflows, or pom's authoring DSL.
 
+CleanDoc means the clean intermediate document model discussed in
+[#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445): it keeps the
+semantic structure and round-trip preservation hooks needed for PPTX documents
+without exposing OOXML's package scattering as the primary authoring surface.
+
 ```text
 @hirokisakabe/pom
   -> @pptx-glimpse/document
@@ -33,6 +38,9 @@ editing workflows, or pom's authoring DSL.
 
 @pptx-glimpse/document
   -> OOXML package parts
+
+@pptx-glimpse/renderer
+  -> computed render view / adapter output
 ```
 
 `@pptx-glimpse/document` must not depend on:
@@ -70,7 +78,7 @@ needed to read, write, validate, and preserve that domain model:
 - Source-level values plus the metadata required to recover or preserve OOXML
   constructs that CleanDoc does not model directly.
 - Raw OOXML escape hatch for vendor extensions, uncommon DrawingML constructs,
-  `mc:AlternateContent`, and other lossless-tax cases.
+  `mc:AlternateContent`, and other cases needed to keep round-trips lossless.
 - Validation and diagnostics that are about document correctness, not rendering
   fidelity or UI behavior.
 

--- a/docs/document-boundaries.md
+++ b/docs/document-boundaries.md
@@ -13,7 +13,9 @@ depend on pom.**
 Package names with the `@pptx-glimpse/*` scope describe the intended long-term
 package boundaries. The current repository still contains unscoped packages such
 as `pptx-glimpse` and `pptx-glimpse-renderer`; this RFC uses the scoped names to
-describe the target architecture.
+describe the target architecture. In that target architecture, current
+`pptx-glimpse` corresponds to `@pptx-glimpse/core`, and current
+`pptx-glimpse-renderer` corresponds to `@pptx-glimpse/renderer`.
 
 ## Dependency direction
 
@@ -35,12 +37,14 @@ without exposing OOXML's package scattering as the primary authoring surface.
 
 @pptx-glimpse/core
   -> @pptx-glimpse/document
+  -> @pptx-glimpse/renderer
+  (owns orchestration and the CleanDoc-to-render-view adapter)
 
 @pptx-glimpse/document
   -> OOXML package parts
 
 @pptx-glimpse/renderer
-  -> computed render view / adapter output
+  -> computed render view
 ```
 
 `@pptx-glimpse/document` must not depend on:
@@ -107,13 +111,13 @@ application-level packages that depend on `document`.
 
 ## Package roles
 
-| Package                     | Role                                               | Depends on `document`?           | `document` may depend on it? |
-| --------------------------- | -------------------------------------------------- | -------------------------------- | ---------------------------- |
-| `@pptx-glimpse/document`    | CleanDoc, OOXML reader/writer, document validation | n/a                              | n/a                          |
-| `@pptx-glimpse/core`        | Public preview/conversion API and orchestration    | Yes                              | No                           |
-| `@pptx-glimpse/editor-core` | Headless editing commands and state machine        | Yes                              | No                           |
-| `@pptx-glimpse/renderer`    | Render-oriented model and SVG/PNG generation       | Possibly via an adapter consumer | No                           |
-| `@hirokisakabe/pom`         | Authoring DSL and generation workflow              | Yes, eventually                  | No                           |
+| Package                     | Role                                               | Depends on `document`?                        | `document` may depend on it? |
+| --------------------------- | -------------------------------------------------- | --------------------------------------------- | ---------------------------- |
+| `@pptx-glimpse/document`    | CleanDoc, OOXML reader/writer, document validation | n/a                                           | n/a                          |
+| `@pptx-glimpse/core`        | Public preview/conversion API and orchestration    | Yes                                           | No                           |
+| `@pptx-glimpse/editor-core` | Headless editing commands and state machine        | Yes                                           | No                           |
+| `@pptx-glimpse/renderer`    | Render-oriented model and SVG/PNG generation       | No direct dependency; consumes adapter output | No                           |
+| `@hirokisakabe/pom`         | Authoring DSL and generation workflow              | Yes, eventually                               | No                           |
 
 ## Renderer model and CleanDoc
 


### PR DESCRIPTION
close #449

## 概要

`@pptx-glimpse/document` を CleanDoc / OOXML reader-writer の下位基盤として扱う方針を `docs/document-boundaries.md` に記録しました。

## 変更内容

- `@pptx-glimpse/document` / `core` / `editor-core` / `renderer` / `pom` の依存方向を整理
- `document` が担う責務と担わない責務を明文化
- 既存 renderer model は CleanDoc に統合せず、computed render view / adapter として扱う方針を記録
- #445 に反映できる結論として、CleanDoc を canonical model とする境界を整理

## 影響範囲

- `docs/document-boundaries.md`
- docs-only 変更のため changeset は不要です

## 検証

- `pnpm exec prettier --check docs/document-boundaries.md`
- `pnpm run lint`
- `pnpm run typecheck`
- acceptance-check: #449 の受け入れ条件をすべて満たすことを確認
- cross-review: critical / warning なし