### PR TITLE
CleanDoc computed view generator を実装する

### DIFF
--- a/packages/pptx-glimpse-document/src/computed/clean-doc-computed-view.ts
+++ b/packages/pptx-glimpse-document/src/computed/clean-doc-computed-view.ts
@@ -1,0 +1,163 @@
+/**
+ * CleanDoc computed view の型。
+ *
+ * source model を mutation せず、slide / layout / master / theme cascade から
+ * 消費しやすい effective value を派生させる。renderer 固有の pixel conversion
+ * や font fallback はここに含めない。
+ */
+
+import type {
+  Emu,
+  MediaPart,
+  PartPath,
+  Relationship,
+  RelationshipId,
+  SourceBackground,
+  SourceFill,
+  SourceImage,
+  SourceOutline,
+  SourceParagraphProperties,
+  SourceRawShapeNode,
+  SourceRunProperties,
+  SourceShape,
+  SourceShapeNode,
+  SourceTextBodyProperties,
+  SourceTransform,
+} from "../source/index.js";
+
+export interface CreateComputedViewOptions {
+  /** 1-based slide numbers. 未指定時は presentation order の全 slide。 */
+  readonly slides?: readonly number[];
+  /** `p:sld@showMasterSp` / `p:sldLayout@showMasterSp` を反映する。既定 true。 */
+  readonly applyMasterVisibility?: boolean;
+}
+
+export interface CleanDocComputedView {
+  readonly slideSize?: ComputedSlideSize;
+  readonly slides: readonly ComputedSlide[];
+}
+
+export interface ComputedSlideSize {
+  readonly width: Emu;
+  readonly height: Emu;
+}
+
+export interface ComputedSlide {
+  readonly slideNumber: number;
+  readonly partPath: PartPath;
+  readonly layoutPartPath?: PartPath;
+  readonly masterPartPath?: PartPath;
+  readonly themePartPath?: PartPath;
+  readonly slideSize?: ComputedSlideSize;
+  readonly relationships: readonly ComputedRelationship[];
+  readonly colorMap: Readonly<Record<string, string>>;
+  readonly background?: ComputedBackground;
+  readonly showMasterShapes: boolean;
+  readonly layoutShowMasterShapes: boolean;
+  readonly elements: readonly ComputedElement[];
+}
+
+export interface ComputedRelationship {
+  readonly id: RelationshipId;
+  readonly type: string;
+  readonly source: Relationship;
+  readonly target: string;
+  readonly targetMode?: "Internal" | "External";
+  readonly targetPartPath?: PartPath;
+  readonly media?: MediaPart;
+}
+
+export type ComputedElement = ComputedShapeElement | ComputedImageElement | ComputedRawElement;
+
+export type ComputedElementLayer = "master" | "layout" | "slide";
+
+interface ComputedElementBase {
+  readonly sourceLayer: ComputedElementLayer;
+  readonly sourcePartPath: PartPath;
+  readonly sourceNode: SourceShapeNode;
+}
+
+export interface ComputedShapeElement extends ComputedElementBase {
+  readonly kind: "shape";
+  readonly sourceNode: SourceShape;
+  readonly transform?: SourceTransform;
+  readonly geometry?: SourceShape["geometry"];
+  readonly fill?: ComputedFill;
+  readonly outline?: ComputedOutline;
+  readonly textBody?: ComputedTextBody;
+  readonly placeholderMatch?: ComputedPlaceholderMatch;
+}
+
+export interface ComputedImageElement extends ComputedElementBase {
+  readonly kind: "image";
+  readonly sourceNode: SourceImage;
+  readonly transform?: SourceTransform;
+  readonly relationship?: ComputedRelationship;
+  readonly media?: MediaPart;
+}
+
+export interface ComputedRawElement extends ComputedElementBase {
+  readonly kind: "raw";
+  readonly sourceNode: SourceRawShapeNode;
+}
+
+export interface ComputedPlaceholderMatch {
+  readonly layout?: SourceShape;
+  readonly master?: SourceShape;
+}
+
+export type ComputedBackground =
+  | {
+      readonly kind: "fill";
+      readonly source: SourceBackground;
+      readonly fill: ComputedFill;
+      readonly sourceLayer: "slide" | "layout" | "master";
+    }
+  | {
+      readonly kind: "styleReference";
+      readonly source: SourceBackground;
+      readonly index: number;
+      readonly color?: ComputedColor;
+      readonly sourceLayer: "slide" | "layout" | "master";
+    }
+  | {
+      readonly kind: "raw";
+      readonly source: SourceBackground;
+      readonly sourceLayer: "slide" | "layout" | "master";
+    };
+
+export type ComputedFill =
+  | { readonly kind: "none"; readonly source: SourceFill }
+  | { readonly kind: "solid"; readonly source: SourceFill; readonly color: ComputedColor }
+  | { readonly kind: "raw"; readonly source: SourceFill };
+
+export interface ComputedOutline {
+  readonly width?: Emu;
+  readonly fill?: ComputedFill;
+  readonly source: SourceOutline;
+}
+
+export interface ComputedColor {
+  /** `#rrggbb`。 */
+  readonly hex: string;
+  readonly alpha: number;
+}
+
+export interface ComputedTextBody {
+  readonly properties?: SourceTextBodyProperties;
+  readonly paragraphs: readonly ComputedParagraph[];
+}
+
+export interface ComputedParagraph {
+  readonly properties?: SourceParagraphProperties;
+  readonly runs: readonly ComputedTextRun[];
+}
+
+export interface ComputedTextRun {
+  readonly text: string;
+  readonly properties?: ComputedRunProperties;
+}
+
+export type ComputedRunProperties = Omit<SourceRunProperties, "color"> & {
+  readonly color?: ComputedColor;
+};

--- a/packages/pptx-glimpse-document/src/computed/clean-doc-computed-view.ts
+++ b/packages/pptx-glimpse-document/src/computed/clean-doc-computed-view.ts
@@ -111,19 +111,19 @@ export type ComputedBackground =
       readonly kind: "fill";
       readonly source: SourceBackground;
       readonly fill: ComputedFill;
-      readonly sourceLayer: "slide" | "layout" | "master";
+      readonly sourceLayer: ComputedElementLayer;
     }
   | {
       readonly kind: "styleReference";
       readonly source: SourceBackground;
       readonly index: number;
       readonly color?: ComputedColor;
-      readonly sourceLayer: "slide" | "layout" | "master";
+      readonly sourceLayer: ComputedElementLayer;
     }
   | {
       readonly kind: "raw";
       readonly source: SourceBackground;
-      readonly sourceLayer: "slide" | "layout" | "master";
+      readonly sourceLayer: ComputedElementLayer;
     };
 
 export type ComputedFill =
@@ -140,6 +140,7 @@ export interface ComputedOutline {
 export interface ComputedColor {
   /** `#rrggbb`。 */
   readonly hex: string;
+  /** 0-1 の正規化 opacity。 */
   readonly alpha: number;
 }
 

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CleanDocSource,
+  ComputedElement,
+  ComputedShapeElement,
+  ComputedSlide,
+  SourceRunProperties,
+  SourceShape,
+  SourceTextBody,
+} from "../experimental.js";
+import {
+  asEmu,
+  asOoxmlPercent,
+  asPartPath,
+  asPt,
+  asRelationshipId,
+  createComputedView,
+} from "../experimental.js";
+
+describe("createComputedView", () => {
+  it("slide size / order / relationships を computed view に反映する", () => {
+    const source = buildSource();
+    const computed = createComputedView(source);
+
+    expect(computed.slideSize).toEqual({ width: 9144000, height: 5143500 });
+    expect(computed.slides.map((slide) => slide.partPath)).toEqual([
+      "ppt/slides/slide2.xml",
+      "ppt/slides/slide1.xml",
+    ]);
+
+    const slide = getSlide(computed.slides, 0);
+    expect(slide.slideNumber).toBe(1);
+    expect(slide.slideSize).toEqual({ width: 9144000, height: 5143500 });
+    const imageRelationship = slide.relationships.find((rel) => rel.id === "rIdImage");
+    expect(imageRelationship?.target).toBe("ppt/media/image1.png");
+    expect(imageRelationship?.targetPartPath).toBe("ppt/media/image1.png");
+    expect(imageRelationship?.media?.contentType).toBe("image/png");
+    const externalRelationship = slide.relationships.find((rel) => rel.id === "rIdExternal");
+    expect(externalRelationship?.target).toBe("https://example.com/");
+    expect(externalRelationship?.targetMode).toBe("External");
+
+    const image = slide.elements.find((element) => element.kind === "image");
+    expect(image?.media?.bytes).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it("theme color resolution と background fallback を解決する", () => {
+    const computed = createComputedView(buildSource());
+    const slide = getSlide(computed.slides, 0);
+
+    // layout clrMapOvr が accent1 -> accent2 に差し替えるため、theme accent2 へ解決される。
+    expect(slide.colorMap.accent1).toBe("accent2");
+    expect(slide.background?.kind).toBe("fill");
+    expect(slide.background?.sourceLayer).toBe("master");
+    expect(slide.background?.kind === "fill" ? slide.background.fill.kind : undefined).toBe(
+      "solid",
+    );
+    expect(
+      slide.background?.kind === "fill" && slide.background.fill.kind === "solid"
+        ? slide.background.fill.color
+        : undefined,
+    ).toEqual({ hex: "#336699", alpha: 1 });
+
+    const slideTitle = findShape(slide.elements, "Slide title");
+    expect(slideTitle.fill).toEqual(
+      expect.objectContaining({
+        kind: "solid",
+        color: { hex: "#99b3cc", alpha: 0.5 },
+      }),
+    );
+  });
+
+  it("placeholder matching と basic text style inheritance を解決する", () => {
+    const computed = createComputedView(buildSource());
+    const slideTitle = findShape(getSlide(computed.slides, 0).elements, "Slide title");
+
+    expect(slideTitle.placeholderMatch?.layout?.name).toBe("Layout title");
+    expect(slideTitle.placeholderMatch?.master?.name).toBe("Master title");
+    expect(slideTitle.transform).toEqual({
+      offsetX: 10,
+      offsetY: 20,
+      width: 300,
+      height: 40,
+    });
+    expect(slideTitle.geometry).toEqual({ preset: "roundRect" });
+    expect(slideTitle.textBody?.paragraphs[0].properties).toEqual({ align: "center" });
+    expect(slideTitle.textBody?.paragraphs[0].runs[0]).toEqual({
+      text: "Hello",
+      properties: {
+        bold: true,
+        fontSize: 30,
+        typeface: "Aptos",
+        color: { hex: "#111111", alpha: 1 },
+      },
+    });
+  });
+
+  it("showMasterSp visibility と effective element ordering を解決する", () => {
+    const computed = createComputedView(buildSource());
+
+    expect(elementNames(getSlide(computed.slides, 0).elements)).toEqual([
+      "Master decoration",
+      "Layout decoration",
+      "Slide title",
+      "Hero image",
+    ]);
+
+    // slide1 は showMasterSp=false なので master decoration が落ちる。
+    expect(getSlide(computed.slides, 1).showMasterShapes).toBe(false);
+    expect(elementNames(getSlide(computed.slides, 1).elements)).toEqual([
+      "Layout decoration",
+      "Visible body",
+    ]);
+  });
+
+  it("source model を in-place mutation しない", () => {
+    const source = buildSource();
+    const before = structuredClone(source);
+
+    createComputedView(source);
+
+    expect(source).toEqual(before);
+  });
+
+  it("target slide selection を presentation order の slide number で適用する", () => {
+    const computed = createComputedView(buildSource(), { slides: [2] });
+
+    expect(computed.slides.map((slide) => slide.partPath)).toEqual(["ppt/slides/slide1.xml"]);
+    expect(getSlide(computed.slides, 0).slideNumber).toBe(2);
+  });
+});
+
+function getSlide(slides: readonly ComputedSlide[], index: number): ComputedSlide {
+  const slide = slides[index];
+  if (slide === undefined) throw new Error(`slide at index ${index} not found`);
+  return slide;
+}
+
+function findShape(elements: readonly ComputedElement[], name: string): ComputedShapeElement {
+  const shape = elements.find(
+    (element): element is ComputedShapeElement =>
+      element.kind === "shape" && element.sourceNode.name === name,
+  );
+  if (shape === undefined || shape.kind !== "shape") throw new Error(`shape '${name}' not found`);
+  return shape;
+}
+
+function elementNames(elements: readonly ComputedElement[]): (string | undefined)[] {
+  return elements.map((element) =>
+    "name" in element.sourceNode ? element.sourceNode.name : undefined,
+  );
+}
+
+function buildSource(): CleanDocSource {
+  const masterTitle = placeholder("Master title", "title", 1, {
+    transform: transform(100, 200, 300, 400),
+    geometry: { preset: "rect" },
+    textBody: textBody("", { fontSize: asPt(20), color: { kind: "srgb", hex: "222222" } }),
+  });
+  const layoutTitle = placeholder("Layout title", "ctrTitle", 1, {
+    transform: transform(10, 20, 300, 40),
+    geometry: { preset: "roundRect" },
+    textBody: textBody("", {
+      fontSize: asPt(30),
+      typeface: "Aptos",
+      color: { kind: "srgb", hex: "111111" },
+    }),
+  });
+
+  return {
+    packageGraph: {
+      contentTypes: { defaults: [], overrides: [] },
+      parts: [],
+      relationships: [
+        {
+          sourcePartPath: asPartPath("ppt/slides/slide2.xml"),
+          relationships: [
+            {
+              id: asRelationshipId("rIdImage"),
+              type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+              target: "../media/image1.png",
+            },
+            {
+              id: asRelationshipId("rIdExternal"),
+              type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+              target: "https://example.com/",
+              targetMode: "External",
+            },
+          ],
+        },
+      ],
+      media: [
+        {
+          partPath: asPartPath("ppt/media/image1.png"),
+          contentType: "image/png",
+          bytes: new Uint8Array([1, 2, 3]),
+        },
+      ],
+    },
+    presentation: {
+      partPath: asPartPath("ppt/presentation.xml"),
+      slideSize: { width: asEmu(9144000), height: asEmu(5143500) },
+      slidePartPaths: [asPartPath("ppt/slides/slide2.xml"), asPartPath("ppt/slides/slide1.xml")],
+    },
+    slides: [
+      {
+        partPath: asPartPath("ppt/slides/slide1.xml"),
+        layoutPartPath: asPartPath("ppt/slideLayouts/layout1.xml"),
+        showMasterShapes: false,
+        shapes: [
+          placeholder("Empty placeholder", "body", 2, { textBody: textBody("") }),
+          shape("Visible body", { transform: transform(1, 2, 3, 4) }),
+        ],
+      },
+      {
+        partPath: asPartPath("ppt/slides/slide2.xml"),
+        layoutPartPath: asPartPath("ppt/slideLayouts/layout1.xml"),
+        shapes: [
+          placeholder("Slide title", "ctrTitle", 1, {
+            textBody: textBody("Hello", { bold: true }),
+            fill: {
+              kind: "solid",
+              color: {
+                kind: "scheme",
+                scheme: "accent1",
+                transforms: [
+                  { kind: "tint", value: asOoxmlPercent(50000) },
+                  { kind: "alpha", value: asOoxmlPercent(50000) },
+                ],
+              },
+            },
+          }),
+          {
+            kind: "image",
+            name: "Hero image",
+            transform: transform(50, 60, 70, 80),
+            blipRelationshipId: asRelationshipId("rIdImage"),
+          },
+        ],
+      },
+    ],
+    slideLayouts: [
+      {
+        partPath: asPartPath("ppt/slideLayouts/layout1.xml"),
+        masterPartPath: asPartPath("ppt/slideMasters/master1.xml"),
+        colorMapOverride: { mapping: { accent1: "accent2" } },
+        shapes: [layoutTitle, shape("Layout decoration", { transform: transform(2, 2, 2, 2) })],
+      },
+    ],
+    slideMasters: [
+      {
+        partPath: asPartPath("ppt/slideMasters/master1.xml"),
+        themePartPath: asPartPath("ppt/theme/theme1.xml"),
+        layoutPartPaths: [asPartPath("ppt/slideLayouts/layout1.xml")],
+        colorMap: { mapping: { bg1: "lt1", tx1: "dk1", accent1: "accent1" } },
+        background: {
+          kind: "fill",
+          fill: { kind: "solid", color: { kind: "scheme", scheme: "accent1" } },
+        },
+        shapes: [masterTitle, shape("Master decoration", { transform: transform(9, 9, 9, 9) })],
+      },
+    ],
+    themes: [
+      {
+        partPath: asPartPath("ppt/theme/theme1.xml"),
+        colorScheme: {
+          colors: {
+            lt1: { kind: "srgb", hex: "FFFFFF" },
+            dk1: { kind: "srgb", hex: "000000" },
+            accent1: { kind: "srgb", hex: "990000" },
+            accent2: { kind: "srgb", hex: "336699" },
+          },
+        },
+      },
+    ],
+    diagnostics: [],
+  };
+}
+
+function transform(offsetX: number, offsetY: number, width: number, height: number) {
+  return {
+    offsetX: asEmu(offsetX),
+    offsetY: asEmu(offsetY),
+    width: asEmu(width),
+    height: asEmu(height),
+  };
+}
+
+function shape(name: string, overrides: Partial<SourceShape> = {}): SourceShape {
+  return {
+    kind: "shape",
+    name,
+    ...overrides,
+  };
+}
+
+function placeholder(
+  name: string,
+  type: string,
+  index: number,
+  overrides: Partial<SourceShape> = {},
+): SourceShape {
+  return shape(name, {
+    placeholder: { type, index },
+    ...overrides,
+  });
+}
+
+function textBody(text: string, runProperties: SourceRunProperties = {}): SourceTextBody {
+  return {
+    paragraphs: [
+      {
+        properties: { align: "center" as const },
+        runs: [{ kind: "textRun" as const, text, properties: runProperties }],
+      },
+    ],
+  };
+}

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
@@ -122,7 +122,17 @@ describe("createComputedView", () => {
 
     // slide1 は showMasterSp=false なので master decoration が落ちる。
     expect(getSlide(computed.slides, 1).showMasterShapes).toBe(false);
+    expect(getSlide(computed.slides, 1).layoutShowMasterShapes).toBe(true);
     expect(elementNames(getSlide(computed.slides, 1).elements)).toEqual([
+      "Layout decoration",
+      "Visible body",
+    ]);
+
+    const withoutVisibilityFilter = createComputedView(buildSource(), {
+      applyMasterVisibility: false,
+    });
+    expect(elementNames(getSlide(withoutVisibilityFilter.slides, 1).elements)).toEqual([
+      "Master decoration",
       "Layout decoration",
       "Visible body",
     ]);
@@ -156,7 +166,7 @@ function findShape(elements: readonly ComputedElement[], name: string): Computed
     (element): element is ComputedShapeElement =>
       element.kind === "shape" && element.sourceNode.name === name,
   );
-  if (shape === undefined || shape.kind !== "shape") throw new Error(`shape '${name}' not found`);
+  if (shape === undefined) throw new Error(`shape '${name}' not found`);
   return shape;
 }
 

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
@@ -68,6 +68,20 @@ describe("createComputedView", () => {
         color: { hex: "#99b3cc", alpha: 0.5 },
       }),
     );
+
+    const transformed = findShape(slide.elements, "Transformed colors");
+    expect(transformed.fill).toEqual(
+      expect.objectContaining({
+        kind: "solid",
+        color: { hex: "#ff8080", alpha: 1 },
+      }),
+    );
+    expect(transformed.outline?.fill).toEqual(
+      expect.objectContaining({
+        kind: "solid",
+        color: { hex: "#404040", alpha: 1 },
+      }),
+    );
   });
 
   it("placeholder matching と basic text style inheritance を解決する", () => {
@@ -103,6 +117,7 @@ describe("createComputedView", () => {
       "Layout decoration",
       "Slide title",
       "Hero image",
+      "Transformed colors",
     ]);
 
     // slide1 は showMasterSp=false なので master decoration が落ちる。
@@ -236,6 +251,30 @@ function buildSource(): CleanDocSource {
             transform: transform(50, 60, 70, 80),
             blipRelationshipId: asRelationshipId("rIdImage"),
           },
+          shape("Transformed colors", {
+            transform: transform(11, 12, 13, 14),
+            fill: {
+              kind: "solid",
+              color: {
+                kind: "srgb",
+                hex: "FF0000",
+                transforms: [
+                  { kind: "lumMod", value: asOoxmlPercent(50000) },
+                  { kind: "lumOff", value: asOoxmlPercent(50000) },
+                ],
+              },
+            },
+            outline: {
+              fill: {
+                kind: "solid",
+                color: {
+                  kind: "srgb",
+                  hex: "808080",
+                  transforms: [{ kind: "shade", value: asOoxmlPercent(50000) }],
+                },
+              },
+            },
+          }),
         ],
       },
     ],

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
@@ -230,14 +230,13 @@ function computeBackground(
     };
   }
   if (background.kind === "styleReference") {
+    const color = resolveColor(context, background.color);
     return {
       background: {
         kind: "styleReference",
         source: background,
         index: background.index,
-        ...(resolveColor(context, background.color) !== undefined
-          ? { color: resolveColor(context, background.color) }
-          : {}),
+        ...(color !== undefined ? { color } : {}),
         sourceLayer,
       },
     };
@@ -374,12 +373,13 @@ function computeParagraph(
   const inheritedRun = inherited?.runs[0];
   return {
     ...(properties !== undefined ? { properties } : {}),
-    runs: paragraph.runs.map((run) => ({
-      text: run.text,
-      ...(mergeRunProperties(context, inheritedRun?.properties, run.properties) !== undefined
-        ? { properties: mergeRunProperties(context, inheritedRun?.properties, run.properties) }
-        : {}),
-    })),
+    runs: paragraph.runs.map((run) => {
+      const runProperties = mergeRunProperties(context, inheritedRun?.properties, run.properties);
+      return {
+        text: run.text,
+        ...(runProperties !== undefined ? { properties: runProperties } : {}),
+      };
+    }),
   };
 }
 

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
@@ -28,6 +28,7 @@ import type {
   ComputedImageElement,
   ComputedOutline,
   ComputedParagraph,
+  ComputedPlaceholderMatch,
   ComputedRelationship,
   ComputedRunProperties,
   ComputedShapeElement,
@@ -399,13 +400,7 @@ function mergeRunProperties(
   const merged = { ...inherited, ...local };
   if (Object.keys(merged).length === 0) return undefined;
   const color = merged.color !== undefined ? resolveColor(context, merged.color) : undefined;
-  const withoutColor: Omit<SourceRunProperties, "color"> = {
-    ...(merged.bold !== undefined ? { bold: merged.bold } : {}),
-    ...(merged.italic !== undefined ? { italic: merged.italic } : {}),
-    ...(merged.underline !== undefined ? { underline: merged.underline } : {}),
-    ...(merged.fontSize !== undefined ? { fontSize: merged.fontSize } : {}),
-    ...(merged.typeface !== undefined ? { typeface: merged.typeface } : {}),
-  };
+  const withoutColor = omitColor(merged);
   return {
     ...withoutColor,
     ...(color !== undefined ? { color } : {}),
@@ -415,7 +410,7 @@ function mergeRunProperties(
 function findPlaceholderMatch(
   context: ComputeContext,
   shape: SourceShape,
-): { readonly layout?: SourceShape; readonly master?: SourceShape } | undefined {
+): ComputedPlaceholderMatch | undefined {
   if (shape.placeholder === undefined) return undefined;
   const type = shape.placeholder.type ?? "body";
   const index = shape.placeholder.index;
@@ -554,8 +549,15 @@ function resolveRelationshipTarget(sourcePartPath: string, target: string): stri
 }
 
 function normalizeHex(hex: string): string {
+  // OOXML `srgbClr@val` / `sysClr@lastClr` は 6 桁 RRGGBB 前提。
   const normalized = hex.replace(/^#/, "").toLowerCase();
   return `#${normalized.padStart(6, "0").slice(0, 6)}`;
+}
+
+function omitColor(properties: SourceRunProperties): Omit<SourceRunProperties, "color"> {
+  const withoutColor = { ...properties };
+  delete withoutColor.color;
+  return withoutColor;
 }
 
 function applyLuminance(hex: string, lumMod: number, lumOff: number): string {

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
@@ -1,0 +1,648 @@
+import type {
+  CleanDocSource,
+  PartPath,
+  SourceColor,
+  SourceColorMap,
+  SourceFill,
+  SourceImage,
+  SourceOutline,
+  SourceParagraph,
+  SourceParagraphProperties,
+  SourceRunProperties,
+  SourceShape,
+  SourceShapeNode,
+  SourceSlide,
+  SourceSlideLayout,
+  SourceSlideMaster,
+  SourceTextBody,
+  SourceTheme,
+} from "../source/index.js";
+import { asPartPath } from "../source/index.js";
+import type {
+  CleanDocComputedView,
+  ComputedBackground,
+  ComputedColor,
+  ComputedElement,
+  ComputedElementLayer,
+  ComputedFill,
+  ComputedImageElement,
+  ComputedOutline,
+  ComputedParagraph,
+  ComputedRelationship,
+  ComputedRunProperties,
+  ComputedShapeElement,
+  ComputedSlide,
+  ComputedTextBody,
+  CreateComputedViewOptions,
+} from "./clean-doc-computed-view.js";
+
+const DEFAULT_COLOR_MAP: Readonly<Record<string, string>> = {
+  bg1: "lt1",
+  tx1: "dk1",
+  bg2: "lt2",
+  tx2: "dk2",
+  accent1: "accent1",
+  accent2: "accent2",
+  accent3: "accent3",
+  accent4: "accent4",
+  accent5: "accent5",
+  accent6: "accent6",
+  hlink: "hlink",
+  folHlink: "folHlink",
+};
+
+const FALLBACK_SCHEME_COLORS: Readonly<Record<string, string>> = {
+  dk1: "#000000",
+  lt1: "#ffffff",
+  dk2: "#44546a",
+  lt2: "#e7e6e6",
+  accent1: "#4472c4",
+  accent2: "#ed7d31",
+  accent3: "#a5a5a5",
+  accent4: "#ffc000",
+  accent5: "#5b9bd5",
+  accent6: "#70ad47",
+  hlink: "#0563c1",
+  folHlink: "#954f72",
+};
+
+const IMAGE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+
+export function createComputedView(
+  source: CleanDocSource,
+  options: CreateComputedViewOptions = {},
+): CleanDocComputedView {
+  const slidesByPath = new Map(source.slides.map((slide) => [slide.partPath, slide]));
+  const selectedSlideNumbers = options.slides !== undefined ? new Set(options.slides) : undefined;
+
+  const slides: ComputedSlide[] = [];
+  source.presentation.slidePartPaths.forEach((partPath, index) => {
+    const slideNumber = index + 1;
+    if (selectedSlideNumbers !== undefined && !selectedSlideNumbers.has(slideNumber)) return;
+
+    const slide = slidesByPath.get(partPath);
+    if (slide === undefined) return;
+    slides.push(computeSlide(source, slide, slideNumber, options));
+  });
+
+  return {
+    ...(source.presentation.slideSize !== undefined
+      ? { slideSize: { ...source.presentation.slideSize } }
+      : {}),
+    slides,
+  };
+}
+
+function computeSlide(
+  source: CleanDocSource,
+  slide: SourceSlide,
+  slideNumber: number,
+  options: CreateComputedViewOptions,
+): ComputedSlide {
+  const layout = source.slideLayouts.find(
+    (candidate) => candidate.partPath === slide.layoutPartPath,
+  );
+  const master =
+    layout !== undefined
+      ? source.slideMasters.find((candidate) => candidate.partPath === layout.masterPartPath)
+      : undefined;
+  const theme =
+    master?.themePartPath !== undefined
+      ? source.themes.find((candidate) => candidate.partPath === master.themePartPath)
+      : undefined;
+  const colorMap = buildEffectiveColorMap(
+    master?.colorMap,
+    layout?.colorMapOverride,
+    slide.colorMapOverride,
+  );
+  const relationships = resolveRelationships(source, slide.partPath);
+  const context: ComputeContext = { source, layout, master, theme, colorMap, relationships };
+
+  const layoutShowMasterShapes = layout?.showMasterShapes ?? true;
+  const showMasterShapes = slide.showMasterShapes ?? true;
+  const includeMaster =
+    options.applyMasterVisibility === false ? true : showMasterShapes && layoutShowMasterShapes;
+
+  return {
+    slideNumber,
+    partPath: slide.partPath,
+    ...(layout !== undefined ? { layoutPartPath: layout.partPath } : {}),
+    ...(master !== undefined ? { masterPartPath: master.partPath } : {}),
+    ...(theme?.partPath !== undefined ? { themePartPath: theme.partPath } : {}),
+    ...(source.presentation.slideSize !== undefined
+      ? { slideSize: { ...source.presentation.slideSize } }
+      : {}),
+    relationships,
+    colorMap,
+    ...(computeBackground(context, slide, layout, master) ?? {}),
+    showMasterShapes,
+    layoutShowMasterShapes,
+    elements: [
+      ...(includeMaster && master !== undefined
+        ? computeTemplateElements(context, master.shapes, "master", master.partPath)
+        : []),
+      ...(layout !== undefined
+        ? computeTemplateElements(context, layout.shapes, "layout", layout.partPath)
+        : []),
+      ...computeSlideElements(context, slide.shapes, slide.partPath),
+    ],
+  };
+}
+
+interface ComputeContext {
+  readonly source: CleanDocSource;
+  readonly layout?: SourceSlideLayout;
+  readonly master?: SourceSlideMaster;
+  readonly theme?: SourceTheme;
+  readonly colorMap: Readonly<Record<string, string>>;
+  readonly relationships: readonly ComputedRelationship[];
+}
+
+function buildEffectiveColorMap(
+  master?: SourceColorMap,
+  layoutOverride?: SourceColorMap,
+  slideOverride?: SourceColorMap,
+): Readonly<Record<string, string>> {
+  return {
+    ...DEFAULT_COLOR_MAP,
+    ...master?.mapping,
+    ...layoutOverride?.mapping,
+    ...slideOverride?.mapping,
+  };
+}
+
+function resolveRelationships(
+  source: CleanDocSource,
+  sourcePartPath: PartPath,
+): ComputedRelationship[] {
+  const rels =
+    source.packageGraph.relationships.find((entry) => entry.sourcePartPath === sourcePartPath)
+      ?.relationships ?? [];
+
+  return rels.map((relationship) => {
+    const external = relationship.targetMode === "External";
+    const target = external
+      ? relationship.target
+      : resolveRelationshipTarget(sourcePartPath, relationship.target);
+    const targetPartPath = external ? undefined : asPartPath(target);
+    const media =
+      targetPartPath !== undefined
+        ? source.packageGraph.media.find((part) => part.partPath === targetPartPath)
+        : undefined;
+
+    return {
+      id: relationship.id,
+      type: relationship.type,
+      source: relationship,
+      target,
+      ...(relationship.targetMode !== undefined ? { targetMode: relationship.targetMode } : {}),
+      ...(targetPartPath !== undefined ? { targetPartPath } : {}),
+      ...(media !== undefined ? { media } : {}),
+    };
+  });
+}
+
+function computeBackground(
+  context: ComputeContext,
+  slide: SourceSlide,
+  layout: SourceSlideLayout | undefined,
+  master: SourceSlideMaster | undefined,
+): { readonly background: ComputedBackground } | undefined {
+  const picked =
+    slide.background !== undefined
+      ? { sourceLayer: "slide" as const, background: slide.background }
+      : layout?.background !== undefined
+        ? { sourceLayer: "layout" as const, background: layout.background }
+        : master?.background !== undefined
+          ? { sourceLayer: "master" as const, background: master.background }
+          : undefined;
+  if (picked === undefined) return undefined;
+
+  const { background, sourceLayer } = picked;
+  if (background.kind === "fill") {
+    return {
+      background: {
+        kind: "fill",
+        source: background,
+        fill: computeFill(context, background.fill),
+        sourceLayer,
+      },
+    };
+  }
+  if (background.kind === "styleReference") {
+    return {
+      background: {
+        kind: "styleReference",
+        source: background,
+        index: background.index,
+        ...(resolveColor(context, background.color) !== undefined
+          ? { color: resolveColor(context, background.color) }
+          : {}),
+        sourceLayer,
+      },
+    };
+  }
+  return { background: { kind: "raw", source: background, sourceLayer } };
+}
+
+function computeTemplateElements(
+  context: ComputeContext,
+  elements: readonly SourceShapeNode[],
+  layer: "master" | "layout",
+  partPath: PartPath,
+): ComputedElement[] {
+  return elements
+    .filter((element) => !(element.kind === "shape" && element.placeholder !== undefined))
+    .map((element) => computeElement(context, element, layer, partPath));
+}
+
+function computeSlideElements(
+  context: ComputeContext,
+  elements: readonly SourceShapeNode[],
+  partPath: PartPath,
+): ComputedElement[] {
+  return elements
+    .filter((element) => !(element.kind === "shape" && isEmptyPlaceholder(element)))
+    .map((element) => computeElement(context, element, "slide", partPath));
+}
+
+function computeElement(
+  context: ComputeContext,
+  element: SourceShapeNode,
+  layer: ComputedElementLayer,
+  partPath: PartPath,
+): ComputedElement {
+  if (element.kind === "shape") return computeShapeElement(context, element, layer, partPath);
+  if (element.kind === "image") return computeImageElement(context, element, layer, partPath);
+  return { kind: "raw", sourceLayer: layer, sourcePartPath: partPath, sourceNode: element };
+}
+
+function computeShapeElement(
+  context: ComputeContext,
+  shape: SourceShape,
+  layer: ComputedElementLayer,
+  partPath: PartPath,
+): ComputedShapeElement {
+  const match = layer === "slide" ? findPlaceholderMatch(context, shape) : undefined;
+  const styleSource = firstDefined(match?.layout, match?.master);
+  const transform = firstDefined(
+    shape.transform,
+    match?.layout?.transform,
+    match?.master?.transform,
+  );
+  const geometry = firstDefined(shape.geometry, match?.layout?.geometry, match?.master?.geometry);
+
+  return {
+    kind: "shape",
+    sourceLayer: layer,
+    sourcePartPath: partPath,
+    sourceNode: shape,
+    ...(transform !== undefined ? { transform } : {}),
+    ...(geometry !== undefined ? { geometry } : {}),
+    ...(shape.fill !== undefined ? { fill: computeFill(context, shape.fill) } : {}),
+    ...(shape.outline !== undefined ? { outline: computeOutline(context, shape.outline) } : {}),
+    ...(shape.textBody !== undefined
+      ? { textBody: computeTextBody(context, shape.textBody, styleSource?.textBody) }
+      : {}),
+    ...(match !== undefined ? { placeholderMatch: match } : {}),
+  };
+}
+
+function computeImageElement(
+  context: ComputeContext,
+  image: SourceImage,
+  layer: ComputedElementLayer,
+  partPath: PartPath,
+): ComputedImageElement {
+  const relationship = context.relationships.find(
+    (rel) => rel.id === image.blipRelationshipId && rel.type === IMAGE_REL_TYPE,
+  );
+
+  return {
+    kind: "image",
+    sourceLayer: layer,
+    sourcePartPath: partPath,
+    sourceNode: image,
+    ...(image.transform !== undefined ? { transform: image.transform } : {}),
+    ...(relationship !== undefined ? { relationship } : {}),
+    ...(relationship?.media !== undefined ? { media: relationship.media } : {}),
+  };
+}
+
+function computeFill(context: ComputeContext, fill: SourceFill): ComputedFill {
+  if (fill.kind === "none") return { kind: "none", source: fill };
+  if (fill.kind === "raw") return { kind: "raw", source: fill };
+  return {
+    kind: "solid",
+    source: fill,
+    color: resolveColor(context, fill.color) ?? { hex: "#000000", alpha: 1 },
+  };
+}
+
+function computeOutline(context: ComputeContext, outline: SourceOutline): ComputedOutline {
+  return {
+    source: outline,
+    ...(outline.width !== undefined ? { width: outline.width } : {}),
+    ...(outline.fill !== undefined ? { fill: computeFill(context, outline.fill) } : {}),
+  };
+}
+
+function computeTextBody(
+  context: ComputeContext,
+  textBody: SourceTextBody,
+  inherited?: SourceTextBody,
+): ComputedTextBody {
+  const inheritedParagraph = inherited?.paragraphs[0];
+  return {
+    ...(textBody.properties !== undefined
+      ? { properties: { ...inherited?.properties, ...textBody.properties } }
+      : inherited?.properties !== undefined
+        ? { properties: { ...inherited.properties } }
+        : {}),
+    paragraphs: textBody.paragraphs.map((paragraph) =>
+      computeParagraph(context, paragraph, inheritedParagraph),
+    ),
+  };
+}
+
+function computeParagraph(
+  context: ComputeContext,
+  paragraph: SourceParagraph,
+  inherited?: SourceParagraph,
+): ComputedParagraph {
+  const properties = mergeParagraphProperties(inherited?.properties, paragraph.properties);
+  const inheritedRun = inherited?.runs[0];
+  return {
+    ...(properties !== undefined ? { properties } : {}),
+    runs: paragraph.runs.map((run) => ({
+      text: run.text,
+      ...(mergeRunProperties(context, inheritedRun?.properties, run.properties) !== undefined
+        ? { properties: mergeRunProperties(context, inheritedRun?.properties, run.properties) }
+        : {}),
+    })),
+  };
+}
+
+function mergeParagraphProperties(
+  inherited: SourceParagraphProperties | undefined,
+  local: SourceParagraphProperties | undefined,
+): SourceParagraphProperties | undefined {
+  const merged = { ...inherited, ...local };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function mergeRunProperties(
+  context: ComputeContext,
+  inherited: SourceRunProperties | undefined,
+  local: SourceRunProperties | undefined,
+): ComputedRunProperties | undefined {
+  const merged = { ...inherited, ...local };
+  if (Object.keys(merged).length === 0) return undefined;
+  const color = merged.color !== undefined ? resolveColor(context, merged.color) : undefined;
+  const withoutColor: Omit<SourceRunProperties, "color"> = {
+    ...(merged.bold !== undefined ? { bold: merged.bold } : {}),
+    ...(merged.italic !== undefined ? { italic: merged.italic } : {}),
+    ...(merged.underline !== undefined ? { underline: merged.underline } : {}),
+    ...(merged.fontSize !== undefined ? { fontSize: merged.fontSize } : {}),
+    ...(merged.typeface !== undefined ? { typeface: merged.typeface } : {}),
+  };
+  return {
+    ...withoutColor,
+    ...(color !== undefined ? { color } : {}),
+  };
+}
+
+function findPlaceholderMatch(
+  context: ComputeContext,
+  shape: SourceShape,
+): { readonly layout?: SourceShape; readonly master?: SourceShape } | undefined {
+  if (shape.placeholder === undefined) return undefined;
+  const type = shape.placeholder.type ?? "body";
+  const index = shape.placeholder.index;
+  const layout = findMatchingPlaceholder(type, index, context.layout?.shapes ?? []);
+  const master = findMatchingPlaceholder(type, index, context.master?.shapes ?? []);
+  if (layout === undefined && master === undefined) return undefined;
+  return {
+    ...(layout !== undefined ? { layout } : {}),
+    ...(master !== undefined ? { master } : {}),
+  };
+}
+
+function findMatchingPlaceholder(
+  type: string,
+  index: number | undefined,
+  shapes: readonly SourceShapeNode[],
+): SourceShape | undefined {
+  const placeholders = shapes.filter(
+    (shape): shape is SourceShape => shape.kind === "shape" && shape.placeholder !== undefined,
+  );
+
+  if (index !== undefined) {
+    const byIndexWithTransform = placeholders.find(
+      (shape) => shape.placeholder?.index === index && shape.transform !== undefined,
+    );
+    if (byIndexWithTransform !== undefined) return byIndexWithTransform;
+    const byIndex = placeholders.find((shape) => shape.placeholder?.index === index);
+    if (byIndex !== undefined) return byIndex;
+  }
+
+  const byTypeWithTransform = placeholders.find(
+    (shape) => (shape.placeholder?.type ?? "body") === type && shape.transform !== undefined,
+  );
+  if (byTypeWithTransform !== undefined) return byTypeWithTransform;
+
+  const fallbackType = getPlaceholderFallbackType(type);
+  if (fallbackType !== undefined) {
+    const byFallbackWithTransform = placeholders.find(
+      (shape) =>
+        (shape.placeholder?.type ?? "body") === fallbackType && shape.transform !== undefined,
+    );
+    if (byFallbackWithTransform !== undefined) return byFallbackWithTransform;
+  }
+
+  const byType = placeholders.find((shape) => (shape.placeholder?.type ?? "body") === type);
+  if (byType !== undefined) return byType;
+
+  if (fallbackType !== undefined) {
+    return placeholders.find((shape) => (shape.placeholder?.type ?? "body") === fallbackType);
+  }
+
+  return undefined;
+}
+
+function getPlaceholderFallbackType(type: string): string | undefined {
+  if (type === "ctrTitle") return "title";
+  if (type === "subTitle") return "body";
+  return undefined;
+}
+
+function isEmptyPlaceholder(shape: SourceShape): boolean {
+  if (shape.placeholder === undefined) return false;
+  const paragraphs = shape.textBody?.paragraphs;
+  if (paragraphs === undefined || paragraphs.length === 0) return true;
+  return !paragraphs.some((paragraph) => paragraph.runs.some((run) => run.text.length > 0));
+}
+
+function resolveColor(
+  context: ComputeContext,
+  color: SourceColor,
+  visited: ReadonlySet<string> = new Set(),
+): ComputedColor | undefined {
+  let hex: string | undefined;
+  if (color.kind === "srgb") {
+    hex = normalizeHex(color.hex);
+  } else if (color.kind === "system") {
+    hex = normalizeHex(color.lastColor ?? "000000");
+  } else {
+    const mappedName = context.colorMap[color.scheme] ?? color.scheme;
+    if (visited.has(mappedName)) return { hex: "#000000", alpha: 1 };
+    const schemeColor = context.theme?.colorScheme?.colors[mappedName];
+    hex =
+      schemeColor !== undefined
+        ? resolveColor(context, schemeColor, new Set([...visited, mappedName]))?.hex
+        : FALLBACK_SCHEME_COLORS[mappedName];
+  }
+  if (hex === undefined) return undefined;
+
+  let alpha = 1;
+  for (const transform of color.transforms ?? []) {
+    if (transform.kind === "lumMod") {
+      const lumOff = color.transforms?.find((candidate) => candidate.kind === "lumOff");
+      hex = applyLuminance(
+        hex,
+        Number(transform.value) / 100000,
+        Number(lumOff?.value ?? 0) / 100000,
+      );
+    } else if (transform.kind === "lumOff") {
+      if (!color.transforms?.some((candidate) => candidate.kind === "lumMod")) {
+        hex = applyLuminance(hex, 1, Number(transform.value) / 100000);
+      }
+    } else if (transform.kind === "tint") {
+      hex = applyTint(hex, Number(transform.value) / 100000);
+    } else if (transform.kind === "shade") {
+      hex = applyShade(hex, Number(transform.value) / 100000);
+    } else if (transform.kind === "alpha") {
+      alpha = Number(transform.value) / 100000;
+    }
+  }
+
+  return { hex, alpha };
+}
+
+function resolveRelationshipTarget(sourcePartPath: string, target: string): string {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return target;
+
+  let combined: string;
+  if (target.startsWith("/")) {
+    combined = target.slice(1);
+  } else {
+    const slash = sourcePartPath.lastIndexOf("/");
+    const baseDir = slash === -1 ? "" : sourcePartPath.slice(0, slash);
+    combined = baseDir === "" ? target : `${baseDir}/${target}`;
+  }
+
+  const segments: string[] = [];
+  for (const segment of combined.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join("/");
+}
+
+function normalizeHex(hex: string): string {
+  const normalized = hex.replace(/^#/, "").toLowerCase();
+  return `#${normalized.padStart(6, "0").slice(0, 6)}`;
+}
+
+function applyLuminance(hex: string, lumMod: number, lumOff: number): string {
+  const { h, s, l } = hexToHsl(hex);
+  return hslToHex(h, s, Math.min(1, Math.max(0, l * lumMod + lumOff)));
+}
+
+function applyTint(hex: string, tintAmount: number): string {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex(
+    Math.round(r + (255 - r) * tintAmount),
+    Math.round(g + (255 - g) * tintAmount),
+    Math.round(b + (255 - b) * tintAmount),
+  );
+}
+
+function applyShade(hex: string, shadeAmount: number): string {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex(
+    Math.round(r * shadeAmount),
+    Math.round(g * shadeAmount),
+    Math.round(b * shadeAmount),
+  );
+}
+
+function hexToRgb(hex: string): { readonly r: number; readonly g: number; readonly b: number } {
+  const normalized = hex.replace("#", "");
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+  };
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (value: number) => Math.min(255, Math.max(0, value)).toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hexToHsl(hex: string): { readonly h: number; readonly s: number; readonly l: number } {
+  const { r: r255, g: g255, b: b255 } = hexToRgb(hex);
+  const r = r255 / 255;
+  const g = g255 / 255;
+  const b = b255 / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return { h: 0, s: 0, l };
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  const h =
+    max === r
+      ? ((g - b) / d + (g < b ? 6 : 0)) / 6
+      : max === g
+        ? ((b - r) / d + 2) / 6
+        : ((r - g) / d + 4) / 6;
+
+  return { h, s, l };
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  if (s === 0) {
+    const value = Math.round(l * 255);
+    return rgbToHex(value, value, value);
+  }
+
+  const hue2rgb = (p: number, q: number, t: number): number => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return rgbToHex(
+    Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
+    Math.round(hue2rgb(p, q, h) * 255),
+    Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
+  );
+}
+
+function firstDefined<T>(...values: readonly (T | undefined)[]): T | undefined {
+  return values.find((value) => value !== undefined);
+}

--- a/packages/pptx-glimpse-document/src/computed/index.ts
+++ b/packages/pptx-glimpse-document/src/computed/index.ts
@@ -8,6 +8,8 @@ export type {
   ComputedImageElement,
   ComputedOutline,
   ComputedParagraph,
+  ComputedPlaceholderMatch,
+  ComputedRawElement,
   ComputedRelationship,
   ComputedRunProperties,
   ComputedShapeElement,

--- a/packages/pptx-glimpse-document/src/computed/index.ts
+++ b/packages/pptx-glimpse-document/src/computed/index.ts
@@ -1,0 +1,20 @@
+export type {
+  CleanDocComputedView,
+  ComputedBackground,
+  ComputedColor,
+  ComputedElement,
+  ComputedElementLayer,
+  ComputedFill,
+  ComputedImageElement,
+  ComputedOutline,
+  ComputedParagraph,
+  ComputedRelationship,
+  ComputedRunProperties,
+  ComputedShapeElement,
+  ComputedSlide,
+  ComputedSlideSize,
+  ComputedTextBody,
+  ComputedTextRun,
+  CreateComputedViewOptions,
+} from "./clean-doc-computed-view.js";
+export { createComputedView } from "./create-computed-view.js";

--- a/packages/pptx-glimpse-document/src/experimental.ts
+++ b/packages/pptx-glimpse-document/src/experimental.ts
@@ -15,3 +15,7 @@ export * from "./source/index.js";
 // CleanDoc source reader (experimental)。PPTX package を読み、package graph と
 // presentation metadata を含む CleanDoc source を返す。
 export * from "./reader/index.js";
+
+// CleanDoc computed view generator (experimental)。source model を mutation せず、
+// slide/layout/master/theme cascade と relationship を解決した derived view を返す。
+export * from "./computed/index.js";


### PR DESCRIPTION
close #465

## 概要

- `@pptx-glimpse/document/experimental` に `createComputedView(source, options)` と computed view 型を追加
- slide size / presentation order / relationship target / media 解決を computed view に反映
- theme color + clrMap/clrMapOvr、background fallback、placeholder matching、basic text style inheritance、`showMasterSp` と effective element ordering を解決
- source model の in-place mutation が起きないことを unit test で検証

## 影響範囲

- `packages/pptx-glimpse-document/src/computed/`
- `packages/pptx-glimpse-document/src/experimental.ts`

## 検証

- `npm run knip`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test -- packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts`

## 補足

- `@pptx-glimpse/document` は private package の experimental entry point への追加のため changeset は追加していません。
- `npm run build` では既存の `import.meta` CJS warning が表示されますが、build は成功しています。
