### PR TITLE
dual-reader structural comparison tests を追加

### DIFF
--- a/packages/pptx-glimpse/src/converter.ts
+++ b/packages/pptx-glimpse/src/converter.ts
@@ -236,6 +236,8 @@ function mergeElements(
   layoutElements: SlideElement[],
   slideElements: SlideElement[],
 ): SlideElement[] {
+  // Keep packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
+  // in sync when this effective render element merge behavior changes.
   // Placeholder shapes in master and layout are templates (position/style definitions).
   // Their text content should never appear on actual slides.
   // Only non-placeholder shapes (decorative elements, logos, etc.) are shown.

--- a/packages/pptx-glimpse/src/converter.ts
+++ b/packages/pptx-glimpse/src/converter.ts
@@ -22,6 +22,7 @@ import { DEFAULT_OUTPUT_WIDTH } from "pptx-glimpse-renderer";
 import { flushWarnings, initWarningLogger, warn } from "pptx-glimpse-renderer";
 
 import { clearXmlCache, enableXmlCache } from "./parser/xml-parser.js";
+import type { ParsedSlide } from "./pptx-data-parser.js";
 import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 
 export interface ConvertOptions {
@@ -60,6 +61,12 @@ export interface SlideImage {
   png: Buffer;
   width: number;
   height: number;
+}
+
+export function buildEffectiveSlideElements(parsed: ParsedSlide): SlideElement[] {
+  const effectiveMasterElements =
+    parsed.slide.showMasterSp && parsed.layoutShowMasterSp ? parsed.masterElements : [];
+  return mergeElements(effectiveMasterElements, parsed.layoutElements, parsed.slide.elements);
 }
 
 export async function convertPptxToSvg(
@@ -107,12 +114,9 @@ export async function convertPptxToSvg(
       const parsed = parseSlideWithLayout(slideNumber, path, data);
       if (!parsed) continue;
 
-      const { slide, layoutElements, layoutShowMasterSp, masterElements } = parsed;
-
       // Merge shapes: master (back) → layout → slide (front)
-      const effectiveMasterElements =
-        slide.showMasterSp && layoutShowMasterSp ? masterElements : [];
-      slide.elements = mergeElements(effectiveMasterElements, layoutElements, slide.elements);
+      const { slide } = parsed;
+      slide.elements = buildEffectiveSlideElements(parsed);
 
       fontUsageCollector?.reset();
       let svg = renderSlideToSvg(slide, data.presInfo.slideSize);
@@ -236,8 +240,6 @@ function mergeElements(
   layoutElements: SlideElement[],
   slideElements: SlideElement[],
 ): SlideElement[] {
-  // Keep packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
-  // in sync when this effective render element merge behavior changes.
   // Placeholder shapes in master and layout are templates (position/style definitions).
   // Their text content should never appear on actual slides.
   // Only non-placeholder shapes (decorative elements, logos, etc.) are shown.

--- a/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
+++ b/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from "vitest";
 
 import { createComputedView, readPptx } from "../../pptx-glimpse-document/src/experimental.js";
 import { adaptComputedViewToRendererModel } from "./cleandoc-renderer-adapter.js";
+import { buildEffectiveSlideElements } from "./converter.js";
 import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 
 const CASES = [
@@ -217,15 +218,9 @@ function buildCurrentParserSlides(input: Buffer): PresentationSlides {
     const parsed = parseSlideWithLayout(slideNumber, path, data);
     if (parsed === null) continue;
 
-    const effectiveMasterElements =
-      parsed.slide.showMasterSp && parsed.layoutShowMasterSp ? parsed.masterElements : [];
     slides.push({
       ...parsed.slide,
-      elements: mergeElements(
-        effectiveMasterElements,
-        parsed.layoutElements,
-        parsed.slide.elements,
-      ),
+      elements: buildEffectiveSlideElements(parsed),
     });
   }
 
@@ -241,32 +236,6 @@ function buildDocumentPathSlides(input: Buffer, options: NormalizeOptions): Docu
     presentation: normalizePresentation(adapted, options),
     diagnostics: adapted.diagnostics,
   };
-}
-
-function mergeElements(
-  masterElements: readonly SlideElement[],
-  layoutElements: readonly SlideElement[],
-  slideElements: readonly SlideElement[],
-): SlideElement[] {
-  // Keep this in sync with converter.ts mergeElements. The public converter
-  // intentionally does not expose the intermediate renderer model.
-  const filterTemplatePlaceholders = (elements: readonly SlideElement[]) =>
-    elements.filter((element) => !(element.type === "shape" && element.placeholderType));
-  const filterEmptySlidePlaceholders = (elements: readonly SlideElement[]) =>
-    elements.filter((element) => !(element.type === "shape" && isEmptyPlaceholder(element)));
-
-  return [
-    ...filterTemplatePlaceholders(masterElements),
-    ...filterTemplatePlaceholders(layoutElements),
-    ...filterEmptySlidePlaceholders(slideElements),
-  ];
-}
-
-function isEmptyPlaceholder(shape: ShapeElement): boolean {
-  if (!shape.placeholderType) return false;
-  const paragraphs = shape.textBody?.paragraphs;
-  if (paragraphs === undefined || paragraphs.length === 0) return true;
-  return !paragraphs.some((paragraph) => paragraph.runs.some((run) => run.text.length > 0));
 }
 
 function normalizePresentation(

--- a/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
+++ b/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
@@ -24,6 +24,8 @@ import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 
 const CASES = [
   { fixtureName: "real-product-page.pptx", includeRunProperties: true },
+  // real-basic-theme uses inherited placeholder/theme text styles that the
+  // document path does not expose yet. Flip this to true when that support lands.
   { fixtureName: "real-basic-theme.pptx", includeRunProperties: false },
 ] as const;
 
@@ -81,9 +83,12 @@ describe("dual-reader structural comparison", () => {
       const current = normalizePresentation(buildCurrentParserSlides(input), options);
       const document = buildDocumentPathSlides(input, options);
 
-      expect(new Set(document.diagnostics.map((diagnostic) => diagnostic.code))).toEqual(
-        new Set(document.diagnostics.length > 0 ? ["cleandoc-adapter.raw-element-skipped"] : []),
-      );
+      for (const diagnostic of document.diagnostics) {
+        expect(diagnostic).toMatchObject({
+          severity: "warning",
+          code: "cleandoc-adapter.raw-element-skipped",
+        });
+      }
       expect(document.presentation).toEqual(current);
     },
   );
@@ -134,7 +139,7 @@ interface ComparableImage {
   readonly type: "image";
   readonly transform: ComparableTransform;
   readonly mimeType: string;
-  readonly imageDataLength: number;
+  readonly imageData: string;
   readonly srcRect: ImageElement["srcRect"];
 }
 
@@ -243,6 +248,8 @@ function mergeElements(
   layoutElements: readonly SlideElement[],
   slideElements: readonly SlideElement[],
 ): SlideElement[] {
+  // Keep this in sync with converter.ts mergeElements. The public converter
+  // intentionally does not expose the intermediate renderer model.
   const filterTemplatePlaceholders = (elements: readonly SlideElement[]) =>
     elements.filter((element) => !(element.type === "shape" && element.placeholderType));
   const filterEmptySlidePlaceholders = (elements: readonly SlideElement[]) =>
@@ -317,7 +324,7 @@ function normalizeImage(image: ImageElement): ComparableImage {
     type: "image",
     transform: normalizeTransform(image.transform),
     mimeType: image.mimeType,
-    imageDataLength: image.imageData.length,
+    imageData: image.imageData,
     srcRect: image.srcRect,
   };
 }

--- a/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
+++ b/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
@@ -1,0 +1,402 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import type {
+  Background,
+  BodyProperties,
+  Fill,
+  ImageElement,
+  Outline,
+  Paragraph,
+  RunProperties,
+  ShapeElement,
+  Slide,
+  SlideElement,
+  SlideSize,
+  TextBody,
+  Transform,
+} from "pptx-glimpse-renderer";
+import { describe, expect, it } from "vitest";
+
+import { createComputedView, readPptx } from "../../pptx-glimpse-document/src/experimental.js";
+import { adaptComputedViewToRendererModel } from "./cleandoc-renderer-adapter.js";
+import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
+
+const CASES = [
+  { fixtureName: "real-product-page.pptx", includeRunProperties: true },
+  { fixtureName: "real-basic-theme.pptx", includeRunProperties: false },
+] as const;
+
+const COMPARISON_SCOPE = [
+  "slide size",
+  "slide background fill",
+  "effective element ordering after template placeholder filtering",
+  "simple shape transform / preset geometry / placeholder metadata",
+  "simple shape solid fill / outline colors resolved through theme data",
+  "plain text runs and basic run styling",
+  "embedded raster image transform / media type / payload presence / crop rectangle",
+] as const;
+
+const OUT_OF_SCOPE_FIELDS = [
+  "alt text / source node names",
+  "shape geometry adjustment handles",
+  "effects, shadows, gradients, pattern fills, and picture fills on shapes",
+  "tables, charts, SmartArt, graphicFrame, groups, and raw shape tree nodes",
+  "complex paragraph features such as bullets, numbering, tab stops, and hyperlinks",
+  "inherited placeholder/theme text styling when it is not yet exposed by the document path",
+  "renderer-only text defaults such as East Asian / complex script fallback fields",
+] as const;
+
+describe("dual-reader structural comparison", () => {
+  it("comparison scope is intentionally limited to the CleanDoc PoC supported subset", () => {
+    expect(COMPARISON_SCOPE).toMatchInlineSnapshot(`
+      [
+        "slide size",
+        "slide background fill",
+        "effective element ordering after template placeholder filtering",
+        "simple shape transform / preset geometry / placeholder metadata",
+        "simple shape solid fill / outline colors resolved through theme data",
+        "plain text runs and basic run styling",
+        "embedded raster image transform / media type / payload presence / crop rectangle",
+      ]
+    `);
+    expect(OUT_OF_SCOPE_FIELDS).toMatchInlineSnapshot(`
+      [
+        "alt text / source node names",
+        "shape geometry adjustment handles",
+        "effects, shadows, gradients, pattern fills, and picture fills on shapes",
+        "tables, charts, SmartArt, graphicFrame, groups, and raw shape tree nodes",
+        "complex paragraph features such as bullets, numbering, tab stops, and hyperlinks",
+        "inherited placeholder/theme text styling when it is not yet exposed by the document path",
+        "renderer-only text defaults such as East Asian / complex script fallback fields",
+      ]
+    `);
+  });
+
+  it.each(CASES)(
+    "$fixtureName matches between current parser and CleanDoc document path for supported fields",
+    ({ fixtureName, includeRunProperties }) => {
+      const input = readFixture(fixtureName);
+      const options = { includeRunProperties };
+      const current = normalizePresentation(buildCurrentParserSlides(input), options);
+      const document = buildDocumentPathSlides(input, options);
+
+      expect(new Set(document.diagnostics.map((diagnostic) => diagnostic.code))).toEqual(
+        new Set(document.diagnostics.length > 0 ? ["cleandoc-adapter.raw-element-skipped"] : []),
+      );
+      expect(document.presentation).toEqual(current);
+    },
+  );
+});
+
+interface PresentationSlides {
+  readonly slideSize?: SlideSize;
+  readonly slides: readonly Slide[];
+}
+
+interface DocumentPathSlides {
+  readonly presentation: ComparablePresentation;
+  readonly diagnostics: readonly { readonly severity: string; readonly code: string }[];
+}
+
+interface ComparablePresentation {
+  readonly slideSize?: ComparableSlideSize;
+  readonly slides: readonly ComparableSlide[];
+}
+
+interface ComparableSlideSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+interface ComparableSlide {
+  readonly slideNumber: number;
+  readonly background: ComparableBackground;
+  readonly elements: readonly ComparableElement[];
+}
+
+type ComparableBackground = { readonly fill: ComparableFill } | null;
+
+type ComparableElement = ComparableShape | ComparableImage;
+
+interface ComparableShape {
+  readonly type: "shape";
+  readonly transform: ComparableTransform;
+  readonly geometry: ComparableGeometry;
+  readonly placeholderType?: string;
+  readonly placeholderIdx?: number;
+  readonly fill: ComparableFill;
+  readonly outline: ComparableOutline;
+  readonly textBody: ComparableTextBody | null;
+}
+
+interface ComparableImage {
+  readonly type: "image";
+  readonly transform: ComparableTransform;
+  readonly mimeType: string;
+  readonly imageDataLength: number;
+  readonly srcRect: ImageElement["srcRect"];
+}
+
+interface ComparableTransform {
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly extentWidth: number;
+  readonly extentHeight: number;
+  readonly rotation: number;
+  readonly flipH: boolean;
+  readonly flipV: boolean;
+}
+
+interface ComparableGeometry {
+  readonly type: "preset";
+  readonly preset: string;
+}
+
+type ComparableFill =
+  | { readonly type: "none" }
+  | { readonly type: "solid"; readonly color: ComparableColor }
+  | null;
+
+type ComparableOutline = { readonly width: number; readonly fill: ComparableFill } | null;
+
+interface ComparableColor {
+  readonly hex: string;
+  readonly alpha: number;
+}
+
+interface ComparableTextBody {
+  readonly bodyProperties: ComparableBodyProperties;
+  readonly paragraphs: readonly ComparableParagraph[];
+}
+
+interface ComparableBodyProperties {
+  readonly anchor: BodyProperties["anchor"];
+  readonly marginLeft: number;
+  readonly marginRight: number;
+  readonly marginTop: number;
+  readonly marginBottom: number;
+}
+
+interface ComparableParagraph {
+  readonly runs: readonly ComparableRun[];
+}
+
+interface ComparableRun {
+  readonly text: string;
+  readonly properties: ComparableRunProperties;
+}
+
+interface ComparableRunProperties {
+  readonly fontSize?: number | null;
+  readonly fontFamily?: string | null;
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+  readonly underline?: boolean;
+  readonly color?: ComparableColor | null;
+}
+
+interface NormalizeOptions {
+  readonly includeRunProperties: boolean;
+}
+
+function readFixture(name: string): Buffer {
+  return readFileSync(fileURLToPath(new URL(`../../../shared-fixtures/${name}`, import.meta.url)));
+}
+
+function buildCurrentParserSlides(input: Buffer): PresentationSlides {
+  const data = parsePptxData(input);
+  const slides: Slide[] = [];
+
+  for (const { slideNumber, path } of data.slidePaths) {
+    const parsed = parseSlideWithLayout(slideNumber, path, data);
+    if (parsed === null) continue;
+
+    const effectiveMasterElements =
+      parsed.slide.showMasterSp && parsed.layoutShowMasterSp ? parsed.masterElements : [];
+    slides.push({
+      ...parsed.slide,
+      elements: mergeElements(
+        effectiveMasterElements,
+        parsed.layoutElements,
+        parsed.slide.elements,
+      ),
+    });
+  }
+
+  return { slideSize: data.presInfo.slideSize, slides };
+}
+
+function buildDocumentPathSlides(input: Buffer, options: NormalizeOptions): DocumentPathSlides {
+  const source = readPptx(input);
+  const computed = createComputedView(source);
+  const adapted = adaptComputedViewToRendererModel(computed);
+
+  return {
+    presentation: normalizePresentation(adapted, options),
+    diagnostics: adapted.diagnostics,
+  };
+}
+
+function mergeElements(
+  masterElements: readonly SlideElement[],
+  layoutElements: readonly SlideElement[],
+  slideElements: readonly SlideElement[],
+): SlideElement[] {
+  const filterTemplatePlaceholders = (elements: readonly SlideElement[]) =>
+    elements.filter((element) => !(element.type === "shape" && element.placeholderType));
+  const filterEmptySlidePlaceholders = (elements: readonly SlideElement[]) =>
+    elements.filter((element) => !(element.type === "shape" && isEmptyPlaceholder(element)));
+
+  return [
+    ...filterTemplatePlaceholders(masterElements),
+    ...filterTemplatePlaceholders(layoutElements),
+    ...filterEmptySlidePlaceholders(slideElements),
+  ];
+}
+
+function isEmptyPlaceholder(shape: ShapeElement): boolean {
+  if (!shape.placeholderType) return false;
+  const paragraphs = shape.textBody?.paragraphs;
+  if (paragraphs === undefined || paragraphs.length === 0) return true;
+  return !paragraphs.some((paragraph) => paragraph.runs.some((run) => run.text.length > 0));
+}
+
+function normalizePresentation(
+  presentation: PresentationSlides,
+  options: NormalizeOptions,
+): ComparablePresentation {
+  return {
+    ...(presentation.slideSize !== undefined
+      ? { slideSize: normalizeSlideSize(presentation.slideSize) }
+      : {}),
+    slides: presentation.slides.map((slide) => ({
+      slideNumber: slide.slideNumber,
+      background: normalizeBackground(slide.background),
+      elements: slide.elements.flatMap((element) => normalizeElement(element, options)),
+    })),
+  };
+}
+
+function normalizeSlideSize(slideSize: SlideSize): ComparableSlideSize {
+  return {
+    width: Number(slideSize.width),
+    height: Number(slideSize.height),
+  };
+}
+
+function normalizeBackground(background: Background | null): ComparableBackground {
+  if (background === null) return null;
+  return { fill: normalizeFill(background.fill) };
+}
+
+function normalizeElement(element: SlideElement, options: NormalizeOptions): ComparableElement[] {
+  if (element.type === "shape") return [normalizeShape(element, options)];
+  if (element.type === "image") return [normalizeImage(element)];
+  return [];
+}
+
+function normalizeShape(shape: ShapeElement, options: NormalizeOptions): ComparableShape {
+  return {
+    type: "shape",
+    transform: normalizeTransform(shape.transform),
+    geometry: {
+      type: "preset",
+      preset: shape.geometry.type === "preset" ? shape.geometry.preset : "unsupported",
+    },
+    ...(shape.placeholderType !== undefined ? { placeholderType: shape.placeholderType } : {}),
+    ...(shape.placeholderIdx !== undefined ? { placeholderIdx: shape.placeholderIdx } : {}),
+    fill: normalizeFill(shape.fill),
+    outline: normalizeOutline(shape.outline),
+    textBody: normalizeTextBody(shape.textBody, options),
+  };
+}
+
+function normalizeImage(image: ImageElement): ComparableImage {
+  return {
+    type: "image",
+    transform: normalizeTransform(image.transform),
+    mimeType: image.mimeType,
+    imageDataLength: image.imageData.length,
+    srcRect: image.srcRect,
+  };
+}
+
+function normalizeTransform(transform: Transform): ComparableTransform {
+  return {
+    offsetX: Number(transform.offsetX),
+    offsetY: Number(transform.offsetY),
+    extentWidth: Number(transform.extentWidth),
+    extentHeight: Number(transform.extentHeight),
+    rotation: transform.rotation,
+    flipH: transform.flipH,
+    flipV: transform.flipV,
+  };
+}
+
+function normalizeFill(fill: Fill | null): ComparableFill {
+  if (fill === null) return null;
+  if (fill.type === "none") return { type: "none" };
+  if (fill.type === "solid") return { type: "solid", color: normalizeColor(fill.color) };
+  return null;
+}
+
+function normalizeOutline(outline: Outline | null): ComparableOutline {
+  if (outline === null) return null;
+  return {
+    width: Number(outline.width),
+    fill: normalizeFill(outline.fill),
+  };
+}
+
+function normalizeTextBody(
+  textBody: TextBody | null,
+  options: NormalizeOptions,
+): ComparableTextBody | null {
+  if (textBody === null) return null;
+  return {
+    bodyProperties: normalizeBodyProperties(textBody.bodyProperties),
+    paragraphs: textBody.paragraphs.map((paragraph) => normalizeParagraph(paragraph, options)),
+  };
+}
+
+function normalizeBodyProperties(properties: BodyProperties): ComparableBodyProperties {
+  return {
+    anchor: properties.anchor,
+    marginLeft: Number(properties.marginLeft),
+    marginRight: Number(properties.marginRight),
+    marginTop: Number(properties.marginTop),
+    marginBottom: Number(properties.marginBottom),
+  };
+}
+
+function normalizeParagraph(paragraph: Paragraph, options: NormalizeOptions): ComparableParagraph {
+  return {
+    runs: paragraph.runs.map((run) => ({
+      text: run.text,
+      properties: normalizeRunProperties(run.properties, options),
+    })),
+  };
+}
+
+function normalizeRunProperties(
+  properties: RunProperties,
+  options: NormalizeOptions,
+): ComparableRunProperties {
+  if (!options.includeRunProperties) return {};
+  return {
+    fontSize: properties.fontSize === null ? null : Number(properties.fontSize),
+    fontFamily: properties.fontFamily,
+    bold: properties.bold,
+    italic: properties.italic,
+    underline: properties.underline,
+    color: properties.color === null ? null : normalizeColor(properties.color),
+  };
+}
+
+function normalizeColor(color: { readonly hex: string; readonly alpha: number }): ComparableColor {
+  return {
+    hex: color.hex.toLowerCase(),
+    alpha: color.alpha,
+  };
+}

--- a/packages/pptx-glimpse/src/pptx-data-parser.ts
+++ b/packages/pptx-glimpse/src/pptx-data-parser.ts
@@ -141,7 +141,7 @@ export function parsePptxData(input: Buffer | Uint8Array): ParsedPptxData {
   };
 }
 
-interface ParsedSlide {
+export interface ParsedSlide {
   slide: Slide;
   layoutElements: SlideElement[];
   layoutShowMasterSp: boolean;


### PR DESCRIPTION
close #467

## 目的

現行 parser path と CleanDoc reader + computed view + adapter path を同じ shared fixtures で走らせ、CleanDoc PoC の supported subset が構造的に一致することを検証する dual-reader test を追加します。

## 変更内容

- `packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts` を追加し、`real-product-page.pptx` / `real-basic-theme.pptx` を対象に比較
- 比較対象と scope 外 field をテスト内で明示
- current parser 側の effective element merge を `buildEffectiveSlideElements` として内部共有し、converter と test の重複を解消
- public `convertPptxToSvg` / `convertPptxToPng` の default path は変更なし

## 検証

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test -- packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts`
- `npm run test`
- acceptance-check: 5/5 件達成
- cross-review: critical 0 / warning 0

## VRT

レンダリング実装・snapshot は変更していないため、VRT snapshot update は不要です。
