### PR TITLE
core package に @pptx-glimpse/document 依存を明示する

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -17,6 +17,13 @@ const config: KnipConfig = {
         "bench/conversion.bench.ts",
       ],
     },
+    "packages/pptx-glimpse": {
+      ignoreDependencies: [
+        // Core currently dogfoods document through workspace source imports.
+        // Keep the manifest dependency explicit until package imports migrate.
+        "@pptx-glimpse/document",
+      ],
+    },
   },
 };
 

--- a/packages/pptx-glimpse/package.json
+++ b/packages/pptx-glimpse/package.json
@@ -25,6 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@pptx-glimpse/document": "workspace:*",
     "fast-xml-parser": "^5.7.3",
     "fflate": "^0.8.2",
     "pptx-glimpse-renderer": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
 
   packages/pptx-glimpse:
     dependencies:
+      '@pptx-glimpse/document':
+        specifier: workspace:*
+        version: link:../pptx-glimpse-document
       fast-xml-parser:
         specifier: ^5.7.3
         version: 5.8.0


### PR DESCRIPTION
close #510

## 目的

`packages/pptx-glimpse` が CleanDoc document path を利用している実態に合わせて、`@pptx-glimpse/document` への workspace 依存を package manifest と lockfile に明示します。

## 変更内容

- `packages/pptx-glimpse/package.json` の dependencies に `@pptx-glimpse/document: workspace:*` を追加
- `pnpm-lock.yaml` の `packages/pptx-glimpse` importer に `@pptx-glimpse/document` の workspace link を追加
- 現時点では document package を相対 source import しているため、`knip.config.ts` に `packages/pptx-glimpse` 限定の依存例外を追加

## 影響範囲

- `packages/pptx-glimpse/package.json`
- `pnpm-lock.yaml`
- `knip.config.ts`

## 検証

- `pnpm knip`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm --filter pptx-glimpse-skeleton build`
- `pnpm test`

`pnpm --filter pptx-glimpse-skeleton build` では既存の `import.meta` / CJS 警告が出ますが、build 自体は成功しています。
