### PR TITLE
feat(document): package graph と presentation metadata の readPptx を実装

### DIFF
--- a/packages/pptx-glimpse-document/package.json
+++ b/packages/pptx-glimpse-document/package.json
@@ -22,6 +22,10 @@
   "scripts": {
     "build": "tsup"
   },
+  "dependencies": {
+    "fast-xml-parser": "^5.7.3",
+    "fflate": "^0.8.2"
+  },
   "files": [
     "dist"
   ],

--- a/packages/pptx-glimpse-document/src/experimental.ts
+++ b/packages/pptx-glimpse-document/src/experimental.ts
@@ -11,3 +11,7 @@ export const documentExperimentalApi: DocumentExperimentalApi = {
 // CleanDoc source model 型 (experimental)。後続の reader / writer / computed
 // view 実装が参照する source of truth の最小 contract。
 export * from "./source/index.js";
+
+// CleanDoc source reader (experimental)。PPTX package を読み、package graph と
+// presentation metadata を含む CleanDoc source を返す。
+export * from "./reader/index.js";

--- a/packages/pptx-glimpse-document/src/reader/index.ts
+++ b/packages/pptx-glimpse-document/src/reader/index.ts
@@ -1,0 +1,6 @@
+/**
+ * CleanDoc source reader の barrel re-export。
+ */
+
+export type { ReadPptxInput } from "./read-pptx.js";
+export { readPptx } from "./read-pptx.js";

--- a/packages/pptx-glimpse-document/src/reader/read-pptx.test.ts
+++ b/packages/pptx-glimpse-document/src/reader/read-pptx.test.ts
@@ -174,6 +174,57 @@ describe("readPptx — package graph と presentation metadata", () => {
     });
     expect(() => readPptx(bogus)).toThrow(/presentation part not found/);
   });
+
+  it("officeDocument relationship が presentation 以外を指す場合はエラーを投げる", () => {
+    const bogus = zipSync({
+      "[Content_Types].xml": xml(
+        `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+          `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+          `<Default Extension="xml" ContentType="application/xml"/>` +
+          `</Types>`,
+      ),
+      "_rels/.rels": xml(
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+          // officeDocument が誤って別 XML part を指している。
+          `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="docProps/app.xml"/>` +
+          `</Relationships>`,
+      ),
+      "docProps/app.xml": xml(`<Properties/>`),
+    });
+    expect(() => readPptx(bogus)).toThrow(/not a presentation part/);
+  });
+
+  it("p:sldId が slide 以外の relationship を指す場合は除外し diagnostic を残す", () => {
+    const bogus = zipSync({
+      "[Content_Types].xml": xml(
+        `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+          `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+          `<Default Extension="xml" ContentType="application/xml"/>` +
+          `</Types>`,
+      ),
+      "_rels/.rels": xml(
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+          `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+          `</Relationships>`,
+      ),
+      "ppt/presentation.xml": xml(
+        `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+          `<p:sldIdLst><p:sldId id="256" r:id="rIdBogus"/></p:sldIdLst>` +
+          `</p:presentation>`,
+      ),
+      "ppt/_rels/presentation.xml.rels": xml(
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+          // slide ではなく notesMaster を指す relationship。
+          `<Relationship Id="rIdBogus" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster" Target="notesMasters/notesMaster1.xml"/>` +
+          `</Relationships>`,
+      ),
+    });
+    const result = readPptx(bogus);
+    expect(result.presentation.slidePartPaths).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "slide-relationship-invalid" }),
+    );
+  });
 });
 
 describe("readPptx — real fixture smoke test", () => {

--- a/packages/pptx-glimpse-document/src/reader/read-pptx.test.ts
+++ b/packages/pptx-glimpse-document/src/reader/read-pptx.test.ts
@@ -1,0 +1,204 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { zipSync } from "fflate";
+import { describe, expect, it } from "vitest";
+
+// 実際の公開面 (`@pptx-glimpse/document/experimental`) 経由で import する。
+import { readPptx } from "../experimental.js";
+
+const encoder = new TextEncoder();
+
+function xml(content: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+/**
+ * 受け入れ条件を精密に検証するための合成 PPTX。slide 2 枚 (順序が rId と
+ * 逆になるよう意図的に並べる)、media 1 つ、未対応 part (docProps/custom.xml)、
+ * external relationship、`../` を含む相対 target を含む。
+ */
+function buildSyntheticPptx(): Uint8Array {
+  const files: Record<string, Uint8Array> = {
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Default Extension="png" ContentType="image/png"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst>` +
+        // sldIdLst の並び順 (slide1 → slide2) が slide order の真実。
+        `<p:sldId id="256" r:id="rIdSlide1"/>` +
+        `<p:sldId id="257" r:id="rIdSlide2"/>` +
+        `</p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `<Relationship Id="rIdSlide2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(`<p:sld xmlns:p="x"><p:cSld/></p:sld>`),
+    "ppt/slides/slide2.xml": xml(`<p:sld xmlns:p="x"><p:cSld/></p:sld>`),
+    "ppt/slides/_rels/slide1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        // `../` を含む相対 target と external relationship。
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>` +
+        `<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/" TargetMode="External"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/media/image1.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
+    "docProps/custom.xml": xml(`<Properties><custom/></Properties>`),
+  };
+  return zipSync(files);
+}
+
+describe("readPptx — package graph と presentation metadata", () => {
+  const source = readPptx(buildSyntheticPptx());
+
+  it("presentation metadata を含む CleanDoc source を返す", () => {
+    expect(source.presentation.partPath).toBe("ppt/presentation.xml");
+    expect(source.presentation.handle?.partPath).toBe("ppt/presentation.xml");
+    // typed slide/layout/master/theme reading は本 slice の scope 外。
+    expect(source.slides).toEqual([]);
+    expect(source.slideLayouts).toEqual([]);
+    expect(source.slideMasters).toEqual([]);
+    expect(source.themes).toEqual([]);
+  });
+
+  it("slide count / slide order / slide size を取得できる", () => {
+    expect(source.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(source.presentation.slideSize).toEqual({ width: 9144000, height: 5143500 });
+  });
+
+  it("relationship IDs / targets / target modes を保持できる", () => {
+    const slideRels = source.packageGraph.relationships.find(
+      (rel) => rel.sourcePartPath === "ppt/slides/slide1.xml",
+    );
+    expect(slideRels?.relationships).toEqual([
+      {
+        id: "rId1",
+        type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+        target: "../media/image1.png",
+      },
+      {
+        id: "rId2",
+        type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+        target: "https://example.com/",
+        targetMode: "External",
+      },
+    ]);
+
+    // package root の rels は sourcePartPath を "" として保持する。
+    const rootRels = source.packageGraph.relationships.find((rel) => rel.sourcePartPath === "");
+    expect(rootRels?.relationships[0]?.id).toBe("rId1");
+  });
+
+  it("content type defaults / overrides を保持できる", () => {
+    expect(source.packageGraph.contentTypes.defaults).toContainEqual({
+      extension: "png",
+      contentType: "image/png",
+    });
+    // override の PartName は先頭スラッシュを除去して PartPath に正規化する。
+    expect(source.packageGraph.contentTypes.overrides).toContainEqual({
+      partName: "ppt/slides/slide1.xml",
+      contentType: "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+    });
+  });
+
+  it("media bytes と part paths を保持できる", () => {
+    expect(source.packageGraph.media).toEqual([
+      {
+        partPath: "ppt/media/image1.png",
+        contentType: "image/png",
+        bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
+      },
+    ]);
+  });
+
+  it("unsupported package parts を raw material として保持できる", () => {
+    const rawPaths = source.packageGraph.rawParts?.map((part) => part.partPath) ?? [];
+    // 未対応 part / typed 化しない slide / presentation は raw として保持する。
+    expect(rawPaths).toContain("docProps/custom.xml");
+    expect(rawPaths).toContain("ppt/slides/slide1.xml");
+    expect(rawPaths).toContain("ppt/presentation.xml");
+    // content types / rels / media は structural data / media として別管理し raw に含めない。
+    expect(rawPaths).not.toContain("[Content_Types].xml");
+    expect(rawPaths).not.toContain("ppt/media/image1.png");
+    expect(rawPaths.some((path) => path.endsWith(".rels"))).toBe(false);
+
+    const customPart = source.packageGraph.rawParts?.find(
+      (part) => part.partPath === "docProps/custom.xml",
+    );
+    expect(customPart?.kind).toBe("binary");
+    expect(customPart?.contentType).toBe("application/xml");
+  });
+
+  it("part manifest が全 part を content type 付きで列挙する", () => {
+    const partMap = new Map(
+      source.packageGraph.parts.map((part) => [part.partPath, part.contentType]),
+    );
+    expect(partMap.get("ppt/media/image1.png")).toBe("image/png");
+    expect(partMap.get("ppt/slides/slide1.xml")).toBe(
+      "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+    );
+    // rels part は Default extension で content type を解決する。
+    expect(partMap.get("ppt/_rels/presentation.xml.rels")).toBe(
+      "application/vnd.openxmlformats-package.relationships+xml",
+    );
+    // [Content_Types].xml 自体は part manifest に含めない。
+    expect(partMap.has("[Content_Types].xml")).toBe(false);
+  });
+
+  it("presentation part が無い場合はエラーを投げる", () => {
+    const bogus = zipSync({
+      "[Content_Types].xml": xml(
+        `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>`,
+      ),
+    });
+    expect(() => readPptx(bogus)).toThrow(/presentation part not found/);
+  });
+});
+
+describe("readPptx — real fixture smoke test", () => {
+  const fixturePath = fileURLToPath(
+    new URL("../../../../shared-fixtures/real-basic-theme.pptx", import.meta.url),
+  );
+  const source = readPptx(readFileSync(fixturePath));
+
+  it("real-basic-theme から slide order / size / media を読める", () => {
+    expect(source.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(source.presentation.slideSize?.width).toBeGreaterThan(0);
+    expect(source.presentation.slideSize?.height).toBeGreaterThan(0);
+
+    const image = source.packageGraph.media.find(
+      (part) => part.partPath === "ppt/media/image1.png",
+    );
+    expect(image?.contentType).toBe("image/png");
+    expect(image && image.bytes.length).toBeGreaterThan(0);
+
+    // 全 slide part が raw として round-trip 用に保持されている。
+    const rawPaths = source.packageGraph.rawParts?.map((part) => part.partPath) ?? [];
+    expect(rawPaths).toContain("ppt/slides/slide1.xml");
+    expect(rawPaths).toContain("ppt/slides/slide2.xml");
+  });
+});

--- a/packages/pptx-glimpse-document/src/reader/read-pptx.ts
+++ b/packages/pptx-glimpse-document/src/reader/read-pptx.ts
@@ -51,6 +51,7 @@ const PACKAGE_ROOT_PART = "";
 
 const OFFICE_DOCUMENT_REL_TYPE =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+const SLIDE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide";
 const PRESENTATION_CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml";
 
@@ -206,6 +207,13 @@ function readPresentation(
 
   const presentationPartPath = asPartPath(presentationPath);
   const root = getChild(parseXml(textDecoder.decode(bytes)), "presentation");
+  if (root === undefined) {
+    // 解決した part が `<p:presentation>` でない (relationship / content type が
+    // 別 part を指している等) 場合に、壊れた package を「読めた」ように見せない。
+    throw new Error(
+      `readPptx: part '${presentationPath}' is not a presentation part (missing p:presentation root)`,
+    );
+  }
 
   const slideSize = readSlideSize(root);
   const presentationRels = relationships.find(
@@ -217,17 +225,29 @@ function readPresentation(
   for (const sldId of getChildArray(sldIdLst, "sldId")) {
     const relId = getNamespacedAttr(sldId, "id");
     if (relId === undefined) continue;
-    const target = presentationRels?.find((rel) => rel.id === relId)?.target;
-    if (target === undefined) {
+    const handle = { partPath: presentationPartPath, relationshipId: asRelationshipId(relId) };
+    const relationship = presentationRels?.find((rel) => rel.id === relId);
+    if (relationship === undefined) {
       diagnostics.push({
         severity: "warning",
         code: "slide-relationship-unresolved",
         message: `slide relationship '${relId}' referenced by presentation could not be resolved`,
-        handle: { partPath: presentationPartPath, relationshipId: asRelationshipId(relId) },
+        handle,
       });
       continue;
     }
-    slidePartPaths.push(asPartPath(resolveTarget(presentationPath, target)));
+    // sldId が指す relationship は slide 内部参照のはず。type / targetMode が
+    // 一致しないものを slidePartPaths に混ぜると契約が壊れるため除外する。
+    if (relationship.type !== SLIDE_REL_TYPE || relationship.targetMode === "External") {
+      diagnostics.push({
+        severity: "warning",
+        code: "slide-relationship-invalid",
+        message: `relationship '${relId}' referenced by p:sldId is not an internal slide relationship`,
+        handle,
+      });
+      continue;
+    }
+    slidePartPaths.push(asPartPath(resolveTarget(presentationPath, relationship.target)));
   }
 
   return {
@@ -260,7 +280,9 @@ function locatePresentationPart(
   const rootRels = relationships.find(
     (rel) => rel.sourcePartPath === PACKAGE_ROOT_PART,
   )?.relationships;
-  const officeDocumentRel = rootRels?.find((rel) => rel.type === OFFICE_DOCUMENT_REL_TYPE);
+  const officeDocumentRel = rootRels?.find(
+    (rel) => rel.type === OFFICE_DOCUMENT_REL_TYPE && rel.targetMode !== "External",
+  );
   if (officeDocumentRel !== undefined) {
     return resolveTarget(PACKAGE_ROOT_PART, officeDocumentRel.target);
   }

--- a/packages/pptx-glimpse-document/src/reader/read-pptx.ts
+++ b/packages/pptx-glimpse-document/src/reader/read-pptx.ts
@@ -1,0 +1,352 @@
+/**
+ * `readPptx(input)` — CleanDoc source reader の最初の slice。
+ *
+ * PPTX ZIP package を読み、package graph (content types / relationships /
+ * media) と presentation metadata (slide size / slide order) を CleanDoc source
+ * として返す。未編集・未対応の part は raw package material として保持し、
+ * structural round-trip の土台にする (`docs/raw-ooxml-round-trip.md`)。
+ *
+ * 本 slice の scope 外 (後続 issue):
+ * - shape / text / image source node の typed parsing → slide/layout/master/
+ *   theme part は raw として保持しつつ、typed 配列は空のままにする。
+ * - computed view 生成 / writer 出力。
+ *
+ * そのため `slides` / `slideLayouts` / `slideMasters` / `themes` は空配列を返し、
+ * これらの part は `packageGraph.rawParts` 経由で round-trip 可能な形で保持する。
+ */
+
+import { unzipSync } from "fflate";
+
+import type {
+  CleanDocSource,
+  ContentTypeDefault,
+  ContentTypeOverride,
+  Diagnostic,
+  MediaPart,
+  PackagePartRef,
+  PartPath,
+  PartRelationships,
+  RawPackagePart,
+  Relationship,
+  RelationshipTargetMode,
+  SlideSize,
+  SourcePresentation,
+} from "../source/index.js";
+import { asEmu, asPartPath, asRelationshipId } from "../source/index.js";
+import {
+  getAttr,
+  getChild,
+  getChildArray,
+  getNamespacedAttr,
+  parseXml,
+  type XmlNode,
+} from "./xml.js";
+
+/** `readPptx` の入力。`Buffer` は `Uint8Array` のサブクラスとして受け付ける。 */
+export type ReadPptxInput = Uint8Array;
+
+const CONTENT_TYPES_PART = "[Content_Types].xml";
+const RELS_SUFFIX = ".rels";
+const PACKAGE_ROOT_PART = "";
+
+const OFFICE_DOCUMENT_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+const PRESENTATION_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml";
+
+const textDecoder = new TextDecoder();
+
+/**
+ * PPTX バイト列を読み、CleanDoc source を返す。
+ *
+ * @throws presentation part が見つからない (= 有効な PPTX ではない) 場合。
+ */
+export function readPptx(input: ReadPptxInput): CleanDocSource {
+  const entries = unzipPackage(input);
+  const diagnostics: Diagnostic[] = [];
+
+  const contentTypes = readContentTypes(entries);
+  const relationships = readRelationships(entries);
+
+  const parts: PackagePartRef[] = [];
+  const media: MediaPart[] = [];
+  const rawParts: RawPackagePart[] = [];
+
+  for (const [path, bytes] of entries) {
+    if (path === CONTENT_TYPES_PART) continue;
+    const contentType = resolveContentType(path, contentTypes.defaults, contentTypes.overrides);
+    parts.push({ partPath: asPartPath(path), contentType });
+
+    if (isMediaContentType(contentType)) {
+      media.push({ partPath: asPartPath(path), contentType, bytes });
+      continue;
+    }
+
+    // content types / relationships は structural data として
+    // `contentTypes` / `relationships` から再構成できるため raw には含めない。
+    if (isRelationshipPart(path)) continue;
+
+    // 本 slice では typed に解釈しない part をすべて元バイト列で保持する。
+    // byte 一致は目標にしないが、untouched part は原バイトのまま書き戻すのが
+    // 最も忠実な structural round-trip になる (`docs/raw-ooxml-round-trip.md`)。
+    rawParts.push({ kind: "binary", partPath: asPartPath(path), contentType, bytes });
+  }
+
+  const presentation = readPresentation(
+    entries,
+    relationships,
+    contentTypes.overrides,
+    diagnostics,
+  );
+
+  return {
+    packageGraph: {
+      contentTypes,
+      parts,
+      relationships,
+      media,
+      rawParts,
+    },
+    presentation,
+    // typed slide/layout/master/theme reading は後続 slice。冒頭コメント参照。
+    slides: [],
+    slideLayouts: [],
+    slideMasters: [],
+    themes: [],
+    diagnostics,
+  };
+}
+
+/** ZIP を展開し、ディレクトリエントリを除いた part path → bytes の Map を返す。 */
+function unzipPackage(input: ReadPptxInput): Map<string, Uint8Array> {
+  const unzipped = unzipSync(input);
+  const entries = new Map<string, Uint8Array>();
+  for (const [path, bytes] of Object.entries(unzipped)) {
+    if (path.endsWith("/")) continue; // ディレクトリエントリは無視。
+    entries.set(path, bytes);
+  }
+  return entries;
+}
+
+interface ContentTypes {
+  readonly defaults: readonly ContentTypeDefault[];
+  readonly overrides: readonly ContentTypeOverride[];
+}
+
+function readContentTypes(entries: Map<string, Uint8Array>): ContentTypes {
+  const bytes = entries.get(CONTENT_TYPES_PART);
+  if (!bytes) return { defaults: [], overrides: [] };
+
+  const root = getChild(parseXml(textDecoder.decode(bytes)), "Types");
+
+  const defaults: ContentTypeDefault[] = [];
+  for (const node of getChildArray(root, "Default")) {
+    const extension = getAttr(node, "Extension");
+    const contentType = getAttr(node, "ContentType");
+    if (extension === undefined || contentType === undefined) continue;
+    defaults.push({ extension, contentType });
+  }
+
+  const overrides: ContentTypeOverride[] = [];
+  for (const node of getChildArray(root, "Override")) {
+    const partName = getAttr(node, "PartName");
+    const contentType = getAttr(node, "ContentType");
+    if (partName === undefined || contentType === undefined) continue;
+    overrides.push({ partName: asPartPath(stripLeadingSlash(partName)), contentType });
+  }
+
+  return { defaults, overrides };
+}
+
+function readRelationships(entries: Map<string, Uint8Array>): PartRelationships[] {
+  const result: PartRelationships[] = [];
+
+  for (const [path, bytes] of entries) {
+    if (!isRelationshipPart(path)) continue;
+
+    const root = getChild(parseXml(textDecoder.decode(bytes)), "Relationships");
+    const relationships: Relationship[] = [];
+    for (const node of getChildArray(root, "Relationship")) {
+      const id = getAttr(node, "Id");
+      const type = getAttr(node, "Type");
+      const target = getAttr(node, "Target");
+      if (id === undefined || type === undefined || target === undefined) continue;
+      const targetMode = getAttr(node, "TargetMode");
+      relationships.push({
+        id: asRelationshipId(id),
+        type,
+        target,
+        ...(targetMode !== undefined ? { targetMode: targetMode as RelationshipTargetMode } : {}),
+      });
+    }
+
+    result.push({ sourcePartPath: asPartPath(relsSourcePartPath(path)), relationships });
+  }
+
+  return result;
+}
+
+function readPresentation(
+  entries: Map<string, Uint8Array>,
+  relationships: readonly PartRelationships[],
+  overrides: readonly ContentTypeOverride[],
+  diagnostics: Diagnostic[],
+): SourcePresentation {
+  const presentationPath = locatePresentationPart(relationships, overrides);
+  if (presentationPath === undefined) {
+    throw new Error("readPptx: presentation part not found; input is not a valid PPTX package");
+  }
+
+  const bytes = entries.get(presentationPath);
+  if (!bytes) {
+    throw new Error(
+      `readPptx: presentation part '${presentationPath}' is missing from the package`,
+    );
+  }
+
+  const presentationPartPath = asPartPath(presentationPath);
+  const root = getChild(parseXml(textDecoder.decode(bytes)), "presentation");
+
+  const slideSize = readSlideSize(root);
+  const presentationRels = relationships.find(
+    (rel) => rel.sourcePartPath === presentationPath,
+  )?.relationships;
+
+  const slidePartPaths: PartPath[] = [];
+  const sldIdLst = getChild(root, "sldIdLst");
+  for (const sldId of getChildArray(sldIdLst, "sldId")) {
+    const relId = getNamespacedAttr(sldId, "id");
+    if (relId === undefined) continue;
+    const target = presentationRels?.find((rel) => rel.id === relId)?.target;
+    if (target === undefined) {
+      diagnostics.push({
+        severity: "warning",
+        code: "slide-relationship-unresolved",
+        message: `slide relationship '${relId}' referenced by presentation could not be resolved`,
+        handle: { partPath: presentationPartPath, relationshipId: asRelationshipId(relId) },
+      });
+      continue;
+    }
+    slidePartPaths.push(asPartPath(resolveTarget(presentationPath, target)));
+  }
+
+  return {
+    partPath: presentationPartPath,
+    ...(slideSize !== undefined ? { slideSize } : {}),
+    slidePartPaths,
+    handle: { partPath: presentationPartPath },
+  };
+}
+
+function readSlideSize(presentationRoot: XmlNode | undefined): SlideSize | undefined {
+  const sldSz = getChild(presentationRoot, "sldSz");
+  const cx = getAttr(sldSz, "cx");
+  const cy = getAttr(sldSz, "cy");
+  if (cx === undefined || cy === undefined) return undefined;
+  const width = Number(cx);
+  const height = Number(cy);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return undefined;
+  return { width: asEmu(width), height: asEmu(height) };
+}
+
+/**
+ * presentation part path を解決する。root relationship (officeDocument 型) を
+ * 優先し、無ければ content type override から探す。
+ */
+function locatePresentationPart(
+  relationships: readonly PartRelationships[],
+  overrides: readonly ContentTypeOverride[],
+): string | undefined {
+  const rootRels = relationships.find(
+    (rel) => rel.sourcePartPath === PACKAGE_ROOT_PART,
+  )?.relationships;
+  const officeDocumentRel = rootRels?.find((rel) => rel.type === OFFICE_DOCUMENT_REL_TYPE);
+  if (officeDocumentRel !== undefined) {
+    return resolveTarget(PACKAGE_ROOT_PART, officeDocumentRel.target);
+  }
+
+  const override = overrides.find((entry) => entry.contentType === PRESENTATION_CONTENT_TYPE);
+  return override?.partName;
+}
+
+const MEDIA_CONTENT_TYPE_PREFIXES = ["image/", "audio/", "video/"];
+
+function isMediaContentType(contentType: string): boolean {
+  return MEDIA_CONTENT_TYPE_PREFIXES.some((prefix) => contentType.startsWith(prefix));
+}
+
+function isRelationshipPart(path: string): boolean {
+  return path.endsWith(RELS_SUFFIX) && path.includes("_rels/");
+}
+
+function resolveContentType(
+  path: string,
+  defaults: readonly ContentTypeDefault[],
+  overrides: readonly ContentTypeOverride[],
+): string {
+  const override = overrides.find((entry) => entry.partName === path);
+  if (override !== undefined) return override.contentType;
+
+  const extension = extensionOf(path);
+  if (extension !== undefined) {
+    const fallback = defaults.find(
+      (entry) => entry.extension.toLowerCase() === extension.toLowerCase(),
+    );
+    if (fallback !== undefined) return fallback.contentType;
+  }
+
+  return "application/octet-stream";
+}
+
+function extensionOf(path: string): string | undefined {
+  const dot = path.lastIndexOf(".");
+  const slash = path.lastIndexOf("/");
+  if (dot === -1 || dot < slash) return undefined;
+  return path.slice(dot + 1);
+}
+
+function stripLeadingSlash(path: string): string {
+  return path.startsWith("/") ? path.slice(1) : path;
+}
+
+/**
+ * `_rels/*.rels` part path から、その rels が属する source part path を求める。
+ * 例: `ppt/_rels/presentation.xml.rels` → `ppt/presentation.xml`、
+ * `_rels/.rels` → `""` (package root)。
+ */
+function relsSourcePartPath(relsPath: string): string {
+  const marker = "_rels/";
+  const idx = relsPath.lastIndexOf(marker);
+  const dir = relsPath.slice(0, idx); // "" / "ppt/" / "ppt/slides/"
+  const file = relsPath.slice(idx + marker.length); // ".rels" / "presentation.xml.rels"
+  const base = file.endsWith(RELS_SUFFIX) ? file.slice(0, -RELS_SUFFIX.length) : file;
+  return dir + base;
+}
+
+/**
+ * relationship target を source part path 基準で解決し、package 内の絶対 part
+ * path (先頭スラッシュ無し) に正規化する。external (絶対 URI) はそのまま返す。
+ */
+function resolveTarget(sourcePartPath: string, target: string): string {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return target; // 絶対 URI (external)。
+
+  let combined: string;
+  if (target.startsWith("/")) {
+    combined = target.slice(1); // package root 起点。
+  } else {
+    const slash = sourcePartPath.lastIndexOf("/");
+    const baseDir = slash === -1 ? "" : sourcePartPath.slice(0, slash);
+    combined = baseDir === "" ? target : `${baseDir}/${target}`;
+  }
+
+  const segments: string[] = [];
+  for (const segment of combined.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join("/");
+}

--- a/packages/pptx-glimpse-document/src/reader/xml.ts
+++ b/packages/pptx-glimpse-document/src/reader/xml.ts
@@ -1,0 +1,102 @@
+/**
+ * reader 内部で使う最小限の OOXML XML ヘルパー。
+ *
+ * `@pptx-glimpse/document` は下位基盤であり renderer 側の XML パーサーを参照
+ * できないため、fast-xml-parser を直接利用する。namespace prefix は **保持**
+ * する (`removeNSPrefix: false`)。これは `p:sldId` が namespace 無しの `id`
+ * (スライド ID) と relationships namespace の `r:id` (relationship 参照) を
+ * 同時に持ち、prefix を落とすと両者が衝突して relationship 参照を復元できなく
+ * なるため。要素アクセスは local name (prefix を無視) で行い、属性は plain /
+ * namespaced を区別して取得する。
+ */
+
+import { XMLParser } from "fast-xml-parser";
+
+export type XmlNode = Record<string, unknown>;
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  parseAttributeValue: false,
+  // prefix を保持する。理由はファイル冒頭コメント参照。
+  removeNSPrefix: false,
+  trimValues: true,
+});
+
+/** XML 文字列をパースして root オブジェクトを返す。 */
+export function parseXml(xml: string): XmlNode {
+  return parser.parse(xml) as XmlNode;
+}
+
+/** `a:foo` のような qualified name から local part (`foo`) を取り出す。 */
+function localName(key: string): string {
+  const colon = key.indexOf(":");
+  return colon === -1 ? key : key.slice(colon + 1);
+}
+
+/**
+ * 子要素を local name で取得する (prefix は無視)。属性キー (`@_`) は対象外。
+ * 同名要素が複数ある場合は最初の一致を返す。
+ */
+export function getChild(node: XmlNode | undefined, name: string): XmlNode | undefined {
+  if (!node) return undefined;
+  for (const key of Object.keys(node)) {
+    if (key.startsWith("@_")) continue;
+    if (localName(key) === name) {
+      const value = node[key];
+      return Array.isArray(value)
+        ? (value[0] as XmlNode | undefined)
+        : (value as XmlNode | undefined);
+    }
+  }
+  return undefined;
+}
+
+/** 子要素を local name で取得し、常に配列として返す。 */
+export function getChildArray(node: XmlNode | undefined, name: string): XmlNode[] {
+  if (!node) return [];
+  for (const key of Object.keys(node)) {
+    if (key.startsWith("@_")) continue;
+    if (localName(key) === name) {
+      const value = node[key];
+      if (value === undefined || value === null) return [];
+      return (Array.isArray(value) ? value : [value]) as XmlNode[];
+    }
+  }
+  return [];
+}
+
+/** namespace 無しの属性 (`@_<name>`) を取得する。 */
+export function getAttr(node: XmlNode | undefined, name: string): string | undefined {
+  if (!node) return undefined;
+  return scalarToString(node[`@_${name}`]);
+}
+
+/**
+ * namespace 付き属性 (`@_<prefix>:<localName>`) を取得する。`p:sldId` の
+ * `r:id` のように、plain な `id` と区別して relationship 参照を取り出すために
+ * 使う。prefix は問わず、local part が一致する最初の属性を返す。
+ */
+export function getNamespacedAttr(
+  node: XmlNode | undefined,
+  localAttr: string,
+): string | undefined {
+  if (!node) return undefined;
+  for (const key of Object.keys(node)) {
+    if (!key.startsWith("@_")) continue;
+    const attr = key.slice(2);
+    const colon = attr.indexOf(":");
+    if (colon !== -1 && attr.slice(colon + 1) === localAttr) {
+      const value = scalarToString(node[key]);
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+/** 属性値 (string/number/boolean) を文字列化する。object 等は undefined。 */
+function scalarToString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,14 @@ importers:
 
   packages/pptx-glimpse-cli: {}
 
-  packages/pptx-glimpse-document: {}
+  packages/pptx-glimpse-document:
+    dependencies:
+      fast-xml-parser:
+        specifier: ^5.7.3
+        version: 5.8.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
 
   packages/pptx-glimpse-renderer:
     dependencies:


### PR DESCRIPTION
close #463

親 issue: #460 (sub-issue 3 / 12)

## 概要

`@pptx-glimpse/document` の experimental entry point に `readPptx(input)` を追加した。CleanDoc source reader の最初の slice として、PPTX ZIP package を読み **package graph** と **presentation metadata** を CleanDoc source として返す。

`docs/cleandoc-minimal-poc-scope.md` / `docs/raw-ooxml-round-trip.md` の決定に従い、byte 一致ではなく structural round-trip を土台とする raw preservation を採用している。

## 実装内容

- `[Content_Types].xml` の defaults / overrides を保持（Override の `PartName` は先頭スラッシュを除去して `PartPath` に正規化）
- `_rels/*.rels` を relationship ID / target / target mode 付きで保持（package root の rels は `sourcePartPath` を `""` として表現）
- `ppt/presentation.xml` から slide size (`p:sldSz`) と slide order (`p:sldIdLst`) を解決。`r:id` の namespace 衝突（`p:sldId` の `id` と `r:id`）を避けるため reader 専用に prefix 保持のパーサーを使用
- media（image/audio/video）は bytes と part path を保持
- 未対応 / 未編集 part は raw package material（binary）として round-trip 用に保持（content types / rels / media は structural data として別管理し raw からは除外）
- presentation 入口解決を厳密化（root が `p:presentation` でない / officeDocument が External / `p:sldId` が slide 以外を指す場合をエラー or diagnostic で扱う）

typed な shape / text / image source node の parsing、computed view 生成、writer 出力は本 slice の scope 外（後続 sub-issue）。そのため `slides` / `slideLayouts` / `slideMasters` / `themes` は空配列を返し、これらの part は `rawParts` 経由で保持する。

## 影響パッケージ

- `packages/pptx-glimpse-document/` のみ（experimental・private package）。公開パッケージ `pptx-glimpse` の挙動には影響しないため changeset は不要。
- 依存追加: `fflate` / `fast-xml-parser`（document package の直接依存として宣言）

## ローカル検証

- `npm run test`（全 988 件 pass、reader の focused unit test 11 件を含む）
- `npm run lint` / `npm run typecheck` / `npm run format:check` / `knip` すべて pass
- 受け入れ条件 7 項目すべて自動検査で ✓
- Codex cross-review 実施済み（critical 0 / warning 2 → 追加 commit で対応 / info 1 → 負ケーステスト追加）

## 受け入れ条件

- [x] `readPptx(input)` が presentation metadata を含む CleanDoc source を返す
- [x] slide count / slide order / slide size を取得できる
- [x] relationship IDs / targets / target modes を保持できる
- [x] content type defaults / overrides を保持できる
- [x] media bytes と part paths を保持できる
- [x] unsupported package parts を raw material として保持できる
- [x] focused unit tests が追加されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
