### PR TITLE
no-edit writer round-trip を実装する

### DIFF
--- a/packages/pptx-glimpse-document/src/experimental.ts
+++ b/packages/pptx-glimpse-document/src/experimental.ts
@@ -19,3 +19,7 @@ export * from "./reader/index.js";
 // CleanDoc computed view generator (experimental)。source model を mutation せず、
 // slide/layout/master/theme cascade と relationship を解決した derived view を返す。
 export * from "./computed/index.js";
+
+// CleanDoc source writer (experimental)。まずは no-edit structural round-trip
+// 用に、保持済み package material を PPTX ZIP として書き戻す。
+export * from "./writer/index.js";

--- a/packages/pptx-glimpse-document/src/writer/index.ts
+++ b/packages/pptx-glimpse-document/src/writer/index.ts
@@ -1,0 +1,6 @@
+/**
+ * CleanDoc source writer の barrel re-export。
+ */
+
+export type { WritePptxOutput } from "./write-pptx.js";
+export { writePptx } from "./write-pptx.js";

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
@@ -104,6 +104,74 @@ describe("writePptx — no-edit round-trip", () => {
     );
   });
 
+  it("xml raw package material を serializable な範囲で write できる", () => {
+    const source = readPptx(buildRoundTripFixture());
+    const withXmlRaw = {
+      ...source,
+      packageGraph: {
+        ...source.packageGraph,
+        contentTypes: {
+          ...source.packageGraph.contentTypes,
+          overrides: [
+            ...source.packageGraph.contentTypes.overrides,
+            { partName: "customXml/item1.xml", contentType: "application/xml" },
+          ],
+        },
+        parts: [
+          ...source.packageGraph.parts,
+          { partPath: "customXml/item1.xml", contentType: "application/xml" },
+        ],
+        rawParts: [
+          ...(source.packageGraph.rawParts ?? []),
+          {
+            kind: "xml",
+            partPath: "customXml/item1.xml",
+            contentType: "application/xml",
+            xml: {
+              name: "x:root",
+              attributes: { "xmlns:x": "urn:test", "a:flag": "A&B" },
+              children: [{ name: "x:child", text: "nested < text" }],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(decoder.decode(getEntry(writePptx(withXmlRaw), "customXml/item1.xml"))).toBe(
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n` +
+        `<x:root xmlns:x="urn:test" a:flag="A&amp;B"><x:child>nested &lt; text</x:child></x:root>`,
+    );
+  });
+
+  it("xml raw package material の mixed content は順序保持できないため reject する", () => {
+    const source = readPptx(buildRoundTripFixture());
+    const withMixedContentRaw = {
+      ...source,
+      packageGraph: {
+        ...source.packageGraph,
+        parts: [
+          ...source.packageGraph.parts,
+          { partPath: "customXml/item1.xml", contentType: "application/xml" },
+        ],
+        rawParts: [
+          ...(source.packageGraph.rawParts ?? []),
+          {
+            kind: "xml",
+            partPath: "customXml/item1.xml",
+            contentType: "application/xml",
+            xml: {
+              name: "x:root",
+              text: "pre",
+              children: [{ name: "x:child" }],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => writePptx(withMixedContentRaw)).toThrow(/mixed text\/element content/);
+  });
+
   it("byte equality ではなく structural preservation を検証対象にする", () => {
     const input = buildRoundTripFixture();
     const output = writePptx(readPptx(input));

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
@@ -1,0 +1,151 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { unzipSync, zipSync } from "fflate";
+import { describe, expect, it } from "vitest";
+
+// 実際の公開面 (`@pptx-glimpse/document/experimental`) 経由で import する。
+import { readPptx, writePptx } from "../experimental.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function xml(content: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+function buildRoundTripFixture(): Uint8Array {
+  return zipSync({
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Default Extension="png" ContentType="image/png"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst>` +
+        `<p:sldId id="256" r:id="rIdSlide1"/>` +
+        `<p:sldId id="257" r:id="rIdSlide2"/>` +
+        `</p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `<Relationship Id="rIdSlide2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(`<p:sld xmlns:p="x"><p:cSld/></p:sld>`),
+    "ppt/slides/slide2.xml": xml(`<p:sld xmlns:p="x"><p:cSld/></p:sld>`),
+    "ppt/slides/_rels/slide1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>` +
+        `<Relationship Id="rIdLink" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/?a=1&amp;b=2" TargetMode="External"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/media/image1.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
+    "docProps/custom.xml": xml(`<Properties><custom value="preserve-me"/></Properties>`),
+  });
+}
+
+function getEntry(output: Uint8Array, path: string): Uint8Array {
+  const entry = unzipSync(output)[path];
+  if (entry === undefined) throw new Error(`missing zip entry: ${path}`);
+  return entry;
+}
+
+describe("writePptx — no-edit round-trip", () => {
+  it("CleanDoc source から no-edit PPTX を write し、再読込できる", () => {
+    const input = buildRoundTripFixture();
+    const original = readPptx(input);
+
+    const output = writePptx(original);
+    const reread = readPptx(output);
+
+    expect(reread.presentation.slidePartPaths).toEqual(original.presentation.slidePartPaths);
+    expect(reread.presentation.slideSize).toEqual(original.presentation.slideSize);
+    expect(reread.slides.map((slide) => slide.partPath)).toEqual(
+      original.slides.map((slide) => slide.partPath),
+    );
+  });
+
+  it("relationship IDs と content types を structural に preserving する", () => {
+    const original = readPptx(buildRoundTripFixture());
+    const reread = readPptx(writePptx(original));
+
+    expect(reread.packageGraph.contentTypes).toEqual(original.packageGraph.contentTypes);
+    expect(reread.packageGraph.relationships).toEqual(original.packageGraph.relationships);
+  });
+
+  it("media bytes と unsupported raw package material を preserving する", () => {
+    const input = buildRoundTripFixture();
+    const source = readPptx(input);
+    const output = writePptx(source);
+
+    expect(getEntry(output, "ppt/media/image1.png")).toEqual(
+      getEntry(input, "ppt/media/image1.png"),
+    );
+    expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toBe(
+      decoder.decode(getEntry(input, "docProps/custom.xml")),
+    );
+    expect(decoder.decode(getEntry(output, "ppt/slides/slide1.xml"))).toBe(
+      decoder.decode(getEntry(input, "ppt/slides/slide1.xml")),
+    );
+  });
+
+  it("byte equality ではなく structural preservation を検証対象にする", () => {
+    const input = buildRoundTripFixture();
+    const output = writePptx(readPptx(input));
+
+    expect(output).not.toEqual(input);
+    expect(readPptx(output).presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+  });
+
+  it("real fixture でも write 後の PPTX を readPptx で再読込できる", () => {
+    const fixturePath = fileURLToPath(
+      new URL("../../../../shared-fixtures/real-basic-theme.pptx", import.meta.url),
+    );
+    const source = readPptx(readFileSync(fixturePath));
+    const output = writePptx(source);
+    const reread = readPptx(output);
+    const originalImage = source.packageGraph.media.find(
+      (part) => part.partPath === "ppt/media/image1.png",
+    );
+    const rereadImage = reread.packageGraph.media.find(
+      (part) => part.partPath === "ppt/media/image1.png",
+    );
+
+    expect(reread.presentation.slidePartPaths).toEqual(source.presentation.slidePartPaths);
+    expect(reread.presentation.slideSize).toEqual(source.presentation.slideSize);
+    expect(rereadImage?.bytes).toEqual(originalImage?.bytes);
+  });
+
+  it("preserved material が無い part は no-edit writer で暗黙に再生成しない", () => {
+    const source = readPptx(buildRoundTripFixture());
+    const withoutRawSlide = {
+      ...source,
+      packageGraph: {
+        ...source.packageGraph,
+        rawParts: source.packageGraph.rawParts?.filter(
+          (part) => part.partPath !== "ppt/slides/slide1.xml",
+        ),
+      },
+    };
+
+    expect(() => writePptx(withoutRawSlide)).toThrow(/no preserved package material/);
+  });
+});

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.ts
@@ -1,0 +1,162 @@
+/**
+ * `writePptx(source)` — CleanDoc source writer の最初の no-edit slice。
+ *
+ * この writer は structural round-trip を目的に、reader が保持した raw package
+ * material / media bytes / package bookkeeping を PPTX ZIP として再構成する。
+ * edited writer behavior や node-level XML splicing は後続 slice の責務。
+ */
+
+import { zipSync } from "fflate";
+
+import type {
+  CleanDocSource,
+  PartPath,
+  PartRelationships,
+  RawOoxmlNode,
+  RawPackagePart,
+} from "../source/index.js";
+
+/** `writePptx` の出力。 */
+export type WritePptxOutput = Uint8Array;
+
+const CONTENT_TYPES_PART = "[Content_Types].xml";
+const RELS_CONTENT_TYPE = "application/vnd.openxmlformats-package.relationships+xml";
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
+
+const textEncoder = new TextEncoder();
+
+/**
+ * CleanDoc source を PPTX package bytes に書き戻す。
+ *
+ * no-edit round-trip 用の初期 writer であり、未編集 package material を優先して
+ * preserved output を作る。必要な raw bytes が無い non-bookkeeping part は、
+ * 暗黙に再生成せずエラーにする。
+ */
+export function writePptx(source: CleanDocSource): WritePptxOutput {
+  const files: Record<string, Uint8Array> = {
+    [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
+  };
+
+  const written = new Set<string>([CONTENT_TYPES_PART]);
+
+  for (const relationships of source.packageGraph.relationships) {
+    const relsPath = relationshipsPartPath(relationships.sourcePartPath);
+    files[relsPath] = encodeXml(serializeRelationships(relationships));
+    written.add(relsPath);
+  }
+
+  for (const media of source.packageGraph.media) {
+    files[media.partPath] = media.bytes;
+    written.add(media.partPath);
+  }
+
+  for (const rawPart of source.packageGraph.rawParts ?? []) {
+    files[rawPart.partPath] = serializeRawPackagePart(rawPart);
+    written.add(rawPart.partPath);
+  }
+
+  for (const part of source.packageGraph.parts) {
+    if (written.has(part.partPath)) continue;
+    if (part.contentType === RELS_CONTENT_TYPE || isRelationshipPart(part.partPath)) continue;
+    throw new Error(
+      `writePptx: no preserved package material for part '${part.partPath}'; ` +
+        "edited part generation is not implemented in the no-edit writer",
+    );
+  }
+
+  return zipSync(files);
+}
+
+function serializeContentTypes(
+  contentTypes: CleanDocSource["packageGraph"]["contentTypes"],
+): string {
+  const defaults = contentTypes.defaults
+    .map(
+      (entry) =>
+        `<Default Extension="${escapeAttribute(entry.extension)}" ` +
+        `ContentType="${escapeAttribute(entry.contentType)}"/>`,
+    )
+    .join("");
+  const overrides = contentTypes.overrides
+    .map(
+      (entry) =>
+        `<Override PartName="/${escapeAttribute(entry.partName)}" ` +
+        `ContentType="${escapeAttribute(entry.contentType)}"/>`,
+    )
+    .join("");
+  return (
+    XML_DECLARATION +
+    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+    defaults +
+    overrides +
+    `</Types>`
+  );
+}
+
+function serializeRelationships(partRelationships: PartRelationships): string {
+  const relationships = partRelationships.relationships
+    .map((relationship) => {
+      const targetMode =
+        relationship.targetMode === undefined
+          ? ""
+          : ` TargetMode="${escapeAttribute(relationship.targetMode)}"`;
+      return (
+        `<Relationship Id="${escapeAttribute(relationship.id)}" ` +
+        `Type="${escapeAttribute(relationship.type)}" ` +
+        `Target="${escapeAttribute(relationship.target)}"${targetMode}/>`
+      );
+    })
+    .join("");
+  return (
+    XML_DECLARATION +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    relationships +
+    `</Relationships>`
+  );
+}
+
+function serializeRawPackagePart(rawPart: RawPackagePart): Uint8Array {
+  if (rawPart.kind === "binary") return rawPart.bytes;
+  return encodeXml(XML_DECLARATION + serializeRawNode(rawPart.xml));
+}
+
+function serializeRawNode(node: RawOoxmlNode): string {
+  const attributes =
+    node.attributes === undefined
+      ? ""
+      : Object.entries(node.attributes)
+          .map(([name, value]) => ` ${name}="${escapeAttribute(value)}"`)
+          .join("");
+  const text = node.text === undefined ? "" : escapeText(node.text);
+  const children = node.children?.map((child) => serializeRawNode(child)).join("") ?? "";
+  if (text === "" && children === "") return `<${node.name}${attributes}/>`;
+  return `<${node.name}${attributes}>${text}${children}</${node.name}>`;
+}
+
+function relationshipsPartPath(sourcePartPath: PartPath): string {
+  if (sourcePartPath === "") return "_rels/.rels";
+  const slash = sourcePartPath.lastIndexOf("/");
+  const dir = slash === -1 ? "" : sourcePartPath.slice(0, slash + 1);
+  const file = slash === -1 ? sourcePartPath : sourcePartPath.slice(slash + 1);
+  return `${dir}_rels/${file}.rels`;
+}
+
+function isRelationshipPart(path: string): boolean {
+  return path.endsWith(".rels") && path.includes("_rels/");
+}
+
+function encodeXml(xml: string): Uint8Array {
+  return textEncoder.encode(xml);
+}
+
+function escapeAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function escapeText(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.ts
@@ -129,6 +129,12 @@ function serializeRawNode(node: RawOoxmlNode): string {
           .join("");
   const text = node.text === undefined ? "" : escapeText(node.text);
   const children = node.children?.map((child) => serializeRawNode(child)).join("") ?? "";
+  if (text !== "" && children !== "") {
+    throw new Error(
+      `writePptx: raw XML part '${node.name}' contains mixed text/element content; ` +
+        "ordered mixed-content serialization is not implemented in the no-edit writer",
+    );
+  }
   if (text === "" && children === "") return `<${node.name}${attributes}/>`;
   return `<${node.name}${attributes}>${text}${children}</${node.name}>`;
 }


### PR DESCRIPTION
close #468

## 概要

- @pptx-glimpse/document/experimental に no-edit writer の writePptx を追加
- CleanDoc source の content types / relationships / media / raw package material から PPTX ZIP を再構成
- unsupported raw package material と media bytes の preservation、再読込、byte equality 非依存のテストを追加
- raw XML part は serializable な範囲をテストし、mixed content は順序保持できないため明示 reject

## 影響範囲

- packages/pptx-glimpse-document/src/writer/
- packages/pptx-glimpse-document/src/experimental.ts

## 検証

- npm run knip
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test
- npm run build

補足: build 時の import.meta warning は既存 renderer の CJS build warning で、今回差分起因ではありません。