### PR TITLE
Switch public conversion default to document path

### DIFF
--- a/.changeset/public-document-default.md
+++ b/.changeset/public-document-default.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+Switch the public conversion default for `convertPptxToSvg` and `convertPptxToPng` to the CleanDoc document path while keeping an explicit parser-path oracle for parity checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,13 +33,15 @@ CI consists of 4 jobs:
 
 ## Architecture
 
-Data flow: **PPTX binary → Parser (ZIP extraction + XML parsing) → Intermediate model → Renderer (SVG generation) → PNG conversion (optional)**
+Data flow: **PPTX binary → CleanDoc reader → Computed view → Renderer model adapter → Renderer (SVG generation) → PNG conversion (optional)**
+
+The legacy parser path remains available internally as an explicit parser-path oracle for parity checks and VRT, but public `convertPptxToSvg` / `convertPptxToPng` default to the CleanDoc document path.
 
 ソースは pnpm workspaces (`.` + `packages/*`) で分割されている。`packages/*` 配下に renderer / cli の skeleton と `pptx-glimpse` の実装ソースが置かれており、`.` (ルート) は引き続き npm publish 対象の `pptx-glimpse` パッケージとして workspace に含めている (Changesets に root を認識させるための明示指定)。`pptx-glimpse` パッケージは `pptx-glimpse-renderer` を workspace 依存として参照する。
 
 `@pptx-glimpse/document` / CleanDoc / writer / editor-core / pom 連携に関わる issue に着手する前に、責務境界と依存方向の決定記録である `docs/document-boundaries.md` と、そこからリンクされる派生決定記録を必ず読むこと。`document` は `core` / `editor-core` / renderer / pom を知らない下位基盤として扱う。
 
-`packages/pptx-glimpse-document/src/` — experimental `@pptx-glimpse/document` パッケージの skeleton。CleanDoc / OOXML document foundation の下位基盤として追加されており、現時点では public conversion path からは参照しない。`@pptx-glimpse/document/experimental` は後続の source model / reader / writer 実装を積むための experimental entry point。
+`packages/pptx-glimpse-document/src/` — experimental `@pptx-glimpse/document` パッケージの skeleton。CleanDoc / OOXML document foundation の下位基盤として追加されており、public conversion path の default reader / computed view として参照される。`@pptx-glimpse/document/experimental` は後続の source model / reader / writer 実装を積むための experimental entry point。
 
 `packages/pptx-glimpse/src/` — 公開パッケージ `pptx-glimpse` の実装（パーサー + 公開 API）
 

--- a/packages/pptx-glimpse/src/converter.test.ts
+++ b/packages/pptx-glimpse/src/converter.test.ts
@@ -307,9 +307,9 @@ describe("convertPptxToSvg", () => {
     const svg = results[0].svg;
 
     // Blue rectangle fill
-    expect(svg).toContain("#4472C4");
+    expect(svg.toLowerCase()).toContain("#4472c4");
     // Orange ellipse fill
-    expect(svg).toContain("#ED7D31");
+    expect(svg.toLowerCase()).toContain("#ed7d31");
   });
 
   it("supports slide number filtering", async () => {
@@ -512,10 +512,10 @@ describe("master placeholder text filtering", () => {
     // Placeholder shapes should be filtered out
 
     // Decorative shape's red fill should appear
-    expect(svg).toContain("#FF0000");
+    expect(svg.toLowerCase()).toContain("#ff0000");
 
     // Count shape groups — should have decorative master shape + slide shape = 2 groups
-    const groupCount = (svg.match(/<g transform="translate/g) || []).length;
+    const groupCount = (svg.match(/<g\b[^>]*transform="translate/g) || []).length;
     expect(groupCount).toBe(2);
   });
 });
@@ -727,10 +727,10 @@ describe("layout placeholder text filtering", () => {
     // Placeholder shapes should be filtered out
 
     // Decorative shape's blue fill should appear
-    expect(svg).toContain("#0000FF");
+    expect(svg.toLowerCase()).toContain("#0000ff");
 
     // Count shape groups — should have decorative layout shape + slide shape = 2 groups
-    const groupCount = (svg.match(/<g transform="translate/g) || []).length;
+    const groupCount = (svg.match(/<g\b[^>]*transform="translate/g) || []).length;
     expect(groupCount).toBe(2);
   });
 });
@@ -833,13 +833,13 @@ describe("slide placeholder text filtering", () => {
     const svg = results[0].svg;
 
     // Decorative (non-placeholder) shape with magenta fill should remain.
-    expect(svg).toContain("#FF00FF");
+    expect(svg.toLowerCase()).toContain("#ff00ff");
 
     // Empty placeholders' green fill must NOT be rendered.
-    expect(svg).not.toContain("#00FF00");
+    expect(svg.toLowerCase()).not.toContain("#00ff00");
 
     // Only the decorative shape should produce a translate group.
-    const groupCount = (svg.match(/<g transform="translate/g) || []).length;
+    const groupCount = (svg.match(/<g\b[^>]*transform="translate/g) || []).length;
     expect(groupCount).toBe(1);
   });
 
@@ -854,12 +854,12 @@ describe("slide placeholder text filtering", () => {
     const svg = results[0].svg;
 
     // Filled title placeholder is kept (green fill renders).
-    expect(svg).toContain("#00FF00");
+    expect(svg.toLowerCase()).toContain("#00ff00");
     // Decorative shape still rendered.
-    expect(svg).toContain("#FF00FF");
+    expect(svg.toLowerCase()).toContain("#ff00ff");
 
     // Filled title + still-empty body (filtered) + decorative = 2 groups.
-    const groupCount = (svg.match(/<g transform="translate/g) || []).length;
+    const groupCount = (svg.match(/<g\b[^>]*transform="translate/g) || []).length;
     expect(groupCount).toBe(2);
   });
 });

--- a/packages/pptx-glimpse/src/converter.ts
+++ b/packages/pptx-glimpse/src/converter.ts
@@ -81,7 +81,7 @@ export async function convertPptxToSvg(
   return [...result.slides];
 }
 
-export async function convertPptxToSvgViaParserPath(
+async function convertPptxToSvgViaParserPath(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
 ): Promise<SlideSvg[]> {

--- a/packages/pptx-glimpse/src/converter.ts
+++ b/packages/pptx-glimpse/src/converter.ts
@@ -21,6 +21,10 @@ import { renderSlideToSvg } from "pptx-glimpse-renderer";
 import { DEFAULT_OUTPUT_WIDTH } from "pptx-glimpse-renderer";
 import { flushWarnings, initWarningLogger, warn } from "pptx-glimpse-renderer";
 
+import {
+  convertPptxToPngViaDocumentPath,
+  convertPptxToSvgViaDocumentPath,
+} from "./experimental-document-renderer.js";
 import { clearXmlCache, enableXmlCache } from "./parser/xml-parser.js";
 import type { ParsedSlide } from "./pptx-data-parser.js";
 import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
@@ -70,6 +74,14 @@ export function buildEffectiveSlideElements(parsed: ParsedSlide): SlideElement[]
 }
 
 export async function convertPptxToSvg(
+  input: Buffer | Uint8Array,
+  options?: ConvertOptions,
+): Promise<SlideSvg[]> {
+  const result = await convertPptxToSvgViaDocumentPath(input, options);
+  return [...result.slides];
+}
+
+export async function convertPptxToSvgViaParserPath(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
 ): Promise<SlideSvg[]> {
@@ -211,9 +223,17 @@ export async function convertPptxToPng(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
 ): Promise<SlideImage[]> {
+  const result = await convertPptxToPngViaDocumentPath(input, options);
+  return [...result.slides];
+}
+
+export async function convertPptxToPngViaParserPath(
+  input: Buffer | Uint8Array,
+  options?: ConvertOptions,
+): Promise<SlideImage[]> {
   // PNG 経路は常にパス出力で変換する。resvg は <style> 内の @font-face を解釈できず、
   // textOutput: "text" のままでは埋め込みフォントが反映されないため
-  const svgResults = await convertPptxToSvg(input, { ...options, textOutput: "path" });
+  const svgResults = await convertPptxToSvgViaParserPath(input, { ...options, textOutput: "path" });
 
   const width = options?.width ?? DEFAULT_OUTPUT_WIDTH;
   const height = options?.height;

--- a/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.test.ts
@@ -99,7 +99,7 @@ describe("experimental document render path", () => {
     expectUnsupportedDiagnosticsToStayInScope(result.diagnostics);
   });
 
-  it("keeps the public SVG converter on its existing default path", async () => {
+  it("uses the document path as the public SVG converter default", async () => {
     const readPptxSpy = vi.spyOn(documentExperimental, "readPptx");
     const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");
     const input = readFixture("real-basic-theme.pptx");
@@ -111,11 +111,11 @@ describe("experimental document render path", () => {
 
     expect(publicDefault.map((slide) => slide.slideNumber)).toEqual([1]);
     expect(publicDefault[0]?.svg).toContain("<svg");
-    expect(readPptxSpy).not.toHaveBeenCalled();
-    expect(adapterSpy).not.toHaveBeenCalled();
+    expect(readPptxSpy).toHaveBeenCalledOnce();
+    expect(adapterSpy).toHaveBeenCalledOnce();
   });
 
-  it("keeps the public PNG converter on its existing default path", async () => {
+  it("uses the document path as the public PNG converter default", async () => {
     const readPptxSpy = vi.spyOn(documentExperimental, "readPptx");
     const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");
     const input = readFixture("real-basic-theme.pptx");
@@ -127,8 +127,8 @@ describe("experimental document render path", () => {
 
     expect(publicDefault.map((slide) => slide.slideNumber)).toEqual([1]);
     expect(publicDefault[0]).toMatchObject({ width: 240 });
-    expect(readPptxSpy).not.toHaveBeenCalled();
-    expect(adapterSpy).not.toHaveBeenCalled();
+    expect(readPptxSpy).toHaveBeenCalledOnce();
+    expect(adapterSpy).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/pptx-glimpse/src/experimental-document-renderer.ts
+++ b/packages/pptx-glimpse/src/experimental-document-renderer.ts
@@ -44,8 +44,8 @@ interface DocumentPathPngResult {
 }
 
 /**
- * Internal / experimental render orchestration for dogfooding the CleanDoc
- * document path. This intentionally does not replace the public converter path.
+ * CleanDoc document-path render orchestration used by the public converter
+ * default. Parser-path helpers remain available for parity checks.
  */
 export async function convertPptxToSvgViaDocumentPath(
   input: Buffer | Uint8Array,

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -1,5 +1,5 @@
 /**
- * Document path VRT は public snapshot を更新せず、current parser path の PNG を
+ * Document path VRT は public snapshot を更新せず、明示的な parser path の PNG を
  * 参照画像としてその場で比較する full parity harness。
  *
  * mismatchTolerance は #489 時点の実測 gap を blocker issue 単位で固定した上限。
@@ -9,7 +9,7 @@
 export const DOCUMENT_PATH_VRT_RENDER_WIDTH = 320;
 
 export const DOCUMENT_PATH_VRT_SNAPSHOT_POLICY =
-  "No committed snapshot update is required: document path VRT compares against the current parser path in-memory until the public default path changes.";
+  "No committed snapshot update is required: document path VRT compares against the explicit parser path oracle in-memory.";
 
 export const DOCUMENT_PATH_VRT_BLOCKER_ISSUES = {
   tables: 491,

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-import { convertPptxToPng } from "../../packages/pptx-glimpse/src/converter.js";
+import { convertPptxToPngViaParserPath } from "../../packages/pptx-glimpse/src/converter.js";
 import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
 import { compareImageBuffers } from "../compare-utils.js";
 import {
@@ -41,7 +41,7 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
     expect(scopedSharedFixtureNames).toEqual(sharedFixtureNames);
     expect(scopedGeneratedFixtureNames).toEqual(generatedFixtureNames);
     expect(DOCUMENT_PATH_VRT_SNAPSHOT_POLICY).toMatchInlineSnapshot(
-      `"No committed snapshot update is required: document path VRT compares against the current parser path in-memory until the public default path changes."`,
+      `"No committed snapshot update is required: document path VRT compares against the explicit parser path oracle in-memory."`,
     );
   });
 
@@ -75,7 +75,7 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
         const options = {
           width: DOCUMENT_PATH_VRT_RENDER_WIDTH,
         };
-        const currentResults = await convertPptxToPng(input, options);
+        const currentResults = await convertPptxToPngViaParserPath(input, options);
         const documentResults = await convertPptxToPngViaDocumentPath(input, options);
 
         expect(

--- a/vrt/snapshot/document-path-zero-diff-gate.test.ts
+++ b/vrt/snapshot/document-path-zero-diff-gate.test.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-import { convertPptxToPng } from "../../packages/pptx-glimpse/src/converter.js";
+import { convertPptxToPngViaParserPath } from "../../packages/pptx-glimpse/src/converter.js";
 import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
 import { compareImageBuffers } from "../compare-utils.js";
 import {
@@ -62,7 +62,7 @@ describe("Document path zero-diff default switch gate", { timeout: 60000 }, () =
         const options = {
           width: DOCUMENT_PATH_VRT_RENDER_WIDTH,
         };
-        const parserResults = await convertPptxToPng(input, options);
+        const parserResults = await convertPptxToPngViaParserPath(input, options);
         const documentResults = await convertPptxToPngViaDocumentPath(input, options);
 
         expect(


### PR DESCRIPTION
close #484

## 概要
- public の `convertPptxToSvg` / `convertPptxToPng` の default path を CleanDoc document path に切り替えました
- VRT / zero-diff gate の比較元は明示的な parser path helper に切り出し、default switch 後も parser oracle と比較できるようにしました
- default path 変更に合わせて regression test、VRT policy 文言、AGENTS.md、changeset を更新しました

## 確認
- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- Docker snapshot VRT: `vrt/snapshot/regression.test.ts` / `document-path-regression.test.ts` / `document-path-zero-diff-gate.test.ts`
- snapshot / fixture / LibreOffice tolerance の追跡済み差分がないことを確認済み

## レビュー
- acceptance-check: 受け入れ条件を確認済み。CI依存項目はこのPRのchecksで最終確認
- cross-review: critical 0。warning 2件は追加commitで対応済み