### PR TITLE
selected fixtures を document path VRT で検証する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
             -v "${{ github.workspace }}":/workspace \
             ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest \
             bash /workspace/vrt/snapshot/docker-run.sh \
-            bash -c "pnpm run vrt:snapshot:fixtures && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/regression.test.ts"
+            bash -c "pnpm run vrt:snapshot:fixtures && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/regression.test.ts && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts"
 
       - name: Upload diff images on failure
         if: failure()

--- a/shared-fixtures/README.md
+++ b/shared-fixtures/README.md
@@ -39,7 +39,7 @@
 2. `e2e/smoke.test.ts` にスモークテストを追加する
 3. `vrt/snapshot/vrt-cases.ts` の `SHARED_FIXTURE_CASES` にエントリを追加する
 4. `npm run vrt:snapshot:update` でスナップショットを生成する
-5. document path parity VRT の対象にする場合は、`vrt/snapshot/document-path-cases.ts` に opt-in 理由と許容差分を追加する
+5. document path parity VRT では、`vrt/snapshot/document-path-cases.ts` の opt-in または excluded のどちらかに分類する。opt-in する場合は `slides` / `tolerance` / `reason` / `expectedDiagnosticCodes` を設定する
 
 ファイルサイズはリポジトリサイズへの影響を抑えるため **1ファイルあたり 500KB 以下** を目安とする。
 ライセンス上問題のない PPTX のみ追加すること（自作または OSSテンプレート）。

--- a/shared-fixtures/README.md
+++ b/shared-fixtures/README.md
@@ -4,12 +4,13 @@
 
 ## 用途
 
-このディレクトリのファイルは **2つのテストスイートから共有** される:
+このディレクトリのファイルは複数のテストスイートから共有される:
 
 | テスト | ファイル | 目的 |
 |---|---|---|
 | E2E スモークテスト | `e2e/smoke.test.ts` | エラーなく変換できること・主要要素の SVG 出力確認 |
 | スナップショット VRT | `vrt/snapshot/regression.test.ts` | レンダリング結果のリグレッション検出 |
+| document path parity VRT | `vrt/snapshot/document-path-regression.test.ts` | current parser path と experimental document path の PNG 差分追跡 |
 
 ## プログラム合成フィクスチャとの違い
 
@@ -38,6 +39,7 @@
 2. `e2e/smoke.test.ts` にスモークテストを追加する
 3. `vrt/snapshot/vrt-cases.ts` の `SHARED_FIXTURE_CASES` にエントリを追加する
 4. `npm run vrt:snapshot:update` でスナップショットを生成する
+5. document path parity VRT の対象にする場合は、`vrt/snapshot/document-path-cases.ts` に opt-in 理由と許容差分を追加する
 
 ファイルサイズはリポジトリサイズへの影響を抑えるため **1ファイルあたり 500KB 以下** を目安とする。
 ライセンス上問題のない PPTX のみ追加すること（自作または OSSテンプレート）。

--- a/vrt/compare-utils.ts
+++ b/vrt/compare-utils.ts
@@ -3,14 +3,14 @@ import { dirname } from "path";
 import pixelmatch from "pixelmatch";
 import sharp from "sharp";
 
-export interface CompareResult {
+interface CompareResult {
   totalPixels: number;
   mismatchedPixels: number;
   mismatchPercentage: number;
   passed: boolean;
 }
 
-export interface CompareOptions {
+interface CompareOptions {
   pixelThreshold: number;
   mismatchTolerance: number;
   /** 参照画像を actual のサイズにリサイズして比較する (LibreOffice VRT 用) */

--- a/vrt/compare-utils.ts
+++ b/vrt/compare-utils.ts
@@ -3,14 +3,14 @@ import { dirname } from "path";
 import pixelmatch from "pixelmatch";
 import sharp from "sharp";
 
-interface CompareResult {
+export interface CompareResult {
   totalPixels: number;
   mismatchedPixels: number;
   mismatchPercentage: number;
   passed: boolean;
 }
 
-interface CompareOptions {
+export interface CompareOptions {
   pixelThreshold: number;
   mismatchTolerance: number;
   /** 参照画像を actual のサイズにリサイズして比較する (LibreOffice VRT 用) */
@@ -27,7 +27,16 @@ export async function compareImages(
     throw new Error(`Reference snapshot not found: ${referencePath}`);
   }
 
-  const refPng = readFileSync(referencePath);
+  return compareImageBuffers(actualPng, readFileSync(referencePath), diffPath, options);
+}
+
+export async function compareImageBuffers(
+  actualPng: Uint8Array | Buffer,
+  referencePng: Uint8Array | Buffer,
+  diffPath: string,
+  options: CompareOptions,
+): Promise<CompareResult> {
+  const refPng = Buffer.from(referencePng);
 
   const actualMeta = await sharp(actualPng).metadata();
   const width = actualMeta.width ?? 0;

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -1,0 +1,60 @@
+/**
+ * Document path VRT は public snapshot を更新せず、current parser path の PNG を
+ * 参照画像としてその場で比較する opt-in parity harness。
+ */
+
+export const DOCUMENT_PATH_VRT_RENDER_WIDTH = 320;
+
+export const DOCUMENT_PATH_VRT_SNAPSHOT_POLICY =
+  "No committed snapshot update is required: document path VRT compares against the current parser path in-memory until the public default path changes.";
+
+export const DOCUMENT_PATH_VRT_OPT_IN_CASES = [
+  {
+    name: "real-basic-theme",
+    fixture: "real-basic-theme.pptx",
+    slides: [1],
+    tolerance: 0.001,
+    reason:
+      "Shared fixture already covered by focused document render tests; slide 1 stays within the current CleanDoc shape/text subset.",
+    expectedDiagnosticCodes: [
+      "cleandoc-adapter.raw-element-skipped",
+      "document-render.cjk-font-context-unsupported",
+    ],
+  },
+  {
+    name: "real-product-page",
+    fixture: "real-product-page.pptx",
+    slides: [1],
+    tolerance: 0.04,
+    reason:
+      "Shared fixture exercises the image/text render path and intentionally records the current visual parity gap before default-path migration.",
+    expectedDiagnosticCodes: [],
+  },
+] as const;
+
+export const DOCUMENT_PATH_VRT_EXCLUDED_CASES = [
+  {
+    name: "real-financial-report",
+    fixture: "real-financial-report.pptx",
+    reason:
+      "Deferred because the fixture is broader than the initial selected shared fixture slice and would mix document path dogfood with unrelated parity gaps.",
+  },
+  {
+    name: "sample",
+    fixture: "sample.pptx",
+    reason:
+      "Deferred until the selected real app fixtures have stable document path parity metrics.",
+  },
+  {
+    name: "sample-issue-387",
+    fixture: "sample-issue-387.pptx",
+    reason:
+      "Deferred because issue-specific regression fixtures should only opt in after their document path support scope is explicitly reviewed.",
+  },
+  {
+    name: "generated snapshot VRT cases",
+    fixture: "vrt/snapshot/fixtures/*.pptx",
+    reason:
+      "Deferred because generated cases cover many unsupported tables, charts, groups, effects, and advanced text features outside this issue's selected fixture scope.",
+  },
+] as const;

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -27,7 +27,7 @@ export const DOCUMENT_PATH_VRT_OPT_IN_CASES = [
     slides: [1],
     tolerance: 0.04,
     reason:
-      "Shared fixture exercises the image/text render path and intentionally records the current visual parity gap before default-path migration.",
+      "Shared fixture exercises shape/text rendering and intentionally records the current visual parity gap before default-path migration.",
     expectedDiagnosticCodes: [],
   },
 ] as const;

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -1,0 +1,152 @@
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { convertPptxToPng } from "../../packages/pptx-glimpse/src/converter.js";
+import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
+import { compareImageBuffers } from "../compare-utils.js";
+import {
+  DOCUMENT_PATH_VRT_EXCLUDED_CASES,
+  DOCUMENT_PATH_VRT_OPT_IN_CASES,
+  DOCUMENT_PATH_VRT_RENDER_WIDTH,
+  DOCUMENT_PATH_VRT_SNAPSHOT_POLICY,
+} from "./document-path-cases.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SHARED_FIXTURE_DIR = join(__dirname, "..", "..", "shared-fixtures");
+const DIFF_DIR = join(__dirname, "diffs");
+
+const PIXEL_THRESHOLD = 0;
+
+describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
+  it("documents opt-in cases, excluded cases, and snapshot policy", () => {
+    expect(DOCUMENT_PATH_VRT_SNAPSHOT_POLICY).toMatchInlineSnapshot(
+      `"No committed snapshot update is required: document path VRT compares against the current parser path in-memory until the public default path changes."`,
+    );
+    expect(
+      DOCUMENT_PATH_VRT_OPT_IN_CASES.map(({ name, fixture, slides, tolerance, reason }) => ({
+        name,
+        fixture,
+        slides,
+        tolerance,
+        reason,
+      })),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "fixture": "real-basic-theme.pptx",
+          "name": "real-basic-theme",
+          "reason": "Shared fixture already covered by focused document render tests; slide 1 stays within the current CleanDoc shape/text subset.",
+          "slides": [
+            1,
+          ],
+          "tolerance": 0.001,
+        },
+        {
+          "fixture": "real-product-page.pptx",
+          "name": "real-product-page",
+          "reason": "Shared fixture exercises the image/text render path and intentionally records the current visual parity gap before default-path migration.",
+          "slides": [
+            1,
+          ],
+          "tolerance": 0.04,
+        },
+      ]
+    `);
+    expect(DOCUMENT_PATH_VRT_EXCLUDED_CASES).toMatchInlineSnapshot(`
+      [
+        {
+          "fixture": "real-financial-report.pptx",
+          "name": "real-financial-report",
+          "reason": "Deferred because the fixture is broader than the initial selected shared fixture slice and would mix document path dogfood with unrelated parity gaps.",
+        },
+        {
+          "fixture": "sample.pptx",
+          "name": "sample",
+          "reason": "Deferred until the selected real app fixtures have stable document path parity metrics.",
+        },
+        {
+          "fixture": "sample-issue-387.pptx",
+          "name": "sample-issue-387",
+          "reason": "Deferred because issue-specific regression fixtures should only opt in after their document path support scope is explicitly reviewed.",
+        },
+        {
+          "fixture": "vrt/snapshot/fixtures/*.pptx",
+          "name": "generated snapshot VRT cases",
+          "reason": "Deferred because generated cases cover many unsupported tables, charts, groups, effects, and advanced text features outside this issue's selected fixture scope.",
+        },
+      ]
+    `);
+  });
+
+  for (const testCase of DOCUMENT_PATH_VRT_OPT_IN_CASES) {
+    describe(testCase.name, () => {
+      it("tracks current parser vs document path PNG parity", async () => {
+        const fixturePath = join(SHARED_FIXTURE_DIR, testCase.fixture);
+        if (!existsSync(fixturePath)) {
+          throw new Error(`Shared fixture not found: ${fixturePath}.`);
+        }
+
+        const input = readFileSync(fixturePath);
+        const options = {
+          slides: [...testCase.slides],
+          width: DOCUMENT_PATH_VRT_RENDER_WIDTH,
+          skipSystemFonts: true,
+        };
+        const currentResults = await convertPptxToPng(input, options);
+        const documentResults = await convertPptxToPngViaDocumentPath(input, options);
+
+        expect(currentResults.map((slide) => slide.slideNumber)).toEqual([...testCase.slides]);
+        expect(documentResults.slides.map((slide) => slide.slideNumber)).toEqual([
+          ...testCase.slides,
+        ]);
+        expect(uniqueSortedCodes(documentResults.diagnostics)).toEqual(
+          [...testCase.expectedDiagnosticCodes].sort(),
+        );
+
+        for (const documentResult of documentResults.slides) {
+          const currentResult = currentResults.find(
+            (slide) => slide.slideNumber === documentResult.slideNumber,
+          );
+          if (currentResult === undefined) {
+            throw new Error(
+              `Current parser path did not render ${testCase.name} slide ${documentResult.slideNumber}`,
+            );
+          }
+
+          const diffPath = join(
+            DIFF_DIR,
+            `document-path-${testCase.name}-slide${documentResult.slideNumber}-diff.png`,
+          );
+          const comparison = await compareImageBuffers(
+            documentResult.png,
+            currentResult.png,
+            diffPath,
+            {
+              pixelThreshold: PIXEL_THRESHOLD,
+              mismatchTolerance: testCase.tolerance,
+            },
+          );
+
+          console.log(
+            `[document-path-vrt] ${testCase.name} slide${documentResult.slideNumber}: ` +
+              `${(comparison.mismatchPercentage * 100).toFixed(3)}% ` +
+              `(tolerance ${(testCase.tolerance * 100).toFixed(1)}%)`,
+          );
+
+          expect(
+            comparison.passed,
+            `${testCase.name} slide ${documentResult.slideNumber}: ` +
+              `${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ ` +
+              `(${comparison.mismatchedPixels}/${comparison.totalPixels}). ` +
+              `Tolerance: ${testCase.tolerance * 100}%`,
+          ).toBe(true);
+        }
+      });
+    });
+  }
+});
+
+function uniqueSortedCodes(diagnostics: readonly { readonly code: string }[]): string[] {
+  return [...new Set(diagnostics.map((diagnostic) => diagnostic.code))].sort();
+}

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -11,6 +11,7 @@ import {
   DOCUMENT_PATH_VRT_RENDER_WIDTH,
   DOCUMENT_PATH_VRT_SNAPSHOT_POLICY,
 } from "./document-path-cases.js";
+import { SHARED_FIXTURE_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SHARED_FIXTURE_DIR = join(__dirname, "..", "..", "shared-fixtures");
@@ -20,6 +21,16 @@ const PIXEL_THRESHOLD = 0;
 
 describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
   it("documents opt-in cases, excluded cases, and snapshot policy", () => {
+    const scopedSharedFixtureNames = [
+      ...DOCUMENT_PATH_VRT_OPT_IN_CASES,
+      ...DOCUMENT_PATH_VRT_EXCLUDED_CASES.filter(({ fixture }) => !fixture.includes("*")),
+    ]
+      .map(({ fixture }) => fixture)
+      .sort();
+    const sharedFixtureNames = SHARED_FIXTURE_CASES.map(({ fixture }) => fixture).sort();
+
+    expect(scopedSharedFixtureNames).toEqual([...new Set(scopedSharedFixtureNames)]);
+    expect(scopedSharedFixtureNames).toEqual(sharedFixtureNames);
     expect(DOCUMENT_PATH_VRT_SNAPSHOT_POLICY).toMatchInlineSnapshot(
       `"No committed snapshot update is required: document path VRT compares against the current parser path in-memory until the public default path changes."`,
     );
@@ -45,7 +56,7 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
         {
           "fixture": "real-product-page.pptx",
           "name": "real-product-page",
-          "reason": "Shared fixture exercises the image/text render path and intentionally records the current visual parity gap before default-path migration.",
+          "reason": "Shared fixture exercises shape/text rendering and intentionally records the current visual parity gap before default-path migration.",
           "slides": [
             1,
           ],


### PR DESCRIPTION
close #483

## 目的

internal / experimental document render path を使い、selected shared fixtures の current parser path との差分を VRT 側で追跡できるようにします。public default path は変更しません。

## 変更内容

- `real-basic-theme` / `real-product-page` を document path VRT の opt-in case として定義
- current parser path の PNG を in-memory reference として document path PNG を比較する parity VRT を追加
- opt-in / excluded の理由と snapshot update 不要方針を test 上で明示
- shared fixture が opt-in または excluded のどちらかに分類されることを検査
- snapshot VRT CI で document path VRT も実行するように追加
- shared-fixtures の運用 README に document path parity VRT を追記

## 検証

- `npm run test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts`
- `npm run vrt:snapshot:fixtures`

補足: ローカルの macOS / Node 22 環境では既存 `vrt/snapshot/regression.test.ts` 単体が heap OOM で完走しませんでした。今回追加した document path VRT は単体で通過し、CI では既存 snapshot VRT と document path VRT を別 Vitest invocation で直列実行します。