### PR TITLE
document path の full VRT parity harness を追加

### DIFF
--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -1,6 +1,9 @@
 /**
  * Document path VRT は public snapshot を更新せず、current parser path の PNG を
  * 参照画像としてその場で比較する full parity harness。
+ *
+ * mismatchTolerance は #489 時点の実測 gap を blocker issue 単位で固定した上限。
+ * blocker 解消 PR では対象ケースを再測定し、可能なら 0 まで締める。
  */
 
 export const DOCUMENT_PATH_VRT_RENDER_WIDTH = 320;
@@ -17,7 +20,7 @@ export const DOCUMENT_PATH_VRT_BLOCKER_ISSUES = {
   textAndFonts: 496,
 } as const;
 
-type DocumentPathVrtFixtureGroup = "shared" | "generated";
+export type DocumentPathVrtFixtureGroup = "shared" | "generated";
 
 type DocumentPathVrtDiagnosticCode =
   | "cleandoc-adapter.raw-element-skipped"

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -1,6 +1,6 @@
 /**
  * Document path VRT は public snapshot を更新せず、current parser path の PNG を
- * 参照画像としてその場で比較する opt-in parity harness。
+ * 参照画像としてその場で比較する full parity harness。
  */
 
 export const DOCUMENT_PATH_VRT_RENDER_WIDTH = 320;
@@ -8,53 +8,421 @@ export const DOCUMENT_PATH_VRT_RENDER_WIDTH = 320;
 export const DOCUMENT_PATH_VRT_SNAPSHOT_POLICY =
   "No committed snapshot update is required: document path VRT compares against the current parser path in-memory until the public default path changes.";
 
-export const DOCUMENT_PATH_VRT_OPT_IN_CASES = [
-  {
-    name: "real-basic-theme",
-    fixture: "real-basic-theme.pptx",
-    slides: [1],
-    tolerance: 0.001,
-    reason:
-      "Shared fixture already covered by focused document render tests; slide 1 stays within the current CleanDoc shape/text subset.",
-    expectedDiagnosticCodes: [
-      "cleandoc-adapter.raw-element-skipped",
-      "document-render.cjk-font-context-unsupported",
-    ],
-  },
-  {
-    name: "real-product-page",
-    fixture: "real-product-page.pptx",
-    slides: [1],
-    tolerance: 0.04,
-    reason:
-      "Shared fixture exercises shape/text rendering and intentionally records the current visual parity gap before default-path migration.",
-    expectedDiagnosticCodes: [],
-  },
-] as const;
+export const DOCUMENT_PATH_VRT_BLOCKER_ISSUES = {
+  tables: 491,
+  chartsAndSmartArt: 492,
+  shapeTreeAndGeometry: 493,
+  fillsAndBackgrounds: 494,
+  effects: 495,
+  textAndFonts: 496,
+} as const;
 
-export const DOCUMENT_PATH_VRT_EXCLUDED_CASES = [
-  {
-    name: "real-financial-report",
-    fixture: "real-financial-report.pptx",
-    reason:
-      "Deferred because the fixture is broader than the initial selected shared fixture slice and would mix document path dogfood with unrelated parity gaps.",
-  },
-  {
-    name: "sample",
-    fixture: "sample.pptx",
-    reason:
-      "Deferred until the selected real app fixtures have stable document path parity metrics.",
-  },
-  {
-    name: "sample-issue-387",
-    fixture: "sample-issue-387.pptx",
-    reason:
-      "Deferred because issue-specific regression fixtures should only opt in after their document path support scope is explicitly reviewed.",
-  },
-  {
-    name: "generated snapshot VRT cases",
-    fixture: "vrt/snapshot/fixtures/*.pptx",
-    reason:
-      "Deferred because generated cases cover many unsupported tables, charts, groups, effects, and advanced text features outside this issue's selected fixture scope.",
-  },
-] as const;
+type DocumentPathVrtFixtureGroup = "shared" | "generated";
+
+type DocumentPathVrtDiagnosticCode =
+  | "cleandoc-adapter.raw-element-skipped"
+  | "cleandoc-adapter.raw-fill-ignored"
+  | "document-render.cjk-font-context-unsupported";
+
+interface DocumentPathVrtCase {
+  readonly group: DocumentPathVrtFixtureGroup;
+  readonly name: string;
+  readonly fixture: string;
+  readonly mismatchTolerance: number;
+  readonly blockerIssues: readonly number[];
+  readonly expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[];
+}
+
+const B = DOCUMENT_PATH_VRT_BLOCKER_ISSUES;
+
+export const DOCUMENT_PATH_VRT_SHARED_CASES = [
+  shared(
+    "real-basic-theme",
+    "real-basic-theme.pptx",
+    0.02,
+    [B.shapeTreeAndGeometry, B.textAndFonts],
+    ["cleandoc-adapter.raw-element-skipped", "document-render.cjk-font-context-unsupported"],
+  ),
+  shared("real-product-page", "real-product-page.pptx", 0.04, [B.textAndFonts]),
+  shared(
+    "real-financial-report",
+    "real-financial-report.pptx",
+    0.16,
+    [B.tables, B.chartsAndSmartArt, B.shapeTreeAndGeometry, B.textAndFonts],
+    ["cleandoc-adapter.raw-element-skipped", "document-render.cjk-font-context-unsupported"],
+  ),
+  shared(
+    "sample",
+    "sample.pptx",
+    0,
+    [B.textAndFonts],
+    ["document-render.cjk-font-context-unsupported"],
+  ),
+  shared("sample-issue-387", "sample-issue-387.pptx", 0, []),
+] as const satisfies readonly DocumentPathVrtCase[];
+
+export const DOCUMENT_PATH_VRT_GENERATED_CASES = [
+  generated(
+    "shapes",
+    "shapes.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "fill-and-lines",
+    "fill-and-lines.pptx",
+    0.39,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped", "cleandoc-adapter.raw-fill-ignored"],
+  ),
+  generated(
+    "text",
+    "text.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "transform",
+    "transform.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "background",
+    "background.pptx",
+    0.93,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped", "cleandoc-adapter.raw-fill-ignored"],
+  ),
+  generated(
+    "groups",
+    "groups.pptx",
+    0.46,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "charts",
+    "charts.pptx",
+    0.64,
+    [B.chartsAndSmartArt],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "connectors",
+    "connectors.pptx",
+    0.02,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "custom-geometry",
+    "custom-geometry.pptx",
+    0.39,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "image",
+    "image.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated("tables", "tables.pptx", 0.21, [B.tables], ["cleandoc-adapter.raw-element-skipped"]),
+  generated(
+    "bullets",
+    "bullets.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "flowchart",
+    "flowchart.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "callouts-arcs",
+    "callouts-arcs.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "arrows-stars",
+    "arrows-stars.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "math-other",
+    "math-other.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "word-wrap",
+    "word-wrap.pptx",
+    0,
+    [B.shapeTreeAndGeometry, B.textAndFonts],
+    ["cleandoc-adapter.raw-element-skipped", "document-render.cjk-font-context-unsupported"],
+  ),
+  generated(
+    "background-blipfill",
+    "background-blipfill.pptx",
+    0.98,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped", "cleandoc-adapter.raw-fill-ignored"],
+  ),
+  generated(
+    "composite",
+    "composite.pptx",
+    0.24,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped", "cleandoc-adapter.raw-fill-ignored"],
+  ),
+  generated(
+    "text-decoration",
+    "text-decoration.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "slide-size-4-3",
+    "slide-size-4-3.pptx",
+    0.99,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped", "cleandoc-adapter.raw-fill-ignored"],
+  ),
+  generated("effects", "effects.pptx", 0.19, [B.effects], ["cleandoc-adapter.raw-element-skipped"]),
+  generated(
+    "hyperlinks",
+    "hyperlinks.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "pattern-image-fill",
+    "pattern-image-fill.pptx",
+    0.56,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped", "cleandoc-adapter.raw-fill-ignored"],
+  ),
+  generated(
+    "smartart",
+    "smartart.pptx",
+    0.51,
+    [B.chartsAndSmartArt],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "theme-fonts",
+    "theme-fonts.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "text-style-inheritance",
+    "text-style-inheritance.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "z-order-mixed",
+    "z-order-mixed.pptx",
+    0.2,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "paragraph-spacing",
+    "paragraph-spacing.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "placeholder-overlap",
+    "placeholder-overlap.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "image-crop",
+    "image-crop.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "text-advanced",
+    "text-advanced.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "shrink-to-fit",
+    "shrink-to-fit.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "sp-autofit",
+    "sp-autofit.pptx",
+    0.01,
+    [B.shapeTreeAndGeometry, B.textAndFonts],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "style-reference",
+    "style-reference.pptx",
+    0.35,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "blip-effects",
+    "blip-effects.pptx",
+    0.65,
+    [B.effects],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "image-stretch-tile",
+    "image-stretch-tile.pptx",
+    0.34,
+    [B.shapeTreeAndGeometry, B.fillsAndBackgrounds],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "vertical-text",
+    "vertical-text.pptx",
+    0,
+    [B.shapeTreeAndGeometry, B.textAndFonts],
+    ["cleandoc-adapter.raw-element-skipped", "document-render.cjk-font-context-unsupported"],
+  ),
+  generated(
+    "shape-hyperlink-text-outline",
+    "shape-hyperlink-text-outline.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "charts-3d-fallback",
+    "charts-3d-fallback.pptx",
+    0.54,
+    [B.chartsAndSmartArt],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "color-transforms",
+    "color-transforms.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "table-complex-merge",
+    "table-complex-merge.pptx",
+    0.31,
+    [B.tables],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "multi-lang-font",
+    "multi-lang-font.pptx",
+    0,
+    [B.shapeTreeAndGeometry, B.textAndFonts],
+    ["cleandoc-adapter.raw-element-skipped", "document-render.cjk-font-context-unsupported"],
+  ),
+  generated(
+    "placeholder-inheritance-extended",
+    "placeholder-inheritance-extended.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "table-style-border",
+    "table-style-border.pptx",
+    0.14,
+    [B.tables],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "placeholder-geometry-inheritance",
+    "placeholder-geometry-inheritance.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "placeholder-empty-on-slide",
+    "placeholder-empty-on-slide.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+  generated(
+    "interleaved-bullet-ppr",
+    "interleaved-bullet-ppr.pptx",
+    0,
+    [B.shapeTreeAndGeometry],
+    ["cleandoc-adapter.raw-element-skipped"],
+  ),
+] as const satisfies readonly DocumentPathVrtCase[];
+
+export const DOCUMENT_PATH_VRT_CASES = [
+  ...DOCUMENT_PATH_VRT_SHARED_CASES,
+  ...DOCUMENT_PATH_VRT_GENERATED_CASES,
+] as const satisfies readonly DocumentPathVrtCase[];
+
+function shared(
+  name: string,
+  fixture: string,
+  mismatchTolerance: number,
+  blockerIssues: readonly number[],
+  expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[] = [],
+): DocumentPathVrtCase {
+  return {
+    group: "shared",
+    name,
+    fixture,
+    mismatchTolerance,
+    blockerIssues,
+    expectedDiagnosticCodes,
+  };
+}
+
+function generated(
+  name: string,
+  fixture: string,
+  mismatchTolerance: number,
+  blockerIssues: readonly number[],
+  expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[] = [],
+): DocumentPathVrtCase {
+  return {
+    group: "generated",
+    name,
+    fixture,
+    mismatchTolerance,
+    blockerIssues,
+    expectedDiagnosticCodes,
+  };
+}

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -12,6 +12,7 @@ import {
   DOCUMENT_PATH_VRT_RENDER_WIDTH,
   DOCUMENT_PATH_VRT_SHARED_CASES,
   DOCUMENT_PATH_VRT_SNAPSHOT_POLICY,
+  type DocumentPathVrtFixtureGroup,
 } from "./document-path-cases.js";
 import { SHARED_FIXTURE_CASES, VRT_CASES } from "./vrt-cases.js";
 
@@ -32,9 +33,11 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
       ({ fixture }) => fixture,
     ).sort();
     const generatedFixtureNames = VRT_CASES.map(({ fixture }) => fixture).sort();
+    const scopedCaseNames = DOCUMENT_PATH_VRT_CASES.map(({ name }) => name).sort();
 
     expect(scopedSharedFixtureNames).toEqual([...new Set(scopedSharedFixtureNames)]);
     expect(scopedGeneratedFixtureNames).toEqual([...new Set(scopedGeneratedFixtureNames)]);
+    expect(scopedCaseNames).toEqual([...new Set(scopedCaseNames)]);
     expect(scopedSharedFixtureNames).toEqual(sharedFixtureNames);
     expect(scopedGeneratedFixtureNames).toEqual(generatedFixtureNames);
     expect(DOCUMENT_PATH_VRT_SNAPSHOT_POLICY).toMatchInlineSnapshot(
@@ -76,6 +79,14 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
         const currentResults = await convertPptxToPng(input, options);
         const documentResults = await convertPptxToPngViaDocumentPath(input, options);
 
+        expect(
+          currentResults.length,
+          `${testCase.name}: current parser rendered no slides`,
+        ).toBeGreaterThan(0);
+        expect(
+          documentResults.slides.length,
+          `${testCase.name}: document path slide count should match current parser`,
+        ).toBe(currentResults.length);
         expect(documentResults.slides.map((slide) => slide.slideNumber)).toEqual(
           currentResults.map((slide) => slide.slideNumber),
         );
@@ -132,7 +143,7 @@ function uniqueSortedCodes(diagnostics: readonly { readonly code: string }[]): s
   return [...new Set(diagnostics.map((diagnostic) => diagnostic.code))].sort();
 }
 
-function fixtureDir(group: "shared" | "generated"): string {
+function fixtureDir(group: DocumentPathVrtFixtureGroup): string {
   return group === "shared" ? SHARED_FIXTURE_DIR : GENERATED_FIXTURE_DIR;
 }
 

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -6,111 +6,79 @@ import { convertPptxToPng } from "../../packages/pptx-glimpse/src/converter.js";
 import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
 import { compareImageBuffers } from "../compare-utils.js";
 import {
-  DOCUMENT_PATH_VRT_EXCLUDED_CASES,
-  DOCUMENT_PATH_VRT_OPT_IN_CASES,
+  DOCUMENT_PATH_VRT_BLOCKER_ISSUES,
+  DOCUMENT_PATH_VRT_CASES,
+  DOCUMENT_PATH_VRT_GENERATED_CASES,
   DOCUMENT_PATH_VRT_RENDER_WIDTH,
+  DOCUMENT_PATH_VRT_SHARED_CASES,
   DOCUMENT_PATH_VRT_SNAPSHOT_POLICY,
 } from "./document-path-cases.js";
-import { SHARED_FIXTURE_CASES } from "./vrt-cases.js";
+import { SHARED_FIXTURE_CASES, VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SHARED_FIXTURE_DIR = join(__dirname, "..", "..", "shared-fixtures");
+const GENERATED_FIXTURE_DIR = join(__dirname, "fixtures");
 const DIFF_DIR = join(__dirname, "diffs");
 
 const PIXEL_THRESHOLD = 0;
 
 describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
-  it("documents opt-in cases, excluded cases, and snapshot policy", () => {
-    const scopedSharedFixtureNames = [
-      ...DOCUMENT_PATH_VRT_OPT_IN_CASES,
-      ...DOCUMENT_PATH_VRT_EXCLUDED_CASES.filter(({ fixture }) => !fixture.includes("*")),
-    ]
-      .map(({ fixture }) => fixture)
-      .sort();
+  it("covers the full shared fixture and generated VRT sets", () => {
+    const scopedSharedFixtureNames = DOCUMENT_PATH_VRT_SHARED_CASES.map(
+      ({ fixture }) => fixture,
+    ).sort();
     const sharedFixtureNames = SHARED_FIXTURE_CASES.map(({ fixture }) => fixture).sort();
+    const scopedGeneratedFixtureNames = DOCUMENT_PATH_VRT_GENERATED_CASES.map(
+      ({ fixture }) => fixture,
+    ).sort();
+    const generatedFixtureNames = VRT_CASES.map(({ fixture }) => fixture).sort();
 
     expect(scopedSharedFixtureNames).toEqual([...new Set(scopedSharedFixtureNames)]);
+    expect(scopedGeneratedFixtureNames).toEqual([...new Set(scopedGeneratedFixtureNames)]);
     expect(scopedSharedFixtureNames).toEqual(sharedFixtureNames);
+    expect(scopedGeneratedFixtureNames).toEqual(generatedFixtureNames);
     expect(DOCUMENT_PATH_VRT_SNAPSHOT_POLICY).toMatchInlineSnapshot(
       `"No committed snapshot update is required: document path VRT compares against the current parser path in-memory until the public default path changes."`,
     );
-    expect(
-      DOCUMENT_PATH_VRT_OPT_IN_CASES.map(({ name, fixture, slides, tolerance, reason }) => ({
-        name,
-        fixture,
-        slides,
-        tolerance,
-        reason,
-      })),
-    ).toMatchInlineSnapshot(`
-      [
-        {
-          "fixture": "real-basic-theme.pptx",
-          "name": "real-basic-theme",
-          "reason": "Shared fixture already covered by focused document render tests; slide 1 stays within the current CleanDoc shape/text subset.",
-          "slides": [
-            1,
-          ],
-          "tolerance": 0.001,
-        },
-        {
-          "fixture": "real-product-page.pptx",
-          "name": "real-product-page",
-          "reason": "Shared fixture exercises shape/text rendering and intentionally records the current visual parity gap before default-path migration.",
-          "slides": [
-            1,
-          ],
-          "tolerance": 0.04,
-        },
-      ]
-    `);
-    expect(DOCUMENT_PATH_VRT_EXCLUDED_CASES).toMatchInlineSnapshot(`
-      [
-        {
-          "fixture": "real-financial-report.pptx",
-          "name": "real-financial-report",
-          "reason": "Deferred because the fixture is broader than the initial selected shared fixture slice and would mix document path dogfood with unrelated parity gaps.",
-        },
-        {
-          "fixture": "sample.pptx",
-          "name": "sample",
-          "reason": "Deferred until the selected real app fixtures have stable document path parity metrics.",
-        },
-        {
-          "fixture": "sample-issue-387.pptx",
-          "name": "sample-issue-387",
-          "reason": "Deferred because issue-specific regression fixtures should only opt in after their document path support scope is explicitly reviewed.",
-        },
-        {
-          "fixture": "vrt/snapshot/fixtures/*.pptx",
-          "name": "generated snapshot VRT cases",
-          "reason": "Deferred because generated cases cover many unsupported tables, charts, groups, effects, and advanced text features outside this issue's selected fixture scope.",
-        },
-      ]
-    `);
   });
 
-  for (const testCase of DOCUMENT_PATH_VRT_OPT_IN_CASES) {
+  it("keeps every non-zero or diagnostic-emitting gap linked to a blocker issue", () => {
+    const blockerIssueNumbers = new Set(Object.values(DOCUMENT_PATH_VRT_BLOCKER_ISSUES));
+
+    for (const testCase of DOCUMENT_PATH_VRT_CASES) {
+      for (const issue of testCase.blockerIssues) {
+        expect(blockerIssueNumbers.has(issue), `${testCase.name}: unknown blocker #${issue}`).toBe(
+          true,
+        );
+      }
+      if (testCase.mismatchTolerance > 0 || testCase.expectedDiagnosticCodes.length > 0) {
+        expect(
+          testCase.blockerIssues.length,
+          `${testCase.name}: expected blocker issue for residual gap`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  for (const testCase of DOCUMENT_PATH_VRT_CASES) {
     describe(testCase.name, () => {
       it("tracks current parser vs document path PNG parity", async () => {
-        const fixturePath = join(SHARED_FIXTURE_DIR, testCase.fixture);
+        const fixturePath = join(fixtureDir(testCase.group), testCase.fixture);
         if (!existsSync(fixturePath)) {
-          throw new Error(`Shared fixture not found: ${fixturePath}.`);
+          throw new Error(`VRT fixture not found: ${fixturePath}.`);
         }
 
         const input = readFileSync(fixturePath);
         const options = {
-          slides: [...testCase.slides],
           width: DOCUMENT_PATH_VRT_RENDER_WIDTH,
           skipSystemFonts: true,
         };
         const currentResults = await convertPptxToPng(input, options);
         const documentResults = await convertPptxToPngViaDocumentPath(input, options);
 
-        expect(currentResults.map((slide) => slide.slideNumber)).toEqual([...testCase.slides]);
-        expect(documentResults.slides.map((slide) => slide.slideNumber)).toEqual([
-          ...testCase.slides,
-        ]);
+        expect(documentResults.slides.map((slide) => slide.slideNumber)).toEqual(
+          currentResults.map((slide) => slide.slideNumber),
+        );
         expect(uniqueSortedCodes(documentResults.diagnostics)).toEqual(
           [...testCase.expectedDiagnosticCodes].sort(),
         );
@@ -135,14 +103,15 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
             diffPath,
             {
               pixelThreshold: PIXEL_THRESHOLD,
-              mismatchTolerance: testCase.tolerance,
+              mismatchTolerance: testCase.mismatchTolerance,
             },
           );
 
           console.log(
             `[document-path-vrt] ${testCase.name} slide${documentResult.slideNumber}: ` +
               `${(comparison.mismatchPercentage * 100).toFixed(3)}% ` +
-              `(tolerance ${(testCase.tolerance * 100).toFixed(1)}%)`,
+              `(tolerance ${(testCase.mismatchTolerance * 100).toFixed(1)}%)` +
+              blockerSuffix(testCase.blockerIssues),
           );
 
           expect(
@@ -150,7 +119,8 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
             `${testCase.name} slide ${documentResult.slideNumber}: ` +
               `${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ ` +
               `(${comparison.mismatchedPixels}/${comparison.totalPixels}). ` +
-              `Tolerance: ${testCase.tolerance * 100}%`,
+              `Tolerance: ${testCase.mismatchTolerance * 100}%. ` +
+              `Blockers: ${formatBlockers(testCase.blockerIssues)}`,
           ).toBe(true);
         }
       });
@@ -160,4 +130,17 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
 
 function uniqueSortedCodes(diagnostics: readonly { readonly code: string }[]): string[] {
   return [...new Set(diagnostics.map((diagnostic) => diagnostic.code))].sort();
+}
+
+function fixtureDir(group: "shared" | "generated"): string {
+  return group === "shared" ? SHARED_FIXTURE_DIR : GENERATED_FIXTURE_DIR;
+}
+
+function blockerSuffix(blockerIssues: readonly number[]): string {
+  if (blockerIssues.length === 0) return "";
+  return `; blockers ${formatBlockers(blockerIssues)}`;
+}
+
+function formatBlockers(blockerIssues: readonly number[]): string {
+  return blockerIssues.length === 0 ? "none" : blockerIssues.map((issue) => `#${issue}`).join(", ");
 }


### PR DESCRIPTION
close #489

## 概要

- document path VRT を selected fixtures から `SHARED_FIXTURE_CASES` / `VRT_CASES` 全体へ拡張
- current parser path を oracle にした PNG 比較を全 shared / generated VRT fixture で実行
- 0 mismatch ではないケースと unsupported diagnostics が残るケースを default switch blocker issue として #491〜#496 に分離し、harness 側から明示参照
- public snapshot baseline と public default conversion path は変更なし

## 影響範囲

- `vrt/snapshot/document-path-cases.ts`
- `vrt/snapshot/document-path-regression.test.ts`

## 分離した blocker issue

- #491 table / table style parity gap
- #492 chart / graphicFrame / SmartArt parity gap
- #493 group / connectors / custom geometry / z-order parity gap
- #494 complex fill / background / image fill parity gap
- #495 effects / blip effects parity gap
- #496 text / font / autofit residual parity gap

## ローカル検証

- `pnpm run knip`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts --reporter=dot`

## 補足

- `pnpm run build` では既存の `import.meta` / CJS warning が出ますが、build 自体は成功しています。
- cross-review で指摘されたスライド 0 件素通り guard と tolerance 運用コメントを追加済みです。
