### PR TITLE
CleanDoc PoC の end-to-end round-trip tests を追加する

### DIFF
--- a/packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts
+++ b/packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts
@@ -1,0 +1,248 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { unzipSync } from "fflate";
+import { describe, expect, it } from "vitest";
+
+import {
+  type CleanDocSource,
+  createComputedView,
+  findTextRunBySourceHandle,
+  type MediaPart,
+  readPptx,
+  replaceTextRunPlainText,
+  type SourceParagraph,
+  type SourceShape,
+  type SourceTextRun,
+  writePptx,
+} from "../../pptx-glimpse-document/src/experimental.js";
+import { renderSlideToSvg } from "../../pptx-glimpse-renderer/src/index.js";
+import { adaptComputedViewToRendererModel } from "./cleandoc-renderer-adapter.js";
+import { convertPptxToPng, convertPptxToSvg } from "./converter.js";
+
+const SHARED_FIXTURES = ["real-basic-theme.pptx", "real-product-page.pptx"] as const;
+const EDITED_TEXT = "Edited 470";
+
+describe("CleanDoc PoC end-to-end round-trip", () => {
+  it.each(SHARED_FIXTURES)(
+    "renders %s through read -> computed view -> adapter -> SVG",
+    (fixtureName) => {
+      const rendered = renderDocumentPath(readFixture(fixtureName));
+
+      expect(rendered.source.presentation.slidePartPaths.length).toBeGreaterThan(0);
+      expect(rendered.computed.slides).toHaveLength(
+        rendered.source.presentation.slidePartPaths.length,
+      );
+      expect(rendered.adapted.slides).toHaveLength(rendered.computed.slides.length);
+      expect(rendered.adapted.slideSize).toBeDefined();
+      expect(rendered.svgs).toHaveLength(rendered.adapted.slides.length);
+      for (const { svg } of rendered.svgs) {
+        expect(svg).toContain("<svg");
+        expect(svg).toMatch(/viewBox="0 0 \d+ \d+"/);
+        expect(svg).toContain("</svg>");
+      }
+      for (const diagnostic of rendered.adapted.diagnostics) {
+        expect(diagnostic).toMatchObject({
+          severity: "warning",
+          code: "cleandoc-adapter.raw-element-skipped",
+        });
+      }
+    },
+  );
+
+  it.each(SHARED_FIXTURES)("writes and re-reads %s with structural preservation", (fixtureName) => {
+    const input = readFixture(fixtureName);
+    const original = readPptx(input);
+    const output = writePptx(original);
+    const reread = readPptx(output);
+
+    expect(reread.presentation.slidePartPaths).toEqual(original.presentation.slidePartPaths);
+    expect(reread.presentation.slideSize).toEqual(original.presentation.slideSize);
+    expect(reread.packageGraph.contentTypes).toEqual(original.packageGraph.contentTypes);
+    expect(reread.packageGraph.relationships).toEqual(original.packageGraph.relationships);
+    expect(mediaBytesByPath(reread.packageGraph.media)).toEqual(
+      mediaBytesByPath(original.packageGraph.media),
+    );
+
+    const inputEntries = unzipSync(input);
+    const outputEntries = unzipSync(output);
+    for (const partPath of selectedPreservedPartPaths(original)) {
+      expect(outputEntries[partPath]).toEqual(inputEntries[partPath]);
+    }
+
+    const originalRendered = renderDocumentPath(input).svgs;
+    const roundTrippedRendered = renderDocumentPath(output).svgs;
+    expect(roundTrippedRendered).toEqual(originalRendered);
+  });
+
+  it("writes, re-reads, and renders one text-run edit while preserving unrelated material", () => {
+    const input = readFixture("real-product-page.pptx");
+    const source = readPptx(input);
+    const { paragraph, run } = firstEditableRun(source);
+    const handle = run.handle;
+    const edited = replaceTextRunPlainText(source, handle, EDITED_TEXT);
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const rereadRun = findTextRunBySourceHandle(reread, handle);
+
+    expect(run.text).not.toBe(EDITED_TEXT);
+    expect(rereadRun?.text).toBe(EDITED_TEXT);
+    expect(rereadRun?.properties).toEqual(run.properties);
+    expect(firstParagraphForRun(reread, handle)?.properties).toEqual(paragraph.properties);
+    expect(mediaBytesByPath(reread.packageGraph.media)).toEqual(
+      mediaBytesByPath(source.packageGraph.media),
+    );
+    expect(reread.packageGraph.relationships).toEqual(source.packageGraph.relationships);
+
+    const inputEntries = unzipSync(input);
+    const outputEntries = unzipSync(output);
+    expect(outputEntries[handle.partPath]).not.toEqual(inputEntries[handle.partPath]);
+    expect(textDecoder.decode(outputEntries[handle.partPath])).toContain(EDITED_TEXT);
+    for (const partPath of selectedPreservedPartPaths(source)) {
+      if (partPath === handle.partPath) continue;
+      expect(outputEntries[partPath]).toEqual(inputEntries[partPath]);
+    }
+
+    const rendered = renderDocumentPath(output);
+    expect(rendered.svgs.some(({ svg }) => svg.includes(EDITED_TEXT))).toBe(true);
+  });
+
+  it("keeps the public SVG and PNG conversion APIs working for selected fixtures", async () => {
+    const input = readFixture("real-basic-theme.pptx");
+
+    const svgResults = await convertPptxToSvg(input, {
+      slides: [1],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+    const pngResults = await convertPptxToPng(input, {
+      slides: [1],
+      width: 240,
+      skipSystemFonts: true,
+    });
+
+    expect(svgResults.map((result) => result.slideNumber)).toEqual([1]);
+    expect(svgResults[0].svg).toContain("<svg");
+    expect(svgResults[0].svg).toContain("</svg>");
+    expect(pngResults.map((result) => result.slideNumber)).toEqual([1]);
+    expect(pngResults[0]).toMatchObject({ width: 240 });
+    expect([...pngResults[0].png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("does not require VRT snapshot updates because public rendering remains on the current path", () => {
+    expect({
+      productionDefaultPathChanged: false,
+      snapshotUpdateRequired: false,
+      reason:
+        "These e2e tests exercise the experimental CleanDoc path and public API regressions without changing renderer output.",
+    }).toMatchInlineSnapshot(`
+      {
+        "productionDefaultPathChanged": false,
+        "reason": "These e2e tests exercise the experimental CleanDoc path and public API regressions without changing renderer output.",
+        "snapshotUpdateRequired": false,
+      }
+    `);
+  });
+});
+
+const textDecoder = new TextDecoder();
+
+interface RenderedDocumentPath {
+  readonly source: CleanDocSource;
+  readonly computed: ReturnType<typeof createComputedView>;
+  readonly adapted: ReturnType<typeof adaptComputedViewToRendererModel>;
+  readonly svgs: readonly { readonly slideNumber: number; readonly svg: string }[];
+}
+
+function readFixture(name: (typeof SHARED_FIXTURES)[number]): Buffer {
+  return readFileSync(fileURLToPath(new URL(`../../../shared-fixtures/${name}`, import.meta.url)));
+}
+
+function renderDocumentPath(input: Uint8Array): RenderedDocumentPath {
+  const source = readPptx(input);
+  const computed = createComputedView(source);
+  const adapted = adaptComputedViewToRendererModel(computed);
+  const slideSize = adapted.slideSize;
+  if (slideSize === undefined) {
+    throw new Error("CleanDoc render path requires a slide size for selected fixtures");
+  }
+
+  return {
+    source,
+    computed,
+    adapted,
+    svgs: adapted.slides.map((slide) => ({
+      slideNumber: slide.slideNumber,
+      svg: renderSlideToSvg(slide, slideSize),
+    })),
+  };
+}
+
+function mediaBytesByPath(media: readonly MediaPart[]): Record<string, readonly number[]> {
+  return Object.fromEntries(media.map((part) => [part.partPath, [...part.bytes]]));
+}
+
+function selectedPreservedPartPaths(source: CleanDocSource): string[] {
+  return [
+    ...source.presentation.slidePartPaths,
+    ...source.slideLayouts.map((layout) => layout.partPath),
+    ...source.slideMasters.map((master) => master.partPath),
+    ...source.themes.map((theme) => theme.partPath),
+  ];
+}
+
+function firstEditableRun(source: CleanDocSource): {
+  readonly paragraph: SourceParagraph;
+  readonly run: EditableTextRun;
+} {
+  for (const slide of source.slides) {
+    for (const shape of slide.shapes) {
+      if (shape.kind !== "shape") continue;
+      for (const paragraph of shape.textBody?.paragraphs ?? []) {
+        const run = paragraph.runs.find(isEditableTextRun);
+        if (run?.handle !== undefined) return { paragraph, run };
+      }
+    }
+  }
+  throw new Error("No editable text run found in selected CleanDoc fixture");
+}
+
+type EditableTextRun = SourceTextRun & {
+  readonly handle: NonNullable<SourceTextRun["handle"]>;
+};
+
+function isEditableTextRun(run: SourceTextRun): run is EditableTextRun {
+  return run.text.trim() !== "" && run.handle !== undefined;
+}
+
+function firstParagraphForRun(
+  source: CleanDocSource,
+  handle: SourceTextRun["handle"],
+): SourceParagraph | undefined {
+  if (handle === undefined) return undefined;
+  for (const slide of source.slides) {
+    for (const shape of slide.shapes) {
+      if (shape.kind !== "shape") continue;
+      const paragraph = findParagraphForRun(shape, handle);
+      if (paragraph !== undefined) return paragraph;
+    }
+  }
+  return undefined;
+}
+
+function findParagraphForRun(shape: SourceShape, handle: NonNullable<SourceTextRun["handle"]>) {
+  for (const paragraph of shape.textBody?.paragraphs ?? []) {
+    if (
+      paragraph.runs.some(
+        (run) =>
+          run.handle?.partPath === handle.partPath &&
+          run.handle.nodeId === handle.nodeId &&
+          run.handle.relationshipId === handle.relationshipId &&
+          run.handle.orderingSlot === handle.orderingSlot,
+      )
+    ) {
+      return paragraph;
+    }
+  }
+  return undefined;
+}

--- a/packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts
+++ b/packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts
@@ -107,41 +107,48 @@ describe("CleanDoc PoC end-to-end round-trip", () => {
     expect(rendered.svgs.some(({ svg }) => svg.includes(EDITED_TEXT))).toBe(true);
   });
 
-  it("keeps the public SVG and PNG conversion APIs working for selected fixtures", async () => {
+  it("keeps the public SVG and PNG conversion APIs working for written PPTX output", async () => {
     const input = readFixture("real-basic-theme.pptx");
+    const noEditOutput = writePptx(readPptx(input));
 
-    const svgResults = await convertPptxToSvg(input, {
+    const originalSvgResults = await convertPptxToSvg(input, {
       slides: [1],
       textOutput: "text",
       skipSystemFonts: true,
     });
-    const pngResults = await convertPptxToPng(input, {
+    const roundTrippedSvgResults = await convertPptxToSvg(noEditOutput, {
+      slides: [1],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+    const pngResults = await convertPptxToPng(noEditOutput, {
       slides: [1],
       width: 240,
       skipSystemFonts: true,
     });
 
-    expect(svgResults.map((result) => result.slideNumber)).toEqual([1]);
-    expect(svgResults[0].svg).toContain("<svg");
-    expect(svgResults[0].svg).toContain("</svg>");
+    expect(roundTrippedSvgResults).toEqual(originalSvgResults);
     expect(pngResults.map((result) => result.slideNumber)).toEqual([1]);
     expect(pngResults[0]).toMatchObject({ width: 240 });
     expect([...pngResults[0].png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
-  });
 
-  it("does not require VRT snapshot updates because public rendering remains on the current path", () => {
-    expect({
-      productionDefaultPathChanged: false,
-      snapshotUpdateRequired: false,
-      reason:
-        "These e2e tests exercise the experimental CleanDoc path and public API regressions without changing renderer output.",
-    }).toMatchInlineSnapshot(`
-      {
-        "productionDefaultPathChanged": false,
-        "reason": "These e2e tests exercise the experimental CleanDoc path and public API regressions without changing renderer output.",
-        "snapshotUpdateRequired": false,
-      }
-    `);
+    const editedInput = readFixture("real-product-page.pptx");
+    const editedSource = readPptx(editedInput);
+    const editedOutput = writePptx(
+      replaceTextRunPlainText(editedSource, firstEditableRun(editedSource).run.handle, EDITED_TEXT),
+    );
+    const editedSvgResults = await convertPptxToSvg(editedOutput, {
+      slides: [1],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+
+    expect(editedSvgResults.map((result) => result.slideNumber)).toEqual([1]);
+    expect(editedSvgResults[0].svg).toContain(EDITED_TEXT);
+
+    // VRT snapshot updates are unnecessary: this PR does not change production
+    // rendering, and no-edit writer output is asserted to keep public SVG stable
+    // for a selected shared fixture.
   });
 });
 

--- a/packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts
+++ b/packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts
@@ -112,43 +112,44 @@ describe("CleanDoc PoC end-to-end round-trip", () => {
     const noEditOutput = writePptx(readPptx(input));
 
     const originalSvgResults = await convertPptxToSvg(input, {
-      slides: [1],
       textOutput: "text",
       skipSystemFonts: true,
     });
     const roundTrippedSvgResults = await convertPptxToSvg(noEditOutput, {
-      slides: [1],
       textOutput: "text",
       skipSystemFonts: true,
     });
     const pngResults = await convertPptxToPng(noEditOutput, {
-      slides: [1],
       width: 240,
       skipSystemFonts: true,
     });
 
     expect(roundTrippedSvgResults).toEqual(originalSvgResults);
-    expect(pngResults.map((result) => result.slideNumber)).toEqual([1]);
-    expect(pngResults[0]).toMatchObject({ width: 240 });
-    expect([...pngResults[0].png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    expect(pngResults.map((result) => result.slideNumber)).toEqual(
+      originalSvgResults.map((result) => result.slideNumber),
+    );
+    for (const pngResult of pngResults) {
+      expect(pngResult).toMatchObject({ width: 240 });
+      expect([...pngResult.png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    }
 
     const editedInput = readFixture("real-product-page.pptx");
     const editedSource = readPptx(editedInput);
+    const editable = firstEditableRun(editedSource);
     const editedOutput = writePptx(
-      replaceTextRunPlainText(editedSource, firstEditableRun(editedSource).run.handle, EDITED_TEXT),
+      replaceTextRunPlainText(editedSource, editable.run.handle, EDITED_TEXT),
     );
     const editedSvgResults = await convertPptxToSvg(editedOutput, {
-      slides: [1],
+      slides: [editable.slideNumber],
       textOutput: "text",
       skipSystemFonts: true,
     });
 
-    expect(editedSvgResults.map((result) => result.slideNumber)).toEqual([1]);
+    expect(editedSvgResults.map((result) => result.slideNumber)).toEqual([editable.slideNumber]);
     expect(editedSvgResults[0].svg).toContain(EDITED_TEXT);
 
-    // VRT snapshot updates are unnecessary: this PR does not change production
-    // rendering, and no-edit writer output is asserted to keep public SVG stable
-    // for a selected shared fixture.
+    // No-edit writer output is asserted to keep public SVG stable for the
+    // selected shared fixture, so this e2e coverage does not need VRT snapshots.
   });
 });
 
@@ -199,15 +200,18 @@ function selectedPreservedPartPaths(source: CleanDocSource): string[] {
 }
 
 function firstEditableRun(source: CleanDocSource): {
+  readonly slideNumber: number;
   readonly paragraph: SourceParagraph;
   readonly run: EditableTextRun;
 } {
   for (const slide of source.slides) {
+    const slideNumber = source.presentation.slidePartPaths.indexOf(slide.partPath) + 1;
+    if (slideNumber <= 0) continue;
     for (const shape of slide.shapes) {
       if (shape.kind !== "shape") continue;
       for (const paragraph of shape.textBody?.paragraphs ?? []) {
         const run = paragraph.runs.find(isEditableTextRun);
-        if (run?.handle !== undefined) return { paragraph, run };
+        if (run?.handle !== undefined) return { slideNumber, paragraph, run };
       }
     }
   }


### PR DESCRIPTION
close #470

## 目的

CleanDoc PoC の end-to-end 確認として、reader / computed view / renderer adapter / writer / public conversion API をまたぐテストを追加します。

## 変更内容

- `packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts` を追加
- `shared-fixtures/real-basic-theme.pptx` / `shared-fixtures/real-product-page.pptx` を使って以下を検証
  - read → computed view → adapter → SVG render
  - no-edit write → re-read と structural preservation
  - one text-run edit → write → re-read → render
  - writer 出力を public `convertPptxToSvg` / `convertPptxToPng` に通せること
- public rendering の production path は変更していないため、VRT snapshot 更新は不要です。no-edit writer output の public SVG が元入力と一致することもテストで確認しています。

## 検証

- `npm run test -- packages/pptx-glimpse/src/cleandoc-round-trip.e2e.test.ts`
- `npm run test -- packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts packages/pptx-glimpse-document/src/writer/write-pptx.test.ts packages/pptx-glimpse/src/converter.test.ts`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## 備考

- changeset は追加していません。test-only 変更で published package の public API / runtime behavior は変更していません。
