### PR TITLE
one plain text-run edit と dirty-slide writer を実装する

### DIFF
--- a/packages/pptx-glimpse-document/src/reader/shape-tree.ts
+++ b/packages/pptx-glimpse-document/src/reader/shape-tree.ts
@@ -57,6 +57,7 @@ export function parseShapeTree(
   if (!spTree) return [];
 
   const nodes: SourceShapeNode[] = [];
+  let orderingSlot = 0;
   for (const key of Object.keys(spTree)) {
     if (key.startsWith("@_")) continue;
     const local = localName(key);
@@ -68,18 +69,24 @@ export function parseShapeTree(
     for (const item of items) {
       const node = item as XmlNode;
       if (local === "sp") {
-        nodes.push(parseShape(node, partPath, nextId));
+        nodes.push(parseShape(node, partPath, nextId, orderingSlot));
       } else if (local === "pic") {
-        nodes.push(parseImage(node, partPath, nextId));
+        nodes.push(parseImage(node, partPath, nextId, orderingSlot));
       } else {
-        nodes.push(parseRawShapeNode(key, node, partPath, nextId));
+        nodes.push(parseRawShapeNode(key, node, partPath, nextId, orderingSlot));
       }
+      orderingSlot++;
     }
   }
   return nodes;
 }
 
-function parseShape(sp: XmlNode, partPath: PartPath, nextId: () => RawSidecarId): SourceShape {
+function parseShape(
+  sp: XmlNode,
+  partPath: PartPath,
+  nextId: () => RawSidecarId,
+  orderingSlot: number,
+): SourceShape {
   const nvSpPr = getChild(sp, "nvSpPr");
   const cNvPr = getChild(nvSpPr, "cNvPr");
   const nodeId = sourceNodeId(cNvPr);
@@ -91,7 +98,7 @@ function parseShape(sp: XmlNode, partPath: PartPath, nextId: () => RawSidecarId)
   const geometry = parsePresetGeometry(spPr);
   const fill = parseFill(spPr, nextId);
   const outline = parseOutline(spPr, nextId);
-  const textBody = parseTextBody(getChild(sp, "txBody"), partPath, nextId);
+  const textBody = parseTextBody(getChild(sp, "txBody"), partPath, nextId, nodeId, orderingSlot);
 
   const rawSidecars = [
     ...collectUnknownSidecars(sp, KNOWN_SHAPE_CHILDREN, nextId),
@@ -108,12 +115,17 @@ function parseShape(sp: XmlNode, partPath: PartPath, nextId: () => RawSidecarId)
     ...(outline !== undefined ? { outline } : {}),
     ...(textBody !== undefined ? { textBody } : {}),
     ...(placeholder !== undefined ? { placeholder } : {}),
-    handle: { partPath, ...(nodeId !== undefined ? { nodeId } : {}) },
+    handle: { partPath, ...(nodeId !== undefined ? { nodeId } : {}), orderingSlot },
     ...(rawSidecars.length > 0 ? { rawSidecars } : {}),
   };
 }
 
-function parseImage(pic: XmlNode, partPath: PartPath, nextId: () => RawSidecarId): SourceImage {
+function parseImage(
+  pic: XmlNode,
+  partPath: PartPath,
+  nextId: () => RawSidecarId,
+  orderingSlot: number,
+): SourceImage {
   const cNvPr = getChild(getChild(pic, "nvPicPr"), "cNvPr");
   const nodeId = sourceNodeId(cNvPr);
   const name = getAttr(cNvPr, "name");
@@ -145,6 +157,7 @@ function parseImage(pic: XmlNode, partPath: PartPath, nextId: () => RawSidecarId
       partPath,
       ...(nodeId !== undefined ? { nodeId } : {}),
       ...(embed !== undefined ? { relationshipId: asRelationshipId(embed) } : {}),
+      orderingSlot,
     },
     ...(rawSidecars.length > 0 ? { rawSidecars } : {}),
   };
@@ -155,13 +168,14 @@ function parseRawShapeNode(
   node: XmlNode,
   partPath: PartPath,
   nextId: () => RawSidecarId,
+  orderingSlot: number,
 ): SourceRawShapeNode {
   const nodeId = sourceNodeId(getChild(getChild(node, "nvSpPr"), "cNvPr"));
   return {
     kind: "raw",
     ...(nodeId !== undefined ? { nodeId } : {}),
     raw: makeSidecar(key, node, nextId),
-    handle: { partPath, ...(nodeId !== undefined ? { nodeId } : {}) },
+    handle: { partPath, ...(nodeId !== undefined ? { nodeId } : {}), orderingSlot },
   };
 }
 

--- a/packages/pptx-glimpse-document/src/reader/text.ts
+++ b/packages/pptx-glimpse-document/src/reader/text.ts
@@ -10,6 +10,7 @@
 import type {
   PartPath,
   RawSidecarId,
+  SourceNodeId,
   SourceParagraph,
   SourceParagraphProperties,
   SourceRunProperties,
@@ -19,7 +20,7 @@ import type {
   SourceTextRun,
   SourceVerticalAnchor,
 } from "../source/index.js";
-import { asEmu, asHundredthPt, asPt } from "../source/index.js";
+import { asEmu, asHundredthPt, asPt, asSourceNodeId } from "../source/index.js";
 import { parseColorElement } from "./drawing.js";
 import { isTrue, numericAttr } from "./drawing.js";
 import { collectUnknownSidecars } from "./raw-node.js";
@@ -48,11 +49,15 @@ export function parseTextBody(
   txBody: XmlNode | undefined,
   partPath: PartPath,
   nextId: () => RawSidecarId,
+  ownerNodeId: SourceNodeId | undefined,
+  ownerOrderingSlot: number,
 ): SourceTextBody | undefined {
   if (!txBody) return undefined;
 
   const properties = parseBodyProperties(getChild(txBody, "bodyPr"));
-  const paragraphs = getChildArray(txBody, "p").map((p) => parseParagraph(p, partPath, nextId));
+  const paragraphs = getChildArray(txBody, "p").map((p, paragraphIndex) =>
+    parseParagraph(p, partPath, nextId, ownerNodeId, ownerOrderingSlot, paragraphIndex),
+  );
   const rawSidecars = collectUnknownSidecars(txBody, KNOWN_TXBODY_CHILDREN, nextId);
 
   return {
@@ -87,15 +92,24 @@ function parseParagraph(
   p: XmlNode,
   partPath: PartPath,
   nextId: () => RawSidecarId,
+  ownerNodeId: SourceNodeId | undefined,
+  ownerOrderingSlot: number,
+  paragraphIndex: number,
 ): SourceParagraph {
   const properties = parseParagraphProperties(getChild(p, "pPr"));
-  const runs = getChildArray(p, "r").map((r) => parseRun(r, partPath, nextId));
+  const runs = getChildArray(p, "r").map((r, runIndex) =>
+    parseRun(r, partPath, nextId, ownerNodeId, ownerOrderingSlot, paragraphIndex, runIndex),
+  );
   const rawSidecars = collectUnknownSidecars(p, KNOWN_PARAGRAPH_CHILDREN, nextId);
 
   return {
     runs,
     ...(properties !== undefined ? { properties } : {}),
-    handle: { partPath },
+    handle: {
+      partPath,
+      nodeId: textNodeId("paragraph", ownerNodeId, ownerOrderingSlot, paragraphIndex),
+      orderingSlot: paragraphIndex,
+    },
     ...(rawSidecars.length > 0 ? { rawSidecars } : {}),
   };
 }
@@ -116,7 +130,15 @@ function parseParagraphProperties(pPr: XmlNode | undefined): SourceParagraphProp
   return Object.keys(properties).length > 0 ? properties : undefined;
 }
 
-function parseRun(r: XmlNode, partPath: PartPath, nextId: () => RawSidecarId): SourceTextRun {
+function parseRun(
+  r: XmlNode,
+  partPath: PartPath,
+  nextId: () => RawSidecarId,
+  ownerNodeId: SourceNodeId | undefined,
+  ownerOrderingSlot: number,
+  paragraphIndex: number,
+  runIndex: number,
+): SourceTextRun {
   const properties = parseRunProperties(getChild(r, "rPr"));
   const rawSidecars = collectRunSidecars(r, nextId);
 
@@ -124,7 +146,11 @@ function parseRun(r: XmlNode, partPath: PartPath, nextId: () => RawSidecarId): S
     kind: "textRun",
     text: getChildText(r, "t") ?? "",
     ...(properties !== undefined ? { properties } : {}),
-    handle: { partPath },
+    handle: {
+      partPath,
+      nodeId: textNodeId("run", ownerNodeId, ownerOrderingSlot, paragraphIndex, runIndex),
+      orderingSlot: runIndex,
+    },
     ...(rawSidecars.length > 0 ? { rawSidecars } : {}),
   };
 }
@@ -166,4 +192,17 @@ function collectRunSidecars(
 
 function emu(value: number) {
   return asEmu(value);
+}
+
+function textNodeId(
+  kind: "paragraph" | "run",
+  ownerNodeId: SourceNodeId | undefined,
+  ownerOrderingSlot: number,
+  paragraphIndex: number,
+  runIndex?: number,
+): SourceNodeId {
+  const owner =
+    ownerNodeId !== undefined ? `shape:${ownerNodeId}` : `shapeSlot:${ownerOrderingSlot}`;
+  const suffix = kind === "paragraph" ? `p:${paragraphIndex}` : `p:${paragraphIndex}:r:${runIndex}`;
+  return asSourceNodeId(`text:${owner}:${suffix}`);
 }

--- a/packages/pptx-glimpse-document/src/source/clean-doc-source.ts
+++ b/packages/pptx-glimpse-document/src/source/clean-doc-source.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Diagnostic } from "./diagnostics.js";
+import type { SourceHandle } from "./handles.js";
 import type { PackageGraph } from "./package-graph.js";
 import type {
   SourcePresentation,
@@ -28,4 +29,14 @@ export interface CleanDocSource {
   readonly themes: readonly SourceTheme[];
   /** document 正しさに関する診断。 */
   readonly diagnostics: readonly Diagnostic[];
+  /** typed CleanDoc operation と dirty scope。writer はここから最小更新範囲を判断する。 */
+  readonly edits?: readonly CleanDocEdit[];
+}
+
+export type CleanDocEdit = CleanDocTextRunEdit;
+
+export interface CleanDocTextRunEdit {
+  readonly kind: "replaceTextRunPlainText";
+  readonly handle: SourceHandle;
+  readonly text: string;
 }

--- a/packages/pptx-glimpse-document/src/source/editing.ts
+++ b/packages/pptx-glimpse-document/src/source/editing.ts
@@ -1,0 +1,87 @@
+import type {
+  CleanDocSource,
+  SourceHandle,
+  SourceParagraph,
+  SourceShape,
+  SourceTextRun,
+} from "./index.js";
+
+export function findTextRunBySourceHandle(
+  source: CleanDocSource,
+  handle: SourceHandle,
+): SourceTextRun | undefined {
+  for (const slide of source.slides) {
+    for (const shape of slide.shapes) {
+      if (shape.kind !== "shape") continue;
+      const run = findTextRunInShape(shape, handle);
+      if (run !== undefined) return run;
+    }
+  }
+  return undefined;
+}
+
+export function replaceTextRunPlainText(
+  source: CleanDocSource,
+  handle: SourceHandle,
+  text: string,
+): CleanDocSource {
+  let replaced = false;
+
+  const slides = source.slides.map((slide) => ({
+    ...slide,
+    shapes: slide.shapes.map((shape) => {
+      if (shape.kind !== "shape" || shape.textBody === undefined) return shape;
+
+      let shapeChanged = false;
+      const paragraphs = shape.textBody.paragraphs.map((paragraph) => {
+        let paragraphChanged = false;
+        const runs = paragraph.runs.map((run) => {
+          if (!sourceHandlesEqual(run.handle, handle)) return run;
+          replaced = true;
+          paragraphChanged = true;
+          shapeChanged = true;
+          return { ...run, text };
+        });
+        return !paragraphChanged ? paragraph : ({ ...paragraph, runs } satisfies SourceParagraph);
+      });
+
+      if (!shapeChanged) return shape;
+      return {
+        ...shape,
+        textBody: {
+          ...shape.textBody,
+          paragraphs,
+        },
+      } satisfies SourceShape;
+    }),
+  }));
+
+  if (!replaced) {
+    throw new Error("replaceTextRunPlainText: text run handle was not found in CleanDoc source");
+  }
+
+  return {
+    ...source,
+    slides,
+    edits: [...(source.edits ?? []), { kind: "replaceTextRunPlainText", handle, text }],
+  };
+}
+
+function findTextRunInShape(shape: SourceShape, handle: SourceHandle): SourceTextRun | undefined {
+  for (const paragraph of shape.textBody?.paragraphs ?? []) {
+    for (const run of paragraph.runs) {
+      if (sourceHandlesEqual(run.handle, handle)) return run;
+    }
+  }
+  return undefined;
+}
+
+function sourceHandlesEqual(left: SourceHandle | undefined, right: SourceHandle): boolean {
+  if (left === undefined) return false;
+  return (
+    left.partPath === right.partPath &&
+    left.nodeId === right.nodeId &&
+    left.relationshipId === right.relationshipId &&
+    left.orderingSlot === right.orderingSlot
+  );
+}

--- a/packages/pptx-glimpse-document/src/source/index.ts
+++ b/packages/pptx-glimpse-document/src/source/index.ts
@@ -2,8 +2,9 @@
  * CleanDoc source model 型の barrel re-export。
  */
 
-export type { CleanDocSource } from "./clean-doc-source.js";
+export type { CleanDocEdit, CleanDocSource, CleanDocTextRunEdit } from "./clean-doc-source.js";
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
+export { findTextRunBySourceHandle, replaceTextRunPlainText } from "./editing.js";
 export type {
   PartPath,
   RawSidecarId,

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
@@ -6,6 +6,11 @@ import { describe, expect, it } from "vitest";
 
 // 実際の公開面 (`@pptx-glimpse/document/experimental`) 経由で import する。
 import { readPptx, writePptx } from "../experimental.js";
+import {
+  findTextRunBySourceHandle,
+  replaceTextRunPlainText,
+  type SourceShape,
+} from "../experimental.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -56,6 +61,49 @@ function buildRoundTripFixture(): Uint8Array {
     ),
     "ppt/media/image1.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
     "docProps/custom.xml": xml(`<Properties><custom value="preserve-me"/></Properties>`),
+  });
+}
+
+function buildTextEditFixture(): Uint8Array {
+  return zipSync({
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Default Extension="png" ContentType="image/png"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300" cy="400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr anchor="ctr"/><a:lstStyle/>` +
+        `<a:p><a:pPr algn="ctr"/><a:r><a:rPr b="1" i="1" sz="2400"><a:latin typeface="Aptos"/><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:ea typeface="Noto Sans JP"/></a:rPr><a:t>Original</a:t></a:r></a:p>` +
+        `</p:txBody></p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+    "docProps/custom.xml": xml(`<Properties><custom value="preserve-me"/></Properties>`),
+    "ppt/media/image1.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47, 9, 8, 7]),
   });
 }
 
@@ -217,3 +265,69 @@ describe("writePptx — no-edit round-trip", () => {
     expect(() => writePptx(withoutRawSlide)).toThrow(/no preserved package material/);
   });
 });
+
+describe("writePptx — one plain text-run edit", () => {
+  it("existing text run を stable source handle で特定できる", () => {
+    const source = readPptx(buildTextEditFixture());
+    const run = firstRun(source);
+
+    expect(run.handle).toMatchObject({
+      partPath: "ppt/slides/slide1.xml",
+      nodeId: "text:shape:10:p:0:r:0",
+      orderingSlot: 0,
+    });
+    expect(findTextRunBySourceHandle(source, run.handle!)).toBe(run);
+  });
+
+  it("plain text 置換を CleanDoc source に適用し、write 後の PPTX に反映する", () => {
+    const input = buildTextEditFixture();
+    const source = readPptx(input);
+    const run = firstRun(source);
+
+    const edited = replaceTextRunPlainText(source, run.handle!, "Edited text");
+    const reread = readPptx(writePptx(edited));
+    const editedRun = firstRun(reread);
+
+    expect(run.text).toBe("Original");
+    expect(firstRun(edited).text).toBe("Edited text");
+    expect(editedRun.text).toBe("Edited text");
+  });
+
+  it("run / paragraph formatting と unrelated package material を preserving する", () => {
+    const input = buildTextEditFixture();
+    const source = readPptx(input);
+    const edited = replaceTextRunPlainText(source, firstRun(source).handle!, "Edited text");
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const run = firstRun(reread);
+    const paragraph = firstParagraph(reread);
+
+    expect(paragraph.properties).toEqual({ align: "center" });
+    expect(run.properties).toMatchObject({
+      bold: true,
+      italic: true,
+      fontSize: 24,
+      typeface: "Aptos",
+      color: { kind: "srgb", hex: "FF0000" },
+    });
+    expect(run.rawSidecars?.map((sidecar) => sidecar.node.name)).toContain("a:ea");
+    expect(getEntry(output, "docProps/custom.xml")).toEqual(getEntry(input, "docProps/custom.xml"));
+    expect(getEntry(output, "ppt/media/image1.png")).toEqual(
+      getEntry(input, "ppt/media/image1.png"),
+    );
+  });
+});
+
+function firstShape(source: ReturnType<typeof readPptx>): SourceShape {
+  const shape = source.slides[0].shapes[0];
+  if (shape?.kind !== "shape") throw new Error("first shape is not a shape");
+  return shape;
+}
+
+function firstParagraph(source: ReturnType<typeof readPptx>) {
+  return firstShape(source).textBody!.paragraphs[0];
+}
+
+function firstRun(source: ReturnType<typeof readPptx>) {
+  return firstParagraph(source).runs[0];
+}

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
@@ -65,6 +65,25 @@ function buildRoundTripFixture(): Uint8Array {
 }
 
 function buildTextEditFixture(): Uint8Array {
+  return buildTextEditFixtureFromSlide(
+    `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300" cy="400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr anchor="ctr"/><a:lstStyle/>` +
+      `<a:p><a:pPr algn="ctr"/><a:r><a:rPr b="1" i="1" sz="2400"><a:latin typeface="Aptos"/><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:ea typeface="Noto Sans JP"/></a:rPr><a:t>Original</a:t></a:r><a:r><a:t xml:space="preserve"> Keep </a:t></a:r></a:p>` +
+      `</p:txBody></p:sp>`,
+  );
+}
+
+function buildSlotHandleTextEditFixture(): Uint8Array {
+  return buildTextEditFixtureFromSlide(
+    `<p:pic><p:nvPicPr><p:cNvPr id="20" name="Picture"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill/><p:spPr/></p:pic>` +
+      `<p:sp><p:nvSpPr><p:cNvPr name="No Id Shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Original</a:t></a:r></a:p></p:txBody></p:sp>`,
+  );
+}
+
+function buildTextEditFixtureFromSlide(slideSpTree: string): Uint8Array {
   return zipSync({
     "[Content_Types].xml": xml(
       `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
@@ -93,13 +112,7 @@ function buildTextEditFixture(): Uint8Array {
     ),
     "ppt/slides/slide1.xml": xml(
       `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
-        `<p:cSld><p:spTree>` +
-        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
-        `<p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300" cy="400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
-        `<p:txBody><a:bodyPr anchor="ctr"/><a:lstStyle/>` +
-        `<a:p><a:pPr algn="ctr"/><a:r><a:rPr b="1" i="1" sz="2400"><a:latin typeface="Aptos"/><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:ea typeface="Noto Sans JP"/></a:rPr><a:t>Original</a:t></a:r></a:p>` +
-        `</p:txBody></p:sp>` +
-        `</p:spTree></p:cSld>` +
+        `<p:cSld><p:spTree>${slideSpTree}</p:spTree></p:cSld>` +
         `</p:sld>`,
     ),
     "docProps/custom.xml": xml(`<Properties><custom value="preserve-me"/></Properties>`),
@@ -291,6 +304,7 @@ describe("writePptx — one plain text-run edit", () => {
     expect(run.text).toBe("Original");
     expect(firstRun(edited).text).toBe("Edited text");
     expect(editedRun.text).toBe("Edited text");
+    expect(firstParagraph(reread).runs[1].text).toBe(" Keep ");
   });
 
   it("run / paragraph formatting と unrelated package material を preserving する", () => {
@@ -316,11 +330,25 @@ describe("writePptx — one plain text-run edit", () => {
       getEntry(input, "ppt/media/image1.png"),
     );
   });
+
+  it("shape id が無い run も shapeSlot handle で dirty slide XML に反映できる", () => {
+    const source = readPptx(buildSlotHandleTextEditFixture());
+    const run = firstRun(source);
+
+    expect(run.handle).toMatchObject({
+      partPath: "ppt/slides/slide1.xml",
+      nodeId: "text:shapeSlot:1:p:0:r:0",
+      orderingSlot: 0,
+    });
+
+    const edited = replaceTextRunPlainText(source, run.handle!, "Edited via slot");
+    expect(firstRun(readPptx(writePptx(edited))).text).toBe("Edited via slot");
+  });
 });
 
 function firstShape(source: ReturnType<typeof readPptx>): SourceShape {
-  const shape = source.slides[0].shapes[0];
-  if (shape?.kind !== "shape") throw new Error("first shape is not a shape");
+  const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
+  if (shape === undefined) throw new Error("shape not found");
   return shape;
 }
 

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.ts
@@ -1,15 +1,21 @@
 /**
- * `writePptx(source)` — CleanDoc source writer の最初の no-edit slice。
+ * `writePptx(source)` — CleanDoc source writer の最初の round-trip slice。
  *
  * この writer は structural round-trip を目的に、reader が保持した raw package
  * material / media bytes / package bookkeeping を PPTX ZIP として再構成する。
- * edited writer behavior や node-level XML splicing は後続 slice の責務。
+ * one plain text-run edit では dirty slide XML part 内の対象 `a:t` だけを
+ * stable source handle で差し替える。汎用的な edited writer behavior や
+ * node-level XML splicing は後続 slice の責務。
  */
 
+import { XMLBuilder } from "fast-xml-parser";
 import { zipSync } from "fflate";
 
+import { parseXml, type XmlNode } from "../reader/xml.js";
 import type {
+  CleanDocEdit,
   CleanDocSource,
+  CleanDocTextRunEdit,
   PartPath,
   PartRelationships,
   RawOoxmlNode,
@@ -24,15 +30,26 @@ const RELS_CONTENT_TYPE = "application/vnd.openxmlformats-package.relationships+
 const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n';
 
 const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const xmlBuilder = new XMLBuilder({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  format: false,
+  suppressEmptyNode: true,
+});
 
 /**
  * CleanDoc source を PPTX package bytes に書き戻す。
  *
- * no-edit round-trip 用の初期 writer であり、未編集 package material を優先して
- * preserved output を作る。必要な raw bytes が無い non-bookkeeping part は、
+ * round-trip 用の初期 writer であり、未編集 package material を優先して
+ * preserved output を作る。dirty part の patch に必要な raw bytes が無い場合や
+ * 必要な raw bytes が無い non-bookkeeping part は、
  * 暗黙に再生成せずエラーにする。
  */
 export function writePptx(source: CleanDocSource): WritePptxOutput {
+  const textRunEdits = source.edits?.filter(isTextRunEdit) ?? [];
+  const dirtyPartPaths = new Set(textRunEdits.map((edit) => edit.handle.partPath));
   const files: Record<string, Uint8Array> = {
     [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
   };
@@ -51,8 +68,14 @@ export function writePptx(source: CleanDocSource): WritePptxOutput {
   }
 
   for (const rawPart of source.packageGraph.rawParts ?? []) {
+    if (dirtyPartPaths.has(rawPart.partPath)) continue;
     files[rawPart.partPath] = serializeRawPackagePart(rawPart);
     written.add(rawPart.partPath);
+  }
+
+  for (const partPath of dirtyPartPaths) {
+    files[partPath] = serializeDirtyXmlPart(source, partPath, textRunEdits);
+    written.add(partPath);
   }
 
   for (const part of source.packageGraph.parts) {
@@ -65,6 +88,160 @@ export function writePptx(source: CleanDocSource): WritePptxOutput {
   }
 
   return zipSync(files);
+}
+
+function isTextRunEdit(edit: CleanDocEdit): edit is CleanDocTextRunEdit {
+  return edit.kind === "replaceTextRunPlainText";
+}
+
+function serializeDirtyXmlPart(
+  source: CleanDocSource,
+  partPath: PartPath,
+  textRunEdits: readonly CleanDocTextRunEdit[],
+): Uint8Array {
+  const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
+  if (rawPart === undefined) {
+    throw new Error(`writePptx: dirty part '${partPath}' has no preserved raw package material`);
+  }
+  if (rawPart.kind !== "binary") {
+    throw new Error(`writePptx: dirty XML tree part '${partPath}' patching is not implemented`);
+  }
+
+  const root = parseXml(textDecoder.decode(rawPart.bytes));
+  const edits = textRunEdits.filter((edit) => edit.handle.partPath === partPath);
+  for (const edit of edits) {
+    applyTextRunEdit(root, edit);
+  }
+  return encodeXml(XML_DECLARATION + xmlBuilder.build(root));
+}
+
+function applyTextRunEdit(root: XmlNode, edit: CleanDocTextRunEdit): void {
+  const locator = parseTextRunLocator(edit.handle.nodeId);
+  const slide = getChild(root, "sld");
+  const cSld = getChild(slide, "cSld");
+  const spTree = getChild(cSld, "spTree");
+  const shape = locateShape(spTree, locator);
+  const paragraphs = getChildArray(getChild(shape, "txBody"), "p");
+  const paragraph = paragraphs[locator.paragraphIndex];
+  const run = getChildArray(paragraph, "r")[locator.runIndex];
+
+  if (run === undefined) {
+    throw new Error(
+      `writePptx: text run handle '${edit.handle.nodeId}' no longer matches source XML`,
+    );
+  }
+
+  setChildText(run, "t", edit.text);
+}
+
+interface TextRunLocator {
+  readonly shapeNodeId?: string;
+  readonly shapeOrderingSlot?: number;
+  readonly paragraphIndex: number;
+  readonly runIndex: number;
+}
+
+function parseTextRunLocator(nodeId: CleanDocTextRunEdit["handle"]["nodeId"]): TextRunLocator {
+  const value = String(nodeId ?? "");
+  const byShapeId = /^text:shape:(.+):p:(\d+):r:(\d+)$/.exec(value);
+  if (byShapeId !== null) {
+    return {
+      shapeNodeId: byShapeId[1],
+      paragraphIndex: Number(byShapeId[2]),
+      runIndex: Number(byShapeId[3]),
+    };
+  }
+
+  const byShapeSlot = /^text:shapeSlot:(\d+):p:(\d+):r:(\d+)$/.exec(value);
+  if (byShapeSlot !== null) {
+    return {
+      shapeOrderingSlot: Number(byShapeSlot[1]),
+      paragraphIndex: Number(byShapeSlot[2]),
+      runIndex: Number(byShapeSlot[3]),
+    };
+  }
+
+  throw new Error(`writePptx: unsupported text run handle '${value}'`);
+}
+
+function locateShape(spTree: XmlNode | undefined, locator: TextRunLocator): XmlNode | undefined {
+  const shapes = getChildArray(spTree, "sp");
+  if (locator.shapeNodeId !== undefined) {
+    return shapes.find(
+      (shape) =>
+        getAttr(getChild(getChild(shape, "nvSpPr"), "cNvPr"), "id") === locator.shapeNodeId,
+    );
+  }
+  return locator.shapeOrderingSlot !== undefined ? shapes[locator.shapeOrderingSlot] : undefined;
+}
+
+function getChild(node: XmlNode | undefined, name: string): XmlNode | undefined {
+  if (!node) return undefined;
+  for (const key of Object.keys(node)) {
+    if (key.startsWith("@_")) continue;
+    if (localName(key) !== name) continue;
+    const value = node[key];
+    return Array.isArray(value)
+      ? (value[0] as XmlNode | undefined)
+      : (value as XmlNode | undefined);
+  }
+  return undefined;
+}
+
+function getChildArray(node: XmlNode | undefined, name: string): XmlNode[] {
+  if (!node) return [];
+  for (const key of Object.keys(node)) {
+    if (key.startsWith("@_")) continue;
+    if (localName(key) === name) {
+      const value = node[key];
+      if (value === undefined || value === null) return [];
+      return (Array.isArray(value) ? value : [value]) as XmlNode[];
+    }
+  }
+  return [];
+}
+
+function getAttr(node: XmlNode | undefined, name: string): string | undefined {
+  if (!node) return undefined;
+  const value = node[`@_${name}`];
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return undefined;
+}
+
+function setChildText(node: XmlNode, name: string, text: string): void {
+  for (const key of Object.keys(node)) {
+    if (key.startsWith("@_")) continue;
+    if (localName(key) !== name) continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      value[0] = textElementValue(value[0], text);
+      return;
+    }
+    node[key] = textElementValue(value, text);
+    return;
+  }
+  node[`a:${name}`] = textRequiresPreserve(text)
+    ? { "@_xml:space": "preserve", "#text": text }
+    : text;
+}
+
+function textElementValue(existing: unknown, text: string): unknown {
+  if (typeof existing === "object" && existing !== null && !Array.isArray(existing)) {
+    const next: XmlNode = { ...(existing as XmlNode), "#text": text };
+    if (textRequiresPreserve(text)) next["@_xml:space"] = "preserve";
+    return next;
+  }
+  return textRequiresPreserve(text) ? { "@_xml:space": "preserve", "#text": text } : text;
+}
+
+function textRequiresPreserve(text: string): boolean {
+  return text.startsWith(" ") || text.endsWith(" ");
+}
+
+function localName(key: string): string {
+  const colon = key.indexOf(":");
+  return colon === -1 ? key : key.slice(colon + 1);
 }
 
 function serializeContentTypes(

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.ts
@@ -3,9 +3,9 @@
  *
  * この writer は structural round-trip を目的に、reader が保持した raw package
  * material / media bytes / package bookkeeping を PPTX ZIP として再構成する。
- * one plain text-run edit では dirty slide XML part 内の対象 `a:t` だけを
- * stable source handle で差し替える。汎用的な edited writer behavior や
- * node-level XML splicing は後続 slice の責務。
+ * one plain text-run edit では dirty slide XML part を再シリアライズし、対象
+ * run の `a:t` 値だけを stable source handle で差し替える。汎用的な edited
+ * writer behavior や node-level XML splicing は後続 slice の責務。
  */
 
 import { XMLBuilder } from "fast-xml-parser";
@@ -172,7 +172,32 @@ function locateShape(spTree: XmlNode | undefined, locator: TextRunLocator): XmlN
         getAttr(getChild(getChild(shape, "nvSpPr"), "cNvPr"), "id") === locator.shapeNodeId,
     );
   }
-  return locator.shapeOrderingSlot !== undefined ? shapes[locator.shapeOrderingSlot] : undefined;
+  if (locator.shapeOrderingSlot === undefined) return undefined;
+  return getShapeByOrderingSlot(spTree, locator.shapeOrderingSlot);
+}
+
+function getShapeByOrderingSlot(
+  spTree: XmlNode | undefined,
+  orderingSlot: number,
+): XmlNode | undefined {
+  if (!spTree) return undefined;
+
+  let currentSlot = 0;
+  for (const key of Object.keys(spTree)) {
+    if (key.startsWith("@_")) continue;
+    const local = localName(key);
+    if (local === "nvGrpSpPr" || local === "grpSpPr") continue;
+
+    const value = spTree[key];
+    const items = Array.isArray(value) ? value : [value];
+    for (const item of items) {
+      if (currentSlot === orderingSlot) {
+        return local === "sp" ? (item as XmlNode) : undefined;
+      }
+      currentSlot++;
+    }
+  }
+  return undefined;
 }
 
 function getChild(node: XmlNode | undefined, name: string): XmlNode | undefined {
@@ -230,6 +255,7 @@ function textElementValue(existing: unknown, text: string): unknown {
   if (typeof existing === "object" && existing !== null && !Array.isArray(existing)) {
     const next: XmlNode = { ...(existing as XmlNode), "#text": text };
     if (textRequiresPreserve(text)) next["@_xml:space"] = "preserve";
+    else delete next["@_xml:space"];
     return next;
   }
   return textRequiresPreserve(text) ? { "@_xml:space": "preserve", "#text": text } : text;


### PR DESCRIPTION
close #469

## 目的

CleanDoc source 上で既存 text run を stable source handle により特定し、plain text だけを置換して PPTX writer に反映できる最小 edit flow を追加します。

## 変更内容

- text run / paragraph に stable source handle を付与
- `findTextRunBySourceHandle` / `replaceTextRunPlainText` を experimental API として追加
- `writePptx` で dirty slide XML part を再シリアライズし、対象 run の `a:t` 値だけを差し替え
- run / paragraph formatting、raw run sidecar、unrelated package material の保持を検証するテストを追加
- cross-review 指摘に基づき、shape id が無い場合の slot-based handle patching を reader と writer で整合

## 影響範囲

- `packages/pptx-glimpse-document/src/source/*`
- `packages/pptx-glimpse-document/src/reader/*`
- `packages/pptx-glimpse-document/src/writer/*`

public `convertPptxToSvg` / `convertPptxToPng` の既存経路には影響しません。

## 検証

- `npm run test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`

※ build時の `import.meta` warning は既存の renderer CJS 出力由来で、build自体は成功しています。