### PR TITLE
feat(document): CleanDoc source model 型を定義する

### DIFF
--- a/packages/pptx-glimpse-document/src/experimental.ts
+++ b/packages/pptx-glimpse-document/src/experimental.ts
@@ -7,3 +7,7 @@ export const documentExperimentalApi: DocumentExperimentalApi = {
   packageName: "@pptx-glimpse/document",
   status: "experimental",
 };
+
+// CleanDoc source model 型 (experimental)。後続の reader / writer / computed
+// view 実装が参照する source of truth の最小 contract。
+export * from "./source/index.js";

--- a/packages/pptx-glimpse-document/src/source/clean-doc-source.test.ts
+++ b/packages/pptx-glimpse-document/src/source/clean-doc-source.test.ts
@@ -88,7 +88,9 @@ describe("CleanDoc source model types", () => {
             ],
           },
         ],
-        media: [{ partPath: mediaPath, contentType: "image/png", bytes: new Uint8Array([1, 2, 3]) }],
+        media: [
+          { partPath: mediaPath, contentType: "image/png", bytes: new Uint8Array([1, 2, 3]) },
+        ],
         rawParts: [
           {
             partPath: asPartPath("docProps/custom.xml"),

--- a/packages/pptx-glimpse-document/src/source/clean-doc-source.test.ts
+++ b/packages/pptx-glimpse-document/src/source/clean-doc-source.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  asEmu,
+  asOoxmlAngle,
+  asPartPath,
+  asPt,
+  asRawSidecarId,
+  asRelationshipId,
+  asSourceNodeId,
+  type CleanDocSource,
+  type SourceImage,
+  type SourceShape,
+  type SourceTextRun,
+} from "./index.js";
+
+describe("CleanDoc source model types", () => {
+  it("can build a minimal CleanDocSource value", () => {
+    const slidePath = asPartPath("ppt/slides/slide1.xml");
+    const layoutPath = asPartPath("ppt/slideLayouts/slideLayout1.xml");
+    const masterPath = asPartPath("ppt/slideMasters/slideMaster1.xml");
+    const themePath = asPartPath("ppt/theme/theme1.xml");
+    const mediaPath = asPartPath("ppt/media/image1.png");
+
+    const shape: SourceShape = {
+      kind: "shape",
+      nodeId: asSourceNodeId("2"),
+      name: "Title 1",
+      transform: {
+        offsetX: asEmu(0),
+        offsetY: asEmu(0),
+        width: asEmu(9144000),
+        height: asEmu(1143000),
+        rotation: asOoxmlAngle(0),
+      },
+      geometry: { preset: "rect" },
+      fill: { kind: "solid", color: { kind: "scheme", scheme: "accent1" } },
+      textBody: {
+        paragraphs: [
+          {
+            properties: { align: "center" },
+            runs: [
+              {
+                kind: "textRun",
+                text: "Hello",
+                properties: { bold: true, fontSize: asPt(44) },
+              } satisfies SourceTextRun,
+            ],
+          },
+        ],
+      },
+      handle: {
+        partPath: slidePath,
+        nodeId: asSourceNodeId("2"),
+        orderingSlot: 0,
+        rawSidecarIds: [asRawSidecarId("sidecar-1")],
+      },
+    };
+
+    const image: SourceImage = {
+      kind: "image",
+      name: "Picture 1",
+      blipRelationshipId: asRelationshipId("rId2"),
+      handle: { partPath: slidePath, relationshipId: asRelationshipId("rId2") },
+    };
+
+    const source: CleanDocSource = {
+      packageGraph: {
+        contentTypes: {
+          defaults: [{ extension: "png", contentType: "image/png" }],
+          overrides: [
+            {
+              partName: slidePath,
+              contentType: "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+            },
+          ],
+        },
+        parts: [{ partPath: slidePath, contentType: "application/xml" }],
+        relationships: [
+          {
+            sourcePartPath: slidePath,
+            relationships: [
+              {
+                id: asRelationshipId("rId1"),
+                type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout",
+                target: "../slideLayouts/slideLayout1.xml",
+              },
+            ],
+          },
+        ],
+        media: [{ partPath: mediaPath, contentType: "image/png", bytes: new Uint8Array([1, 2, 3]) }],
+        rawParts: [
+          {
+            partPath: asPartPath("docProps/custom.xml"),
+            contentType: "application/xml",
+            xml: { name: "Properties" },
+          },
+        ],
+      },
+      presentation: {
+        partPath: asPartPath("ppt/presentation.xml"),
+        slideSize: { width: asEmu(9144000), height: asEmu(5143500) },
+        slidePartPaths: [slidePath],
+      },
+      slides: [{ partPath: slidePath, layoutPartPath: layoutPath, shapes: [shape, image] }],
+      slideLayouts: [{ partPath: layoutPath, masterPartPath: masterPath, shapes: [] }],
+      slideMasters: [
+        {
+          partPath: masterPath,
+          themePartPath: themePath,
+          layoutPartPaths: [layoutPath],
+          shapes: [],
+        },
+      ],
+      themes: [{ partPath: themePath, name: "Office Theme" }],
+      diagnostics: [
+        {
+          severity: "warning",
+          code: "unsupported-node-preserved",
+          message: "kept raw extLst",
+          handle: { partPath: slidePath },
+        },
+      ],
+    };
+
+    expect(source.slides[0]?.shapes).toHaveLength(2);
+    expect(source.presentation.slideSize?.width).toBe(9144000);
+    expect(source.themes[0]?.partPath).toBe("ppt/theme/theme1.xml");
+    expect(source.packageGraph.media[0]?.bytes).toEqual(new Uint8Array([1, 2, 3]));
+  });
+});

--- a/packages/pptx-glimpse-document/src/source/clean-doc-source.test.ts
+++ b/packages/pptx-glimpse-document/src/source/clean-doc-source.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+// 実際の公開面 (`@pptx-glimpse/document/experimental`) 経由で import し、
+// experimental entry point の re-export ごと検証する。
 import {
   asEmu,
   asOoxmlAngle,
+  asOoxmlPercent,
   asPartPath,
   asPt,
   asRawSidecarId,
@@ -12,7 +15,7 @@ import {
   type SourceImage,
   type SourceShape,
   type SourceTextRun,
-} from "./index.js";
+} from "../experimental.js";
 
 describe("CleanDoc source model types", () => {
   it("can build a minimal CleanDocSource value", () => {
@@ -35,7 +38,12 @@ describe("CleanDoc source model types", () => {
       },
       geometry: { preset: "rect" },
       fill: { kind: "solid", color: { kind: "scheme", scheme: "accent1" } },
+      outline: {
+        width: asEmu(12700),
+        fill: { kind: "solid", color: { kind: "srgb", hex: "000000" } },
+      },
       textBody: {
+        properties: { anchor: "middle", marginLeft: asEmu(91440) },
         paragraphs: [
           {
             properties: { align: "center" },
@@ -61,6 +69,7 @@ describe("CleanDoc source model types", () => {
       kind: "image",
       name: "Picture 1",
       blipRelationshipId: asRelationshipId("rId2"),
+      crop: { left: asOoxmlPercent(10000), top: asOoxmlPercent(0) },
       handle: { partPath: slidePath, relationshipId: asRelationshipId("rId2") },
     };
 
@@ -93,6 +102,7 @@ describe("CleanDoc source model types", () => {
         ],
         rawParts: [
           {
+            kind: "xml",
             partPath: asPartPath("docProps/custom.xml"),
             contentType: "application/xml",
             xml: { name: "Properties" },
@@ -104,17 +114,41 @@ describe("CleanDoc source model types", () => {
         slideSize: { width: asEmu(9144000), height: asEmu(5143500) },
         slidePartPaths: [slidePath],
       },
-      slides: [{ partPath: slidePath, layoutPartPath: layoutPath, shapes: [shape, image] }],
-      slideLayouts: [{ partPath: layoutPath, masterPartPath: masterPath, shapes: [] }],
+      slides: [
+        {
+          partPath: slidePath,
+          layoutPartPath: layoutPath,
+          background: {
+            kind: "fill",
+            fill: { kind: "solid", color: { kind: "scheme", scheme: "bg1" } },
+          },
+          colorMapOverride: { mapping: { bg1: "lt1", tx1: "dk1" } },
+          showMasterShapes: true,
+          shapes: [shape, image],
+        },
+      ],
+      slideLayouts: [
+        { partPath: layoutPath, masterPartPath: masterPath, type: "title", shapes: [] },
+      ],
       slideMasters: [
         {
           partPath: masterPath,
           themePartPath: themePath,
           layoutPartPaths: [layoutPath],
+          colorMap: { mapping: { bg1: "lt1", tx1: "dk1" } },
           shapes: [],
         },
       ],
-      themes: [{ partPath: themePath, name: "Office Theme" }],
+      themes: [
+        {
+          partPath: themePath,
+          name: "Office Theme",
+          colorScheme: {
+            colors: { dk1: { kind: "system", value: "windowText", lastColor: "000000" } },
+          },
+          fontScheme: { majorLatin: "Calibri Light", minorLatin: "Calibri" },
+        },
+      ],
       diagnostics: [
         {
           severity: "warning",
@@ -126,8 +160,10 @@ describe("CleanDoc source model types", () => {
     };
 
     expect(source.slides[0]?.shapes).toHaveLength(2);
+    expect(source.slides[0]?.showMasterShapes).toBe(true);
     expect(source.presentation.slideSize?.width).toBe(9144000);
     expect(source.themes[0]?.partPath).toBe("ppt/theme/theme1.xml");
+    expect(source.themes[0]?.fontScheme?.minorLatin).toBe("Calibri");
     expect(source.packageGraph.media[0]?.bytes).toEqual(new Uint8Array([1, 2, 3]));
   });
 });

--- a/packages/pptx-glimpse-document/src/source/clean-doc-source.ts
+++ b/packages/pptx-glimpse-document/src/source/clean-doc-source.ts
@@ -1,0 +1,31 @@
+/**
+ * CleanDoc source model のトップレベル型。
+ *
+ * `@pptx-glimpse/document` が所有する canonical な document 表現で、writer /
+ * editor / round-trip の source of truth となる。renderer-specific fallback や
+ * pixel output 固有の値は含まない (`docs/document-boundaries.md` /
+ * `docs/cleandoc-source-computed-view.md`)。computed view はこの source から
+ * 派生して生成する derived projection であり、本型には含めない。
+ */
+
+import type { Diagnostic } from "./diagnostics.js";
+import type { PackageGraph } from "./package-graph.js";
+import type {
+  SourcePresentation,
+  SourceSlide,
+  SourceSlideLayout,
+  SourceSlideMaster,
+  SourceTheme,
+} from "./presentation.js";
+
+export interface CleanDocSource {
+  /** package part / relationship / content type / media の構造。 */
+  readonly packageGraph: PackageGraph;
+  readonly presentation: SourcePresentation;
+  readonly slides: readonly SourceSlide[];
+  readonly slideLayouts: readonly SourceSlideLayout[];
+  readonly slideMasters: readonly SourceSlideMaster[];
+  readonly themes: readonly SourceTheme[];
+  /** document 正しさに関する診断。 */
+  readonly diagnostics: readonly Diagnostic[];
+}

--- a/packages/pptx-glimpse-document/src/source/diagnostics.ts
+++ b/packages/pptx-glimpse-document/src/source/diagnostics.ts
@@ -1,0 +1,18 @@
+/**
+ * Diagnostics の型。document の正しさ (round-trip / preservation / 参照解決) に
+ * 関する診断であり、rendering fidelity や UI 挙動の警告ではない
+ * (`docs/document-boundaries.md`)。
+ */
+
+import type { SourceHandle } from "./handles.js";
+
+export type DiagnosticSeverity = "info" | "warning" | "error";
+
+export interface Diagnostic {
+  readonly severity: DiagnosticSeverity;
+  /** 機械判別用の安定コード (例: `unsupported-node-dropped`)。 */
+  readonly code: string;
+  readonly message: string;
+  /** 診断の発生元 source node (特定できる場合)。 */
+  readonly handle?: SourceHandle;
+}

--- a/packages/pptx-glimpse-document/src/source/handles.ts
+++ b/packages/pptx-glimpse-document/src/source/handles.ts
@@ -17,7 +17,9 @@ declare const RawSidecarIdBrand: unique symbol;
 export type PartPath = string & { readonly [PartPathBrand]: typeof PartPathBrand };
 
 /** relationship id (例: `rId1`)。`_rels/*.rels` 由来。 */
-export type RelationshipId = string & { readonly [RelationshipIdBrand]: typeof RelationshipIdBrand };
+export type RelationshipId = string & {
+  readonly [RelationshipIdBrand]: typeof RelationshipIdBrand;
+};
 
 /** source part 内で要素を一意に指す id (spid / 生成 id 等)。 */
 export type SourceNodeId = string & { readonly [SourceNodeIdBrand]: typeof SourceNodeIdBrand };

--- a/packages/pptx-glimpse-document/src/source/handles.ts
+++ b/packages/pptx-glimpse-document/src/source/handles.ts
@@ -1,0 +1,60 @@
+/**
+ * Source handle 関連の型。
+ *
+ * CleanDoc source node は、書き戻し (writer) / 編集 (editor) / round-trip の
+ * ために「どの package part のどのノードから来たか」を stable な handle として
+ * 保持する。handle は直接の mutable pointer ではなく、安定した参照
+ * (part path / relationship id / node id / 兄弟内の順序 / raw sidecar 参照) で
+ * 構成する (`docs/raw-ooxml-round-trip.md` の Raw Preservation Granularity 参照)。
+ */
+
+declare const PartPathBrand: unique symbol;
+declare const RelationshipIdBrand: unique symbol;
+declare const SourceNodeIdBrand: unique symbol;
+declare const RawSidecarIdBrand: unique symbol;
+
+/** OOXML package 内の part path (例: `ppt/slides/slide1.xml`)。 */
+export type PartPath = string & { readonly [PartPathBrand]: typeof PartPathBrand };
+
+/** relationship id (例: `rId1`)。`_rels/*.rels` 由来。 */
+export type RelationshipId = string & { readonly [RelationshipIdBrand]: typeof RelationshipIdBrand };
+
+/** source part 内で要素を一意に指す id (spid / 生成 id 等)。 */
+export type SourceNodeId = string & { readonly [SourceNodeIdBrand]: typeof SourceNodeIdBrand };
+
+/** raw sidecar を指す id。 */
+export type RawSidecarId = string & { readonly [RawSidecarIdBrand]: typeof RawSidecarIdBrand };
+
+export function asPartPath(value: string): PartPath {
+  return value as PartPath;
+}
+
+export function asRelationshipId(value: string): RelationshipId {
+  return value as RelationshipId;
+}
+
+export function asSourceNodeId(value: string): SourceNodeId {
+  return value as SourceNodeId;
+}
+
+export function asRawSidecarId(value: string): RawSidecarId {
+  return value as RawSidecarId;
+}
+
+/**
+ * source node の出自を表す stable handle。writer は handle を見て、生成した
+ * ノードを既存 part に splice できるか、より広い scope を再生成すべきかを
+ * 判断する。
+ */
+export interface SourceHandle {
+  /** このノードを所有する package part。 */
+  readonly partPath: PartPath;
+  /** part 内でのノード id (取得できる場合)。 */
+  readonly nodeId?: SourceNodeId;
+  /** このノードを参照している relationship id (例: blip の `r:embed`)。 */
+  readonly relationshipId?: RelationshipId;
+  /** 親要素内での子の順序スロット。raw sidecar との順序復元に使う。 */
+  readonly orderingSlot?: number;
+  /** このノードに紐づく raw sidecar の id 群。 */
+  readonly rawSidecarIds?: readonly RawSidecarId[];
+}

--- a/packages/pptx-glimpse-document/src/source/index.ts
+++ b/packages/pptx-glimpse-document/src/source/index.ts
@@ -1,0 +1,72 @@
+/**
+ * CleanDoc source model 型の barrel re-export。
+ */
+
+export type {
+  Emu,
+  HundredthPt,
+  OoxmlAngle,
+  OoxmlPercent,
+  Pt,
+} from "./units.js";
+export { asEmu, asHundredthPt, asOoxmlAngle, asOoxmlPercent, asPt } from "./units.js";
+
+export type {
+  PartPath,
+  RawSidecarId,
+  RelationshipId,
+  SourceHandle,
+  SourceNodeId,
+} from "./handles.js";
+export {
+  asPartPath,
+  asRawSidecarId,
+  asRelationshipId,
+  asSourceNodeId,
+} from "./handles.js";
+
+export type { RawOoxmlNode, RawPackagePart, RawSidecar } from "./raw.js";
+
+export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
+
+export type {
+  ContentTypeDefault,
+  ContentTypeOverride,
+  ContentTypes,
+  MediaPart,
+  PackageGraph,
+  PackagePartRef,
+  PartRelationships,
+  Relationship,
+  RelationshipTargetMode,
+} from "./package-graph.js";
+
+export type {
+  SourceColor,
+  SourceColorTransform,
+  SourceFill,
+  SourceImage,
+  SourceParagraph,
+  SourceParagraphProperties,
+  SourcePlaceholder,
+  SourcePresetGeometry,
+  SourceRawShapeNode,
+  SourceRunProperties,
+  SourceShape,
+  SourceShapeNode,
+  SourceTextAlign,
+  SourceTextBody,
+  SourceTextRun,
+  SourceTransform,
+} from "./shapes.js";
+
+export type {
+  SlideSize,
+  SourcePresentation,
+  SourceSlide,
+  SourceSlideLayout,
+  SourceSlideMaster,
+  SourceTheme,
+} from "./presentation.js";
+
+export type { CleanDocSource } from "./clean-doc-source.js";

--- a/packages/pptx-glimpse-document/src/source/index.ts
+++ b/packages/pptx-glimpse-document/src/source/index.ts
@@ -2,15 +2,8 @@
  * CleanDoc source model 型の barrel re-export。
  */
 
-export type {
-  Emu,
-  HundredthPt,
-  OoxmlAngle,
-  OoxmlPercent,
-  Pt,
-} from "./units.js";
-export { asEmu, asHundredthPt, asOoxmlAngle, asOoxmlPercent, asPt } from "./units.js";
-
+export type { CleanDocSource } from "./clean-doc-source.js";
+export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
 export type {
   PartPath,
   RawSidecarId,
@@ -18,17 +11,7 @@ export type {
   SourceHandle,
   SourceNodeId,
 } from "./handles.js";
-export {
-  asPartPath,
-  asRawSidecarId,
-  asRelationshipId,
-  asSourceNodeId,
-} from "./handles.js";
-
-export type { RawOoxmlNode, RawPackagePart, RawSidecar } from "./raw.js";
-
-export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
-
+export { asPartPath, asRawSidecarId, asRelationshipId, asSourceNodeId } from "./handles.js";
 export type {
   ContentTypeDefault,
   ContentTypeOverride,
@@ -40,7 +23,15 @@ export type {
   Relationship,
   RelationshipTargetMode,
 } from "./package-graph.js";
-
+export type {
+  SlideSize,
+  SourcePresentation,
+  SourceSlide,
+  SourceSlideLayout,
+  SourceSlideMaster,
+  SourceTheme,
+} from "./presentation.js";
+export type { RawOoxmlNode, RawPackagePart, RawSidecar } from "./raw.js";
 export type {
   SourceColor,
   SourceColorTransform,
@@ -59,14 +50,5 @@ export type {
   SourceTextRun,
   SourceTransform,
 } from "./shapes.js";
-
-export type {
-  SlideSize,
-  SourcePresentation,
-  SourceSlide,
-  SourceSlideLayout,
-  SourceSlideMaster,
-  SourceTheme,
-} from "./presentation.js";
-
-export type { CleanDocSource } from "./clean-doc-source.js";
+export type { Emu, HundredthPt, OoxmlAngle, OoxmlPercent, Pt } from "./units.js";
+export { asEmu, asHundredthPt, asOoxmlAngle, asOoxmlPercent, asPt } from "./units.js";

--- a/packages/pptx-glimpse-document/src/source/index.ts
+++ b/packages/pptx-glimpse-document/src/source/index.ts
@@ -25,11 +25,15 @@ export type {
 } from "./package-graph.js";
 export type {
   SlideSize,
+  SourceBackground,
+  SourceColorMap,
   SourcePresentation,
   SourceSlide,
   SourceSlideLayout,
   SourceSlideMaster,
   SourceTheme,
+  SourceThemeColorScheme,
+  SourceThemeFontScheme,
 } from "./presentation.js";
 export type { RawOoxmlNode, RawPackagePart, RawSidecar } from "./raw.js";
 export type {
@@ -37,6 +41,8 @@ export type {
   SourceColorTransform,
   SourceFill,
   SourceImage,
+  SourceImageCrop,
+  SourceOutline,
   SourceParagraph,
   SourceParagraphProperties,
   SourcePlaceholder,
@@ -47,8 +53,10 @@ export type {
   SourceShapeNode,
   SourceTextAlign,
   SourceTextBody,
+  SourceTextBodyProperties,
   SourceTextRun,
   SourceTransform,
+  SourceVerticalAnchor,
 } from "./shapes.js";
 export type { Emu, HundredthPt, OoxmlAngle, OoxmlPercent, Pt } from "./units.js";
 export { asEmu, asHundredthPt, asOoxmlAngle, asOoxmlPercent, asPt } from "./units.js";

--- a/packages/pptx-glimpse-document/src/source/package-graph.ts
+++ b/packages/pptx-glimpse-document/src/source/package-graph.ts
@@ -1,0 +1,70 @@
+/**
+ * Package graph の型。package part / relationship / content type / media を
+ * source-model data として表す (`docs/raw-ooxml-round-trip.md` の Package
+ * Bookkeeping)。
+ */
+
+import type { PartPath, RelationshipId } from "./handles.js";
+import type { RawPackagePart } from "./raw.js";
+
+/** relationship の target mode。 */
+export type RelationshipTargetMode = "Internal" | "External";
+
+/** `_rels/*.rels` の 1 エントリ。 */
+export interface Relationship {
+  readonly id: RelationshipId;
+  /** relationship type URI。 */
+  readonly type: string;
+  /** sourcePartPath からの相対 target、もしくは external URL。 */
+  readonly target: string;
+  readonly targetMode?: RelationshipTargetMode;
+}
+
+/** ある source part が持つ relationship 群 (`<part>/_rels/<part>.rels`)。 */
+export interface PartRelationships {
+  readonly sourcePartPath: PartPath;
+  readonly relationships: readonly Relationship[];
+}
+
+/** `[Content_Types].xml` の Default エントリ (拡張子 → content type)。 */
+export interface ContentTypeDefault {
+  readonly extension: string;
+  readonly contentType: string;
+}
+
+/** `[Content_Types].xml` の Override エントリ (part 名 → content type)。 */
+export interface ContentTypeOverride {
+  readonly partName: PartPath;
+  readonly contentType: string;
+}
+
+export interface ContentTypes {
+  readonly defaults: readonly ContentTypeDefault[];
+  readonly overrides: readonly ContentTypeOverride[];
+}
+
+/** package part の参照 (path + content type)。 */
+export interface PackagePartRef {
+  readonly partPath: PartPath;
+  readonly contentType: string;
+}
+
+/** media asset (画像・音声・動画等) の part。bytes をそのまま保持する。 */
+export interface MediaPart {
+  readonly partPath: PartPath;
+  readonly contentType: string;
+  readonly bytes: Uint8Array;
+}
+
+/**
+ * package 全体の構造。content types / part 一覧 / part ごとの relationship /
+ * media、および未編集 part の raw fallback を保持する。
+ */
+export interface PackageGraph {
+  readonly contentTypes: ContentTypes;
+  readonly parts: readonly PackagePartRef[];
+  readonly relationships: readonly PartRelationships[];
+  readonly media: readonly MediaPart[];
+  /** typed に表現しない / 未編集の part を書き戻すための raw fallback。 */
+  readonly rawParts?: readonly RawPackagePart[];
+}

--- a/packages/pptx-glimpse-document/src/source/presentation.ts
+++ b/packages/pptx-glimpse-document/src/source/presentation.ts
@@ -1,0 +1,69 @@
+/**
+ * Presentation hierarchy の source 型。slide / layout / master / theme の参照
+ * 関係を part path で表す。各 part は分離したまま保持し、cascade (master →
+ * layout → slide) の解決は computed view の責務とする
+ * (`docs/cleandoc-source-computed-view.md`)。
+ */
+
+import type { PartPath, SourceHandle } from "./handles.js";
+import type { RawSidecar } from "./raw.js";
+import type { SourceShapeNode } from "./shapes.js";
+import type { Emu } from "./units.js";
+
+/** スライドサイズ (`p:sldSz`)。EMU で保持する。 */
+export interface SlideSize {
+  readonly width: Emu;
+  readonly height: Emu;
+}
+
+/** theme part (`ppt/theme/themeN.xml`)。 */
+export interface SourceTheme {
+  readonly partPath: PartPath;
+  readonly name?: string;
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** slide master part。theme と配下 layout を参照する。 */
+export interface SourceSlideMaster {
+  readonly partPath: PartPath;
+  /** この master が参照する theme part。 */
+  readonly themePartPath?: PartPath;
+  /** この master に属する layout part 群。 */
+  readonly layoutPartPaths: readonly PartPath[];
+  readonly shapes: readonly SourceShapeNode[];
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** slide layout part。親 master を参照する。 */
+export interface SourceSlideLayout {
+  readonly partPath: PartPath;
+  /** この layout の親 slide master part。 */
+  readonly masterPartPath: PartPath;
+  /** layout type (`p:sldLayout@type`)。 */
+  readonly type?: string;
+  readonly shapes: readonly SourceShapeNode[];
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** slide part。適用される layout を参照する。 */
+export interface SourceSlide {
+  readonly partPath: PartPath;
+  /** この slide が参照する layout part。 */
+  readonly layoutPartPath: PartPath;
+  readonly shapes: readonly SourceShapeNode[];
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** presentation part (`ppt/presentation.xml`)。slide の並び順を保持する。 */
+export interface SourcePresentation {
+  readonly partPath: PartPath;
+  readonly slideSize?: SlideSize;
+  /** `p:sldIdLst` の順序を反映した slide part path 列。 */
+  readonly slidePartPaths: readonly PartPath[];
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}

--- a/packages/pptx-glimpse-document/src/source/presentation.ts
+++ b/packages/pptx-glimpse-document/src/source/presentation.ts
@@ -1,13 +1,16 @@
 /**
  * Presentation hierarchy の source 型。slide / layout / master / theme の参照
  * 関係を part path で表す。各 part は分離したまま保持し、cascade (master →
- * layout → slide) の解決は computed view の責務とする
- * (`docs/cleandoc-source-computed-view.md`)。
+ * layout → slide) の **解決** は computed view の責務とする
+ * (`docs/cleandoc-source-computed-view.md`)。ただし解決に必要な素材
+ * (background / clrMap / clrMapOvr / theme scheme / showMasterSp) は、source が
+ * raw XML に戻らず保持できるよう source-local に置く
+ * (`docs/cleandoc-minimal-poc-scope.md` の Included PPTX Subset)。
  */
 
 import type { PartPath, SourceHandle } from "./handles.js";
 import type { RawSidecar } from "./raw.js";
-import type { SourceShapeNode } from "./shapes.js";
+import type { SourceColor, SourceFill, SourceShapeNode } from "./shapes.js";
 import type { Emu } from "./units.js";
 
 /** スライドサイズ (`p:sldSz`)。EMU で保持する。 */
@@ -16,10 +19,42 @@ export interface SlideSize {
   readonly height: Emu;
 }
 
+/**
+ * color map (`p:clrMap`) / color map override (`p:clrMapOvr`)。logical name
+ * (`bg1` / `tx1` / `accent1` 等) から theme scheme slot (`dk1` / `lt1` 等) への
+ * マッピングを未解決のまま保持する。
+ */
+export interface SourceColorMap {
+  readonly mapping: Readonly<Record<string, string>>;
+}
+
+/**
+ * slide / layout / master の background (`p:bg`)。直接 fill (`p:bgPr`) か、
+ * theme の style matrix 参照 (`p:bgRef`)、あるいは raw のいずれか。
+ */
+export type SourceBackground =
+  | { readonly kind: "fill"; readonly fill: SourceFill }
+  | { readonly kind: "styleReference"; readonly index: number; readonly color: SourceColor }
+  | { readonly kind: "raw"; readonly raw: RawSidecar };
+
+/** theme の color scheme (`a:clrScheme`)。slot 名 → 具体色の未変換マップ。 */
+export interface SourceThemeColorScheme {
+  /** `dk1` / `lt1` / `dk2` / `lt2` / `accent1`..`accent6` / `hlink` / `folHlink`。 */
+  readonly colors: Readonly<Record<string, SourceColor>>;
+}
+
+/** theme の font scheme (`a:fontScheme`) の最小 subset (major / minor latin)。 */
+export interface SourceThemeFontScheme {
+  readonly majorLatin?: string;
+  readonly minorLatin?: string;
+}
+
 /** theme part (`ppt/theme/themeN.xml`)。 */
 export interface SourceTheme {
   readonly partPath: PartPath;
   readonly name?: string;
+  readonly colorScheme?: SourceThemeColorScheme;
+  readonly fontScheme?: SourceThemeFontScheme;
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];
 }
@@ -31,6 +66,9 @@ export interface SourceSlideMaster {
   readonly themePartPath?: PartPath;
   /** この master に属する layout part 群。 */
   readonly layoutPartPaths: readonly PartPath[];
+  readonly background?: SourceBackground;
+  /** master の `p:clrMap`。 */
+  readonly colorMap?: SourceColorMap;
   readonly shapes: readonly SourceShapeNode[];
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];
@@ -43,6 +81,11 @@ export interface SourceSlideLayout {
   readonly masterPartPath: PartPath;
   /** layout type (`p:sldLayout@type`)。 */
   readonly type?: string;
+  readonly background?: SourceBackground;
+  /** layout の `p:clrMapOvr` (上書きする場合)。 */
+  readonly colorMapOverride?: SourceColorMap;
+  /** `p:sldLayout@showMasterSp` (master 図形の表示可否)。 */
+  readonly showMasterShapes?: boolean;
   readonly shapes: readonly SourceShapeNode[];
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];
@@ -53,6 +96,11 @@ export interface SourceSlide {
   readonly partPath: PartPath;
   /** この slide が参照する layout part。 */
   readonly layoutPartPath: PartPath;
+  readonly background?: SourceBackground;
+  /** slide の `p:clrMapOvr` (上書きする場合)。 */
+  readonly colorMapOverride?: SourceColorMap;
+  /** `p:sld@showMasterSp` (master 図形の表示可否)。 */
+  readonly showMasterShapes?: boolean;
   readonly shapes: readonly SourceShapeNode[];
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];

--- a/packages/pptx-glimpse-document/src/source/raw.ts
+++ b/packages/pptx-glimpse-document/src/source/raw.ts
@@ -35,13 +35,21 @@ export interface RawSidecar {
 
 /**
  * 未編集の package part をそのまま書き戻すための raw fallback。bytes (binary
- * asset) もしくは XML tree のいずれかで保持する。
+ * asset) もしくは XML tree の **いずれか一方** で保持する判別共用体。両持ち /
+ * 両欠の不正状態を型で排除する。
  */
-export interface RawPackagePart {
-  readonly partPath: PartPath;
-  readonly contentType: string;
-  /** binary part (画像・埋め込みワークブック等) の元バイト列。 */
-  readonly bytes?: Uint8Array;
-  /** XML part を tree として保持する場合の root ノード。 */
-  readonly xml?: RawOoxmlNode;
-}
+export type RawPackagePart =
+  | {
+      readonly kind: "binary";
+      readonly partPath: PartPath;
+      readonly contentType: string;
+      /** binary part (画像・埋め込みワークブック等) の元バイト列。 */
+      readonly bytes: Uint8Array;
+    }
+  | {
+      readonly kind: "xml";
+      readonly partPath: PartPath;
+      readonly contentType: string;
+      /** XML part を tree として保持する場合の root ノード。 */
+      readonly xml: RawOoxmlNode;
+    };

--- a/packages/pptx-glimpse-document/src/source/raw.ts
+++ b/packages/pptx-glimpse-document/src/source/raw.ts
@@ -1,0 +1,47 @@
+/**
+ * Raw OOXML escape hatch 関連の型 (`docs/raw-ooxml-round-trip.md`)。
+ *
+ * CleanDoc は supported semantics を typed field で表しつつ、未対応・部分対応の
+ * XML を raw sidecar として、未編集の part を raw package part として保持し、
+ * structural round-trip を成立させる。byte 一致は目標にしない。
+ */
+
+import type { PartPath, RawSidecarId } from "./handles.js";
+
+/**
+ * 部分的にパースされた raw OOXML ノード。namespace prefix 付きの qualified name、
+ * 属性、子ノード、テキストを保持する。CleanDoc が typed に表現しない要素
+ * (vendor extension / `mc:AlternateContent` / 未知の DrawingML 等) の保存に使う。
+ */
+export interface RawOoxmlNode {
+  /** namespace prefix を含む要素名 (例: `a:extLst`)。 */
+  readonly name: string;
+  readonly attributes?: Readonly<Record<string, string>>;
+  readonly children?: readonly RawOoxmlNode[];
+  /** 要素の text content (持つ場合)。 */
+  readonly text?: string;
+}
+
+/**
+ * CleanDoc source node に付随する raw XML sidecar。最も近い source node に
+ * 紐づけ、親要素内での順序メタデータを保持して書き戻し時の順序を復元する。
+ */
+export interface RawSidecar {
+  readonly id: RawSidecarId;
+  readonly node: RawOoxmlNode;
+  /** 所有要素の子並びにおける順序スロット。 */
+  readonly orderingSlot?: number;
+}
+
+/**
+ * 未編集の package part をそのまま書き戻すための raw fallback。bytes (binary
+ * asset) もしくは XML tree のいずれかで保持する。
+ */
+export interface RawPackagePart {
+  readonly partPath: PartPath;
+  readonly contentType: string;
+  /** binary part (画像・埋め込みワークブック等) の元バイト列。 */
+  readonly bytes?: Uint8Array;
+  /** XML part を tree として保持する場合の root ノード。 */
+  readonly xml?: RawOoxmlNode;
+}

--- a/packages/pptx-glimpse-document/src/source/shapes.ts
+++ b/packages/pptx-glimpse-document/src/source/shapes.ts
@@ -1,0 +1,142 @@
+/**
+ * Simple shape / text run / image の source node 型。
+ *
+ * PoC scope の最小 subset (simple shapes / text / images) のみを typed に表す。
+ * theme color や relationship は source では未解決の参照のまま保持し
+ * (`docs/cleandoc-source-computed-view.md`)、cascade 解決は computed view の
+ * 責務とする。未対応ノードは raw escape hatch で保存する。
+ */
+
+import type { RelationshipId, SourceHandle, SourceNodeId } from "./handles.js";
+import type { RawSidecar } from "./raw.js";
+import type { Emu, HundredthPt, OoxmlAngle, OoxmlPercent, Pt } from "./units.js";
+
+/** `a:xfrm` 由来の source transform。座標・サイズは EMU のまま保持する。 */
+export interface SourceTransform {
+  readonly offsetX: Emu;
+  readonly offsetY: Emu;
+  readonly width: Emu;
+  readonly height: Emu;
+  readonly rotation?: OoxmlAngle;
+  readonly flipHorizontal?: boolean;
+  readonly flipVertical?: boolean;
+}
+
+/** preset geometry (`a:prstGeom`) の source 参照。preset 名のみ保持する。 */
+export interface SourcePresetGeometry {
+  /** preset 名 (例: `rect`, `roundRect`)。 */
+  readonly preset: string;
+}
+
+/**
+ * 未解決の source color 参照。`schemeClr` は scheme 名のまま保持し、computed
+ * view で `clrMap` / `colorScheme` を経由して具体色へ解決する。
+ */
+export type SourceColor =
+  | { readonly kind: "srgb"; readonly hex: string; readonly transforms?: readonly SourceColorTransform[] }
+  | { readonly kind: "scheme"; readonly scheme: string; readonly transforms?: readonly SourceColorTransform[] };
+
+/** lumMod / tint / shade 等の色変換 (値は OOXML パーセンテージ)。 */
+export interface SourceColorTransform {
+  readonly kind: "lumMod" | "lumOff" | "tint" | "shade" | "alpha";
+  readonly value: OoxmlPercent;
+}
+
+/** shape の fill (source レベル、最小)。未対応 fill は raw で保存する。 */
+export type SourceFill =
+  | { readonly kind: "none" }
+  | { readonly kind: "solid"; readonly color: SourceColor }
+  | { readonly kind: "raw"; readonly raw: RawSidecar };
+
+/** placeholder 宣言 (`p:ph`)。type / idx を未解決のまま保持する。 */
+export interface SourcePlaceholder {
+  readonly type?: string;
+  readonly index?: number;
+}
+
+/** text run (`a:r`) の run プロパティ (`a:rPr`) の最小 subset。 */
+export interface SourceRunProperties {
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+  readonly underline?: boolean;
+  /** フォントサイズ。OOXML-domain では pt で保持する。 */
+  readonly fontSize?: Pt;
+  /** latin typeface 名 (theme token も含めて未解決のまま保持)。 */
+  readonly typeface?: string;
+  readonly color?: SourceColor;
+}
+
+/** text run (`a:r`)。 */
+export interface SourceTextRun {
+  readonly kind: "textRun";
+  readonly text: string;
+  readonly properties?: SourceRunProperties;
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+export type SourceTextAlign = "left" | "center" | "right" | "justify";
+
+/** paragraph (`a:p`) の段落プロパティ (`a:pPr`) の最小 subset。 */
+export interface SourceParagraphProperties {
+  readonly align?: SourceTextAlign;
+  /** インデントレベル (`a:pPr@lvl`)。 */
+  readonly level?: number;
+  /** 行間 (`a:spcPts`)。 */
+  readonly lineSpacingPts?: HundredthPt;
+}
+
+/** paragraph (`a:p`)。 */
+export interface SourceParagraph {
+  readonly runs: readonly SourceTextRun[];
+  readonly properties?: SourceParagraphProperties;
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** text body (`p:txBody`)。 */
+export interface SourceTextBody {
+  readonly paragraphs: readonly SourceParagraph[];
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** simple shape (`p:sp`)。 */
+export interface SourceShape {
+  readonly kind: "shape";
+  readonly nodeId?: SourceNodeId;
+  readonly name?: string;
+  readonly transform?: SourceTransform;
+  readonly geometry?: SourcePresetGeometry;
+  readonly fill?: SourceFill;
+  readonly textBody?: SourceTextBody;
+  readonly placeholder?: SourcePlaceholder;
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** image (`p:pic`)。blip は relationship id (`r:embed`) を未解決のまま保持する。 */
+export interface SourceImage {
+  readonly kind: "image";
+  readonly nodeId?: SourceNodeId;
+  readonly name?: string;
+  readonly transform?: SourceTransform;
+  /** `a:blip@r:embed` の relationship id。media part は computed view で解決する。 */
+  readonly blipRelationshipId?: RelationshipId;
+  readonly handle?: SourceHandle;
+  readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/**
+ * typed に表現しない shape tree ノードの raw escape hatch。未対応の図形・
+ * グループ・コネクタ等を round-trip のために保存する。
+ */
+export interface SourceRawShapeNode {
+  readonly kind: "raw";
+  readonly nodeId?: SourceNodeId;
+  readonly raw: RawSidecar;
+  readonly handle?: SourceHandle;
+}
+
+/** shape tree の source node 共用体。 */
+export type SourceShapeNode = SourceShape | SourceImage | SourceRawShapeNode;

--- a/packages/pptx-glimpse-document/src/source/shapes.ts
+++ b/packages/pptx-glimpse-document/src/source/shapes.ts
@@ -30,7 +30,8 @@ export interface SourcePresetGeometry {
 
 /**
  * 未解決の source color 参照。`schemeClr` は scheme 名のまま保持し、computed
- * view で `clrMap` / `colorScheme` を経由して具体色へ解決する。
+ * view で `clrMap` / `colorScheme` を経由して具体色へ解決する。`srgbClr` /
+ * `sysClr` は具体値だが、変換 (lumMod 等) は適用前のまま保持する。
  */
 export type SourceColor =
   | {
@@ -41,6 +42,14 @@ export type SourceColor =
   | {
       readonly kind: "scheme";
       readonly scheme: string;
+      readonly transforms?: readonly SourceColorTransform[];
+    }
+  | {
+      readonly kind: "system";
+      /** `a:sysClr@val` (例: `windowText`)。 */
+      readonly value: string;
+      /** `a:sysClr@lastClr` の解決済みフォールバック hex (持つ場合)。 */
+      readonly lastColor?: string;
       readonly transforms?: readonly SourceColorTransform[];
     };
 
@@ -55,6 +64,12 @@ export type SourceFill =
   | { readonly kind: "none" }
   | { readonly kind: "solid"; readonly color: SourceColor }
   | { readonly kind: "raw"; readonly raw: RawSidecar };
+
+/** simple solid line の outline (`a:ln`)。色と幅のみの最小表現。 */
+export interface SourceOutline {
+  readonly width?: Emu;
+  readonly fill?: SourceFill;
+}
 
 /** placeholder 宣言 (`p:ph`)。type / idx を未解決のまま保持する。 */
 export interface SourcePlaceholder {
@@ -102,9 +117,22 @@ export interface SourceParagraph {
   readonly rawSidecars?: readonly RawSidecar[];
 }
 
+/** vertical anchor (`a:bodyPr@anchor`)。 */
+export type SourceVerticalAnchor = "top" | "middle" | "bottom";
+
+/** text body properties (`a:bodyPr`) の最小 subset。inset と vertical anchor。 */
+export interface SourceTextBodyProperties {
+  readonly marginLeft?: Emu;
+  readonly marginRight?: Emu;
+  readonly marginTop?: Emu;
+  readonly marginBottom?: Emu;
+  readonly anchor?: SourceVerticalAnchor;
+}
+
 /** text body (`p:txBody`)。 */
 export interface SourceTextBody {
   readonly paragraphs: readonly SourceParagraph[];
+  readonly properties?: SourceTextBodyProperties;
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];
 }
@@ -117,10 +145,19 @@ export interface SourceShape {
   readonly transform?: SourceTransform;
   readonly geometry?: SourcePresetGeometry;
   readonly fill?: SourceFill;
+  readonly outline?: SourceOutline;
   readonly textBody?: SourceTextBody;
   readonly placeholder?: SourcePlaceholder;
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];
+}
+
+/** image の crop (`a:srcRect`)。各辺の inset を OOXML パーセンテージで保持する。 */
+export interface SourceImageCrop {
+  readonly left?: OoxmlPercent;
+  readonly top?: OoxmlPercent;
+  readonly right?: OoxmlPercent;
+  readonly bottom?: OoxmlPercent;
 }
 
 /** image (`p:pic`)。blip は relationship id (`r:embed`) を未解決のまま保持する。 */
@@ -131,6 +168,7 @@ export interface SourceImage {
   readonly transform?: SourceTransform;
   /** `a:blip@r:embed` の relationship id。media part は computed view で解決する。 */
   readonly blipRelationshipId?: RelationshipId;
+  readonly crop?: SourceImageCrop;
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];
 }

--- a/packages/pptx-glimpse-document/src/source/shapes.ts
+++ b/packages/pptx-glimpse-document/src/source/shapes.ts
@@ -33,8 +33,16 @@ export interface SourcePresetGeometry {
  * view で `clrMap` / `colorScheme` を経由して具体色へ解決する。
  */
 export type SourceColor =
-  | { readonly kind: "srgb"; readonly hex: string; readonly transforms?: readonly SourceColorTransform[] }
-  | { readonly kind: "scheme"; readonly scheme: string; readonly transforms?: readonly SourceColorTransform[] };
+  | {
+      readonly kind: "srgb";
+      readonly hex: string;
+      readonly transforms?: readonly SourceColorTransform[];
+    }
+  | {
+      readonly kind: "scheme";
+      readonly scheme: string;
+      readonly transforms?: readonly SourceColorTransform[];
+    };
 
 /** lumMod / tint / shade 等の色変換 (値は OOXML パーセンテージ)。 */
 export interface SourceColorTransform {

--- a/packages/pptx-glimpse-document/src/source/units.ts
+++ b/packages/pptx-glimpse-document/src/source/units.ts
@@ -1,0 +1,55 @@
+/**
+ * CleanDoc source model が使う PPTX-native な typed units。
+ *
+ * source model は pixel 変換を持たず、OOXML が定義する単位系をそのまま
+ * 型として保持する。renderer 側の単位型 (`@pptx-glimpse/renderer`) は
+ * 下位基盤である `@pptx-glimpse/document` から参照できないため、ここで
+ * 独立に branded type を定義する。ランタイムコストはゼロ (JS 出力は
+ * plain number と同一)。
+ */
+
+declare const EmuBrand: unique symbol;
+declare const PtBrand: unique symbol;
+declare const HundredthPtBrand: unique symbol;
+declare const OoxmlPercentBrand: unique symbol;
+declare const OoxmlAngleBrand: unique symbol;
+
+/** English Metric Units (1 inch = 914,400 EMU)。座標・サイズに使う。 */
+export type Emu = number & { readonly [EmuBrand]: typeof EmuBrand };
+
+/** ポイント (1 pt = 1/72 inch)。フォントサイズに使う。 */
+export type Pt = number & { readonly [PtBrand]: typeof PtBrand };
+
+/** 1/100 ポイント (ECMA-376 `a:spcPts` 等)。 */
+export type HundredthPt = number & { readonly [HundredthPtBrand]: typeof HundredthPtBrand };
+
+/**
+ * OOXML パーセンテージ (ST_Percentage)。整数値で 1% = 1000。
+ * `a:spcPct` / `a:lumMod` / `a:tint` 等の transform で使う。
+ */
+export type OoxmlPercent = number & { readonly [OoxmlPercentBrand]: typeof OoxmlPercentBrand };
+
+/**
+ * OOXML 角度 (ST_Angle)。1 度 = 60,000。`a:xfrm@rot` 等で使う。
+ */
+export type OoxmlAngle = number & { readonly [OoxmlAngleBrand]: typeof OoxmlAngleBrand };
+
+export function asEmu(value: number): Emu {
+  return value as Emu;
+}
+
+export function asPt(value: number): Pt {
+  return value as Pt;
+}
+
+export function asHundredthPt(value: number): HundredthPt {
+  return value as HundredthPt;
+}
+
+export function asOoxmlPercent(value: number): OoxmlPercent {
+  return value as OoxmlPercent;
+}
+
+export function asOoxmlAngle(value: number): OoxmlAngle {
+  return value as OoxmlAngle;
+}


### PR DESCRIPTION
close #462

## 概要

`@pptx-glimpse/document` (experimental) に CleanDoc source model の最小 TypeScript 型を定義する。親 issue #460 の sub-issue で、後続の reader / writer / computed view 実装が参照する source of truth の最小 contract を用意する。

## 背景

- #450: CleanDoc は canonical source model、computed view は derived projection
- #451: structural preservation と raw sidecar 方針
- source model は writer/editor/round-trip の source of truth として設計し、renderer-specific fields や pixel 変換は含めない

決定記録 `docs/document-boundaries.md` / `docs/cleandoc-source-computed-view.md` / `docs/raw-ooxml-round-trip.md` / `docs/cleandoc-minimal-poc-scope.md` に準拠。

## 変更内容

`packages/pptx-glimpse-document/src/source/` に型を新規追加し、`experimental.ts` から re-export:

- **units**: EMU / pt / 1/100pt / OOXML percent / OOXML angle の branded typed units (pixel 変換なし)
- **handles**: part path / relationship id / source node id / raw sidecar id と `SourceHandle`
- **raw**: `RawOoxmlNode` / `RawSidecar` / `RawPackagePart` (binary/xml 判別共用体) の escape hatch
- **diagnostics**: document 正しさの `Diagnostic`
- **package-graph**: package part / relationship / content type / media
- **shapes**: simple shape / text run / image の source node。outline / text body properties / image crop を含み、theme color や relationship は未解決のまま保持
- **presentation**: slide / layout / master / theme の参照関係。background / clrMap / clrMapOvr / theme color・font scheme / showMasterSp を source-local に保持
- **clean-doc-source**: トップレベル `CleanDocSource`

cross-review (codex) の指摘を反映し、`RawPackagePart` の不正状態排除、cascade 解決素材の source 保持、PoC subset フィールド追加、公開 entry 経由のテスト検証を行った。

## 影響パッケージ

- `packages/pptx-glimpse-document/` のみ (experimental・private。公開 conversion path からは未参照)

## ローカル検証

- `npm run typecheck` ✓
- `npm run lint` / `npm run format:check` ✓
- `npx knip` ✓
- `npm run test -- packages/pptx-glimpse-document` ✓
- `cd packages/pptx-glimpse-document && npm run build` ✓

## 補足

`@pptx-glimpse/document` は `private: true` で公開 `pptx-glimpse` パッケージの挙動に影響しないため changeset は追加していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
