### PR TITLE
Shrink legacy parser semantics after CleanDoc default

### DIFF
--- a/.changeset/shrink-parser-semantics.md
+++ b/.changeset/shrink-parser-semantics.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+Move remaining public font collection to the CleanDoc path and keep legacy parser rendering scoped to the internal parity oracle.

--- a/docs/legacy-parser-semantics-audit.md
+++ b/docs/legacy-parser-semantics-audit.md
@@ -1,0 +1,106 @@
+# Legacy parser semantics audit after the CleanDoc default switch
+
+- Status: implementation note for [#485](https://github.com/hirokisakabe/pptx-glimpse/issues/485)
+- Date: 2026-06-27
+
+This note records the first shrink pass after public SVG/PNG conversion moved to
+the CleanDoc document path. It complements
+[core-document-dogfood-migration.md](./core-document-dogfood-migration.md) and
+[document-boundaries.md](./document-boundaries.md).
+
+## Current owner split
+
+The public conversion path is now:
+
+```text
+convertPptxToSvg / convertPptxToPng
+  -> convertPptxToSvgViaDocumentPath / convertPptxToPngViaDocumentPath
+  -> @pptx-glimpse/document readPptx
+  -> createComputedView
+  -> core-owned CleanDoc renderer adapter
+  -> renderer
+```
+
+The old parser path is no longer part of public conversion orchestration. Its
+remaining render entry points live in
+`packages/pptx-glimpse/src/parser-path-oracle.ts` and are intentionally scoped as
+an internal oracle for parity checks.
+
+## Semantics moved to `document`
+
+These reusable OOXML semantics are now owned by `@pptx-glimpse/document` source
+or computed view code:
+
+| Semantics | Document owner | Previous parser overlap removed or reduced |
+| --- | --- | --- |
+| Package graph, slide order, relationships, media payloads | `reader/read-pptx.ts`, source package graph, computed relationships | Public conversion no longer calls `parsePptxData` for package traversal |
+| Slide/layout/master chain resolution | `createComputedView` | Public conversion no longer calls `parseSlideWithLayout` for cascade assembly |
+| Background fallback | `createComputedView` | Public conversion uses computed `background` instead of parser-side fallback |
+| Theme color and color map resolution | source theme data + computed color resolution | Public conversion uses computed colors through the adapter |
+| Placeholder filtering and effective element ordering | `createComputedView` | Core converter no longer owns parser-path `mergeElements` |
+| Text style and theme font resolution for rendering/inspection | `createComputedView` | `collectUsedFonts` now reads CleanDoc/computed text instead of parser slides |
+| Table/chart/image relationship resolution for rendering | `createComputedView` + adapter | Parser path remains only as comparison oracle |
+
+## Responsibilities left outside `document`
+
+These remain in core or renderer by design:
+
+| Responsibility | Owner | Reason |
+| --- | --- | --- |
+| Public API options, warning setup, font setup, SVG text-output mode, PNG sizing | `packages/pptx-glimpse/src/experimental-document-renderer.ts` | API compatibility and renderer environment setup are core concerns |
+| CleanDoc computed view to renderer model mapping | `packages/pptx-glimpse/src/cleandoc-renderer-adapter.ts` | The renderer model is a display-oriented compatibility target, not the CleanDoc source model |
+| Chart XML to renderer chart model mapping | Adapter calling parser `parseChart` | Chart rendering model is still renderer-specific; move only after a chart source/computed contract exists |
+| SmartArt drawing XML fallback to renderer shape tree | Adapter calling parser `parseShapeTree` | This is a rendering fallback for resolved diagram drawing XML, not canonical document semantics yet |
+| Font discovery, font mapping, text measurement, text-to-path, SVG/PNG output | `pptx-glimpse-renderer` | Renderer-specific behavior per `document-boundaries.md` |
+
+## Remaining legacy parser uses
+
+The old parser code still has three explicit roles:
+
+1. `parser-path-oracle.ts` renders through the old parser for document-path
+   parity checks.
+2. `dual-reader-structural-comparison.test.ts` compares a focused structural
+   subset against the old parser while the migration still needs a readable
+   model-level oracle.
+3. `cleandoc-renderer-adapter.ts` reuses `parseChart` and `parseShapeTree` for
+   renderer-specific chart and SmartArt fallbacks.
+
+No public API currently imports old parser render orchestration. `converter.ts`
+only calls the document path.
+
+## Shrink applied in #485
+
+- Moved `collectUsedFonts` from `parsePptxData` / `parseSlideWithLayout` to
+  `readPptx` / `createComputedView`.
+- Moved parser-path SVG/PNG rendering and effective element merging out of
+  `converter.ts` into `parser-path-oracle.ts`.
+- Updated VRT zero-diff and document-path regression tests to import the parser
+  oracle explicitly.
+
+## Remaining duplication and follow-up candidates
+
+Some duplication intentionally remains:
+
+- `pptx-data-parser.ts` still assembles slide/layout/master render models. Keep
+  it until the parser oracle is no longer needed for zero-diff gates.
+- Parser unit tests under `packages/pptx-glimpse/src/parser/` still protect the
+  old oracle and adapter fallback helpers. Delete or narrow them only after the
+  corresponding oracle role is removed.
+- `cleandoc-renderer-adapter.ts` still calls parser helpers for chart parsing
+  and SmartArt fallback rendering. Split follow-up issues should define
+  document-owned chart/diagram source contracts before moving this logic.
+- Comments in `packages/pptx-glimpse-document/src/computed/create-computed-view.ts`
+  that mention current-parser compatibility are retained as parity signposts.
+  They should be removed only when the document path intentionally owns a
+  different behavior and tests are updated with that decision.
+
+Suggested follow-up slices:
+
+1. Replace adapter SmartArt fallback use of `parseShapeTree` with a
+   document-owned diagram drawing source model.
+2. Introduce a chart source/computed contract and remove adapter dependence on
+   parser `parseChart`.
+3. Retire `dual-reader-structural-comparison.test.ts` after VRT and public
+   regression tests fully cover the parser oracle's remaining value.
+4. Remove `pptx-data-parser.ts` and parser render-model tests after the explicit
+   parser-path oracle is no longer used by VRT/CI.

--- a/docs/legacy-parser-semantics-audit.md
+++ b/docs/legacy-parser-semantics-audit.md
@@ -6,7 +6,10 @@
 This note records the first shrink pass after public SVG/PNG conversion moved to
 the CleanDoc document path. It complements
 [core-document-dogfood-migration.md](./core-document-dogfood-migration.md) and
-[document-boundaries.md](./document-boundaries.md).
+[document-boundaries.md](./document-boundaries.md). For #485, this note
+supersedes the earlier "current state" and parallel-reader descriptions in the
+dogfood migration note where those descriptions still mention public conversion
+flowing through the old parser.
 
 ## Current owner split
 
@@ -38,7 +41,8 @@ or computed view code:
 | Background fallback | `createComputedView` | Public conversion uses computed `background` instead of parser-side fallback |
 | Theme color and color map resolution | source theme data + computed color resolution | Public conversion uses computed colors through the adapter |
 | Placeholder filtering and effective element ordering | `createComputedView` | Core converter no longer owns parser-path `mergeElements` |
-| Text style and theme font resolution for rendering/inspection | `createComputedView` | `collectUsedFonts` now reads CleanDoc/computed text instead of parser slides |
+| Text style cascade for rendering/inspection | `createComputedView` | `collectUsedFonts` now reads CleanDoc/computed text instead of parser slides |
+| Theme font source data for rendering/inspection | source theme data + core runtime helpers | `collectUsedFonts` and rendering setup no longer depend on parser slide assembly |
 | Table/chart/image relationship resolution for rendering | `createComputedView` + adapter | Parser path remains only as comparison oracle |
 
 ## Responsibilities left outside `document`
@@ -47,7 +51,8 @@ These remain in core or renderer by design:
 
 | Responsibility | Owner | Reason |
 | --- | --- | --- |
-| Public API options, warning setup, font setup, SVG text-output mode, PNG sizing | `packages/pptx-glimpse/src/experimental-document-renderer.ts` | API compatibility and renderer environment setup are core concerns |
+| Public API options | `packages/pptx-glimpse/src/converter.ts`, `packages/pptx-glimpse/src/index.ts` | Stable API compatibility remains a core package concern |
+| Warning setup, font setup, SVG text-output mode, PNG sizing | `packages/pptx-glimpse/src/experimental-document-renderer.ts` | Renderer environment setup and runtime conversion options are core concerns |
 | CleanDoc computed view to renderer model mapping | `packages/pptx-glimpse/src/cleandoc-renderer-adapter.ts` | The renderer model is a display-oriented compatibility target, not the CleanDoc source model |
 | Chart XML to renderer chart model mapping | Adapter calling parser `parseChart` | Chart rendering model is still renderer-specific; move only after a chart source/computed contract exists |
 | SmartArt drawing XML fallback to renderer shape tree | Adapter calling parser `parseShapeTree` | This is a rendering fallback for resolved diagram drawing XML, not canonical document semantics yet |

--- a/packages/pptx-glimpse/src/converter.ts
+++ b/packages/pptx-glimpse/src/converter.ts
@@ -1,33 +1,10 @@
-import { readFileSync, statSync } from "node:fs";
-
 import type { FontMapping } from "pptx-glimpse-renderer";
-import type { ShapeElement, SlideElement } from "pptx-glimpse-renderer";
 import type { LogLevel } from "pptx-glimpse-renderer";
-import { buildFontFaceStyle } from "pptx-glimpse-renderer";
-import { createFontMapping } from "pptx-glimpse-renderer";
-import { resetFontMapping, setFontMapping } from "pptx-glimpse-renderer";
-import {
-  FontUsageCollector,
-  resetFontUsageCollector,
-  setFontUsageCollector,
-} from "pptx-glimpse-renderer";
-import { createOpentypeSetupFromSystem } from "pptx-glimpse-renderer";
-import { resetScriptFonts, setScriptFonts } from "pptx-glimpse-renderer";
-import { collectFontFilePaths } from "pptx-glimpse-renderer";
-import { resetTextMeasurer, setTextMeasurer } from "pptx-glimpse-renderer";
-import { resetTextPathFontResolver, setTextPathFontResolver } from "pptx-glimpse-renderer";
-import { svgToPng } from "pptx-glimpse-renderer";
-import { renderSlideToSvg } from "pptx-glimpse-renderer";
-import { DEFAULT_OUTPUT_WIDTH } from "pptx-glimpse-renderer";
-import { flushWarnings, initWarningLogger, warn } from "pptx-glimpse-renderer";
 
 import {
   convertPptxToPngViaDocumentPath,
   convertPptxToSvgViaDocumentPath,
 } from "./experimental-document-renderer.js";
-import { clearXmlCache, enableXmlCache } from "./parser/xml-parser.js";
-import type { ParsedSlide } from "./pptx-data-parser.js";
-import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 
 export interface ConvertOptions {
   /** 変換対象のスライド番号 (1始まり)。未指定で全スライド */
@@ -67,12 +44,6 @@ export interface SlideImage {
   height: number;
 }
 
-export function buildEffectiveSlideElements(parsed: ParsedSlide): SlideElement[] {
-  const effectiveMasterElements =
-    parsed.slide.showMasterSp && parsed.layoutShowMasterSp ? parsed.masterElements : [];
-  return mergeElements(effectiveMasterElements, parsed.layoutElements, parsed.slide.elements);
-}
-
 export async function convertPptxToSvg(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
@@ -81,211 +52,10 @@ export async function convertPptxToSvg(
   return [...result.slides];
 }
 
-async function convertPptxToSvgViaParserPath(
-  input: Buffer | Uint8Array,
-  options?: ConvertOptions,
-): Promise<SlideSvg[]> {
-  const textOutput = options?.textOutput ?? "path";
-  const setup = await createOpentypeSetupFromSystem(
-    options?.fontDirs,
-    options?.fontMapping,
-    options?.skipSystemFonts,
-  );
-  if (setup) {
-    setTextMeasurer(setup.measurer);
-    // "text" モードではフォントリゾルバーを設定しないことで
-    // renderTextBody が <text>/<tspan> 出力にフォールバックする
-    if (textOutput !== "text") {
-      setTextPathFontResolver(setup.fontResolver);
-    }
-  }
-  const fontUsageCollector = textOutput === "text" ? new FontUsageCollector() : null;
-  if (fontUsageCollector) {
-    setFontUsageCollector(fontUsageCollector);
-  }
-  setFontMapping(createFontMapping(options?.fontMapping));
-  enableXmlCache();
-  try {
-    initWarningLogger(options?.logLevel ?? "off");
-
-    const data = parsePptxData(input);
-    setScriptFonts(data.theme.fontScheme.majorFontJpan, data.theme.fontScheme.minorFontJpan);
-
-    // Filter slides if specified
-    const targetSlides = options?.slides
-      ? data.slidePaths.filter((s) => options.slides!.includes(s.slideNumber))
-      : data.slidePaths;
-
-    if (data.slidePaths.length === 0) {
-      warn("presentation.noSlides", "No slides found in the PPTX file");
-    }
-
-    // Parse and render each slide
-    const results: SlideSvg[] = [];
-    for (const { slideNumber, path } of targetSlides) {
-      const parsed = parseSlideWithLayout(slideNumber, path, data);
-      if (!parsed) continue;
-
-      // Merge shapes: master (back) → layout → slide (front)
-      const { slide } = parsed;
-      slide.elements = buildEffectiveSlideElements(parsed);
-
-      fontUsageCollector?.reset();
-      let svg = renderSlideToSvg(slide, data.presInfo.slideSize);
-      if (fontUsageCollector && setup) {
-        const style = await buildFontFaceStyle(fontUsageCollector.getUsages(), setup.fontResolver);
-        if (style) {
-          svg = injectIntoSvgDefs(svg, style);
-        }
-      }
-      results.push({ slideNumber, svg });
-    }
-
-    flushWarnings();
-
-    return results;
-  } finally {
-    clearXmlCache();
-    resetTextMeasurer();
-    resetTextPathFontResolver();
-    resetFontUsageCollector();
-    resetFontMapping();
-    resetScriptFonts();
-  }
-}
-
-/**
- * SVG ルート要素の直後に <defs> でラップしたコンテンツを挿入する。
- */
-function injectIntoSvgDefs(svg: string, content: string): string {
-  const openTagEnd = svg.indexOf(">");
-  if (openTagEnd === -1) return svg;
-  return `${svg.slice(0, openTagEnd + 1)}<defs>${content}</defs>${svg.slice(openTagEnd + 1)}`;
-}
-
-/**
- * resvg に渡すフォントバッファのキャッシュ。
- * collectFontFilePaths と同じキャッシュキーで管理する。
- */
-let cachedFontBuffers: Uint8Array[] | null = null;
-let cachedFontBuffersKey: string | null = null;
-
-/**
- * TTF/OTF フォントファイルを読み込んでバッファとして返す。
- * resvg-wasm は fontFiles (ファイルパス) を解釈できないため、
- * fontBuffers (生バイト) として渡す必要がある。
- * 合計サイズが MAX_TOTAL_FONT_BUFFER_BYTES を超えた時点で読み込みを打ち切る。
- */
-const MAX_TOTAL_FONT_BUFFER_BYTES = 100 * 1024 * 1024; // 100MB
-
-function loadFontBuffers(fontDirs?: string[], skipSystemFonts?: boolean): Uint8Array[] {
-  const key = `${(fontDirs ?? []).join("\0")}\n${skipSystemFonts ?? false}`;
-  if (cachedFontBuffers !== null && cachedFontBuffersKey === key) {
-    return cachedFontBuffers;
-  }
-
-  const allPaths = collectFontFilePaths(fontDirs, skipSystemFonts);
-  // TTC は resvg-wasm では不安定なため TTF/OTF のみを対象とする
-  const ttfOtfPaths = allPaths.filter((p) => {
-    const lower = p.toLowerCase();
-    return lower.endsWith(".ttf") || lower.endsWith(".otf");
-  });
-
-  // ファイルサイズ昇順に並べ、小さいフォントから優先的に読み込む
-  const pathsWithSize: { path: string; size: number }[] = [];
-  for (const p of ttfOtfPaths) {
-    try {
-      pathsWithSize.push({ path: p, size: statSync(p).size });
-    } catch {
-      // 読み取れないファイルはスキップ
-    }
-  }
-  pathsWithSize.sort((a, b) => a.size - b.size);
-
-  const buffers: Uint8Array[] = [];
-  let totalSize = 0;
-  for (const { path, size } of pathsWithSize) {
-    if (totalSize + size > MAX_TOTAL_FONT_BUFFER_BYTES) break;
-    try {
-      buffers.push(new Uint8Array(readFileSync(path)));
-      totalSize += size;
-    } catch {
-      // 読み取り失敗はスキップ
-    }
-  }
-
-  cachedFontBuffers = buffers;
-  cachedFontBuffersKey = key;
-  return buffers;
-}
-
 export async function convertPptxToPng(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
 ): Promise<SlideImage[]> {
   const result = await convertPptxToPngViaDocumentPath(input, options);
   return [...result.slides];
-}
-
-export async function convertPptxToPngViaParserPath(
-  input: Buffer | Uint8Array,
-  options?: ConvertOptions,
-): Promise<SlideImage[]> {
-  // PNG 経路は常にパス出力で変換する。resvg は <style> 内の @font-face を解釈できず、
-  // textOutput: "text" のままでは埋め込みフォントが反映されないため
-  const svgResults = await convertPptxToSvgViaParserPath(input, { ...options, textOutput: "path" });
-
-  const width = options?.width ?? DEFAULT_OUTPUT_WIDTH;
-  const height = options?.height;
-
-  // resvg に渡すフォントバッファを収集する（チャートの <text> 要素を描画するため）
-  const fontBuffers = loadFontBuffers(options?.fontDirs, options?.skipSystemFonts);
-
-  const results: SlideImage[] = [];
-  for (const { slideNumber, svg } of svgResults) {
-    const pngResult = await svgToPng(svg, { width, height, fontBuffers });
-    results.push({
-      slideNumber,
-      png: pngResult.png,
-      width: pngResult.width,
-      height: pngResult.height,
-    });
-  }
-
-  return results;
-}
-
-function mergeElements(
-  masterElements: SlideElement[],
-  layoutElements: SlideElement[],
-  slideElements: SlideElement[],
-): SlideElement[] {
-  // Placeholder shapes in master and layout are templates (position/style definitions).
-  // Their text content should never appear on actual slides.
-  // Only non-placeholder shapes (decorative elements, logos, etc.) are shown.
-  const filterTemplatePlaceholders = (elements: SlideElement[]) =>
-    elements.filter((el) => {
-      if (el.type !== "shape") return true;
-      return !el.placeholderType;
-    });
-
-  // Placeholder shapes on the slide itself are templates that the user has not
-  // filled in when their TextBody contains no run text. PowerPoint hides them
-  // entirely (the "Click to add title" prompt lives in the layout and is never
-  // copied into the slide), so we drop them too.
-  const filterEmptySlidePlaceholders = (elements: SlideElement[]) =>
-    elements.filter((el) => !(el.type === "shape" && isEmptyPlaceholder(el)));
-
-  const filteredMaster = filterTemplatePlaceholders(masterElements);
-  const filteredLayout = filterTemplatePlaceholders(layoutElements);
-  const filteredSlide = filterEmptySlidePlaceholders(slideElements);
-
-  return [...filteredMaster, ...filteredLayout, ...filteredSlide];
-}
-
-function isEmptyPlaceholder(shape: ShapeElement): boolean {
-  if (!shape.placeholderType) return false;
-  const paragraphs = shape.textBody?.paragraphs;
-  if (!paragraphs || paragraphs.length === 0) return true;
-  return !paragraphs.some((p) => p.runs.some((r) => r.text.length > 0));
 }

--- a/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
+++ b/packages/pptx-glimpse/src/dual-reader-structural-comparison.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, it } from "vitest";
 
 import { createComputedView, readPptx } from "../../pptx-glimpse-document/src/experimental.js";
 import { adaptComputedViewToRendererModel } from "./cleandoc-renderer-adapter.js";
-import { buildEffectiveSlideElements } from "./converter.js";
+import { buildEffectiveSlideElements } from "./parser-path-oracle.js";
 import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 
 const CASES = [

--- a/packages/pptx-glimpse/src/font/font-collector.test.ts
+++ b/packages/pptx-glimpse/src/font/font-collector.test.ts
@@ -171,19 +171,60 @@ const theme1 = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   </a:themeElements>
 </a:theme>`;
 
-async function createTestPptx(): Promise<Buffer> {
+const slideWithThemeAliases = slide1Xml
+  .replace(
+    `<a:p>
+            <a:r>
+              <a:rPr lang="en-US">
+                <a:latin typeface="Arial"/>
+                <a:ea typeface="MS PGothic"/>
+                <a:cs typeface="Arial"/>
+              </a:rPr>`,
+    `<a:p>
+            <a:pPr><a:buFont typeface="+mj-lt"/></a:pPr>
+            <a:r>
+              <a:rPr lang="en-US">
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:rPr>`,
+  )
+  .replace(
+    `<a:rPr lang="ja-JP">
+                <a:latin typeface="Times New Roman"/>
+                <a:ea typeface="Yu Gothic"/>
+              </a:rPr>`,
+    `<a:rPr lang="ja-JP">
+                <a:latin typeface="+mj-lt"/>
+                <a:ea typeface="+mj-ea"/>
+                <a:cs typeface="+mj-cs"/>
+              </a:rPr>`,
+  );
+
+const themeWithoutRegionalFonts = theme1
+  .replaceAll('\n        <a:ea typeface="MS PGothic"/>', "")
+  .replace('\n        <a:cs typeface="Times New Roman"/>', "")
+  .replace('\n        <a:cs typeface="Arial"/>', "");
+
+async function createTestPptx({
+  slideXml = slide1Xml,
+  themeXml = theme1,
+}: {
+  slideXml?: string;
+  themeXml?: string;
+} = {}): Promise<Buffer> {
   const zip = new JSZip();
   zip.file("[Content_Types].xml", contentTypes);
   zip.file("_rels/.rels", rootRels);
   zip.file("ppt/presentation.xml", presentationXml);
   zip.file("ppt/_rels/presentation.xml.rels", presentationRels);
-  zip.file("ppt/slides/slide1.xml", slide1Xml);
+  zip.file("ppt/slides/slide1.xml", slideXml);
   zip.file("ppt/slides/_rels/slide1.xml.rels", slide1Rels);
   zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
   zip.file("ppt/slideMasters/_rels/slideMaster1.xml.rels", slideMaster1Rels);
   zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
   zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
-  zip.file("ppt/theme/theme1.xml", theme1);
+  zip.file("ppt/theme/theme1.xml", themeXml);
   return zip.generateAsync({ type: "nodebuffer" });
 }
 
@@ -220,6 +261,42 @@ describe("collectUsedFonts", () => {
 
     expect(result.fonts).toContain("Calibri Light");
     expect(result.fonts).toContain("Calibri");
+  });
+
+  it("テーマフォント alias を解決して収集する", async () => {
+    const pptx = await createTestPptx({ slideXml: slideWithThemeAliases });
+    const result = collectUsedFonts(pptx);
+
+    expect(result.fonts).toContain("Calibri Light");
+    expect(result.fonts).toContain("Calibri");
+    expect(result.fonts).toContain("MS PGothic");
+    expect(result.fonts).toContain("Times New Roman");
+    expect(result.fonts).toContain("Arial");
+    expect(result.fonts).not.toContain("+mj-lt");
+    expect(result.fonts).not.toContain("+mn-lt");
+    expect(result.fonts).not.toContain("+mj-ea");
+    expect(result.fonts).not.toContain("+mn-ea");
+    expect(result.fonts).not.toContain("+mj-cs");
+    expect(result.fonts).not.toContain("+mn-cs");
+  });
+
+  it("解決できない theme regional alias は fonts 一覧へ漏らさない", async () => {
+    const pptx = await createTestPptx({
+      slideXml: slideWithThemeAliases,
+      themeXml: themeWithoutRegionalFonts,
+    });
+    const result = collectUsedFonts(pptx);
+
+    expect(result.theme.majorFontEa).toBeNull();
+    expect(result.theme.minorFontEa).toBeNull();
+    expect(result.theme.majorFontCs).toBeNull();
+    expect(result.theme.minorFontCs).toBeNull();
+    expect(result.fonts).toContain("Calibri Light");
+    expect(result.fonts).toContain("Calibri");
+    expect(result.fonts).not.toContain("+mj-ea");
+    expect(result.fonts).not.toContain("+mn-ea");
+    expect(result.fonts).not.toContain("+mj-cs");
+    expect(result.fonts).not.toContain("+mn-cs");
   });
 
   it("フォント名は重複なしでソート済み", () => {

--- a/packages/pptx-glimpse/src/font/font-collector.test.ts
+++ b/packages/pptx-glimpse/src/font/font-collector.test.ts
@@ -206,18 +206,79 @@ const themeWithoutRegionalFonts = theme1
   .replace('\n        <a:cs typeface="Times New Roman"/>', "")
   .replace('\n        <a:cs typeface="Arial"/>', "");
 
+const contentTypesWithSecondSlide = contentTypes.replace(
+  "</Types>",
+  `  <Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+  <Override PartName="/ppt/slideLayouts/slideLayout2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>
+  <Override PartName="/ppt/slideMasters/slideMaster2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>
+  <Override PartName="/ppt/theme/theme2.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
+</Types>`,
+);
+
+const presentationWithTwoSlidesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:sldMasterIdLst>
+    <p:sldMasterId r:id="rId1"/>
+    <p:sldMasterId r:id="rId4"/>
+  </p:sldMasterIdLst>
+  <p:sldIdLst>
+    <p:sldId id="256" r:id="rId2"/>
+    <p:sldId id="257" r:id="rId5"/>
+  </p:sldIdLst>
+  <p:sldSz cx="9144000" cy="5143500" type="screen16x9"/>
+</p:presentation>`;
+
+const presentationWithTwoSlidesRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+  <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster2.xml"/>
+  <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>
+</Relationships>`;
+
+const slide2Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>
+</Relationships>`;
+
+const slideMaster2Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="../theme/theme2.xml"/>
+</Relationships>`;
+
+const slideLayout2Rels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster2.xml"/>
+</Relationships>`;
+
+const theme2 = theme1
+  .replace("Calibri Light", "Contoso Heading")
+  .replace("Calibri", "Contoso Body")
+  .replaceAll("MS PGothic", "MS Mincho")
+  .replace("Times New Roman", "Contoso Complex")
+  .replace("Arial", "Contoso Minor Complex");
+
 async function createTestPptx({
+  contentTypesXml = contentTypes,
+  presentationXmlOverride = presentationXml,
+  presentationRelsXml = presentationRels,
   slideXml = slide1Xml,
   themeXml = theme1,
+  extraFiles = {},
 }: {
+  contentTypesXml?: string;
+  presentationXmlOverride?: string;
+  presentationRelsXml?: string;
   slideXml?: string;
   themeXml?: string;
+  extraFiles?: Record<string, string>;
 } = {}): Promise<Buffer> {
   const zip = new JSZip();
-  zip.file("[Content_Types].xml", contentTypes);
+  zip.file("[Content_Types].xml", contentTypesXml);
   zip.file("_rels/.rels", rootRels);
-  zip.file("ppt/presentation.xml", presentationXml);
-  zip.file("ppt/_rels/presentation.xml.rels", presentationRels);
+  zip.file("ppt/presentation.xml", presentationXmlOverride);
+  zip.file("ppt/_rels/presentation.xml.rels", presentationRelsXml);
   zip.file("ppt/slides/slide1.xml", slideXml);
   zip.file("ppt/slides/_rels/slide1.xml.rels", slide1Rels);
   zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
@@ -225,6 +286,9 @@ async function createTestPptx({
   zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
   zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
   zip.file("ppt/theme/theme1.xml", themeXml);
+  for (const [path, content] of Object.entries(extraFiles)) {
+    zip.file(path, content);
+  }
   return zip.generateAsync({ type: "nodebuffer" });
 }
 
@@ -293,6 +357,36 @@ describe("collectUsedFonts", () => {
     expect(result.theme.minorFontCs).toBeNull();
     expect(result.fonts).toContain("Calibri Light");
     expect(result.fonts).toContain("Calibri");
+    expect(result.fonts).not.toContain("+mj-ea");
+    expect(result.fonts).not.toContain("+mn-ea");
+    expect(result.fonts).not.toContain("+mj-cs");
+    expect(result.fonts).not.toContain("+mn-cs");
+  });
+
+  it("スライドごとの theme font alias を各 slide の theme で解決する", async () => {
+    const pptx = await createTestPptx({
+      contentTypesXml: contentTypesWithSecondSlide,
+      presentationXmlOverride: presentationWithTwoSlidesXml,
+      presentationRelsXml: presentationWithTwoSlidesRels,
+      extraFiles: {
+        "ppt/slides/slide2.xml": slideWithThemeAliases,
+        "ppt/slides/_rels/slide2.xml.rels": slide2Rels,
+        "ppt/slideMasters/slideMaster2.xml": slideMaster1,
+        "ppt/slideMasters/_rels/slideMaster2.xml.rels": slideMaster2Rels,
+        "ppt/slideLayouts/slideLayout2.xml": slideLayout1,
+        "ppt/slideLayouts/_rels/slideLayout2.xml.rels": slideLayout2Rels,
+        "ppt/theme/theme2.xml": theme2,
+      },
+    });
+    const result = collectUsedFonts(pptx);
+
+    expect(result.fonts).toContain("Contoso Heading");
+    expect(result.fonts).toContain("Contoso Body");
+    expect(result.fonts).toContain("MS Mincho");
+    expect(result.fonts).toContain("Contoso Complex");
+    expect(result.fonts).toContain("Contoso Minor Complex");
+    expect(result.fonts).not.toContain("+mj-lt");
+    expect(result.fonts).not.toContain("+mn-lt");
     expect(result.fonts).not.toContain("+mj-ea");
     expect(result.fonts).not.toContain("+mn-ea");
     expect(result.fonts).not.toContain("+mj-cs");

--- a/packages/pptx-glimpse/src/font/font-collector.ts
+++ b/packages/pptx-glimpse/src/font/font-collector.ts
@@ -44,8 +44,29 @@ export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
 
   collectThemeFonts(fontScheme, fonts);
 
+  const visitedTemplateParts = new Set<string>();
   for (const slide of computed.slides) {
-    collectFontsFromElements(slide.elements, fonts);
+    const templateElementsByPart = new Map<string, ComputedElement[]>();
+    for (const element of slide.elements) {
+      if (element.sourceLayer === "slide") {
+        collectFontsFromElements([element], fonts, fontScheme);
+        continue;
+      }
+
+      const key = `${element.sourceLayer}:${element.sourcePartPath}`;
+      const elements = templateElementsByPart.get(key);
+      if (elements) {
+        elements.push(element);
+      } else {
+        templateElementsByPart.set(key, [element]);
+      }
+    }
+
+    for (const [key, elements] of templateElementsByPart) {
+      if (visitedTemplateParts.has(key)) continue;
+      visitedTemplateParts.add(key);
+      collectFontsFromElements(elements, fonts, fontScheme);
+    }
   }
 
   return {
@@ -77,27 +98,33 @@ function findThemeFontScheme(
 }
 
 function collectThemeFonts(fontScheme: SourceThemeFontScheme, fonts: Set<string>): void {
-  addFont(fonts, fontScheme.majorLatin);
-  addFont(fonts, fontScheme.minorLatin);
-  addFont(fonts, fontScheme.majorEastAsian);
-  addFont(fonts, fontScheme.minorEastAsian);
-  addFont(fonts, fontScheme.majorComplexScript);
-  addFont(fonts, fontScheme.minorComplexScript);
+  addFont(fonts, fontScheme.majorLatin, fontScheme);
+  addFont(fonts, fontScheme.minorLatin, fontScheme);
+  addFont(fonts, fontScheme.majorEastAsian, fontScheme);
+  addFont(fonts, fontScheme.minorEastAsian, fontScheme);
+  addFont(fonts, fontScheme.majorComplexScript, fontScheme);
+  addFont(fonts, fontScheme.minorComplexScript, fontScheme);
+  addFont(fonts, fontScheme.majorJapanese, fontScheme);
+  addFont(fonts, fontScheme.minorJapanese, fontScheme);
 }
 
-function collectFontsFromElements(elements: readonly ComputedElement[], fonts: Set<string>): void {
+function collectFontsFromElements(
+  elements: readonly ComputedElement[],
+  fonts: Set<string>,
+  fontScheme: SourceThemeFontScheme,
+): void {
   for (const el of elements) {
     switch (el.kind) {
       case "shape":
-        if (el.textBody) collectFontsFromTextBody(el.textBody, fonts);
+        if (el.textBody) collectFontsFromTextBody(el.textBody, fonts, fontScheme);
         break;
       case "group":
-        collectFontsFromElements(el.children, fonts);
+        collectFontsFromElements(el.children, fonts, fontScheme);
         break;
       case "table":
         for (const row of el.table.rows) {
           for (const cell of row.cells) {
-            if (cell.textBody) collectFontsFromTextBody(cell.textBody, fonts);
+            if (cell.textBody) collectFontsFromTextBody(cell.textBody, fonts, fontScheme);
           }
         }
         break;
@@ -105,17 +132,48 @@ function collectFontsFromElements(elements: readonly ComputedElement[], fonts: S
   }
 }
 
-function collectFontsFromTextBody(textBody: ComputedTextBody, fonts: Set<string>): void {
+function collectFontsFromTextBody(
+  textBody: ComputedTextBody,
+  fonts: Set<string>,
+  fontScheme: SourceThemeFontScheme,
+): void {
   for (const para of textBody.paragraphs) {
-    addFont(fonts, para.properties?.bulletFont);
+    addFont(fonts, para.properties?.bulletFont, fontScheme);
     for (const run of para.runs) {
-      addFont(fonts, run.properties?.typeface);
-      addFont(fonts, run.properties?.typefaceEa);
-      addFont(fonts, run.properties?.typefaceCs);
+      addFont(fonts, run.properties?.typeface, fontScheme);
+      addFont(fonts, run.properties?.typefaceEa, fontScheme);
+      addFont(fonts, run.properties?.typefaceCs, fontScheme);
     }
   }
 }
 
-function addFont(fonts: Set<string>, font: string | undefined): void {
-  if (font) fonts.add(font);
+function addFont(
+  fonts: Set<string>,
+  font: string | undefined,
+  fontScheme: SourceThemeFontScheme,
+): void {
+  const resolved = resolveThemeFontAlias(font, fontScheme);
+  if (resolved) fonts.add(resolved);
+}
+
+function resolveThemeFontAlias(
+  font: string | undefined,
+  fontScheme: SourceThemeFontScheme,
+): string | undefined {
+  switch (font) {
+    case "+mj-lt":
+      return fontScheme.majorLatin;
+    case "+mn-lt":
+      return fontScheme.minorLatin;
+    case "+mj-ea":
+      return fontScheme.majorEastAsian ?? fontScheme.majorJapanese;
+    case "+mn-ea":
+      return fontScheme.minorEastAsian ?? fontScheme.minorJapanese;
+    case "+mj-cs":
+      return fontScheme.majorComplexScript;
+    case "+mn-cs":
+      return fontScheme.minorComplexScript;
+    default:
+      return font?.startsWith("+mj-") || font?.startsWith("+mn-") ? undefined : font;
+  }
 }

--- a/packages/pptx-glimpse/src/font/font-collector.ts
+++ b/packages/pptx-glimpse/src/font/font-collector.ts
@@ -25,8 +25,10 @@ export interface UsedFonts {
   fonts: string[];
 }
 
-const DEFAULT_THEME_FONTS: Required<Pick<SourceThemeFontScheme, "majorLatin" | "minorLatin">> &
-  SourceThemeFontScheme = {
+type ResolvedThemeFontScheme = Required<Pick<SourceThemeFontScheme, "majorLatin" | "minorLatin">> &
+  SourceThemeFontScheme;
+
+const DEFAULT_THEME_FONTS: ResolvedThemeFontScheme = {
   majorLatin: "Calibri",
   minorLatin: "Calibri",
 };
@@ -37,19 +39,21 @@ const DEFAULT_THEME_FONTS: Required<Pick<SourceThemeFontScheme, "majorLatin" | "
  */
 export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
   const source = readPptx(input);
-  const fontScheme = findThemeFontScheme(source);
+  const defaultFontScheme = findDefaultThemeFontScheme(source);
   const computed = createComputedView(source);
 
   const fonts = new Set<string>();
 
-  collectThemeFonts(fontScheme, fonts);
+  collectThemeFonts(defaultFontScheme, fonts);
 
   const visitedTemplateParts = new Set<string>();
   for (const slide of computed.slides) {
+    const slideFontScheme = findThemeFontScheme(source, slide.themePartPath) ?? defaultFontScheme;
+
     const templateElementsByPart = new Map<string, ComputedElement[]>();
     for (const element of slide.elements) {
       if (element.sourceLayer === "slide") {
-        collectFontsFromElements([element], fonts, fontScheme);
+        collectFontsFromElements([element], fonts, slideFontScheme);
         continue;
       }
 
@@ -65,32 +69,43 @@ export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
     for (const [key, elements] of templateElementsByPart) {
       if (visitedTemplateParts.has(key)) continue;
       visitedTemplateParts.add(key);
-      collectFontsFromElements(elements, fonts, fontScheme);
+      collectFontsFromElements(elements, fonts, slideFontScheme);
     }
   }
 
   return {
     theme: {
-      majorFont: fontScheme.majorLatin,
-      minorFont: fontScheme.minorLatin,
-      majorFontEa: fontScheme.majorEastAsian ?? null,
-      minorFontEa: fontScheme.minorEastAsian ?? null,
-      majorFontCs: fontScheme.majorComplexScript ?? null,
-      minorFontCs: fontScheme.minorComplexScript ?? null,
+      majorFont: defaultFontScheme.majorLatin,
+      minorFont: defaultFontScheme.minorLatin,
+      majorFontEa: defaultFontScheme.majorEastAsian ?? null,
+      minorFontEa: defaultFontScheme.minorEastAsian ?? null,
+      majorFontCs: defaultFontScheme.majorComplexScript ?? null,
+      minorFontCs: defaultFontScheme.minorComplexScript ?? null,
     },
     fonts: [...fonts].sort(),
   };
 }
 
-function findThemeFontScheme(
-  source: CleanDocSource,
-): Required<Pick<SourceThemeFontScheme, "majorLatin" | "minorLatin">> & SourceThemeFontScheme {
+function findDefaultThemeFontScheme(source: CleanDocSource): ResolvedThemeFontScheme {
   const firstThemePartPath = source.slideMasters.find(
     (master) => master.themePartPath !== undefined,
   )?.themePartPath;
-  const scheme =
-    source.themes.find((theme) => theme.partPath === firstThemePartPath)?.fontScheme ??
-    source.themes[0]?.fontScheme;
+  const scheme = findThemeFontScheme(source, firstThemePartPath) ?? source.themes[0]?.fontScheme;
+  return applyDefaultThemeFonts(scheme);
+}
+
+function findThemeFontScheme(
+  source: CleanDocSource,
+  themePartPath: string | undefined,
+): ResolvedThemeFontScheme | undefined {
+  if (themePartPath === undefined) return undefined;
+  const scheme = source.themes.find((theme) => theme.partPath === themePartPath)?.fontScheme;
+  return scheme !== undefined ? applyDefaultThemeFonts(scheme) : undefined;
+}
+
+function applyDefaultThemeFonts(
+  scheme: SourceThemeFontScheme | undefined,
+): ResolvedThemeFontScheme {
   return {
     ...DEFAULT_THEME_FONTS,
     ...scheme,

--- a/packages/pptx-glimpse/src/font/font-collector.ts
+++ b/packages/pptx-glimpse/src/font/font-collector.ts
@@ -1,12 +1,14 @@
 /**
  * PPTX から使用フォント名を収集する API。
  */
-import type { SlideElement } from "pptx-glimpse-renderer";
-import type { TextBody } from "pptx-glimpse-renderer";
-import type { FontScheme } from "pptx-glimpse-renderer";
-
-import { clearXmlCache, enableXmlCache } from "../parser/xml-parser.js";
-import { parsePptxData, parseSlideWithLayout } from "../pptx-data-parser.js";
+import {
+  type CleanDocSource,
+  type ComputedElement,
+  type ComputedTextBody,
+  createComputedView,
+  readPptx,
+  type SourceThemeFontScheme,
+} from "../../../pptx-glimpse-document/src/experimental.js";
 
 /** フォント収集結果 */
 export interface UsedFonts {
@@ -23,61 +25,69 @@ export interface UsedFonts {
   fonts: string[];
 }
 
+const DEFAULT_THEME_FONTS: Required<Pick<SourceThemeFontScheme, "majorLatin" | "minorLatin">> &
+  SourceThemeFontScheme = {
+  majorLatin: "Calibri",
+  minorLatin: "Calibri",
+};
+
 /**
  * PPTX をパースして使用されているフォント名を収集する。
  * レンダリングは行わないため軽量。
  */
 export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
-  enableXmlCache();
-  try {
-    const data = parsePptxData(input);
-    const fontScheme = data.theme.fontScheme;
+  const source = readPptx(input);
+  const fontScheme = findThemeFontScheme(source);
+  const computed = createComputedView(source);
 
-    const fonts = new Set<string>();
+  const fonts = new Set<string>();
 
-    // テーマフォントを収集
-    collectThemeFonts(fontScheme, fonts);
+  collectThemeFonts(fontScheme, fonts);
 
-    // 各スライドから収集（スライドごとのマスター要素も含む）
-    const collectedMasters = new Set<SlideElement[]>();
-    for (const { slideNumber, path } of data.slidePaths) {
-      const parsed = parseSlideWithLayout(slideNumber, path, data);
-      if (!parsed) continue;
-      collectFontsFromElements(parsed.slide.elements, fonts);
-      if (!collectedMasters.has(parsed.masterElements)) {
-        collectedMasters.add(parsed.masterElements);
-        collectFontsFromElements(parsed.masterElements, fonts);
-      }
-    }
-
-    return {
-      theme: {
-        majorFont: fontScheme.majorFont,
-        minorFont: fontScheme.minorFont,
-        majorFontEa: fontScheme.majorFontEa,
-        minorFontEa: fontScheme.minorFontEa,
-        majorFontCs: fontScheme.majorFontCs,
-        minorFontCs: fontScheme.minorFontCs,
-      },
-      fonts: [...fonts].sort(),
-    };
-  } finally {
-    clearXmlCache();
+  for (const slide of computed.slides) {
+    collectFontsFromElements(slide.elements, fonts);
   }
+
+  return {
+    theme: {
+      majorFont: fontScheme.majorLatin,
+      minorFont: fontScheme.minorLatin,
+      majorFontEa: fontScheme.majorEastAsian ?? null,
+      minorFontEa: fontScheme.minorEastAsian ?? null,
+      majorFontCs: fontScheme.majorComplexScript ?? null,
+      minorFontCs: fontScheme.minorComplexScript ?? null,
+    },
+    fonts: [...fonts].sort(),
+  };
 }
 
-function collectThemeFonts(fontScheme: FontScheme, fonts: Set<string>): void {
-  fonts.add(fontScheme.majorFont);
-  fonts.add(fontScheme.minorFont);
-  if (fontScheme.majorFontEa) fonts.add(fontScheme.majorFontEa);
-  if (fontScheme.minorFontEa) fonts.add(fontScheme.minorFontEa);
-  if (fontScheme.majorFontCs) fonts.add(fontScheme.majorFontCs);
-  if (fontScheme.minorFontCs) fonts.add(fontScheme.minorFontCs);
+function findThemeFontScheme(
+  source: CleanDocSource,
+): Required<Pick<SourceThemeFontScheme, "majorLatin" | "minorLatin">> & SourceThemeFontScheme {
+  const firstThemePartPath = source.slideMasters.find(
+    (master) => master.themePartPath !== undefined,
+  )?.themePartPath;
+  const scheme =
+    source.themes.find((theme) => theme.partPath === firstThemePartPath)?.fontScheme ??
+    source.themes[0]?.fontScheme;
+  return {
+    ...DEFAULT_THEME_FONTS,
+    ...scheme,
+  };
 }
 
-function collectFontsFromElements(elements: SlideElement[], fonts: Set<string>): void {
+function collectThemeFonts(fontScheme: SourceThemeFontScheme, fonts: Set<string>): void {
+  addFont(fonts, fontScheme.majorLatin);
+  addFont(fonts, fontScheme.minorLatin);
+  addFont(fonts, fontScheme.majorEastAsian);
+  addFont(fonts, fontScheme.minorEastAsian);
+  addFont(fonts, fontScheme.majorComplexScript);
+  addFont(fonts, fontScheme.minorComplexScript);
+}
+
+function collectFontsFromElements(elements: readonly ComputedElement[], fonts: Set<string>): void {
   for (const el of elements) {
-    switch (el.type) {
+    switch (el.kind) {
       case "shape":
         if (el.textBody) collectFontsFromTextBody(el.textBody, fonts);
         break;
@@ -95,13 +105,17 @@ function collectFontsFromElements(elements: SlideElement[], fonts: Set<string>):
   }
 }
 
-function collectFontsFromTextBody(textBody: TextBody, fonts: Set<string>): void {
+function collectFontsFromTextBody(textBody: ComputedTextBody, fonts: Set<string>): void {
   for (const para of textBody.paragraphs) {
-    if (para.properties.bulletFont) fonts.add(para.properties.bulletFont);
+    addFont(fonts, para.properties?.bulletFont);
     for (const run of para.runs) {
-      if (run.properties.fontFamily) fonts.add(run.properties.fontFamily);
-      if (run.properties.fontFamilyEa) fonts.add(run.properties.fontFamilyEa);
-      if (run.properties.fontFamilyCs) fonts.add(run.properties.fontFamilyCs);
+      addFont(fonts, run.properties?.typeface);
+      addFont(fonts, run.properties?.typefaceEa);
+      addFont(fonts, run.properties?.typefaceCs);
     }
   }
+}
+
+function addFont(fonts: Set<string>, font: string | undefined): void {
+  if (font) fonts.add(font);
 }

--- a/packages/pptx-glimpse/src/parser-path-oracle.test.ts
+++ b/packages/pptx-glimpse/src/parser-path-oracle.test.ts
@@ -1,0 +1,112 @@
+import type { ShapeElement, Slide, SlideElement } from "pptx-glimpse-renderer";
+import { describe, expect, it } from "vitest";
+
+import { buildEffectiveSlideElements } from "./parser-path-oracle.js";
+import type { ParsedSlide } from "./pptx-data-parser.js";
+
+describe("buildEffectiveSlideElements", () => {
+  it("omits master elements when the slide hides master shapes", () => {
+    const master = shape("master");
+    const layout = shape("layout");
+    const slideElement = shape("slide");
+
+    const result = buildEffectiveSlideElements(
+      parsedSlide({
+        showMasterSp: false,
+        layoutShowMasterSp: true,
+        masterElements: [master],
+        layoutElements: [layout],
+        slideElements: [slideElement],
+      }),
+    );
+
+    expect(result).toEqual([layout, slideElement]);
+  });
+
+  it("omits master elements when the layout hides master shapes", () => {
+    const master = shape("master");
+    const layout = shape("layout");
+    const slideElement = shape("slide");
+
+    const result = buildEffectiveSlideElements(
+      parsedSlide({
+        showMasterSp: true,
+        layoutShowMasterSp: false,
+        masterElements: [master],
+        layoutElements: [layout],
+        slideElements: [slideElement],
+      }),
+    );
+
+    expect(result).toEqual([layout, slideElement]);
+  });
+
+  it("filters template placeholders and empty slide placeholders", () => {
+    const masterPlaceholder = shape("master-placeholder", { placeholderType: "body" });
+    const masterShape = shape("master-shape");
+    const layoutPlaceholder = shape("layout-placeholder", { placeholderType: "title" });
+    const layoutShape = shape("layout-shape");
+    const emptySlidePlaceholder = shape("empty-slide-placeholder", { placeholderType: "body" });
+    const filledSlidePlaceholder = shape("filled-slide-placeholder", {
+      placeholderType: "body",
+      text: "Keep me",
+    });
+
+    const result = buildEffectiveSlideElements(
+      parsedSlide({
+        showMasterSp: true,
+        layoutShowMasterSp: true,
+        masterElements: [masterPlaceholder, masterShape],
+        layoutElements: [layoutPlaceholder, layoutShape],
+        slideElements: [emptySlidePlaceholder, filledSlidePlaceholder],
+      }),
+    );
+
+    expect(result).toEqual([masterShape, layoutShape, filledSlidePlaceholder]);
+  });
+});
+
+function parsedSlide({
+  showMasterSp,
+  layoutShowMasterSp,
+  masterElements,
+  layoutElements,
+  slideElements,
+}: {
+  showMasterSp: boolean;
+  layoutShowMasterSp: boolean;
+  masterElements: SlideElement[];
+  layoutElements: SlideElement[];
+  slideElements: SlideElement[];
+}): ParsedSlide {
+  return {
+    slide: {
+      slideNumber: 1,
+      background: null,
+      elements: slideElements,
+      showMasterSp,
+    } satisfies Slide,
+    layoutElements,
+    layoutShowMasterSp,
+    masterElements,
+  };
+}
+
+function shape(
+  id: string,
+  options: { placeholderType?: string; text?: string } = {},
+): ShapeElement {
+  const textBody =
+    options.text === undefined
+      ? null
+      : {
+          paragraphs: [{ runs: [{ text: options.text }] }],
+        };
+
+  return {
+    type: "shape",
+    id,
+    placeholderType: options.placeholderType,
+    textBody,
+  } as unknown as ShapeElement;
+}

--- a/packages/pptx-glimpse/src/parser-path-oracle.ts
+++ b/packages/pptx-glimpse/src/parser-path-oracle.ts
@@ -107,6 +107,13 @@ export async function convertPptxToPngViaParserPath(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
 ): Promise<SlideImage[]> {
+  return runParserPathExclusive(() => convertPptxToPngViaParserPathUnsafe(input, options));
+}
+
+async function convertPptxToPngViaParserPathUnsafe(
+  input: Buffer | Uint8Array,
+  options?: ConvertOptions,
+): Promise<SlideImage[]> {
   const svgResults = await convertPptxToSvgViaParserPath(input, { ...options, textOutput: "path" });
   const width = options?.width ?? DEFAULT_OUTPUT_WIDTH;
   const height = options?.height;
@@ -124,6 +131,23 @@ export async function convertPptxToPngViaParserPath(
   }
 
   return results;
+}
+
+let parserPathQueue: Promise<void> = Promise.resolve();
+
+async function runParserPathExclusive<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = parserPathQueue;
+  let release!: () => void;
+  parserPathQueue = new Promise((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
 }
 
 export function buildEffectiveSlideElements(parsed: ParsedSlide): SlideElement[] {
@@ -144,7 +168,7 @@ let cachedFontBuffersKey: string | null = null;
 const MAX_TOTAL_FONT_BUFFER_BYTES = 100 * 1024 * 1024;
 
 function loadFontBuffers(fontDirs?: string[], skipSystemFonts?: boolean): Uint8Array[] {
-  const key = `${(fontDirs ?? []).join("\0")}\n${skipSystemFonts ?? false}`;
+  const key = `${[...(fontDirs ?? [])].sort().join("\0")}\n${skipSystemFonts ?? false}`;
   if (cachedFontBuffers !== null && cachedFontBuffersKey === key) {
     return cachedFontBuffers;
   }

--- a/packages/pptx-glimpse/src/parser-path-oracle.ts
+++ b/packages/pptx-glimpse/src/parser-path-oracle.ts
@@ -1,0 +1,211 @@
+import { readFileSync, statSync } from "node:fs";
+
+import type { ShapeElement, SlideElement } from "pptx-glimpse-renderer";
+import {
+  buildFontFaceStyle,
+  collectFontFilePaths,
+  createFontMapping,
+  createOpentypeSetupFromSystem,
+  DEFAULT_OUTPUT_WIDTH,
+  flushWarnings,
+  FontUsageCollector,
+  initWarningLogger,
+  renderSlideToSvg,
+  resetFontMapping,
+  resetFontUsageCollector,
+  resetScriptFonts,
+  resetTextMeasurer,
+  resetTextPathFontResolver,
+  setFontMapping,
+  setFontUsageCollector,
+  setScriptFonts,
+  setTextMeasurer,
+  setTextPathFontResolver,
+  svgToPng,
+  warn,
+} from "pptx-glimpse-renderer";
+
+import type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
+import { clearXmlCache, enableXmlCache } from "./parser/xml-parser.js";
+import type { ParsedSlide } from "./pptx-data-parser.js";
+import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
+
+/**
+ * Explicit old-parser render oracle for document-path parity checks.
+ *
+ * Public conversion defaults to the CleanDoc document path. Keep this module
+ * internal so old parser semantics do not leak back into core orchestration.
+ */
+async function convertPptxToSvgViaParserPath(
+  input: Buffer | Uint8Array,
+  options?: ConvertOptions,
+): Promise<SlideSvg[]> {
+  const textOutput = options?.textOutput ?? "path";
+  const setup = await createOpentypeSetupFromSystem(
+    options?.fontDirs,
+    options?.fontMapping,
+    options?.skipSystemFonts,
+  );
+  if (setup) {
+    setTextMeasurer(setup.measurer);
+    if (textOutput !== "text") {
+      setTextPathFontResolver(setup.fontResolver);
+    }
+  }
+  const fontUsageCollector = textOutput === "text" ? new FontUsageCollector() : null;
+  if (fontUsageCollector) {
+    setFontUsageCollector(fontUsageCollector);
+  }
+  setFontMapping(createFontMapping(options?.fontMapping));
+  enableXmlCache();
+  try {
+    initWarningLogger(options?.logLevel ?? "off");
+
+    const data = parsePptxData(input);
+    setScriptFonts(data.theme.fontScheme.majorFontJpan, data.theme.fontScheme.minorFontJpan);
+
+    const targetSlides = options?.slides
+      ? data.slidePaths.filter((s) => options.slides!.includes(s.slideNumber))
+      : data.slidePaths;
+
+    if (data.slidePaths.length === 0) {
+      warn("presentation.noSlides", "No slides found in the PPTX file");
+    }
+
+    const results: SlideSvg[] = [];
+    for (const { slideNumber, path } of targetSlides) {
+      const parsed = parseSlideWithLayout(slideNumber, path, data);
+      if (!parsed) continue;
+
+      const { slide } = parsed;
+      slide.elements = buildEffectiveSlideElements(parsed);
+
+      fontUsageCollector?.reset();
+      let svg = renderSlideToSvg(slide, data.presInfo.slideSize);
+      if (fontUsageCollector && setup) {
+        const style = await buildFontFaceStyle(fontUsageCollector.getUsages(), setup.fontResolver);
+        if (style) {
+          svg = injectIntoSvgDefs(svg, style);
+        }
+      }
+      results.push({ slideNumber, svg });
+    }
+
+    flushWarnings();
+    return results;
+  } finally {
+    clearXmlCache();
+    resetTextMeasurer();
+    resetTextPathFontResolver();
+    resetFontUsageCollector();
+    resetFontMapping();
+    resetScriptFonts();
+  }
+}
+
+export async function convertPptxToPngViaParserPath(
+  input: Buffer | Uint8Array,
+  options?: ConvertOptions,
+): Promise<SlideImage[]> {
+  const svgResults = await convertPptxToSvgViaParserPath(input, { ...options, textOutput: "path" });
+  const width = options?.width ?? DEFAULT_OUTPUT_WIDTH;
+  const height = options?.height;
+  const fontBuffers = loadFontBuffers(options?.fontDirs, options?.skipSystemFonts);
+
+  const results: SlideImage[] = [];
+  for (const { slideNumber, svg } of svgResults) {
+    const pngResult = await svgToPng(svg, { width, height, fontBuffers });
+    results.push({
+      slideNumber,
+      png: pngResult.png,
+      width: pngResult.width,
+      height: pngResult.height,
+    });
+  }
+
+  return results;
+}
+
+export function buildEffectiveSlideElements(parsed: ParsedSlide): SlideElement[] {
+  const effectiveMasterElements =
+    parsed.slide.showMasterSp && parsed.layoutShowMasterSp ? parsed.masterElements : [];
+  return mergeElements(effectiveMasterElements, parsed.layoutElements, parsed.slide.elements);
+}
+
+function injectIntoSvgDefs(svg: string, content: string): string {
+  const openTagEnd = svg.indexOf(">");
+  if (openTagEnd === -1) return svg;
+  return `${svg.slice(0, openTagEnd + 1)}<defs>${content}</defs>${svg.slice(openTagEnd + 1)}`;
+}
+
+let cachedFontBuffers: Uint8Array[] | null = null;
+let cachedFontBuffersKey: string | null = null;
+
+const MAX_TOTAL_FONT_BUFFER_BYTES = 100 * 1024 * 1024;
+
+function loadFontBuffers(fontDirs?: string[], skipSystemFonts?: boolean): Uint8Array[] {
+  const key = `${(fontDirs ?? []).join("\0")}\n${skipSystemFonts ?? false}`;
+  if (cachedFontBuffers !== null && cachedFontBuffersKey === key) {
+    return cachedFontBuffers;
+  }
+
+  const allPaths = collectFontFilePaths(fontDirs, skipSystemFonts);
+  const ttfOtfPaths = allPaths.filter((p) => {
+    const lower = p.toLowerCase();
+    return lower.endsWith(".ttf") || lower.endsWith(".otf");
+  });
+
+  const pathsWithSize: { path: string; size: number }[] = [];
+  for (const p of ttfOtfPaths) {
+    try {
+      pathsWithSize.push({ path: p, size: statSync(p).size });
+    } catch {
+      // Ignore unreadable font files.
+    }
+  }
+  pathsWithSize.sort((a, b) => a.size - b.size);
+
+  const buffers: Uint8Array[] = [];
+  let totalSize = 0;
+  for (const { path, size } of pathsWithSize) {
+    if (totalSize + size > MAX_TOTAL_FONT_BUFFER_BYTES) break;
+    try {
+      buffers.push(new Uint8Array(readFileSync(path)));
+      totalSize += size;
+    } catch {
+      // Ignore fonts that disappear between stat and read.
+    }
+  }
+
+  cachedFontBuffers = buffers;
+  cachedFontBuffersKey = key;
+  return buffers;
+}
+
+function mergeElements(
+  masterElements: SlideElement[],
+  layoutElements: SlideElement[],
+  slideElements: SlideElement[],
+): SlideElement[] {
+  const filterTemplatePlaceholders = (elements: SlideElement[]) =>
+    elements.filter((el) => {
+      if (el.type !== "shape") return true;
+      return !el.placeholderType;
+    });
+
+  const filterEmptySlidePlaceholders = (elements: SlideElement[]) =>
+    elements.filter((el) => !(el.type === "shape" && isEmptyPlaceholder(el)));
+
+  const filteredMaster = filterTemplatePlaceholders(masterElements);
+  const filteredLayout = filterTemplatePlaceholders(layoutElements);
+  const filteredSlide = filterEmptySlidePlaceholders(slideElements);
+
+  return [...filteredMaster, ...filteredLayout, ...filteredSlide];
+}
+
+function isEmptyPlaceholder(shape: ShapeElement): boolean {
+  if (!shape.placeholderType) return false;
+  const paragraphs = shape.textBody?.paragraphs;
+  if (!paragraphs || paragraphs.length === 0) return true;
+  return !paragraphs.some((p) => p.runs.some((r) => r.text.length > 0));
+}

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-import { convertPptxToPngViaParserPath } from "../../packages/pptx-glimpse/src/converter.js";
 import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
+import { convertPptxToPngViaParserPath } from "../../packages/pptx-glimpse/src/parser-path-oracle.js";
 import { compareImageBuffers } from "../compare-utils.js";
 import {
   DOCUMENT_PATH_VRT_BLOCKER_ISSUES,

--- a/vrt/snapshot/document-path-zero-diff-gate.test.ts
+++ b/vrt/snapshot/document-path-zero-diff-gate.test.ts
@@ -2,8 +2,8 @@ import { existsSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
-import { convertPptxToPngViaParserPath } from "../../packages/pptx-glimpse/src/converter.js";
 import { convertPptxToPngViaDocumentPath } from "../../packages/pptx-glimpse/src/experimental-document-renderer.js";
+import { convertPptxToPngViaParserPath } from "../../packages/pptx-glimpse/src/parser-path-oracle.js";
 import { compareImageBuffers } from "../compare-utils.js";
 import {
   DOCUMENT_PATH_VRT_CASES,


### PR DESCRIPTION
close #485

## 概要
- public `convertPptxToSvg` / `convertPptxToPng` から旧 parser render orchestration を外し、旧 parser render は `parser-path-oracle.ts` に internal oracle として隔離
- `collectUsedFonts` を CleanDoc `readPptx` / `createComputedView` ベースへ移行し、theme font alias と multi-theme slide の bulletFont 解決を補強
- 旧 parser に残す責務、document/core/renderer の責務境界、後続 slice 候補を `docs/legacy-parser-semantics-audit.md` に記録
- parser oracle のグローバル renderer state を直列化し、effective element merge の単体テストを追加

## 受け入れ条件チェック
- ✓ 旧 parser 側で document path と重複している OOXML semantics を棚卸し
- ✓ document package に寄せる責務と core / renderer に残す責務を整理
- ✓ 不要になった parser orchestration を public converter から削除 / internal 化
- ✓ public conversion regression tests を含む全体テストを通過
- ✓ 残る重複の理由と後続対応を audit doc に明記

## 確認
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npx knip`
- `npm run test`
- `npm run build`
- cross-review: Codex review 実施、指摘対応済み