### PR TITLE
@pptx-glimpse/document package skeleton を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Data flow: **PPTX binary → Parser (ZIP extraction + XML parsing) → Intermedi
 
 `@pptx-glimpse/document` / CleanDoc / writer / editor-core / pom 連携に関わる issue に着手する前に、責務境界と依存方向の決定記録である `docs/document-boundaries.md` と、そこからリンクされる派生決定記録を必ず読むこと。`document` は `core` / `editor-core` / renderer / pom を知らない下位基盤として扱う。
 
+`packages/pptx-glimpse-document/src/` — experimental `@pptx-glimpse/document` パッケージの skeleton。CleanDoc / OOXML document foundation の下位基盤として追加されており、現時点では public conversion path からは参照しない。`@pptx-glimpse/document/experimental` は後続の source model / reader / writer 実装を積むための experimental entry point。
+
 `packages/pptx-glimpse/src/` — 公開パッケージ `pptx-glimpse` の実装（パーサー + 公開 API）
 
 - `parser/` — Builds intermediate model from PPTX via ZIP extraction (`fflate`) and XML parsing (`fast-xml-parser`)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "pnpm --filter pptx-glimpse-renderer build && tsup",
+    "build": "pnpm --filter @pptx-glimpse/document build && pnpm --filter pptx-glimpse-renderer build && tsup",
     "bench": "vitest bench",
     "lint": "eslint packages/*/src/ vrt/ scripts/ bench/ e2e/",
     "lint:fix": "eslint packages/*/src/ vrt/ scripts/ bench/ e2e/ --fix",

--- a/packages/pptx-glimpse-document/package.json
+++ b/packages/pptx-glimpse-document/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@pptx-glimpse/document",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Experimental CleanDoc and OOXML document foundation for pptx-glimpse.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./experimental": {
+      "types": "./dist/experimental.d.ts",
+      "import": "./dist/experimental.js",
+      "require": "./dist/experimental.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/pptx-glimpse-document/src/experimental.ts
+++ b/packages/pptx-glimpse-document/src/experimental.ts
@@ -1,0 +1,9 @@
+export interface DocumentExperimentalApi {
+  readonly packageName: "@pptx-glimpse/document";
+  readonly status: "experimental";
+}
+
+export const documentExperimentalApi: DocumentExperimentalApi = {
+  packageName: "@pptx-glimpse/document",
+  status: "experimental",
+};

--- a/packages/pptx-glimpse-document/src/index.ts
+++ b/packages/pptx-glimpse-document/src/index.ts
@@ -1,0 +1,2 @@
+export type { DocumentExperimentalApi } from "./experimental.js";
+export { documentExperimentalApi } from "./experimental.js";

--- a/packages/pptx-glimpse-document/src/package-boundary.test.ts
+++ b/packages/pptx-glimpse-document/src/package-boundary.test.ts
@@ -1,0 +1,108 @@
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { documentExperimentalApi } from "./experimental.js";
+
+interface PackageJson {
+  readonly dependencies?: Record<string, string>;
+  readonly devDependencies?: Record<string, string>;
+  readonly exports?: Record<string, PackageJsonExport>;
+  readonly peerDependencies?: Record<string, string>;
+}
+
+interface PackageJsonExport {
+  readonly import?: string;
+  readonly require?: string;
+  readonly types?: string;
+}
+
+const FORBIDDEN_DEPENDENCIES = new Set([
+  "@hirokisakabe/pom",
+  "@pptx-glimpse/core",
+  "@pptx-glimpse/editor-core",
+  "@pptx-glimpse/renderer",
+  "pptx-glimpse",
+  "pptx-glimpse-renderer",
+]);
+
+const SOURCE_ROOT = new URL(".", import.meta.url);
+const PACKAGE_JSON = new URL("../package.json", import.meta.url);
+
+const IMPORT_PATTERN = /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?["']([^"']+)["']/g;
+
+async function listTypeScriptFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        return listTypeScriptFiles(path);
+      }
+
+      return extname(entry.name) === ".ts" && !entry.name.endsWith(".test.ts") ? [path] : [];
+    }),
+  );
+
+  return files.flat();
+}
+
+function parsePackageJson(text: string): PackageJson {
+  const parsed: unknown = JSON.parse(text);
+
+  return parsed as PackageJson;
+}
+
+describe("@pptx-glimpse/document package boundary", () => {
+  it("exposes the experimental entry point", async () => {
+    const packageJson = parsePackageJson(await readFile(PACKAGE_JSON, "utf8"));
+
+    expect(documentExperimentalApi).toEqual({
+      packageName: "@pptx-glimpse/document",
+      status: "experimental",
+    });
+    expect(packageJson.exports?.["./experimental"]).toEqual({
+      types: "./dist/experimental.d.ts",
+      import: "./dist/experimental.js",
+      require: "./dist/experimental.cjs",
+    });
+  });
+
+  it("does not declare dependencies on higher-level packages", async () => {
+    const packageJson = parsePackageJson(await readFile(PACKAGE_JSON, "utf8"));
+    const declaredDependencies = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+      ...packageJson.peerDependencies,
+    };
+
+    expect(Object.keys(declaredDependencies)).not.toContainEqual(
+      expect.stringMatching(
+        /^(?:@hirokisakabe\/pom|@pptx-glimpse\/(?:core|editor-core|renderer)|pptx-glimpse(?:-renderer)?)$/,
+      ),
+    );
+  });
+
+  it("does not import higher-level packages from source", async () => {
+    const sourceFiles = await listTypeScriptFiles(SOURCE_ROOT.pathname);
+    const violations: string[] = [];
+
+    await Promise.all(
+      sourceFiles.map(async (sourceFile) => {
+        const source = await readFile(sourceFile, "utf8");
+
+        for (const match of source.matchAll(IMPORT_PATTERN)) {
+          const specifier = match[1];
+
+          if (FORBIDDEN_DEPENDENCIES.has(specifier)) {
+            violations.push(`${relative(SOURCE_ROOT.pathname, sourceFile)} imports ${specifier}`);
+          }
+        }
+      }),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/pptx-glimpse-document/src/package-boundary.test.ts
+++ b/packages/pptx-glimpse-document/src/package-boundary.test.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import { extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -27,10 +28,21 @@ const FORBIDDEN_DEPENDENCIES = new Set([
   "pptx-glimpse-renderer",
 ]);
 
-const SOURCE_ROOT = new URL(".", import.meta.url);
+const SOURCE_ROOT = fileURLToPath(new URL(".", import.meta.url));
 const PACKAGE_JSON = new URL("../package.json", import.meta.url);
 
-const IMPORT_PATTERN = /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?["']([^"']+)["']/g;
+const IMPORT_PATTERN =
+  /\b(?:import\s*\(\s*["']([^"']+)["']|(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?["']([^"']+)["'])/g;
+
+function isForbiddenDependency(specifier: string): boolean {
+  for (const dependency of FORBIDDEN_DEPENDENCIES) {
+    if (specifier === dependency || specifier.startsWith(`${dependency}/`)) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 async function listTypeScriptFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -78,15 +90,11 @@ describe("@pptx-glimpse/document package boundary", () => {
       ...packageJson.peerDependencies,
     };
 
-    expect(Object.keys(declaredDependencies)).not.toContainEqual(
-      expect.stringMatching(
-        /^(?:@hirokisakabe\/pom|@pptx-glimpse\/(?:core|editor-core|renderer)|pptx-glimpse(?:-renderer)?)$/,
-      ),
-    );
+    expect(Object.keys(declaredDependencies).filter(isForbiddenDependency)).toEqual([]);
   });
 
   it("does not import higher-level packages from source", async () => {
-    const sourceFiles = await listTypeScriptFiles(SOURCE_ROOT.pathname);
+    const sourceFiles = await listTypeScriptFiles(SOURCE_ROOT);
     const violations: string[] = [];
 
     await Promise.all(
@@ -94,10 +102,10 @@ describe("@pptx-glimpse/document package boundary", () => {
         const source = await readFile(sourceFile, "utf8");
 
         for (const match of source.matchAll(IMPORT_PATTERN)) {
-          const specifier = match[1];
+          const specifier = match[1] ?? match[2];
 
-          if (FORBIDDEN_DEPENDENCIES.has(specifier)) {
-            violations.push(`${relative(SOURCE_ROOT.pathname, sourceFile)} imports ${specifier}`);
+          if (specifier !== undefined && isForbiddenDependency(specifier)) {
+            violations.push(`${relative(SOURCE_ROOT, sourceFile)} imports ${specifier}`);
           }
         }
       }),

--- a/packages/pptx-glimpse-document/src/package-boundary.test.ts
+++ b/packages/pptx-glimpse-document/src/package-boundary.test.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile } from "node:fs/promises";
-import { extname, join, relative } from "node:path";
+import { dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
@@ -29,6 +29,7 @@ const FORBIDDEN_DEPENDENCIES = new Set([
 ]);
 
 const SOURCE_ROOT = fileURLToPath(new URL(".", import.meta.url));
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const PACKAGE_JSON = new URL("../package.json", import.meta.url);
 
 const IMPORT_PATTERN =
@@ -42,6 +43,21 @@ function isForbiddenDependency(specifier: string): boolean {
   }
 
   return false;
+}
+
+function isExternalRelativeImport(sourceFile: string, specifier: string): boolean {
+  if (!specifier.startsWith(".")) {
+    return false;
+  }
+
+  const resolvedImportPath = resolve(dirname(sourceFile), specifier);
+  const relativeImportPath = relative(PACKAGE_ROOT, resolvedImportPath);
+
+  return (
+    relativeImportPath.startsWith(`..${sep}`) ||
+    relativeImportPath === ".." ||
+    isAbsolute(relativeImportPath)
+  );
 }
 
 async function listTypeScriptFiles(dir: string): Promise<string[]> {
@@ -104,7 +120,10 @@ describe("@pptx-glimpse/document package boundary", () => {
         for (const match of source.matchAll(IMPORT_PATTERN)) {
           const specifier = match[1] ?? match[2];
 
-          if (specifier !== undefined && isForbiddenDependency(specifier)) {
+          if (
+            specifier !== undefined &&
+            (isForbiddenDependency(specifier) || isExternalRelativeImport(sourceFile, specifier))
+          ) {
             violations.push(`${relative(SOURCE_ROOT, sourceFile)} imports ${specifier}`);
           }
         }

--- a/packages/pptx-glimpse-document/tsconfig.json
+++ b/packages/pptx-glimpse-document/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/pptx-glimpse-document/tsup.config.ts
+++ b/packages/pptx-glimpse-document/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/experimental.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,8 @@ importers:
 
   packages/pptx-glimpse-cli: {}
 
+  packages/pptx-glimpse-document: {}
+
   packages/pptx-glimpse-renderer:
     dependencies:
       '@resvg/resvg-wasm':


### PR DESCRIPTION
close #461

## 目的

`@pptx-glimpse/document` の最小 package skeleton を追加し、後続の CleanDoc source model / reader / writer 実装を積むための experimental entry point と build wiring を用意します。

## 変更内容

- `packages/pptx-glimpse-document/` を workspace package として追加
- `@pptx-glimpse/document/experimental` entry point を追加
- root `build` で document package も build するように配線
- document package が core / renderer / editor-core / pom に依存しないことを検証する boundary test を追加
- `AGENTS.md` に document package skeleton の位置づけを追記

## 影響範囲

- `packages/pptx-glimpse-document/`
- `package.json`
- `pnpm-lock.yaml`
- `AGENTS.md`

public `pptx-glimpse` の export / conversion path は変更していません。

## ローカル検証

- `pnpm run knip`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`
- `pnpm --filter @pptx-glimpse/document exec node -e "import('@pptx-glimpse/document/experimental').then((m)=>console.log(m.documentExperimentalApi.packageName, m.documentExperimentalApi.status))"`

## レビュー

- acceptance-check: 全受け入れ条件を満たすことを確認
- cross-review: critical / warning なし
