### PR TITLE
docs: raw OOXML round-trip 方針を記録する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Data flow: **PPTX binary → Parser (ZIP extraction + XML parsing) → Intermedi
 
 ソースは pnpm workspaces (`.` + `packages/*`) で分割されている。`packages/*` 配下に renderer / cli の skeleton と `pptx-glimpse` の実装ソースが置かれており、`.` (ルート) は引き続き npm publish 対象の `pptx-glimpse` パッケージとして workspace に含めている (Changesets に root を認識させるための明示指定)。`pptx-glimpse` パッケージは `pptx-glimpse-renderer` を workspace 依存として参照する。
 
-`@pptx-glimpse/document` / CleanDoc / writer / editor-core / pom 連携に関わる issue に着手する前に、責務境界と依存方向の決定記録である `docs/document-boundaries.md` を必ず読むこと。`document` は `core` / `editor-core` / renderer / pom を知らない下位基盤として扱う。
+`@pptx-glimpse/document` / CleanDoc / writer / editor-core / pom 連携に関わる issue に着手する前に、責務境界と依存方向の決定記録である `docs/document-boundaries.md` と、そこからリンクされる派生決定記録を必ず読むこと。`document` は `core` / `editor-core` / renderer / pom を知らない下位基盤として扱う。
 
 `packages/pptx-glimpse/src/` — 公開パッケージ `pptx-glimpse` の実装（パーサー + 公開 API）
 

--- a/docs/cleandoc-source-computed-view.md
+++ b/docs/cleandoc-source-computed-view.md
@@ -10,6 +10,12 @@ the package boundary decision in
 the lower-level OOXML / CleanDoc foundation, and renderer / core / editor-core /
 pom are consumers of it.
 
+The related raw preservation and round-trip decision is recorded in
+[raw-ooxml-round-trip.md](./raw-ooxml-round-trip.md). In short, CleanDoc targets
+structural preservation rather than byte equality, and raw OOXML is kept as
+source-model sidecars or untouched package parts instead of becoming the primary
+editing surface.
+
 ## Decision
 
 Adopt a two-layer CleanDoc design:

--- a/docs/document-boundaries.md
+++ b/docs/document-boundaries.md
@@ -15,6 +15,12 @@ The related source/computed layering decision is recorded in
 CleanDoc is the source model owned by `@pptx-glimpse/document`, and computed
 views are generated projections for renderer, AI reading, and editor consumers.
 
+The related raw preservation and round-trip decision is recorded in
+[raw-ooxml-round-trip.md](./raw-ooxml-round-trip.md). In short,
+`@pptx-glimpse/document` should preserve raw OOXML for untouched or unsupported
+source material, while keeping typed CleanDoc operations as the normal editing
+API.
+
 Package names with the `@pptx-glimpse/*` scope describe the intended long-term
 package boundaries. The current repository still contains unscoped packages such
 as `pptx-glimpse` and `pptx-glimpse-renderer`; this RFC uses the scoped names to

--- a/docs/raw-ooxml-round-trip.md
+++ b/docs/raw-ooxml-round-trip.md
@@ -1,0 +1,242 @@
+# Raw OOXML escape hatch and round-trip policy
+
+- Status: RFC decision for [#451](https://github.com/hirokisakabe/pptx-glimpse/issues/451)
+- Date: 2026-06-20
+
+This note records the raw OOXML preservation and round-trip policy that should
+feed into [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445). It
+builds on the package boundary decision in
+[document-boundaries.md](./document-boundaries.md) and the source/computed
+layering decision in
+[cleandoc-source-computed-view.md](./cleandoc-source-computed-view.md).
+
+The goal is to make `@pptx-glimpse/document` reliable for existing PPTX files
+without turning CleanDoc into a byte-level OOXML editor. CleanDoc should expose a
+clean document model for supported semantics, while retaining enough raw source
+material to write back unsupported or unedited content.
+
+## Round-trip Target
+
+Adopt **structural round-trip preservation** as the writer target.
+
+Structural preservation means:
+
+- The package parts, relationships, content types, media, theme, master, layout,
+  slide, chart, table, and notes parts that are not edited are kept intact where
+  practical.
+- Supported edits update only the affected semantic nodes and their required
+  package bookkeeping.
+- Unknown elements, vendor extensions, and compatibility branches remain in the
+  written package unless an explicit edit invalidates their owning node.
+- Output is expected to reopen in PowerPoint, LibreOffice, and other PPTX
+  consumers with the same visible meaning for untouched content.
+
+Do not target byte equality.
+
+Byte equality is intentionally out of scope because XML serialization can change
+attribute order, namespace prefix placement, insignificant whitespace, ZIP entry
+metadata, compression settings, relationship ID allocation, and defaulted OOXML
+values. Preserving those details would force CleanDoc to become a package patcher
+first and a document model second.
+
+Do not claim full semantic equality for edited content.
+
+Edited nodes are regenerated according to the capabilities of
+`@pptx-glimpse/document`. If a user edits a partially supported construct, the
+writer may need to replace that construct with the supported representation and
+emit diagnostics about discarded raw material. Semantic equality is a best-effort
+goal for edited content, not a guarantee.
+
+## Raw Preservation Granularity
+
+Adopt a hybrid preservation model:
+
+```text
+PPTX package part
+  -> parsed CleanDoc source nodes
+  -> raw node sidecars for unsupported or partially supported XML
+  -> raw package part fallback for untouched parts
+```
+
+### Adopted Granularities
+
+Preserve raw data at the following levels:
+
+| Level              | Use case                                              | Policy                                                                                 |
+| ------------------ | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Package part       | Untouched slide/layout/master/theme/chart/media parts | Keep the original bytes or original XML tree and write them back unchanged.            |
+| XML node sidecar   | Unknown child elements, vendor extensions, `extLst`   | Attach raw XML to the nearest CleanDoc source node with ordering metadata.             |
+| Alternate branch   | `mc:AlternateContent`                                 | Preserve all choices/fallback branches unless the owning node is regenerated.          |
+| Relationship entry | `_rels/*.rels` references                             | Preserve existing relationship IDs and targets where the referenced part is unchanged. |
+| Content type entry | `[Content_Types].xml` overrides/defaults              | Preserve entries for existing parts; add/remove entries only for package edits.        |
+| Binary asset       | Images, media, embedded workbooks                     | Preserve bytes and part paths unless the asset is replaced or removed.                 |
+
+CleanDoc source nodes should carry stable source handles, for example original
+part path, relationship ID, element ID, child ordering slots, and raw sidecar
+references. These handles let the writer decide whether it can splice a generated
+node into an existing part or must regenerate a larger scope.
+
+### Rejected Granularities
+
+Reject byte-range patching as the primary model.
+
+Byte-range patching would preserve formatting and attribute ordering, but it is
+too fragile for XML namespace changes, relationship rewrites, and edits that move
+nodes across parts. It can be considered later as an optimization for specific
+safe edits, not as the foundation.
+
+Reject element-property raw storage as the default.
+
+Storing raw XML beside every property would make the public model noisy and would
+still not solve child ordering, namespace declarations, `mc:AlternateContent`,
+or relationship updates. Properties should become typed CleanDoc fields when they
+are supported; unsupported material should stay as raw node sidecars.
+
+Reject a single opaque raw XML string per slide as the only escape hatch.
+
+That approach preserves untouched slides, but it cannot support precise edits or
+diagnostics. It also prevents editor-core from knowing which unsupported content
+is attached to which shape, table, chart, or text node.
+
+Reject full normalization into CleanDoc without raw sidecars.
+
+That would produce the cleanest model, but it would drop unsupported OOXML and
+make existing-file editing unsafe.
+
+## Write Policy
+
+Use an edit-tracking writer that prefers preserving unedited source material and
+regenerating only dirty scopes.
+
+Recommended dirty-scope levels:
+
+```text
+field edit
+  -> owning XML element dirty
+  -> owning XML part dirty
+  -> package manifest / relationship dirty
+```
+
+Policy:
+
+- If a package part is untouched, write the original part back as-is.
+- If a part is dirty but contains mostly supported edits, regenerate only the
+  dirty XML elements and splice preserved raw sidecars back into their original
+  order.
+- If node-level splicing is unsafe, regenerate the whole XML part from CleanDoc
+  source plus preserved raw sidecars.
+- If an edit invalidates an unsupported node that cannot be preserved, drop that
+  raw node only with an explicit diagnostic.
+- If package topology changes, update the affected `.rels` files and
+  `[Content_Types].xml` entries while preserving unrelated entries.
+
+Do not make whole-package regeneration the default. Whole-package regeneration is
+acceptable for new documents and for operations that intentionally rewrite the
+document topology, but it is too destructive for existing-file round-trips.
+
+Do not require node-level splicing for the first writer implementation. A
+part-level dirty writer with raw sidecars is an acceptable first slice as long as
+the API and data model leave room for more precise node-level preservation later.
+
+## Package Bookkeeping
+
+`@pptx-glimpse/document` should treat package bookkeeping as source-model data,
+not renderer data.
+
+Preserve:
+
+- `_rels` files, relationship IDs, relationship types, targets, and target modes.
+- `[Content_Types].xml` defaults and overrides for existing parts.
+- Media assets and embedded object bytes.
+- Theme, slide master, slide layout, notes master, and notes slide parts.
+- Chart parts, embedded workbook parts, chart style/color parts, and their
+  relationship graphs.
+- Unknown package parts and their relationships when they remain reachable.
+
+When adding or removing parts, update only the affected package graph:
+
+- Allocate new part names deterministically and avoid collisions.
+- Keep existing `rId` values where possible.
+- Add required content type overrides for new part types.
+- Remove orphaned parts only when the edit explicitly deletes the owning object,
+  or when a cleanup option requests pruning.
+
+## Unsupported Elements and Extensions
+
+Preserve unsupported XML by default.
+
+This includes:
+
+- `mc:AlternateContent`, including all `mc:Choice` and `mc:Fallback` branches.
+- Vendor extension elements such as `p:extLst`, `a:extLst`, and vendor-specific
+  extension namespaces.
+- Unknown DrawingML, PresentationML, chart, table, media, timing, transition, and
+  animation nodes.
+- Unknown attributes on otherwise supported elements.
+
+`mc:AlternateContent` should be represented in the source model as a compatibility
+container, not eagerly flattened. The computed view may choose the best branch
+for rendering or AI reading, but the source model must keep the complete
+alternate content block for writing.
+
+When an edit targets a node that owns unsupported material:
+
+- Preserve unsupported children and attributes when they do not conflict with the
+  edit.
+- Mark unsupported material as invalidated when the edit changes the semantics of
+  the owning node in a way the writer cannot reconcile.
+- Emit diagnostics that identify the source part, element, and reason raw content
+  was dropped or ignored.
+
+## Raw Escape Hatch API
+
+Keep the raw OOXML escape hatch primarily as an internal source-model mechanism
+for the first implementation.
+
+Public APIs should expose raw material cautiously through explicit expert-level
+handles, not as the default editing surface. The default CleanDoc API should stay
+semantic and typed.
+
+Recommended public shape:
+
+```text
+readPptx(input, { preserveRaw: true }) -> CleanDocSource
+
+source.getRaw(handle) -> RawOoxmlNode | RawPackagePart | undefined
+source.replaceRaw(handle, raw, options) -> CleanDocSource
+source.listDiagnostics() -> Diagnostic[]
+```
+
+API principles:
+
+- Raw handles are stable source references, not direct mutable object pointers.
+- Raw replacement is opt-in and should require namespace-aware XML validation.
+- Raw access should be available for advanced tools, migrations, and emergency
+  preservation workflows, but ordinary editor commands should use typed CleanDoc
+  operations.
+- Computed views may expose provenance back to raw handles for diagnostics, but
+  they should not expose raw XML as their primary data.
+
+Defer a broad public raw editing API until writer behavior and diagnostics are
+proven. Exposing raw XML too early would make it difficult to evolve the source
+schema and could encourage consumers to depend on OOXML internals that
+`@pptx-glimpse/document` is meant to hide.
+
+## Conclusion for #445
+
+For #445, CleanDoc should define lossless behavior as structural preservation,
+not byte equality. `@pptx-glimpse/document` should preserve raw OOXML at package
+part and XML-node sidecar granularity, keep relationships/content types/assets as
+source-model data, and use edit tracking so unedited parts can be written back
+without regeneration.
+
+The initial writer may regenerate dirty parts, but it must preserve untouched
+parts and attach raw sidecars in a way that allows future node-level splicing.
+Unsupported elements, vendor extensions, and `mc:AlternateContent` are preserved
+by default and are only dropped when an explicit edit invalidates them, with a
+diagnostic.
+
+The raw escape hatch should remain mostly internal at first, with a narrow
+expert-level public API based on stable raw handles. CleanDoc remains the normal
+semantic editing API; raw OOXML is a preservation and emergency escape mechanism,
+not the primary programming model.


### PR DESCRIPTION
close #451

## 目的

CleanDoc / `@pptx-glimpse/document` における raw OOXML escape hatch と round-trip 方針を RFC 決定記録として追加します。

## 変更内容

- `docs/raw-ooxml-round-trip.md` を追加し、以下の方針を整理
  - round-trip の目標をバイト等価ではなく構造的保持とする
  - raw OOXML の保持粒度の採用案 / 却下案
  - dirty scope に基づく write 方針
  - `_rels` / `[Content_Types].xml` / media / theme / master / layout 等の保持方針
  - 未対応要素、vendor extension、`mc:AlternateContent` の扱い
  - raw escape hatch の API 露出方針
- `docs/document-boundaries.md` と `docs/cleandoc-source-computed-view.md` から新規決定記録へリンク
- `AGENTS.md` に、派生決定記録も読む旨を追記

## 影響範囲

- `docs/`
- `AGENTS.md`

コード変更はありません。published package の挙動や public API には影響しないため changeset は追加していません。

## ローカル検証

- `npm run format -- docs/raw-ooxml-round-trip.md docs/cleandoc-source-computed-view.md docs/document-boundaries.md`
- `npx prettier --check AGENTS.md docs/raw-ooxml-round-trip.md docs/cleandoc-source-computed-view.md docs/document-boundaries.md`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`

## 補足

- acceptance-check: #451 の受け入れ条件 6 件すべて充足を確認
- cross-review: critical / warning なし。info 指摘を受け、`AGENTS.md` の派生決定記録への案内を追加
