### PR TITLE
document path: text/font/autofit residual VRT parity gap を潰す

### DIFF
--- a/.changeset/document-text-autofit-parity.md
+++ b/.changeset/document-text-autofit-parity.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+Fix CleanDoc document-path text font and autofit parity with the current parser path.

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
@@ -205,6 +205,73 @@ describe("createComputedView", () => {
     });
   });
 
+  it("local sp/no autofit で inherited normAutofit の scale 値をリセットする", () => {
+    const source = buildSource();
+    const sourceWithAutofitPlaceholders: CleanDocSource = {
+      ...source,
+      slides: source.slides.map((slide) =>
+        slide.partPath === asPartPath("ppt/slides/slide2.xml")
+          ? {
+              ...slide,
+              shapes: [
+                ...slide.shapes,
+                placeholder("Slide sp autofit", "body", 9, {
+                  textBody: {
+                    properties: { autoFit: "spAutofit" },
+                    paragraphs: [{ runs: [{ kind: "textRun", text: "grow" }] }],
+                  },
+                }),
+                placeholder("Slide no autofit", "body", 10, {
+                  textBody: {
+                    properties: { autoFit: "noAutofit" },
+                    paragraphs: [{ runs: [{ kind: "textRun", text: "fixed" }] }],
+                  },
+                }),
+              ],
+            }
+          : slide,
+      ),
+      slideLayouts: source.slideLayouts.map((layout) => ({
+        ...layout,
+        shapes: [
+          ...layout.shapes,
+          placeholder("Layout norm autofit 9", "body", 9, {
+            textBody: {
+              properties: {
+                autoFit: "normAutofit",
+                fontScale: 0.5,
+                lnSpcReduction: 0.3,
+              },
+              paragraphs: [{ runs: [{ kind: "textRun", text: "" }] }],
+            },
+          }),
+          placeholder("Layout norm autofit 10", "body", 10, {
+            textBody: {
+              properties: {
+                autoFit: "normAutofit",
+                fontScale: 0.5,
+                lnSpcReduction: 0.3,
+              },
+              paragraphs: [{ runs: [{ kind: "textRun", text: "" }] }],
+            },
+          }),
+        ],
+      })),
+    };
+
+    const slide = getSlide(createComputedView(sourceWithAutofitPlaceholders).slides, 0);
+    expect(findShape(slide.elements, "Slide sp autofit").textBody?.properties).toMatchObject({
+      autoFit: "spAutofit",
+      fontScale: 1,
+      lnSpcReduction: 0,
+    });
+    expect(findShape(slide.elements, "Slide no autofit").textBody?.properties).toMatchObject({
+      autoFit: "noAutofit",
+      fontScale: 1,
+      lnSpcReduction: 0,
+    });
+  });
+
   it("table の cell fill / text color / style default border を解決する", () => {
     const computed = createComputedView(buildSource());
     const table = findTable(getSlide(computed.slides, 0).elements, "Metrics table");

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.test.ts
@@ -153,6 +153,58 @@ describe("createComputedView", () => {
     });
   });
 
+  it("theme font token と text body autofit properties を解決する", () => {
+    const source = withSlide2Shapes(buildSource(), [
+      shape("Theme fonts", {
+        transform: transform(20, 21, 22, 23),
+        textBody: {
+          properties: {
+            autoFit: "normAutofit",
+            fontScale: 0.625,
+            lnSpcReduction: 0.2,
+            wrap: "none",
+            numCol: 2,
+            vert: "eaVert",
+          },
+          paragraphs: [
+            {
+              runs: [
+                {
+                  kind: "textRun",
+                  text: "文",
+                  properties: {
+                    typeface: "+mn-lt",
+                    typefaceEa: "+mn-ea",
+                    typefaceCs: "+mn-cs",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const themeFonts = findShape(
+      getSlide(createComputedView(source).slides, 0).elements,
+      "Theme fonts",
+    );
+
+    expect(themeFonts.textBody?.properties).toMatchObject({
+      autoFit: "normAutofit",
+      fontScale: 0.625,
+      lnSpcReduction: 0.2,
+      wrap: "none",
+      numCol: 2,
+      vert: "eaVert",
+    });
+    expect(themeFonts.textBody?.paragraphs[0].runs[0].properties).toMatchObject({
+      typeface: "Aptos",
+      typefaceEa: "Yu Gothic",
+      typefaceCs: "Arial",
+    });
+  });
+
   it("table の cell fill / text color / style default border を解決する", () => {
     const computed = createComputedView(buildSource());
     const table = findTable(getSlide(computed.slides, 0).elements, "Metrics table");
@@ -786,6 +838,14 @@ function buildSource(): CleanDocSource {
     themes: [
       {
         partPath: asPartPath("ppt/theme/theme1.xml"),
+        fontScheme: {
+          majorLatin: "Aptos Display",
+          minorLatin: "Aptos",
+          majorEastAsian: "Yu Mincho",
+          minorEastAsian: "Yu Gothic",
+          majorComplexScript: "Times New Roman",
+          minorComplexScript: "Arial",
+        },
         colorScheme: {
           colors: {
             lt1: { kind: "srgb", hex: "FFFFFF" },

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
@@ -874,11 +874,50 @@ function mergeRunProperties(
   const merged = { ...inherited, ...local };
   if (Object.keys(merged).length === 0) return undefined;
   const color = merged.color !== undefined ? resolveColor(context, merged.color) : undefined;
-  const withoutColor = omitColor(merged);
+  const withoutColor = resolveThemeRunFonts(context, omitColor(merged));
   return {
     ...withoutColor,
     ...(color !== undefined ? { color } : {}),
   };
+}
+
+function resolveThemeRunFonts(
+  context: ComputeContext,
+  properties: Omit<SourceRunProperties, "color">,
+): Omit<SourceRunProperties, "color"> {
+  return {
+    ...properties,
+    ...(properties.typeface !== undefined
+      ? { typeface: resolveThemeTypeface(context, properties.typeface) }
+      : {}),
+    ...(properties.typefaceEa !== undefined
+      ? { typefaceEa: resolveThemeTypeface(context, properties.typefaceEa) }
+      : {}),
+    ...(properties.typefaceCs !== undefined
+      ? { typefaceCs: resolveThemeTypeface(context, properties.typefaceCs) }
+      : {}),
+  };
+}
+
+function resolveThemeTypeface(context: ComputeContext, typeface: string): string {
+  const scheme = context.theme?.fontScheme;
+  if (scheme === undefined) return typeface;
+  switch (typeface) {
+    case "+mj-lt":
+      return scheme.majorLatin ?? typeface;
+    case "+mn-lt":
+      return scheme.minorLatin ?? typeface;
+    case "+mj-ea":
+      return scheme.majorEastAsian ?? scheme.majorJapanese ?? typeface;
+    case "+mn-ea":
+      return scheme.minorEastAsian ?? scheme.minorJapanese ?? typeface;
+    case "+mj-cs":
+      return scheme.majorComplexScript ?? typeface;
+    case "+mn-cs":
+      return scheme.minorComplexScript ?? typeface;
+    default:
+      return typeface;
+  }
 }
 
 function findPlaceholderMatch(

--- a/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
+++ b/packages/pptx-glimpse-document/src/computed/create-computed-view.ts
@@ -827,16 +827,36 @@ function computeTextBody(
   inherited?: SourceTextBody,
 ): ComputedTextBody {
   const inheritedParagraph = inherited?.paragraphs[0];
+  const properties = mergeTextBodyProperties(inherited?.properties, textBody.properties);
   return {
-    ...(textBody.properties !== undefined
-      ? { properties: { ...inherited?.properties, ...textBody.properties } }
-      : inherited?.properties !== undefined
-        ? { properties: { ...inherited.properties } }
-        : {}),
+    ...(properties !== undefined ? { properties } : {}),
     paragraphs: textBody.paragraphs.map((paragraph) =>
       computeParagraph(context, paragraph, inheritedParagraph),
     ),
   };
+}
+
+function mergeTextBodyProperties(
+  inherited: SourceTextBody["properties"] | undefined,
+  local: SourceTextBody["properties"] | undefined,
+): SourceTextBody["properties"] | undefined {
+  const merged = { ...inherited, ...local };
+  if (Object.keys(merged).length === 0) return undefined;
+  if (merged.autoFit === "normAutofit") {
+    return {
+      ...merged,
+      fontScale: merged.fontScale ?? 1,
+      lnSpcReduction: merged.lnSpcReduction ?? 0,
+    };
+  }
+  if (merged.autoFit === "spAutofit" || merged.autoFit === "noAutofit") {
+    return {
+      ...merged,
+      fontScale: 1,
+      lnSpcReduction: 0,
+    };
+  }
+  return merged;
 }
 
 function computeParagraph(

--- a/packages/pptx-glimpse-document/src/reader/slide-parts.ts
+++ b/packages/pptx-glimpse-document/src/reader/slide-parts.ts
@@ -218,13 +218,39 @@ function parseColorScheme(clrScheme: XmlNode | undefined): SourceThemeColorSchem
 
 function parseFontScheme(fontScheme: XmlNode | undefined): SourceThemeFontScheme | undefined {
   if (!fontScheme) return undefined;
-  const majorLatin = getAttr(getChild(getChild(fontScheme, "majorFont"), "latin"), "typeface");
-  const minorLatin = getAttr(getChild(getChild(fontScheme, "minorFont"), "latin"), "typeface");
+  const majorFont = getChild(fontScheme, "majorFont");
+  const minorFont = getChild(fontScheme, "minorFont");
+  const majorLatin = getAttr(getChild(majorFont, "latin"), "typeface");
+  const minorLatin = getAttr(getChild(minorFont, "latin"), "typeface");
+  const majorEastAsian = resolveEastAsianFont(majorFont);
+  const minorEastAsian = resolveEastAsianFont(minorFont);
+  const majorComplexScript = getAttr(getChild(majorFont, "cs"), "typeface");
+  const minorComplexScript = getAttr(getChild(minorFont, "cs"), "typeface");
+  const majorJapanese = findScriptFont(majorFont, "Jpan");
+  const minorJapanese = findScriptFont(minorFont, "Jpan");
   const scheme: SourceThemeFontScheme = {
     ...(isNonEmpty(majorLatin) ? { majorLatin } : {}),
     ...(isNonEmpty(minorLatin) ? { minorLatin } : {}),
+    ...(isNonEmpty(majorEastAsian) ? { majorEastAsian } : {}),
+    ...(isNonEmpty(minorEastAsian) ? { minorEastAsian } : {}),
+    ...(isNonEmpty(majorComplexScript) ? { majorComplexScript } : {}),
+    ...(isNonEmpty(minorComplexScript) ? { minorComplexScript } : {}),
+    ...(isNonEmpty(majorJapanese) ? { majorJapanese } : {}),
+    ...(isNonEmpty(minorJapanese) ? { minorJapanese } : {}),
   };
   return Object.keys(scheme).length > 0 ? scheme : undefined;
+}
+
+function resolveEastAsianFont(fontNode: XmlNode | undefined): string | undefined {
+  const typeface = getAttr(getChild(fontNode, "ea"), "typeface");
+  return isNonEmpty(typeface) ? typeface : findScriptFont(fontNode, "Jpan");
+}
+
+function findScriptFont(fontNode: XmlNode | undefined, script: string): string | undefined {
+  const font = getChildArray(fontNode, "font").find(
+    (candidate) => getAttr(candidate, "script") === script,
+  );
+  return getAttr(font, "typeface");
 }
 
 function parseFormatScheme(

--- a/packages/pptx-glimpse-document/src/reader/slide-reader.test.ts
+++ b/packages/pptx-glimpse-document/src/reader/slide-reader.test.ts
@@ -290,6 +290,24 @@ describe("readPptx — typed shape detail (synthetic)", () => {
     expect(shape.textBody?.properties).toMatchObject({ autoFit: "spAutofit" });
   });
 
+  it("noAutofit を typed source body property として読む", () => {
+    const source = readPptx(
+      buildSyntheticPptx(
+        `<p:sp><p:nvSpPr><p:cNvPr id="16" name="No autofit"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm></p:spPr>` +
+          `<p:txBody><a:bodyPr><a:noAutofit/></a:bodyPr><a:p><a:r><a:t>fixed</a:t></a:r></a:p></p:txBody>` +
+          `</p:sp>`,
+      ),
+    );
+
+    const shape = source.slides[0].shapes[0] as SourceShape;
+    expect(shape.textBody?.properties).toMatchObject({
+      autoFit: "noAutofit",
+      fontScale: 1,
+      lnSpcReduction: 0,
+    });
+  });
+
   it("gradient fill を typed source fill、custom geometry を raw として保持する", () => {
     const source = readPptx(
       buildSyntheticPptx(

--- a/packages/pptx-glimpse-document/src/reader/slide-reader.test.ts
+++ b/packages/pptx-glimpse-document/src/reader/slide-reader.test.ts
@@ -139,11 +139,15 @@ describe("readPptx — typed slide reading (real fixtures)", () => {
     const names = shadowed.rawSidecars?.map((sidecar) => sidecar.node.name) ?? [];
     expect(names).not.toContain("a:effectLst");
 
-    // run property の `a:ea` / `a:cs` も sidecar として保持する。
+    // run property の `a:ea` / `a:cs` は typed source property として保持する。
     const run = firstShape(product, "Text 0").textBody!.paragraphs[0].runs[0];
+    expect(run.properties).toMatchObject({
+      typefaceEa: "Noto Sans JP",
+      typefaceCs: "Noto Sans JP",
+    });
     const runSidecarNames = run.rawSidecars?.map((sidecar) => sidecar.node.name) ?? [];
-    expect(runSidecarNames).toContain("a:ea");
-    expect(runSidecarNames).toContain("a:cs");
+    expect(runSidecarNames).not.toContain("a:ea");
+    expect(runSidecarNames).not.toContain("a:cs");
 
     // 画像の default `a:stretch` は typed に解釈し、未対応の blip 子は保持する。
     const slide2 = basic.slides.find((s) => s.partPath === "ppt/slides/slide2.xml");
@@ -241,6 +245,49 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       width: 12700,
       fill: { kind: "solid", color: { kind: "srgb", hex: "FF0000" } },
     });
+  });
+
+  it("bodyPr autofit / wrap / vert と ea/cs run fonts を typed source property として読む", () => {
+    const source = readPptx(
+      buildSyntheticPptx(
+        `<p:sp><p:nvSpPr><p:cNvPr id="14" name="Text props"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm></p:spPr>` +
+          `<p:txBody>` +
+          `<a:bodyPr wrap="none" vert="eaVert" numCol="2"><a:normAutofit fontScale="62500" lnSpcReduction="20000"/></a:bodyPr>` +
+          `<a:p><a:r><a:rPr sz="1800"><a:latin typeface="+mn-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:rPr><a:t>文</a:t></a:r></a:p>` +
+          `</p:txBody>` +
+          `</p:sp>`,
+      ),
+    );
+
+    const shape = source.slides[0].shapes[0] as SourceShape;
+    expect(shape.textBody?.properties).toMatchObject({
+      wrap: "none",
+      vert: "eaVert",
+      numCol: 2,
+      autoFit: "normAutofit",
+      fontScale: 0.625,
+      lnSpcReduction: 0.2,
+    });
+    expect(shape.textBody?.paragraphs[0].runs[0].properties).toMatchObject({
+      typeface: "+mn-lt",
+      typefaceEa: "+mn-ea",
+      typefaceCs: "+mn-cs",
+    });
+  });
+
+  it("spAutoFit を typed source body property として読む", () => {
+    const source = readPptx(
+      buildSyntheticPptx(
+        `<p:sp><p:nvSpPr><p:cNvPr id="15" name="Sp autofit"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm></p:spPr>` +
+          `<p:txBody><a:bodyPr><a:spAutoFit/></a:bodyPr><a:p><a:r><a:t>grow</a:t></a:r></a:p></p:txBody>` +
+          `</p:sp>`,
+      ),
+    );
+
+    const shape = source.slides[0].shapes[0] as SourceShape;
+    expect(shape.textBody?.properties).toMatchObject({ autoFit: "spAutofit" });
   });
 
   it("gradient fill を typed source fill、custom geometry を raw として保持する", () => {

--- a/packages/pptx-glimpse-document/src/reader/text.ts
+++ b/packages/pptx-glimpse-document/src/reader/text.ts
@@ -99,6 +99,7 @@ function parseBodyProperties(bodyPr: XmlNode | undefined): SourceTextBodyPropert
   const numCol = numericAttr(bodyPr, "numCol");
   const normAutofit = getChild(bodyPr, "normAutofit");
   const hasSpAutofit = getChild(bodyPr, "spAutoFit") !== undefined;
+  const hasNoAutofit = getChild(bodyPr, "noAutofit") !== undefined;
   const fontScale = numericAttr(normAutofit, "fontScale");
   const lnSpcReduction = numericAttr(normAutofit, "lnSpcReduction");
 
@@ -116,8 +117,10 @@ function parseBodyProperties(bodyPr: XmlNode | undefined): SourceTextBodyPropert
           lnSpcReduction: lnSpcReduction !== undefined ? lnSpcReduction / 100000 : 0,
         }
       : hasSpAutofit
-        ? { autoFit: "spAutofit" }
-        : {}),
+        ? { autoFit: "spAutofit", fontScale: 1, lnSpcReduction: 0 }
+        : hasNoAutofit
+          ? { autoFit: "noAutofit", fontScale: 1, lnSpcReduction: 0 }
+          : {}),
     ...(numCol !== undefined ? { numCol: Math.max(1, numCol) } : {}),
     ...(vert !== undefined ? { vert } : {}),
   };
@@ -229,7 +232,7 @@ function parseRunProperties(rPr: XmlNode | undefined): SourceRunProperties | und
 
 /**
  * run の未対応素材を sidecar に集める。run 直下 (`a:rPr` / `a:t` 以外) に加え、
- * `a:rPr` 内の未対応子要素 (`a:ea` / `a:cs` / `a:hlinkClick` 等) も保持する。
+ * `a:rPr` 内の未対応子要素 (`a:hlinkClick` / `a:ln` 等) も保持する。
  */
 function collectRunSidecars(
   r: XmlNode,

--- a/packages/pptx-glimpse-document/src/reader/text.ts
+++ b/packages/pptx-glimpse-document/src/reader/text.ts
@@ -18,6 +18,8 @@ import type {
   SourceTextBody,
   SourceTextBodyProperties,
   SourceTextRun,
+  SourceTextVerticalType,
+  SourceTextWrap,
   SourceVerticalAnchor,
 } from "../source/index.js";
 import { asEmu, asHundredthPt, asPt, asSourceNodeId } from "../source/index.js";
@@ -29,7 +31,12 @@ import { getAttr, getChild, getChildArray, getChildText, type XmlNode } from "./
 const KNOWN_TXBODY_CHILDREN: ReadonlySet<string> = new Set(["bodyPr", "lstStyle", "p"]);
 const KNOWN_PARAGRAPH_CHILDREN: ReadonlySet<string> = new Set(["pPr", "r"]);
 const KNOWN_RUN_CHILDREN: ReadonlySet<string> = new Set(["rPr", "t"]);
-const KNOWN_RUN_PROPERTY_CHILDREN: ReadonlySet<string> = new Set(["latin", "solidFill"]);
+const KNOWN_RUN_PROPERTY_CHILDREN: ReadonlySet<string> = new Set([
+  "latin",
+  "ea",
+  "cs",
+  "solidFill",
+]);
 
 const ALIGN_MAP: Readonly<Record<string, SourceTextAlign>> = {
   l: "left",
@@ -43,6 +50,16 @@ const ANCHOR_MAP: Readonly<Record<string, SourceVerticalAnchor>> = {
   ctr: "middle",
   b: "bottom",
 };
+
+const WRAP_VALUES = new Set(["square", "none"]);
+const VERTICAL_VALUES = new Set([
+  "horz",
+  "vert",
+  "vert270",
+  "eaVert",
+  "wordArtVert",
+  "mongolianVert",
+]);
 
 /** `p:txBody` を読む。`txBody` が無い shape では undefined。 */
 export function parseTextBody(
@@ -77,6 +94,13 @@ function parseBodyProperties(bodyPr: XmlNode | undefined): SourceTextBodyPropert
   const marginBottom = numericAttr(bodyPr, "bIns");
   const anchorToken = getAttr(bodyPr, "anchor");
   const anchor = anchorToken !== undefined ? ANCHOR_MAP[anchorToken] : undefined;
+  const wrap = parseWrap(getAttr(bodyPr, "wrap"));
+  const vert = parseVerticalType(getAttr(bodyPr, "vert"));
+  const numCol = numericAttr(bodyPr, "numCol");
+  const normAutofit = getChild(bodyPr, "normAutofit");
+  const hasSpAutofit = getChild(bodyPr, "spAutoFit") !== undefined;
+  const fontScale = numericAttr(normAutofit, "fontScale");
+  const lnSpcReduction = numericAttr(normAutofit, "lnSpcReduction");
 
   const properties: SourceTextBodyProperties = {
     ...(marginLeft !== undefined ? { marginLeft: emu(marginLeft) } : {}),
@@ -84,8 +108,30 @@ function parseBodyProperties(bodyPr: XmlNode | undefined): SourceTextBodyPropert
     ...(marginTop !== undefined ? { marginTop: emu(marginTop) } : {}),
     ...(marginBottom !== undefined ? { marginBottom: emu(marginBottom) } : {}),
     ...(anchor !== undefined ? { anchor } : {}),
+    ...(wrap !== undefined ? { wrap } : {}),
+    ...(normAutofit !== undefined
+      ? {
+          autoFit: "normAutofit",
+          fontScale: fontScale !== undefined ? fontScale / 100000 : 1,
+          lnSpcReduction: lnSpcReduction !== undefined ? lnSpcReduction / 100000 : 0,
+        }
+      : hasSpAutofit
+        ? { autoFit: "spAutofit" }
+        : {}),
+    ...(numCol !== undefined ? { numCol: Math.max(1, numCol) } : {}),
+    ...(vert !== undefined ? { vert } : {}),
   };
   return Object.keys(properties).length > 0 ? properties : undefined;
+}
+
+function parseWrap(value: string | undefined): SourceTextWrap | undefined {
+  return value !== undefined && WRAP_VALUES.has(value) ? (value as SourceTextWrap) : undefined;
+}
+
+function parseVerticalType(value: string | undefined): SourceTextVerticalType | undefined {
+  return value !== undefined && VERTICAL_VALUES.has(value)
+    ? (value as SourceTextVerticalType)
+    : undefined;
 }
 
 function parseParagraph(
@@ -163,6 +209,8 @@ function parseRunProperties(rPr: XmlNode | undefined): SourceRunProperties | und
   const underline = getAttr(rPr, "u");
   const size = numericAttr(rPr, "sz");
   const typeface = getAttr(getChild(rPr, "latin"), "typeface");
+  const typefaceEa = getAttr(getChild(rPr, "ea"), "typeface");
+  const typefaceCs = getAttr(getChild(rPr, "cs"), "typeface");
   const color = parseColorElement(getChild(rPr, "solidFill"));
 
   const properties: SourceRunProperties = {
@@ -172,6 +220,8 @@ function parseRunProperties(rPr: XmlNode | undefined): SourceRunProperties | und
     // `a:rPr@sz` は 1/100 pt 単位。pt へ変換して保持する。
     ...(size !== undefined ? { fontSize: asPt(size / 100) } : {}),
     ...(typeface !== undefined ? { typeface } : {}),
+    ...(typefaceEa !== undefined ? { typefaceEa } : {}),
+    ...(typefaceCs !== undefined ? { typefaceCs } : {}),
     ...(color !== undefined ? { color } : {}),
   };
   return Object.keys(properties).length > 0 ? properties : undefined;

--- a/packages/pptx-glimpse-document/src/source/index.ts
+++ b/packages/pptx-glimpse-document/src/source/index.ts
@@ -90,9 +90,12 @@ export type {
   SourceTableData,
   SourceTableRow,
   SourceTextAlign,
+  SourceTextAutoFit,
   SourceTextBody,
   SourceTextBodyProperties,
   SourceTextRun,
+  SourceTextVerticalType,
+  SourceTextWrap,
   SourceTransform,
   SourceVerticalAnchor,
 } from "./shapes.js";

--- a/packages/pptx-glimpse-document/src/source/presentation.ts
+++ b/packages/pptx-glimpse-document/src/source/presentation.ts
@@ -49,10 +49,16 @@ export interface SourceThemeColorScheme {
   readonly colors: Readonly<Record<string, SourceColor>>;
 }
 
-/** theme の font scheme (`a:fontScheme`) の最小 subset (major / minor latin)。 */
+/** theme の font scheme (`a:fontScheme`) の最小 subset。 */
 export interface SourceThemeFontScheme {
   readonly majorLatin?: string;
   readonly minorLatin?: string;
+  readonly majorEastAsian?: string;
+  readonly minorEastAsian?: string;
+  readonly majorComplexScript?: string;
+  readonly minorComplexScript?: string;
+  readonly majorJapanese?: string;
+  readonly minorJapanese?: string;
 }
 
 /** theme の format scheme (`a:fmtScheme`) のうち shape style ref 解決に使う subset。 */

--- a/packages/pptx-glimpse-document/src/source/shapes.ts
+++ b/packages/pptx-glimpse-document/src/source/shapes.ts
@@ -238,6 +238,10 @@ export interface SourceRunProperties {
   readonly fontSize?: Pt;
   /** latin typeface 名 (theme token も含めて未解決のまま保持)。 */
   readonly typeface?: string;
+  /** East Asian typeface 名 (theme token も含めて未解決のまま保持)。 */
+  readonly typefaceEa?: string;
+  /** Complex script typeface 名 (theme token も含めて未解決のまま保持)。 */
+  readonly typefaceCs?: string;
   readonly color?: SourceColor;
 }
 
@@ -272,6 +276,18 @@ export interface SourceParagraph {
 /** vertical anchor (`a:bodyPr@anchor`)。 */
 export type SourceVerticalAnchor = "top" | "middle" | "bottom";
 
+export type SourceTextWrap = "square" | "none";
+
+export type SourceTextVerticalType =
+  | "horz"
+  | "vert"
+  | "vert270"
+  | "eaVert"
+  | "wordArtVert"
+  | "mongolianVert";
+
+export type SourceTextAutoFit = "noAutofit" | "normAutofit" | "spAutofit";
+
 /** text body properties (`a:bodyPr`) の最小 subset。inset と vertical anchor。 */
 export interface SourceTextBodyProperties {
   readonly marginLeft?: Emu;
@@ -279,6 +295,12 @@ export interface SourceTextBodyProperties {
   readonly marginTop?: Emu;
   readonly marginBottom?: Emu;
   readonly anchor?: SourceVerticalAnchor;
+  readonly wrap?: SourceTextWrap;
+  readonly autoFit?: SourceTextAutoFit;
+  readonly fontScale?: number;
+  readonly lnSpcReduction?: number;
+  readonly numCol?: number;
+  readonly vert?: SourceTextVerticalType;
 }
 
 /** text body (`p:txBody`)。 */

--- a/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
+++ b/packages/pptx-glimpse-document/src/writer/write-pptx.test.ts
@@ -322,9 +322,10 @@ describe("writePptx — one plain text-run edit", () => {
       italic: true,
       fontSize: 24,
       typeface: "Aptos",
+      typefaceEa: "Noto Sans JP",
       color: { kind: "srgb", hex: "FF0000" },
     });
-    expect(run.rawSidecars?.map((sidecar) => sidecar.node.name)).toContain("a:ea");
+    expect(run.rawSidecars?.map((sidecar) => sidecar.node.name) ?? []).not.toContain("a:ea");
     expect(getEntry(output, "docProps/custom.xml")).toEqual(getEntry(input, "docProps/custom.xml"));
     expect(getEntry(output, "ppt/media/image1.png")).toEqual(
       getEntry(input, "ppt/media/image1.png"),

--- a/packages/pptx-glimpse/src/cleandoc-renderer-adapter.test.ts
+++ b/packages/pptx-glimpse/src/cleandoc-renderer-adapter.test.ts
@@ -73,6 +73,12 @@ describe("adaptComputedViewToRendererModel", () => {
         marginRight: 91440,
         marginTop: 45720,
         marginBottom: 45720,
+        wrap: "none",
+        autoFit: "normAutofit",
+        fontScale: 0.625,
+        lnSpcReduction: 0.2,
+        numCol: 2,
+        vert: "eaVert",
       },
       paragraphs: [
         {
@@ -87,6 +93,8 @@ describe("adaptComputedViewToRendererModel", () => {
               properties: {
                 fontSize: 30,
                 fontFamily: "Aptos",
+                fontFamilyEa: "Yu Gothic",
+                fontFamilyCs: "Arial",
                 bold: true,
                 italic: false,
                 underline: true,
@@ -693,7 +701,16 @@ function buildSource(options: BuildSourceOptions = {}): CleanDocSource {
             name: "Slide title",
             placeholder: { type: "ctrTitle", index: 1 },
             textBody: {
-              properties: { marginLeft: asEmu(111), anchor: "middle" },
+              properties: {
+                marginLeft: asEmu(111),
+                anchor: "middle",
+                wrap: "none",
+                autoFit: "normAutofit",
+                fontScale: 0.625,
+                lnSpcReduction: 0.2,
+                numCol: 2,
+                vert: "eaVert",
+              },
               paragraphs: [
                 {
                   properties: { align: "center", lineSpacingPts: 1200, level: 2 },
@@ -743,6 +760,8 @@ function buildSource(options: BuildSourceOptions = {}): CleanDocSource {
             textBody: textBody("", {
               fontSize: asPt(30),
               typeface: "Aptos",
+              typefaceEa: "+mn-ea",
+              typefaceCs: "+mn-cs",
               color: { kind: "srgb", hex: "111111" },
               underline: true,
             }),
@@ -767,6 +786,10 @@ function buildSource(options: BuildSourceOptions = {}): CleanDocSource {
     themes: [
       {
         partPath: themePath,
+        fontScheme: {
+          minorEastAsian: "Yu Gothic",
+          minorComplexScript: "Arial",
+        },
         colorScheme: {
           colors: {
             lt1: { kind: "srgb", hex: "FFFFFF" },

--- a/packages/pptx-glimpse/src/cleandoc-renderer-adapter.ts
+++ b/packages/pptx-glimpse/src/cleandoc-renderer-adapter.ts
@@ -703,12 +703,12 @@ function adaptBodyProperties(properties: ComputedTextBody["properties"]): BodyPr
     marginRight: toRendererEmu(properties?.marginRight ?? 91440),
     marginTop: toRendererEmu(properties?.marginTop ?? 45720),
     marginBottom: toRendererEmu(properties?.marginBottom ?? 45720),
-    wrap: "square",
-    autoFit: "noAutofit",
-    fontScale: 1,
-    lnSpcReduction: 0,
-    numCol: 1,
-    vert: "horz",
+    wrap: properties?.wrap ?? "square",
+    autoFit: properties?.autoFit ?? "noAutofit",
+    fontScale: properties?.fontScale ?? 1,
+    lnSpcReduction: properties?.lnSpcReduction ?? 0,
+    numCol: properties?.numCol ?? 1,
+    vert: properties?.vert ?? "horz",
   };
 }
 
@@ -765,8 +765,8 @@ function adaptRunProperties(properties: ComputedRunProperties | undefined): RunP
   return {
     fontSize: properties?.fontSize !== undefined ? toRendererPt(properties.fontSize) : null,
     fontFamily: properties?.typeface ?? null,
-    fontFamilyEa: null,
-    fontFamilyCs: null,
+    fontFamilyEa: properties?.typefaceEa ?? null,
+    fontFamilyCs: properties?.typefaceCs ?? null,
     bold: properties?.bold ?? false,
     italic: properties?.italic ?? false,
     underline: properties?.underline ?? false,

--- a/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
@@ -26,7 +26,6 @@ const DOCUMENT_RENDER_UNSUPPORTED_SUBSET = [
   "raw background and fill variants outside the CleanDoc adapter subset",
   "unresolved images without a package media payload",
   "elements missing computed transforms",
-  "East Asian / complex-script theme font context for CJK text",
 ] as const;
 
 describe("experimental document render path", () => {
@@ -50,7 +49,6 @@ describe("experimental document render path", () => {
         "raw background and fill variants outside the CleanDoc adapter subset",
         "unresolved images without a package media payload",
         "elements missing computed transforms",
-        "East Asian / complex-script theme font context for CJK text",
       ]
     `);
   });
@@ -72,18 +70,15 @@ describe("experimental document render path", () => {
     },
   );
 
-  it("surfaces unsupported document subset through adapter diagnostics", async () => {
+  it("does not emit CJK font-context diagnostics when document text fonts are exposed", async () => {
     const result = await convertPptxToSvgViaDocumentPath(readFixture("real-basic-theme.pptx"), {
       slides: [1],
       textOutput: "text",
       skipSystemFonts: true,
     });
 
-    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics).toEqual([]);
     expectUnsupportedDiagnosticsToStayInScope(result.diagnostics);
-    expect(uniqueDiagnosticCodes(result.diagnostics)).toContain(
-      "document-render.cjk-font-context-unsupported",
-    );
   });
 
   it("connects the document SVG path to the existing PNG conversion", async () => {
@@ -100,11 +95,8 @@ describe("experimental document render path", () => {
       throw new Error("Expected one PNG slide from the document render path");
     }
     expect([...pngSlide.png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
-    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics).toEqual([]);
     expectUnsupportedDiagnosticsToStayInScope(result.diagnostics);
-    expect(uniqueDiagnosticCodes(result.diagnostics)).toContain(
-      "document-render.cjk-font-context-unsupported",
-    );
   });
 
   it("keeps the public SVG converter on its existing default path", async () => {
@@ -143,8 +135,5 @@ function expectUnsupportedDiagnosticsToStayInScope(
 }
 
 function isExpectedDocumentRenderDiagnosticCode(code: string): boolean {
-  return (
-    code === "cleandoc-adapter.raw-element-skipped" ||
-    code === "document-render.cjk-font-context-unsupported"
-  );
+  return code === "cleandoc-adapter.raw-element-skipped";
 }

--- a/packages/pptx-glimpse/src/experimental-document-renderer.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.ts
@@ -23,24 +23,14 @@ import {
   warn,
 } from "pptx-glimpse-renderer";
 
-import {
-  type CleanDocComputedView,
-  createComputedView,
-  readPptx,
-} from "../../pptx-glimpse-document/src/experimental.js";
+import { createComputedView, readPptx } from "../../pptx-glimpse-document/src/experimental.js";
 import {
   adaptComputedViewToRendererModel,
   type RendererAdapterDiagnostic,
 } from "./cleandoc-renderer-adapter.js";
 import type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
 
-type DocumentRenderDiagnostic = RendererAdapterDiagnostic | DocumentRenderPathDiagnostic;
-
-interface DocumentRenderPathDiagnostic {
-  readonly severity: "warning";
-  readonly code: "document-render.cjk-font-context-unsupported";
-  readonly message: string;
-}
+type DocumentRenderDiagnostic = RendererAdapterDiagnostic;
 
 interface DocumentPathSvgResult {
   readonly slides: readonly SlideSvg[];
@@ -89,7 +79,7 @@ export async function convertPptxToSvgViaDocumentPath(
 
     const computed = createComputedView(source, { slides: options?.slides });
     const adapted = adaptComputedViewToRendererModel(computed);
-    const diagnostics = [...collectDocumentRenderDiagnostics(computed), ...adapted.diagnostics];
+    const diagnostics = adapted.diagnostics;
     const slideSize = adapted.slideSize;
     if (slideSize === undefined && adapted.slides.length > 0) {
       throw new Error("Document render path requires a computed slide size");
@@ -149,34 +139,6 @@ export async function convertPptxToPngViaDocumentPath(
 
   return { slides, diagnostics: svgResult.diagnostics };
 }
-
-function collectDocumentRenderDiagnostics(
-  computed: CleanDocComputedView,
-): DocumentRenderPathDiagnostic[] {
-  if (!containsCjkText(computed)) return [];
-  return [
-    {
-      severity: "warning",
-      code: "document-render.cjk-font-context-unsupported",
-      message:
-        "CleanDoc document render path does not yet expose East Asian or complex-script theme fonts; CJK text may not match the public converter output.",
-    },
-  ];
-}
-
-function containsCjkText(computed: CleanDocComputedView): boolean {
-  return computed.slides.some((slide) =>
-    slide.elements.some(
-      (element) =>
-        element.kind === "shape" &&
-        element.textBody?.paragraphs.some((paragraph) =>
-          paragraph.runs.some((run) => cjkTextPattern.test(run.text)),
-        ) === true,
-    ),
-  );
-}
-
-const cjkTextPattern = /[\u3040-\u30ff\u3400-\u9fff\uff00-\uffef]/;
 
 function injectIntoSvgDefs(svg: string, content: string): string {
   const openTagEnd = svg.indexOf(">");

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -23,8 +23,7 @@ export type DocumentPathVrtFixtureGroup = "shared" | "generated";
 
 type DocumentPathVrtDiagnosticCode =
   | "cleandoc-adapter.raw-element-skipped"
-  | "cleandoc-adapter.raw-fill-ignored"
-  | "document-render.cjk-font-context-unsupported";
+  | "cleandoc-adapter.raw-fill-ignored";
 
 interface DocumentPathVrtCase {
   readonly group: DocumentPathVrtFixtureGroup;
@@ -38,28 +37,13 @@ interface DocumentPathVrtCase {
 const B = DOCUMENT_PATH_VRT_BLOCKER_ISSUES;
 
 export const DOCUMENT_PATH_VRT_SHARED_CASES = [
-  shared(
-    "real-basic-theme",
-    "real-basic-theme.pptx",
-    0.02,
-    [B.textAndFonts],
-    ["document-render.cjk-font-context-unsupported"],
-  ),
-  shared("real-product-page", "real-product-page.pptx", 0.04, [B.textAndFonts]),
-  shared(
-    "real-financial-report",
-    "real-financial-report.pptx",
-    0.16,
-    [B.tables, B.shapeTreeAndGeometry, B.textAndFonts],
-    ["document-render.cjk-font-context-unsupported"],
-  ),
-  shared(
-    "sample",
-    "sample.pptx",
-    0,
-    [B.textAndFonts],
-    ["document-render.cjk-font-context-unsupported"],
-  ),
+  shared("real-basic-theme", "real-basic-theme.pptx", 0, []),
+  shared("real-product-page", "real-product-page.pptx", 0, []),
+  shared("real-financial-report", "real-financial-report.pptx", 0.16, [
+    B.tables,
+    B.shapeTreeAndGeometry,
+  ]),
+  shared("sample", "sample.pptx", 0, []),
   shared("sample-issue-387", "sample-issue-387.pptx", 0, []),
 ] as const satisfies readonly DocumentPathVrtCase[];
 
@@ -80,13 +64,7 @@ export const DOCUMENT_PATH_VRT_GENERATED_CASES = [
   generated("callouts-arcs", "callouts-arcs.pptx", 0, [B.shapeTreeAndGeometry], []),
   generated("arrows-stars", "arrows-stars.pptx", 0, [B.shapeTreeAndGeometry], []),
   generated("math-other", "math-other.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated(
-    "word-wrap",
-    "word-wrap.pptx",
-    0,
-    [B.shapeTreeAndGeometry, B.textAndFonts],
-    ["document-render.cjk-font-context-unsupported"],
-  ),
+  generated("word-wrap", "word-wrap.pptx", 0, [B.shapeTreeAndGeometry]),
   generated("background-blipfill", "background-blipfill.pptx", 0, [], []),
   generated("composite", "composite.pptx", 0, [], []),
   generated("text-decoration", "text-decoration.pptx", 0, [B.shapeTreeAndGeometry], []),
@@ -109,17 +87,11 @@ export const DOCUMENT_PATH_VRT_GENERATED_CASES = [
   generated("image-crop", "image-crop.pptx", 0, [B.shapeTreeAndGeometry], []),
   generated("text-advanced", "text-advanced.pptx", 0, [B.shapeTreeAndGeometry], []),
   generated("shrink-to-fit", "shrink-to-fit.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("sp-autofit", "sp-autofit.pptx", 0.01, [B.shapeTreeAndGeometry, B.textAndFonts], []),
+  generated("sp-autofit", "sp-autofit.pptx", 0, [B.shapeTreeAndGeometry], []),
   generated("style-reference", "style-reference.pptx", 0, [], []),
   generated("blip-effects", "blip-effects.pptx", 0, [], []),
   generated("image-stretch-tile", "image-stretch-tile.pptx", 0, [], []),
-  generated(
-    "vertical-text",
-    "vertical-text.pptx",
-    0,
-    [B.shapeTreeAndGeometry, B.textAndFonts],
-    ["document-render.cjk-font-context-unsupported"],
-  ),
+  generated("vertical-text", "vertical-text.pptx", 0, [B.shapeTreeAndGeometry]),
   generated(
     "shape-hyperlink-text-outline",
     "shape-hyperlink-text-outline.pptx",
@@ -130,13 +102,7 @@ export const DOCUMENT_PATH_VRT_GENERATED_CASES = [
   generated("charts-3d-fallback", "charts-3d-fallback.pptx", 0, [], []),
   generated("color-transforms", "color-transforms.pptx", 0, [B.shapeTreeAndGeometry], []),
   generated("table-complex-merge", "table-complex-merge.pptx", 0, [], []),
-  generated(
-    "multi-lang-font",
-    "multi-lang-font.pptx",
-    0,
-    [B.shapeTreeAndGeometry, B.textAndFonts],
-    ["document-render.cjk-font-context-unsupported"],
-  ),
+  generated("multi-lang-font", "multi-lang-font.pptx", 0, [B.shapeTreeAndGeometry]),
   generated(
     "placeholder-inheritance-extended",
     "placeholder-inheritance-extended.pptx",


### PR DESCRIPTION
close #496

## 概要
- CleanDoc source/reader/computed view に text body の wrap/autofit/vertical/column と EA/CS/theme font 情報を追加
- document renderer adapter で body properties と CJK font family を renderer model へ渡すように修正
- text/font/autofit 起因の document-path VRT gap と CJK 未対応 diagnostic を解消
- cross-review 指摘を受けて noAutofit と sp/no autofit の scale 継承リセットを追加

## 確認
- npm run typecheck
- npm run lint
- npm run format:check
- npm run test
- npm run build
- npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts --reporter verbose

## 補足
- build 時の import.meta warning は既存の png-converter 由来で、今回の変更とは無関係です。