### PR TITLE
internal document render path を追加する

### DIFF
--- a/packages/pptx-glimpse/src/cleandoc-renderer-adapter.ts
+++ b/packages/pptx-glimpse/src/cleandoc-renderer-adapter.ts
@@ -40,7 +40,7 @@ interface RendererAdapterResult {
   readonly diagnostics: readonly RendererAdapterDiagnostic[];
 }
 
-interface RendererAdapterDiagnostic {
+export interface RendererAdapterDiagnostic {
   readonly severity: "warning";
   readonly code:
     | "cleandoc-adapter.missing-transform"

--- a/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { convertPptxToSvg } from "./converter.js";
+import {
+  convertPptxToPngViaDocumentPath,
+  convertPptxToSvgViaDocumentPath,
+} from "./experimental-document-renderer.js";
+
+const SELECTED_SHARED_FIXTURES = ["real-basic-theme.pptx", "real-product-page.pptx"] as const;
+
+const DOCUMENT_RENDER_TEST_SCOPE = [
+  "readPptx source model",
+  "createComputedView cascade projection",
+  "CleanDoc computed-view to current renderer model adapter",
+  "existing SVG renderer",
+  "existing SVG to PNG conversion",
+] as const;
+
+const DOCUMENT_RENDER_UNSUPPORTED_SUBSET = [
+  "raw shape-tree nodes such as tables, charts, groups, and unsupported graphicFrame content",
+  "raw background and fill variants outside the CleanDoc adapter subset",
+  "unresolved images without a package media payload",
+  "elements missing computed transforms",
+] as const;
+
+describe("experimental document render path", () => {
+  it("documents the intentionally focused dogfood scope", () => {
+    expect(DOCUMENT_RENDER_TEST_SCOPE).toMatchInlineSnapshot(`
+      [
+        "readPptx source model",
+        "createComputedView cascade projection",
+        "CleanDoc computed-view to current renderer model adapter",
+        "existing SVG renderer",
+        "existing SVG to PNG conversion",
+      ]
+    `);
+    expect(DOCUMENT_RENDER_UNSUPPORTED_SUBSET).toMatchInlineSnapshot(`
+      [
+        "raw shape-tree nodes such as tables, charts, groups, and unsupported graphicFrame content",
+        "raw background and fill variants outside the CleanDoc adapter subset",
+        "unresolved images without a package media payload",
+        "elements missing computed transforms",
+      ]
+    `);
+  });
+
+  it.each(SELECTED_SHARED_FIXTURES)(
+    "renders selected slides from %s to SVG through the document path",
+    async (fixtureName) => {
+      const result = await convertPptxToSvgViaDocumentPath(readFixture(fixtureName), {
+        slides: [1],
+        textOutput: "text",
+        skipSystemFonts: true,
+      });
+
+      expect(result.slides.map((slide) => slide.slideNumber)).toEqual([1]);
+      expect(result.slides[0]?.svg).toContain("<svg");
+      expect(result.slides[0]?.svg).toMatch(/viewBox="0 0 \d+ \d+"/);
+      expect(result.slides[0]?.svg).toContain("</svg>");
+      expectUnsupportedDiagnosticsToStayInScope(result.diagnostics);
+    },
+  );
+
+  it("surfaces unsupported document subset through adapter diagnostics", async () => {
+    const result = await convertPptxToSvgViaDocumentPath(readFixture("real-basic-theme.pptx"), {
+      slides: [1],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(uniqueDiagnosticCodes(result.diagnostics)).toEqual([
+      "cleandoc-adapter.raw-element-skipped",
+    ]);
+  });
+
+  it("connects the document SVG path to the existing PNG conversion", async () => {
+    const result = await convertPptxToPngViaDocumentPath(readFixture("real-basic-theme.pptx"), {
+      slides: [1],
+      width: 240,
+      skipSystemFonts: true,
+    });
+
+    expect(result.slides.map((slide) => slide.slideNumber)).toEqual([1]);
+    const pngSlide = result.slides[0];
+    expect(pngSlide).toMatchObject({ width: 240 });
+    if (pngSlide === undefined) {
+      throw new Error("Expected one PNG slide from the document render path");
+    }
+    expect([...pngSlide.png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(uniqueDiagnosticCodes(result.diagnostics)).toEqual([
+      "cleandoc-adapter.raw-element-skipped",
+    ]);
+  });
+
+  it("keeps the public SVG converter on its existing default path", async () => {
+    const input = readFixture("real-basic-theme.pptx");
+    const publicDefault = await convertPptxToSvg(input, {
+      slides: [1],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+    const documentPath = await convertPptxToSvgViaDocumentPath(input, {
+      slides: [1],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+
+    expect(publicDefault.map((slide) => slide.slideNumber)).toEqual([1]);
+    expect(publicDefault[0]?.svg).toContain("<svg");
+    expect(documentPath.slides.map((slide) => slide.slideNumber)).toEqual([1]);
+    expect(documentPath.diagnostics.length).toBeGreaterThan(0);
+  });
+});
+
+function readFixture(name: (typeof SELECTED_SHARED_FIXTURES)[number]): Buffer {
+  return readFileSync(fileURLToPath(new URL(`../../../shared-fixtures/${name}`, import.meta.url)));
+}
+
+function uniqueDiagnosticCodes(
+  diagnostics: readonly { readonly code: string }[],
+): readonly string[] {
+  return [...new Set(diagnostics.map((diagnostic) => diagnostic.code))].sort();
+}
+
+function expectUnsupportedDiagnosticsToStayInScope(
+  diagnostics: readonly { readonly code: string }[],
+): void {
+  expect(uniqueDiagnosticCodes(diagnostics)).toEqual(
+    diagnostics.length === 0 ? [] : ["cleandoc-adapter.raw-element-skipped"],
+  );
+}

--- a/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import * as documentExperimental from "../../pptx-glimpse-document/src/experimental.js";
+import * as adapterModule from "./cleandoc-renderer-adapter.js";
 import { convertPptxToSvg } from "./converter.js";
 import {
   convertPptxToPngViaDocumentPath,
@@ -24,9 +26,14 @@ const DOCUMENT_RENDER_UNSUPPORTED_SUBSET = [
   "raw background and fill variants outside the CleanDoc adapter subset",
   "unresolved images without a package media payload",
   "elements missing computed transforms",
+  "East Asian / complex-script theme font context for CJK text",
 ] as const;
 
 describe("experimental document render path", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("documents the intentionally focused dogfood scope", () => {
     expect(DOCUMENT_RENDER_TEST_SCOPE).toMatchInlineSnapshot(`
       [
@@ -43,6 +50,7 @@ describe("experimental document render path", () => {
         "raw background and fill variants outside the CleanDoc adapter subset",
         "unresolved images without a package media payload",
         "elements missing computed transforms",
+        "East Asian / complex-script theme font context for CJK text",
       ]
     `);
   });
@@ -72,9 +80,9 @@ describe("experimental document render path", () => {
     });
 
     expect(result.diagnostics.length).toBeGreaterThan(0);
-    expect(uniqueDiagnosticCodes(result.diagnostics)).toEqual([
+    expect(uniqueDiagnosticCodes(result.diagnostics)).toContain(
       "cleandoc-adapter.raw-element-skipped",
-    ]);
+    );
   });
 
   it("connects the document SVG path to the existing PNG conversion", async () => {
@@ -92,19 +100,16 @@ describe("experimental document render path", () => {
     }
     expect([...pngSlide.png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
-    expect(uniqueDiagnosticCodes(result.diagnostics)).toEqual([
+    expect(uniqueDiagnosticCodes(result.diagnostics)).toContain(
       "cleandoc-adapter.raw-element-skipped",
-    ]);
+    );
   });
 
   it("keeps the public SVG converter on its existing default path", async () => {
+    const readPptxSpy = vi.spyOn(documentExperimental, "readPptx");
+    const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");
     const input = readFixture("real-basic-theme.pptx");
     const publicDefault = await convertPptxToSvg(input, {
-      slides: [1],
-      textOutput: "text",
-      skipSystemFonts: true,
-    });
-    const documentPath = await convertPptxToSvgViaDocumentPath(input, {
       slides: [1],
       textOutput: "text",
       skipSystemFonts: true,
@@ -112,8 +117,8 @@ describe("experimental document render path", () => {
 
     expect(publicDefault.map((slide) => slide.slideNumber)).toEqual([1]);
     expect(publicDefault[0]?.svg).toContain("<svg");
-    expect(documentPath.slides.map((slide) => slide.slideNumber)).toEqual([1]);
-    expect(documentPath.diagnostics.length).toBeGreaterThan(0);
+    expect(readPptxSpy).not.toHaveBeenCalled();
+    expect(adapterSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -130,7 +135,14 @@ function uniqueDiagnosticCodes(
 function expectUnsupportedDiagnosticsToStayInScope(
   diagnostics: readonly { readonly code: string }[],
 ): void {
-  expect(uniqueDiagnosticCodes(diagnostics)).toEqual(
-    diagnostics.length === 0 ? [] : ["cleandoc-adapter.raw-element-skipped"],
+  expect(uniqueDiagnosticCodes(diagnostics).every(isExpectedDocumentRenderDiagnosticCode)).toBe(
+    true,
+  );
+}
+
+function isExpectedDocumentRenderDiagnosticCode(code: string): boolean {
+  return (
+    code === "cleandoc-adapter.raw-element-skipped" ||
+    code === "document-render.cjk-font-context-unsupported"
   );
 }

--- a/packages/pptx-glimpse/src/experimental-document-renderer.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.ts
@@ -23,21 +23,33 @@ import {
   warn,
 } from "pptx-glimpse-renderer";
 
-import { createComputedView, readPptx } from "../../pptx-glimpse-document/src/experimental.js";
+import {
+  type CleanDocComputedView,
+  createComputedView,
+  readPptx,
+} from "../../pptx-glimpse-document/src/experimental.js";
 import {
   adaptComputedViewToRendererModel,
   type RendererAdapterDiagnostic,
 } from "./cleandoc-renderer-adapter.js";
 import type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
 
+export type DocumentRenderDiagnostic = RendererAdapterDiagnostic | DocumentRenderPathDiagnostic;
+
+export interface DocumentRenderPathDiagnostic {
+  readonly severity: "warning";
+  readonly code: "document-render.cjk-font-context-unsupported";
+  readonly message: string;
+}
+
 export interface DocumentPathSvgResult {
   readonly slides: readonly SlideSvg[];
-  readonly diagnostics: readonly RendererAdapterDiagnostic[];
+  readonly diagnostics: readonly DocumentRenderDiagnostic[];
 }
 
 export interface DocumentPathPngResult {
   readonly slides: readonly SlideImage[];
-  readonly diagnostics: readonly RendererAdapterDiagnostic[];
+  readonly diagnostics: readonly DocumentRenderDiagnostic[];
 }
 
 /**
@@ -77,6 +89,7 @@ export async function convertPptxToSvgViaDocumentPath(
 
     const computed = createComputedView(source, { slides: options?.slides });
     const adapted = adaptComputedViewToRendererModel(computed);
+    const diagnostics = [...collectDocumentRenderDiagnostics(computed), ...adapted.diagnostics];
     const slideSize = adapted.slideSize;
     if (slideSize === undefined && adapted.slides.length > 0) {
       throw new Error("Document render path requires a computed slide size");
@@ -97,7 +110,7 @@ export async function convertPptxToSvgViaDocumentPath(
     }
 
     flushWarnings();
-    return { slides, diagnostics: adapted.diagnostics };
+    return { slides, diagnostics };
   } finally {
     resetTextMeasurer();
     resetTextPathFontResolver();
@@ -136,6 +149,34 @@ export async function convertPptxToPngViaDocumentPath(
 
   return { slides, diagnostics: svgResult.diagnostics };
 }
+
+function collectDocumentRenderDiagnostics(
+  computed: CleanDocComputedView,
+): DocumentRenderPathDiagnostic[] {
+  if (!containsCjkText(computed)) return [];
+  return [
+    {
+      severity: "warning",
+      code: "document-render.cjk-font-context-unsupported",
+      message:
+        "CleanDoc document render path does not yet expose East Asian or complex-script theme fonts; CJK text may not match the public converter output.",
+    },
+  ];
+}
+
+function containsCjkText(computed: CleanDocComputedView): boolean {
+  return computed.slides.some((slide) =>
+    slide.elements.some(
+      (element) =>
+        element.kind === "shape" &&
+        element.textBody?.paragraphs.some((paragraph) =>
+          paragraph.runs.some((run) => cjkTextPattern.test(run.text)),
+        ) === true,
+    ),
+  );
+}
+
+const cjkTextPattern = /[\u3040-\u30ff\u3400-\u9fff\uff00-\uffef]/;
 
 function injectIntoSvgDefs(svg: string, content: string): string {
   const openTagEnd = svg.indexOf(">");

--- a/packages/pptx-glimpse/src/experimental-document-renderer.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.ts
@@ -34,20 +34,20 @@ import {
 } from "./cleandoc-renderer-adapter.js";
 import type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
 
-export type DocumentRenderDiagnostic = RendererAdapterDiagnostic | DocumentRenderPathDiagnostic;
+type DocumentRenderDiagnostic = RendererAdapterDiagnostic | DocumentRenderPathDiagnostic;
 
-export interface DocumentRenderPathDiagnostic {
+interface DocumentRenderPathDiagnostic {
   readonly severity: "warning";
   readonly code: "document-render.cjk-font-context-unsupported";
   readonly message: string;
 }
 
-export interface DocumentPathSvgResult {
+interface DocumentPathSvgResult {
   readonly slides: readonly SlideSvg[];
   readonly diagnostics: readonly DocumentRenderDiagnostic[];
 }
 
-export interface DocumentPathPngResult {
+interface DocumentPathPngResult {
   readonly slides: readonly SlideImage[];
   readonly diagnostics: readonly DocumentRenderDiagnostic[];
 }

--- a/packages/pptx-glimpse/src/experimental-document-renderer.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.ts
@@ -1,0 +1,186 @@
+import { readFileSync, statSync } from "node:fs";
+
+import {
+  buildFontFaceStyle,
+  collectFontFilePaths,
+  createFontMapping,
+  createOpentypeSetupFromSystem,
+  DEFAULT_OUTPUT_WIDTH,
+  flushWarnings,
+  FontUsageCollector,
+  initWarningLogger,
+  renderSlideToSvg,
+  resetFontMapping,
+  resetFontUsageCollector,
+  resetScriptFonts,
+  resetTextMeasurer,
+  resetTextPathFontResolver,
+  setFontMapping,
+  setFontUsageCollector,
+  setTextMeasurer,
+  setTextPathFontResolver,
+  svgToPng,
+  warn,
+} from "pptx-glimpse-renderer";
+
+import { createComputedView, readPptx } from "../../pptx-glimpse-document/src/experimental.js";
+import {
+  adaptComputedViewToRendererModel,
+  type RendererAdapterDiagnostic,
+} from "./cleandoc-renderer-adapter.js";
+import type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
+
+export interface DocumentPathSvgResult {
+  readonly slides: readonly SlideSvg[];
+  readonly diagnostics: readonly RendererAdapterDiagnostic[];
+}
+
+export interface DocumentPathPngResult {
+  readonly slides: readonly SlideImage[];
+  readonly diagnostics: readonly RendererAdapterDiagnostic[];
+}
+
+/**
+ * Internal / experimental render orchestration for dogfooding the CleanDoc
+ * document path. This intentionally does not replace the public converter path.
+ */
+export async function convertPptxToSvgViaDocumentPath(
+  input: Buffer | Uint8Array,
+  options?: ConvertOptions,
+): Promise<DocumentPathSvgResult> {
+  const textOutput = options?.textOutput ?? "path";
+  const setup = await createOpentypeSetupFromSystem(
+    options?.fontDirs,
+    options?.fontMapping,
+    options?.skipSystemFonts,
+  );
+  if (setup) {
+    setTextMeasurer(setup.measurer);
+    if (textOutput !== "text") {
+      setTextPathFontResolver(setup.fontResolver);
+    }
+  }
+
+  const fontUsageCollector = textOutput === "text" ? new FontUsageCollector() : null;
+  if (fontUsageCollector) {
+    setFontUsageCollector(fontUsageCollector);
+  }
+  setFontMapping(createFontMapping(options?.fontMapping));
+
+  try {
+    initWarningLogger(options?.logLevel ?? "off");
+
+    const source = readPptx(input);
+    if (source.presentation.slidePartPaths.length === 0) {
+      warn("presentation.noSlides", "No slides found in the PPTX file");
+    }
+
+    const computed = createComputedView(source, { slides: options?.slides });
+    const adapted = adaptComputedViewToRendererModel(computed);
+    const slideSize = adapted.slideSize;
+    if (slideSize === undefined && adapted.slides.length > 0) {
+      throw new Error("Document render path requires a computed slide size");
+    }
+
+    const slides: SlideSvg[] = [];
+    for (const slide of adapted.slides) {
+      if (slideSize === undefined) continue;
+      fontUsageCollector?.reset();
+      let svg = renderSlideToSvg(slide, slideSize);
+      if (fontUsageCollector && setup) {
+        const style = await buildFontFaceStyle(fontUsageCollector.getUsages(), setup.fontResolver);
+        if (style) {
+          svg = injectIntoSvgDefs(svg, style);
+        }
+      }
+      slides.push({ slideNumber: slide.slideNumber, svg });
+    }
+
+    flushWarnings();
+    return { slides, diagnostics: adapted.diagnostics };
+  } finally {
+    resetTextMeasurer();
+    resetTextPathFontResolver();
+    resetFontUsageCollector();
+    resetFontMapping();
+    resetScriptFonts();
+  }
+}
+
+/**
+ * Internal / experimental PNG path layered on top of the CleanDoc SVG path and
+ * the existing renderer PNG conversion.
+ */
+export async function convertPptxToPngViaDocumentPath(
+  input: Buffer | Uint8Array,
+  options?: ConvertOptions,
+): Promise<DocumentPathPngResult> {
+  const svgResult = await convertPptxToSvgViaDocumentPath(input, {
+    ...options,
+    textOutput: "path",
+  });
+  const width = options?.width ?? DEFAULT_OUTPUT_WIDTH;
+  const height = options?.height;
+  const fontBuffers = loadFontBuffers(options?.fontDirs, options?.skipSystemFonts);
+
+  const slides: SlideImage[] = [];
+  for (const { slideNumber, svg } of svgResult.slides) {
+    const pngResult = await svgToPng(svg, { width, height, fontBuffers });
+    slides.push({
+      slideNumber,
+      png: pngResult.png,
+      width: pngResult.width,
+      height: pngResult.height,
+    });
+  }
+
+  return { slides, diagnostics: svgResult.diagnostics };
+}
+
+function injectIntoSvgDefs(svg: string, content: string): string {
+  const openTagEnd = svg.indexOf(">");
+  if (openTagEnd === -1) return svg;
+  return `${svg.slice(0, openTagEnd + 1)}<defs>${content}</defs>${svg.slice(openTagEnd + 1)}`;
+}
+
+let cachedFontBuffers: Uint8Array[] | null = null;
+let cachedFontBuffersKey: string | null = null;
+
+const MAX_TOTAL_FONT_BUFFER_BYTES = 100 * 1024 * 1024;
+
+function loadFontBuffers(fontDirs?: string[], skipSystemFonts?: boolean): Uint8Array[] {
+  const key = `${(fontDirs ?? []).join("\0")}\n${skipSystemFonts ?? false}`;
+  if (cachedFontBuffers !== null && cachedFontBuffersKey === key) {
+    return cachedFontBuffers;
+  }
+
+  const fontPaths = collectFontFilePaths(fontDirs, skipSystemFonts).filter((path) => {
+    const lower = path.toLowerCase();
+    return lower.endsWith(".ttf") || lower.endsWith(".otf");
+  });
+  const readableFontPaths: { path: string; size: number }[] = [];
+  for (const path of fontPaths) {
+    try {
+      readableFontPaths.push({ path, size: statSync(path).size });
+    } catch {
+      // Ignore unreadable font files.
+    }
+  }
+  readableFontPaths.sort((a, b) => a.size - b.size);
+
+  const buffers: Uint8Array[] = [];
+  let totalSize = 0;
+  for (const { path, size } of readableFontPaths) {
+    if (totalSize + size > MAX_TOTAL_FONT_BUFFER_BYTES) break;
+    try {
+      buffers.push(new Uint8Array(readFileSync(path)));
+      totalSize += size;
+    } catch {
+      // Ignore fonts that disappear between stat and read.
+    }
+  }
+
+  cachedFontBuffers = buffers;
+  cachedFontBuffersKey = key;
+  return buffers;
+}


### PR DESCRIPTION
close #482

## 概要

- `readPptx` → `createComputedView` → current renderer adapter → existing SVG renderer を通す internal / experimental な document render path を追加しました。
- SVG path を既存 `svgToPng` に接続する PNG render path も追加しました。
- selected shared fixtures で document path を明示的に通す focused tests を追加し、unsupported subset を diagnostics / test scope として明示しました。

## 影響範囲

- `packages/pptx-glimpse/src/experimental-document-renderer.ts`
- `packages/pptx-glimpse/src/experimental-document-renderer.test.ts`
- `packages/pptx-glimpse/src/cleandoc-renderer-adapter.ts`

## 互換性

- public `convertPptxToSvg` / `convertPptxToPng` の default path は変更していません。
- 今回の document render path は root public API には export せず、source internal / experimental entry として追加しています。
- CJK text は East Asian / complex-script theme font context が document path 未対応であることを diagnostics で明示します。

## 検証

- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`
- acceptance-check: 5/5 passed
- cross-review: critical 0 / warning 1 / info 2。warning は diagnostics 追加で対応済み。
