### PR TITLE
document path default switch 用の zero-diff gate を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
             -v "${{ github.workspace }}":/workspace \
             ghcr.io/hirokisakabe/pptx-glimpse-snapshot-vrt:latest \
             bash /workspace/vrt/snapshot/docker-run.sh \
-            bash -c "pnpm run vrt:snapshot:fixtures && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/regression.test.ts && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts"
+            bash -c "pnpm run vrt:snapshot:fixtures && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/regression.test.ts && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-zero-diff-gate.test.ts"
 
       - name: Upload diff images on failure
         if: failure()

--- a/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as documentExperimental from "../../pptx-glimpse-document/src/experimental.js";
 import * as adapterModule from "./cleandoc-renderer-adapter.js";
-import { convertPptxToSvg } from "./converter.js";
+import { convertPptxToPng, convertPptxToSvg } from "./converter.js";
 import {
   convertPptxToPngViaDocumentPath,
   convertPptxToSvgViaDocumentPath,
@@ -111,6 +111,22 @@ describe("experimental document render path", () => {
 
     expect(publicDefault.map((slide) => slide.slideNumber)).toEqual([1]);
     expect(publicDefault[0]?.svg).toContain("<svg");
+    expect(readPptxSpy).not.toHaveBeenCalled();
+    expect(adapterSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps the public PNG converter on its existing default path", async () => {
+    const readPptxSpy = vi.spyOn(documentExperimental, "readPptx");
+    const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");
+    const input = readFixture("real-basic-theme.pptx");
+    const publicDefault = await convertPptxToPng(input, {
+      slides: [1],
+      width: 240,
+      skipSystemFonts: true,
+    });
+
+    expect(publicDefault.map((slide) => slide.slideNumber)).toEqual([1]);
+    expect(publicDefault[0]).toMatchObject({ width: 240 });
     expect(readPptxSpy).not.toHaveBeenCalled();
     expect(adapterSpy).not.toHaveBeenCalled();
   });

--- a/vrt/compare-utils.ts
+++ b/vrt/compare-utils.ts
@@ -15,6 +15,8 @@ interface CompareOptions {
   mismatchTolerance: number;
   /** 参照画像を actual のサイズにリサイズして比較する (LibreOffice VRT 用) */
   resizeRef?: boolean;
+  /** true のとき anti-alias 判定による差分除外を行わない */
+  includeAntiAliased?: boolean;
 }
 
 export async function compareImages(
@@ -62,7 +64,7 @@ export async function compareImageBuffers(
 
   const mismatched = pixelmatch(actualRaw, refRaw, diffBuf, width, height, {
     threshold: options.pixelThreshold,
-    includeAA: false,
+    includeAA: options.includeAntiAliased ?? false,
   });
 
   const mismatchPercentage = mismatched / totalPixels;

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -39,7 +39,7 @@ const B = DOCUMENT_PATH_VRT_BLOCKER_ISSUES;
 export const DOCUMENT_PATH_VRT_SHARED_CASES = [
   shared("real-basic-theme", "real-basic-theme.pptx", 0, []),
   shared("real-product-page", "real-product-page.pptx", 0, []),
-  shared("real-financial-report", "real-financial-report.pptx", 0.16, [
+  shared("real-financial-report", "real-financial-report.pptx", 0, [
     B.tables,
     B.shapeTreeAndGeometry,
   ]),

--- a/vrt/snapshot/document-path-zero-diff-gate.test.ts
+++ b/vrt/snapshot/document-path-zero-diff-gate.test.ts
@@ -5,7 +5,11 @@ import { fileURLToPath } from "url";
 import { convertPptxToPng } from "../../packages/pptx-glimpse/src/converter.js";
 import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
 import { compareImageBuffers } from "../compare-utils.js";
-import { DOCUMENT_PATH_VRT_RENDER_WIDTH } from "./document-path-cases.js";
+import {
+  DOCUMENT_PATH_VRT_CASES,
+  DOCUMENT_PATH_VRT_RENDER_WIDTH,
+  type DocumentPathVrtFixtureGroup,
+} from "./document-path-cases.js";
 import { SHARED_FIXTURE_CASES, VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -16,10 +20,8 @@ const DIFF_DIR = join(__dirname, "diffs");
 const PIXEL_THRESHOLD = 0;
 const MISMATCH_TOLERANCE = 0;
 
-type ZeroDiffFixtureGroup = "shared" | "generated";
-
 interface ZeroDiffCase {
-  readonly group: ZeroDiffFixtureGroup;
+  readonly group: DocumentPathVrtFixtureGroup;
   readonly name: string;
   readonly fixture: string;
 }
@@ -42,6 +44,9 @@ describe("Document path zero-diff default switch gate", { timeout: 60000 }, () =
         ...SHARED_FIXTURE_CASES.map(({ name }) => name),
         ...VRT_CASES.map(({ name }) => name),
       ].sort(),
+    );
+    expect(ZERO_DIFF_CASES.map(({ name }) => name).sort()).toEqual(
+      DOCUMENT_PATH_VRT_CASES.map(({ name }) => name).sort(),
     );
   });
 
@@ -110,6 +115,6 @@ describe("Document path zero-diff default switch gate", { timeout: 60000 }, () =
   }
 });
 
-function fixtureDir(group: ZeroDiffFixtureGroup): string {
+function fixtureDir(group: DocumentPathVrtFixtureGroup): string {
   return group === "shared" ? SHARED_FIXTURE_DIR : GENERATED_FIXTURE_DIR;
 }

--- a/vrt/snapshot/document-path-zero-diff-gate.test.ts
+++ b/vrt/snapshot/document-path-zero-diff-gate.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import { convertPptxToPng } from "../../packages/pptx-glimpse/src/converter.js";
 import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
 import { compareImageBuffers } from "../compare-utils.js";
+import { DOCUMENT_PATH_VRT_RENDER_WIDTH } from "./document-path-cases.js";
 import { SHARED_FIXTURE_CASES, VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -12,7 +13,6 @@ const SHARED_FIXTURE_DIR = join(__dirname, "..", "..", "shared-fixtures");
 const GENERATED_FIXTURE_DIR = join(__dirname, "fixtures");
 const DIFF_DIR = join(__dirname, "diffs");
 
-const RENDER_WIDTH = 320;
 const PIXEL_THRESHOLD = 0;
 const MISMATCH_TOLERANCE = 0;
 
@@ -55,7 +55,7 @@ describe("Document path zero-diff default switch gate", { timeout: 60000 }, () =
 
         const input = readFileSync(fixturePath);
         const options = {
-          width: RENDER_WIDTH,
+          width: DOCUMENT_PATH_VRT_RENDER_WIDTH,
           skipSystemFonts: true,
         };
         const parserResults = await convertPptxToPng(input, options);

--- a/vrt/snapshot/document-path-zero-diff-gate.test.ts
+++ b/vrt/snapshot/document-path-zero-diff-gate.test.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { convertPptxToPng } from "../../packages/pptx-glimpse/src/converter.js";
+import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
+import { compareImageBuffers } from "../compare-utils.js";
+import { SHARED_FIXTURE_CASES, VRT_CASES } from "./vrt-cases.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SHARED_FIXTURE_DIR = join(__dirname, "..", "..", "shared-fixtures");
+const GENERATED_FIXTURE_DIR = join(__dirname, "fixtures");
+const DIFF_DIR = join(__dirname, "diffs");
+
+const RENDER_WIDTH = 320;
+const PIXEL_THRESHOLD = 0;
+const MISMATCH_TOLERANCE = 0;
+
+type ZeroDiffFixtureGroup = "shared" | "generated";
+
+interface ZeroDiffCase {
+  readonly group: ZeroDiffFixtureGroup;
+  readonly name: string;
+  readonly fixture: string;
+}
+
+const ZERO_DIFF_CASES = [
+  ...SHARED_FIXTURE_CASES.map((testCase) => ({ ...testCase, group: "shared" as const })),
+  ...VRT_CASES.map((testCase) => ({ ...testCase, group: "generated" as const })),
+] as const satisfies readonly ZeroDiffCase[];
+
+describe("Document path zero-diff default switch gate", { timeout: 60000 }, () => {
+  it("covers the full shared fixture and generated VRT sets", () => {
+    expect(ZERO_DIFF_CASES.filter((testCase) => testCase.group === "shared")).toHaveLength(
+      SHARED_FIXTURE_CASES.length,
+    );
+    expect(ZERO_DIFF_CASES.filter((testCase) => testCase.group === "generated")).toHaveLength(
+      VRT_CASES.length,
+    );
+    expect(ZERO_DIFF_CASES.map(({ name }) => name).sort()).toEqual(
+      [
+        ...SHARED_FIXTURE_CASES.map(({ name }) => name),
+        ...VRT_CASES.map(({ name }) => name),
+      ].sort(),
+    );
+  });
+
+  for (const testCase of ZERO_DIFF_CASES) {
+    describe(testCase.name, () => {
+      it("matches the current parser path PNG output exactly", async () => {
+        const fixturePath = join(fixtureDir(testCase.group), testCase.fixture);
+        if (!existsSync(fixturePath)) {
+          throw new Error(`VRT fixture not found: ${fixturePath}.`);
+        }
+
+        const input = readFileSync(fixturePath);
+        const options = {
+          width: RENDER_WIDTH,
+          skipSystemFonts: true,
+        };
+        const parserResults = await convertPptxToPng(input, options);
+        const documentResults = await convertPptxToPngViaDocumentPath(input, options);
+
+        expect(
+          parserResults.length,
+          `${testCase.name}: current parser rendered no slides`,
+        ).toBeGreaterThan(0);
+        expect(
+          documentResults.slides.length,
+          `${testCase.name}: document path slide count should match current parser`,
+        ).toBe(parserResults.length);
+        expect(documentResults.slides.map((slide) => slide.slideNumber)).toEqual(
+          parserResults.map((slide) => slide.slideNumber),
+        );
+
+        for (const documentResult of documentResults.slides) {
+          const parserResult = parserResults.find(
+            (slide) => slide.slideNumber === documentResult.slideNumber,
+          );
+          if (parserResult === undefined) {
+            throw new Error(
+              `Current parser path did not render ${testCase.name} slide ${documentResult.slideNumber}`,
+            );
+          }
+
+          const diffPath = join(
+            DIFF_DIR,
+            `document-path-zero-diff-${testCase.name}-slide${documentResult.slideNumber}-diff.png`,
+          );
+          const comparison = await compareImageBuffers(
+            documentResult.png,
+            parserResult.png,
+            diffPath,
+            {
+              pixelThreshold: PIXEL_THRESHOLD,
+              mismatchTolerance: MISMATCH_TOLERANCE,
+              includeAntiAliased: true,
+            },
+          );
+
+          expect(
+            comparison.passed,
+            `${testCase.name} slide ${documentResult.slideNumber}: ` +
+              `${comparison.mismatchedPixels}/${comparison.totalPixels} pixels differ. ` +
+              "The document path must be pixel-identical to the current parser path.",
+          ).toBe(true);
+        }
+      });
+    });
+  }
+});
+
+function fixtureDir(group: ZeroDiffFixtureGroup): string {
+  return group === "shared" ? SHARED_FIXTURE_DIR : GENERATED_FIXTURE_DIR;
+}


### PR DESCRIPTION
close #490

## 目的

`convertPptxToSvg` / `convertPptxToPng` の default path を document path に切り替える前段として、document path と現行 parser path の PNG output が完全一致していることを CI で検証する gate を追加します。

## 変更内容

- `vrt/snapshot/document-path-zero-diff-gate.test.ts` を追加し、`VRT_CASES` と `SHARED_FIXTURE_CASES` 全体で parser path と document path の PNG を比較
- `pixelThreshold: 0` / `mismatchTolerance: 0` / `includeAntiAliased: true` で 1px の差分も fail する strict 比較に設定
- snapshot VRT の CI job に zero-diff gate を追加
- public default が parser path のまま維持されることを PNG 側でも unit test で確認
- `real-financial-report` の document path regression tolerance を実測に合わせて `0` に締める

## 影響範囲

- `.github/workflows/ci.yml`
- `vrt/snapshot/*`
- `vrt/compare-utils.ts`
- `packages/pptx-glimpse/src/experimental-document-renderer.test.ts`

snapshot baseline update と LibreOffice VRT tolerance widening は行っていません。

## ローカル検証

- `pnpm exec vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-zero-diff-gate.test.ts`
- `pnpm exec vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run format:check`
- `pnpm run build`

補足: `pnpm run build` では既存の `import.meta` CJS warning が出ますが、exit code は 0 です。
