### PR TITLE
古い issue 参照と移行前提の記述を整理する

### DIFF
--- a/docs/cleandoc-minimal-poc-scope.md
+++ b/docs/cleandoc-minimal-poc-scope.md
@@ -15,6 +15,12 @@ Issue #453 is the PoC-scope child decision for the broader CleanDoc RFC in
 [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445), so this note
 ends with a #445-ready conclusion.
 
+> Current-state note, 2026-06-27: this is a historical PoC-scope decision. The
+> public conversion default switch tracked by
+> [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481) is complete,
+> and parser comparisons now refer to the explicit internal parser oracle rather
+> than the public default conversion path.
+
 The PoC is not a full PPTX implementation. It is the smallest slice that can
 prove the intended architecture end to end:
 
@@ -271,9 +277,10 @@ Not expected:
 - Safe edits to partially supported rich text constructs beyond plain run text.
 - Byte-level preservation of the edited XML part.
 
-## Follow-up Implementation Issues
+## Historical Follow-up Implementation Issues
 
-After this PoC scope is accepted, split implementation into issues similar to:
+After this PoC scope was accepted, implementation was split into issues similar
+to:
 
 1. Add `@pptx-glimpse/document` workspace package skeleton, public experimental
    entry points, package-boundary tests, and build wiring.
@@ -299,7 +306,7 @@ After this PoC scope is accepted, split implementation into issues similar to:
    for invalidated raw sidecars.
 10. Add end-to-end no-edit and one-text-edit round-trip tests.
 11. Add an internal or experimental core render path that can render selected
-    fixtures through `@pptx-glimpse/document` without changing the public default.
+    fixtures through `@pptx-glimpse/document` before changing the public default.
 12. Expand fixture coverage and opt selected VRT/shared fixtures into the
     document path only after structural parity is stable.
 

--- a/docs/cleandoc-source-computed-view.md
+++ b/docs/cleandoc-source-computed-view.md
@@ -18,9 +18,10 @@ editing surface.
 
 The related core dogfood migration decision is recorded in
 [core-document-dogfood-migration.md](./core-document-dogfood-migration.md). In
-short, the public SVG/PNG conversion path should migrate through a computed view
-and a core-owned adapter while keeping the current parser in parallel until
-rendering parity is proven.
+short, the public SVG/PNG conversion path now routes through a computed view and
+a core-owned adapter after the [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481)
+default switch. The old parser remains only as an explicit internal parity
+oracle and targeted fallback source.
 
 ## Decision
 
@@ -229,10 +230,10 @@ Migration direction:
 6. Only after that, simplify or replace renderer model fields that duplicate
    computed view fields.
 
-## Current Implementation Mapping
+## Historical Implementation Mapping Before #481
 
-Current code already contains several computed-view behaviors, but they are
-spread across parser and core conversion code:
+Before the CleanDoc default switch, parser/core code already contained several
+computed-view behaviors:
 
 - `parseSlideWithLayout` resolves slide -> layout -> master chains.
 - `ColorResolver` resolves `schemeClr` through `clrMap` and `colorScheme`.
@@ -243,9 +244,10 @@ spread across parser and core conversion code:
 - `converter.ts` merges master, layout, and slide elements for rendering and
   filters template placeholders.
 
-Under the two-layer design, these behaviors should move behind explicit
-computed-view generation APIs. The current path can remain for compatibility
-until the CleanDoc reader and adapter exist.
+Under the two-layer design, these behaviors moved behind explicit computed-view
+generation APIs for public conversion. Any remaining old-parser overlap is
+scoped to the parser oracle or renderer-specific adapter fallbacks rather than
+the public default path.
 
 ## Schema Normalization Scope
 

--- a/docs/core-document-dogfood-migration.md
+++ b/docs/core-document-dogfood-migration.md
@@ -16,9 +16,20 @@ raw OOXML round-trip policy in
 The target keeps the standalone `pptx-glimpse` conversion API intact while
 moving reusable OOXML reading semantics into `@pptx-glimpse/document`.
 
-## Current Core Flow
+> Current-state note, 2026-06-27: the migration tracked by
+> [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481) is complete.
+> Public `convertPptxToSvg` / `convertPptxToPng` now default to the CleanDoc
+> document path. This note remains a historical RFC for the migration plan and
+> should be read together with
+> [legacy-parser-semantics-audit.md](./legacy-parser-semantics-audit.md), which
+> records the post-switch owner split. The package-boundary cleanup follow-ups
+> [#510](https://github.com/hirokisakabe/pptx-glimpse/issues/510) and
+> [#511](https://github.com/hirokisakabe/pptx-glimpse/issues/511) are also
+> closed.
 
-The current public conversion API is orchestrated by
+## Historical Core Flow Before #481
+
+At the time of this RFC, the public conversion API was orchestrated by
 `packages/core/src/converter.ts`:
 
 ```text
@@ -32,12 +43,12 @@ PPTX Buffer | Uint8Array
 ```
 
 `parsePptxData` and `parseSlideWithLayout` were the effective core reader before
-the CleanDoc default path. They unzip the package, parse XML, collect
+the CleanDoc default switch. They unzip the package, parse XML, collect
 relationships/theme data, and produce the renderer model consumed by
 `@pptx-glimpse/renderer`.
 
-The current path already contains computed-view behavior, but it is implicit and
-spread across parser and converter code:
+That parser path already contained computed-view behavior, but it was implicit
+and spread across parser and converter code:
 
 - `parseSlideWithLayout` resolves slide, layout, and master package chains.
 - Theme colors are resolved through theme color schemes and effective color
@@ -51,9 +62,29 @@ spread across parser and converter code:
 - `convertPptxToPng` reuses `convertPptxToSvg` and then calls the PNG renderer,
   forcing path text output for resvg compatibility.
 
-This means the current parser is already a parser plus computed render-view
-builder. It is useful for rendering, but it is not the right canonical document
-source model for writer/editor/round-trip work.
+This meant the parser was already a parser plus computed render-view builder. It
+was useful for rendering, but it was not the right canonical document source
+model for writer/editor/round-trip work.
+
+## Current State After #481
+
+The public conversion path is now:
+
+```text
+PPTX Buffer | Uint8Array
+  -> @pptx-glimpse/document readPptx(input)
+  -> CleanDoc source model
+  -> createComputedView(source, options)
+  -> core-owned CleanDoc renderer adapter
+  -> existing @pptx-glimpse/renderer model
+  -> renderSlideToSvg(slide, slideSize)
+  -> svgToPng(svg, options) for PNG output
+```
+
+The old parser path remains only as an explicit internal oracle for parity
+checks and adapter fallbacks documented in
+[legacy-parser-semantics-audit.md](./legacy-parser-semantics-audit.md). It is
+not the public default.
 
 ## Target Flow Through `document`
 
@@ -85,19 +116,21 @@ The ownership boundary should be:
 pom. Core depends on `document`; the renderer consumes the adapter output and
 does not need to know CleanDoc directly.
 
-## Initial Parallel Reader Period
+## Historical Parallel Reader Period
 
-Adopt a parallel period instead of replacing the existing parser in one step.
+This section records the temporary parallel reader period that #481 has now
+completed. It remains useful as historical context for why parser-path oracle
+tests still exist.
 
-The first `document` reader should be introduced behind internal or experimental
-paths and compared against the current parser. The public default
-`convertPptxToSvg` / `convertPptxToPng` path should continue to use the current
-parser until the CleanDoc reader, computed view, and adapter reach rendering
-parity for the supported fixture set.
+The first `document` reader was introduced behind internal or experimental
+paths and compared against the then-current parser path. During that historical
+parallel period, the public `convertPptxToSvg` / `convertPptxToPng` default
+stayed on the parser path until the CleanDoc reader, computed view, and adapter
+reached rendering parity for the supported fixture set.
 
 Recommended sequence during the parallel period:
 
-1. Keep the current parser as the production render path.
+1. Keep the then-current parser as the production render path.
 2. Add `@pptx-glimpse/document` source types and `readPptx(input)` for a small
    but real subset of slides.
 3. Add computed view generation for slide size, slide order, relationships,
@@ -110,10 +143,10 @@ Recommended sequence during the parallel period:
 7. Only after parity is stable, make the document path the default public
    conversion path.
 
-Parallel reading is temporary dogfood scaffolding, not a permanent dual-source
-architecture. Once the document path becomes the default, parser semantics that
-are not renderer-specific should move into `@pptx-glimpse/document`; renderer
-fallbacks and visual diagnostics should stay outside it.
+Parallel reading was temporary dogfood scaffolding, not a permanent dual-source
+architecture. Now that the document path is the default, parser semantics that
+are not renderer-specific should continue to move into `@pptx-glimpse/document`;
+renderer fallbacks and visual diagnostics should stay outside it.
 
 ## Adapter Policy
 
@@ -209,18 +242,18 @@ It also does not require:
 
 ## Conclusion for #445
 
-The conclusion to reflect in #445 is:
+The historical conclusion to reflect in #445 was:
 
 `pptx-glimpse` core should dogfood `@pptx-glimpse/document` by routing the public
 SVG/PNG conversion path through CleanDoc source reading, computed document view
 generation, and a core-owned adapter into the existing renderer model.
 
-The migration should use a temporary parallel reader period. The current parser
-remains the production render path while `document` reader coverage, computed
-view behavior, and adapter parity are proven by unit tests, dual-reader tests,
-package verification, and VRT. After parity is stable, the document path becomes
-the default and reusable OOXML semantics move out of the current parser into
-`@pptx-glimpse/document`.
+That migration used a temporary parallel reader period. The old parser served as
+the production render path while `document` reader coverage, computed-view
+behavior, and adapter parity were proven by unit tests, dual-reader tests,
+package verification, and VRT. After parity stabilized, #481 switched the public
+default to the document path, and reusable OOXML semantics now continue to move
+out of the old parser into `@pptx-glimpse/document`.
 
 The existing renderer model remains a render-specific adapter target during the
 migration. CleanDoc is the canonical source model, computed view resolves

--- a/docs/document-boundaries.md
+++ b/docs/document-boundaries.md
@@ -165,8 +165,11 @@ OOXML package
 This lets `document` preserve enough structure for writer/editor/round-trip
 work, while `renderer` keeps a purpose-built shape for visual output.
 
-Short term, the current parser-to-renderer path can continue to exist. The
-migration path is:
+Historical migration note: the short-term parser-to-renderer public path has
+been replaced by the CleanDoc document path as part of
+[#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481). The old parser
+path remains only as an explicit internal oracle for parity checks and targeted
+adapter fallbacks. The migration path was:
 
 1. Introduce CleanDoc types in `@pptx-glimpse/document`.
 2. Add a reader path that builds CleanDoc from OOXML.

--- a/docs/legacy-parser-semantics-audit.md
+++ b/docs/legacy-parser-semantics-audit.md
@@ -11,6 +11,12 @@ supersedes the earlier "current state" and parallel-reader descriptions in the
 dogfood migration note where those descriptions still mention public conversion
 flowing through the old parser.
 
+This is the current-state companion to the historical migration plan. The
+default switch tracked by [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481)
+is complete, and the package-boundary cleanup follow-ups
+[#510](https://github.com/hirokisakabe/pptx-glimpse/issues/510) and
+[#511](https://github.com/hirokisakabe/pptx-glimpse/issues/511) are closed.
+
 ## Current owner split
 
 The public conversion path is now:
@@ -34,29 +40,29 @@ an internal oracle for parity checks.
 These reusable OOXML semantics are now owned by `@pptx-glimpse/document` source
 or computed view code:
 
-| Semantics | Document owner | Previous parser overlap removed or reduced |
-| --- | --- | --- |
-| Package graph, slide order, relationships, media payloads | `reader/read-pptx.ts`, source package graph, computed relationships | Public conversion no longer calls `parsePptxData` for package traversal |
-| Slide/layout/master chain resolution | `createComputedView` | Public conversion no longer calls `parseSlideWithLayout` for cascade assembly |
-| Background fallback | `createComputedView` | Public conversion uses computed `background` instead of parser-side fallback |
-| Theme color and color map resolution | source theme data + computed color resolution | Public conversion uses computed colors through the adapter |
-| Placeholder filtering and effective element ordering | `createComputedView` | Core converter no longer owns parser-path `mergeElements` |
-| Text style cascade for rendering/inspection | `createComputedView` | `collectUsedFonts` now reads CleanDoc/computed text instead of parser slides |
-| Theme font source data for rendering/inspection | source theme data + core runtime helpers | `collectUsedFonts` and rendering setup no longer depend on parser slide assembly |
-| Table/chart/image relationship resolution for rendering | `createComputedView` + adapter | Parser path remains only as comparison oracle |
+| Semantics                                                 | Document owner                                                      | Previous parser overlap removed or reduced                                       |
+| --------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Package graph, slide order, relationships, media payloads | `reader/read-pptx.ts`, source package graph, computed relationships | Public conversion no longer calls `parsePptxData` for package traversal          |
+| Slide/layout/master chain resolution                      | `createComputedView`                                                | Public conversion no longer calls `parseSlideWithLayout` for cascade assembly    |
+| Background fallback                                       | `createComputedView`                                                | Public conversion uses computed `background` instead of parser-side fallback     |
+| Theme color and color map resolution                      | source theme data + computed color resolution                       | Public conversion uses computed colors through the adapter                       |
+| Placeholder filtering and effective element ordering      | `createComputedView`                                                | Core converter no longer owns parser-path `mergeElements`                        |
+| Text style cascade for rendering/inspection               | `createComputedView`                                                | `collectUsedFonts` now reads CleanDoc/computed text instead of parser slides     |
+| Theme font source data for rendering/inspection           | source theme data + core runtime helpers                            | `collectUsedFonts` and rendering setup no longer depend on parser slide assembly |
+| Table/chart/image relationship resolution for rendering   | `createComputedView` + adapter                                      | Parser path remains only as comparison oracle                                    |
 
 ## Responsibilities left outside `document`
 
 These remain in core or renderer by design:
 
-| Responsibility | Owner | Reason |
-| --- | --- | --- |
-| Public API options | `packages/core/src/converter.ts`, `packages/core/src/index.ts` | Stable API compatibility remains a core package concern |
-| Warning setup, font setup, SVG text-output mode, PNG sizing | `packages/core/src/experimental-document-renderer.ts` | Renderer environment setup and runtime conversion options are core concerns |
-| CleanDoc computed view to renderer model mapping | `packages/core/src/cleandoc-renderer-adapter.ts` | The renderer model is a display-oriented compatibility target, not the CleanDoc source model |
-| Chart XML to renderer chart model mapping | Adapter calling parser `parseChart` | Chart rendering model is still renderer-specific; move only after a chart source/computed contract exists |
-| SmartArt drawing XML fallback to renderer shape tree | Adapter calling parser `parseShapeTree` | This is a rendering fallback for resolved diagram drawing XML, not canonical document semantics yet |
-| Font discovery, font mapping, text measurement, text-to-path, SVG/PNG output | `@pptx-glimpse/renderer` | Renderer-specific behavior per `document-boundaries.md` |
+| Responsibility                                                               | Owner                                                          | Reason                                                                                                    |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Public API options                                                           | `packages/core/src/converter.ts`, `packages/core/src/index.ts` | Stable API compatibility remains a core package concern                                                   |
+| Warning setup, font setup, SVG text-output mode, PNG sizing                  | `packages/core/src/experimental-document-renderer.ts`          | Renderer environment setup and runtime conversion options are core concerns                               |
+| CleanDoc computed view to renderer model mapping                             | `packages/core/src/cleandoc-renderer-adapter.ts`               | The renderer model is a display-oriented compatibility target, not the CleanDoc source model              |
+| Chart XML to renderer chart model mapping                                    | Adapter calling parser `parseChart`                            | Chart rendering model is still renderer-specific; move only after a chart source/computed contract exists |
+| SmartArt drawing XML fallback to renderer shape tree                         | Adapter calling parser `parseShapeTree`                        | This is a rendering fallback for resolved diagram drawing XML, not canonical document semantics yet       |
+| Font discovery, font mapping, text measurement, text-to-path, SVG/PNG output | `@pptx-glimpse/renderer`                                       | Renderer-specific behavior per `document-boundaries.md`                                                   |
 
 ## Remaining legacy parser uses
 

--- a/docs/raw-ooxml-round-trip.md
+++ b/docs/raw-ooxml-round-trip.md
@@ -12,9 +12,10 @@ layering decision in
 
 The related core dogfood migration decision is recorded in
 [core-document-dogfood-migration.md](./core-document-dogfood-migration.md). In
-short, public SVG/PNG conversion should eventually route through CleanDoc source
-reading, computed view generation, and a core-owned adapter into the existing
-renderer model.
+short, public SVG/PNG conversion now routes through CleanDoc source reading,
+computed view generation, and a core-owned adapter into the existing renderer
+model after the [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481)
+default switch.
 
 The goal is to make `@pptx-glimpse/document` reliable for existing PPTX files
 without turning CleanDoc into a byte-level OOXML editor. CleanDoc should expose a

--- a/shared-fixtures/README.md
+++ b/shared-fixtures/README.md
@@ -6,11 +6,11 @@
 
 このディレクトリのファイルは複数のテストスイートから共有される:
 
-| テスト | ファイル | 目的 |
-|---|---|---|
-| E2E スモークテスト | `e2e/smoke.test.ts` | エラーなく変換できること・主要要素の SVG 出力確認 |
-| スナップショット VRT | `vrt/snapshot/regression.test.ts` | レンダリング結果のリグレッション検出 |
-| document path parity VRT | `vrt/snapshot/document-path-regression.test.ts` | current parser path と experimental document path の PNG 差分追跡 |
+| テスト                   | ファイル                                        | 目的                                                                             |
+| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------------- |
+| E2E スモークテスト       | `e2e/smoke.test.ts`                             | エラーなく変換できること・主要要素の SVG 出力確認                                |
+| スナップショット VRT     | `vrt/snapshot/regression.test.ts`               | レンダリング結果のリグレッション検出                                             |
+| document path parity VRT | `vrt/snapshot/document-path-regression.test.ts` | CleanDoc document path と parser path oracle の zero-diff / zero-diagnostic 確認 |
 
 ## プログラム合成フィクスチャとの違い
 
@@ -25,13 +25,13 @@
 
 ## ファイル一覧
 
-| ファイル | 作成元 | スライド数 | 主な内容 |
-|---|---|---|---|
-| `real-basic-theme.pptx` | Google Slides | 2 | タイトル・コンテンツ・テーブル・画像・テーマフォント参照 |
-| `real-product-page.pptx` | 手作成 | 1 | 角丸矩形・楕円・テキストボックス |
-| `real-financial-report.pptx` | 手作成 | 4 | チャート（棒グラフ・円グラフ等）・テキスト |
-| `sample.pptx` | md-pptx 生成 | 6 | 日本語テキスト・箇条書き・テキスト装飾 |
-| `sample-issue-387.pptx` | 手作成 | 1 | インラインテキスト装飾（太字・斜体・太字斜体） |
+| ファイル                     | 作成元        | スライド数 | 主な内容                                                 |
+| ---------------------------- | ------------- | ---------- | -------------------------------------------------------- |
+| `real-basic-theme.pptx`      | Google Slides | 2          | タイトル・コンテンツ・テーブル・画像・テーマフォント参照 |
+| `real-product-page.pptx`     | 手作成        | 1          | 角丸矩形・楕円・テキストボックス                         |
+| `real-financial-report.pptx` | 手作成        | 4          | チャート（棒グラフ・円グラフ等）・テキスト               |
+| `sample.pptx`                | md-pptx 生成  | 6          | 日本語テキスト・箇条書き・テキスト装飾                   |
+| `sample-issue-387.pptx`      | 手作成        | 1          | インラインテキスト装飾（太字・斜体・太字斜体）           |
 
 ## ファイルを追加する場合
 
@@ -39,7 +39,7 @@
 2. `e2e/smoke.test.ts` にスモークテストを追加する
 3. `vrt/snapshot/vrt-cases.ts` の `SHARED_FIXTURE_CASES` にエントリを追加する
 4. `npm run vrt:snapshot:update` でスナップショットを生成する
-5. document path parity VRT では、`vrt/snapshot/document-path-cases.ts` の opt-in または excluded のどちらかに分類する。opt-in する場合は `slides` / `tolerance` / `reason` / `expectedDiagnosticCodes` を設定する
+5. document path parity VRT では、`vrt/snapshot/document-path-cases.ts` の `DOCUMENT_PATH_VRT_SHARED_CASES` に同じ fixture を追加し、zero tolerance で parser path oracle と比較される状態にする
 
 ファイルサイズはリポジトリサイズへの影響を抑えるため **1ファイルあたり 500KB 以下** を目安とする。
 ライセンス上問題のない PPTX のみ追加すること（自作または OSSテンプレート）。

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -14,16 +14,11 @@ export const DOCUMENT_PATH_VRT_SNAPSHOT_POLICY =
 
 export type DocumentPathVrtFixtureGroup = "shared" | "generated";
 
-type DocumentPathVrtDiagnosticCode =
-  | "cleandoc-adapter.raw-element-skipped"
-  | "cleandoc-adapter.raw-fill-ignored";
-
 interface DocumentPathVrtCase {
   readonly group: DocumentPathVrtFixtureGroup;
   readonly name: string;
   readonly fixture: string;
   readonly mismatchTolerance: number;
-  readonly expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[];
 }
 
 export const DOCUMENT_PATH_VRT_SHARED_CASES = [
@@ -90,32 +85,20 @@ export const DOCUMENT_PATH_VRT_CASES = [
   ...DOCUMENT_PATH_VRT_GENERATED_CASES,
 ] as const satisfies readonly DocumentPathVrtCase[];
 
-function shared(
-  name: string,
-  fixture: string,
-  mismatchTolerance: number,
-  expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[] = [],
-): DocumentPathVrtCase {
+function shared(name: string, fixture: string, mismatchTolerance: number): DocumentPathVrtCase {
   return {
     group: "shared",
     name,
     fixture,
     mismatchTolerance,
-    expectedDiagnosticCodes,
   };
 }
 
-function generated(
-  name: string,
-  fixture: string,
-  mismatchTolerance: number,
-  expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[] = [],
-): DocumentPathVrtCase {
+function generated(name: string, fixture: string, mismatchTolerance: number): DocumentPathVrtCase {
   return {
     group: "generated",
     name,
     fixture,
     mismatchTolerance,
-    expectedDiagnosticCodes,
   };
 }

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -2,22 +2,15 @@
  * Document path VRT は public snapshot を更新せず、明示的な parser path の PNG を
  * 参照画像としてその場で比較する full parity harness。
  *
- * mismatchTolerance は #489 時点の実測 gap を blocker issue 単位で固定した上限。
- * blocker 解消 PR では対象ケースを再測定し、可能なら 0 まで締める。
+ * CleanDoc default switch 後も parser path oracle との zero-diff gate として残す。
+ * 以前の migration blocker issue はすべて解消済みなので、ケースごとの issue 番号は
+ * ここでは保持しない。
  */
 
 export const DOCUMENT_PATH_VRT_RENDER_WIDTH = 320;
 
 export const DOCUMENT_PATH_VRT_SNAPSHOT_POLICY =
   "No committed snapshot update is required: document path VRT compares against the explicit parser path oracle in-memory.";
-
-export const DOCUMENT_PATH_VRT_BLOCKER_ISSUES = {
-  tables: 491,
-  chartsAndSmartArt: 492,
-  shapeTreeAndGeometry: 493,
-  fillsAndBackgrounds: 494,
-  textAndFonts: 496,
-} as const;
 
 export type DocumentPathVrtFixtureGroup = "shared" | "generated";
 
@@ -30,108 +23,66 @@ interface DocumentPathVrtCase {
   readonly name: string;
   readonly fixture: string;
   readonly mismatchTolerance: number;
-  readonly blockerIssues: readonly number[];
   readonly expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[];
 }
 
-const B = DOCUMENT_PATH_VRT_BLOCKER_ISSUES;
-
 export const DOCUMENT_PATH_VRT_SHARED_CASES = [
-  shared("real-basic-theme", "real-basic-theme.pptx", 0, []),
-  shared("real-product-page", "real-product-page.pptx", 0, []),
-  shared("real-financial-report", "real-financial-report.pptx", 0, [
-    B.tables,
-    B.shapeTreeAndGeometry,
-  ]),
-  shared("sample", "sample.pptx", 0, []),
-  shared("sample-issue-387", "sample-issue-387.pptx", 0, []),
+  shared("real-basic-theme", "real-basic-theme.pptx", 0),
+  shared("real-product-page", "real-product-page.pptx", 0),
+  shared("real-financial-report", "real-financial-report.pptx", 0),
+  shared("sample", "sample.pptx", 0),
+  shared("sample-issue-387", "sample-issue-387.pptx", 0),
 ] as const satisfies readonly DocumentPathVrtCase[];
 
 export const DOCUMENT_PATH_VRT_GENERATED_CASES = [
-  generated("shapes", "shapes.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("fill-and-lines", "fill-and-lines.pptx", 0, [], []),
-  generated("text", "text.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("transform", "transform.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("background", "background.pptx", 0, [], []),
-  generated("groups", "groups.pptx", 0, []),
-  generated("charts", "charts.pptx", 0, [], []),
-  generated("connectors", "connectors.pptx", 0, []),
-  generated("custom-geometry", "custom-geometry.pptx", 0, []),
-  generated("image", "image.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("tables", "tables.pptx", 0, [], []),
-  generated("bullets", "bullets.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("flowchart", "flowchart.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("callouts-arcs", "callouts-arcs.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("arrows-stars", "arrows-stars.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("math-other", "math-other.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("word-wrap", "word-wrap.pptx", 0, [B.shapeTreeAndGeometry]),
-  generated("background-blipfill", "background-blipfill.pptx", 0, [], []),
-  generated("composite", "composite.pptx", 0, [], []),
-  generated("text-decoration", "text-decoration.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("slide-size-4-3", "slide-size-4-3.pptx", 0, [], []),
-  generated("effects", "effects.pptx", 0, [], []),
-  generated("hyperlinks", "hyperlinks.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("pattern-image-fill", "pattern-image-fill.pptx", 0, [], []),
-  generated("smartart", "smartart.pptx", 0, [], []),
-  generated("theme-fonts", "theme-fonts.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated(
-    "text-style-inheritance",
-    "text-style-inheritance.pptx",
-    0,
-    [B.shapeTreeAndGeometry],
-    [],
-  ),
-  generated("z-order-mixed", "z-order-mixed.pptx", 0, []),
-  generated("paragraph-spacing", "paragraph-spacing.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("placeholder-overlap", "placeholder-overlap.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("image-crop", "image-crop.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("text-advanced", "text-advanced.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("shrink-to-fit", "shrink-to-fit.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("sp-autofit", "sp-autofit.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("style-reference", "style-reference.pptx", 0, [], []),
-  generated("blip-effects", "blip-effects.pptx", 0, [], []),
-  generated("image-stretch-tile", "image-stretch-tile.pptx", 0, [], []),
-  generated("vertical-text", "vertical-text.pptx", 0, [B.shapeTreeAndGeometry]),
-  generated(
-    "shape-hyperlink-text-outline",
-    "shape-hyperlink-text-outline.pptx",
-    0,
-    [B.shapeTreeAndGeometry],
-    [],
-  ),
-  generated("charts-3d-fallback", "charts-3d-fallback.pptx", 0, [], []),
-  generated("color-transforms", "color-transforms.pptx", 0, [B.shapeTreeAndGeometry], []),
-  generated("table-complex-merge", "table-complex-merge.pptx", 0, [], []),
-  generated("multi-lang-font", "multi-lang-font.pptx", 0, [B.shapeTreeAndGeometry]),
-  generated(
-    "placeholder-inheritance-extended",
-    "placeholder-inheritance-extended.pptx",
-    0,
-    [B.shapeTreeAndGeometry],
-    [],
-  ),
-  generated("table-style-border", "table-style-border.pptx", 0, [], []),
-  generated(
-    "placeholder-geometry-inheritance",
-    "placeholder-geometry-inheritance.pptx",
-    0,
-    [B.shapeTreeAndGeometry],
-    [],
-  ),
-  generated(
-    "placeholder-empty-on-slide",
-    "placeholder-empty-on-slide.pptx",
-    0,
-    [B.shapeTreeAndGeometry],
-    [],
-  ),
-  generated(
-    "interleaved-bullet-ppr",
-    "interleaved-bullet-ppr.pptx",
-    0,
-    [B.shapeTreeAndGeometry],
-    [],
-  ),
+  generated("shapes", "shapes.pptx", 0),
+  generated("fill-and-lines", "fill-and-lines.pptx", 0),
+  generated("text", "text.pptx", 0),
+  generated("transform", "transform.pptx", 0),
+  generated("background", "background.pptx", 0),
+  generated("groups", "groups.pptx", 0),
+  generated("charts", "charts.pptx", 0),
+  generated("connectors", "connectors.pptx", 0),
+  generated("custom-geometry", "custom-geometry.pptx", 0),
+  generated("image", "image.pptx", 0),
+  generated("tables", "tables.pptx", 0),
+  generated("bullets", "bullets.pptx", 0),
+  generated("flowchart", "flowchart.pptx", 0),
+  generated("callouts-arcs", "callouts-arcs.pptx", 0),
+  generated("arrows-stars", "arrows-stars.pptx", 0),
+  generated("math-other", "math-other.pptx", 0),
+  generated("word-wrap", "word-wrap.pptx", 0),
+  generated("background-blipfill", "background-blipfill.pptx", 0),
+  generated("composite", "composite.pptx", 0),
+  generated("text-decoration", "text-decoration.pptx", 0),
+  generated("slide-size-4-3", "slide-size-4-3.pptx", 0),
+  generated("effects", "effects.pptx", 0),
+  generated("hyperlinks", "hyperlinks.pptx", 0),
+  generated("pattern-image-fill", "pattern-image-fill.pptx", 0),
+  generated("smartart", "smartart.pptx", 0),
+  generated("theme-fonts", "theme-fonts.pptx", 0),
+  generated("text-style-inheritance", "text-style-inheritance.pptx", 0),
+  generated("z-order-mixed", "z-order-mixed.pptx", 0),
+  generated("paragraph-spacing", "paragraph-spacing.pptx", 0),
+  generated("placeholder-overlap", "placeholder-overlap.pptx", 0),
+  generated("image-crop", "image-crop.pptx", 0),
+  generated("text-advanced", "text-advanced.pptx", 0),
+  generated("shrink-to-fit", "shrink-to-fit.pptx", 0),
+  generated("sp-autofit", "sp-autofit.pptx", 0),
+  generated("style-reference", "style-reference.pptx", 0),
+  generated("blip-effects", "blip-effects.pptx", 0),
+  generated("image-stretch-tile", "image-stretch-tile.pptx", 0),
+  generated("vertical-text", "vertical-text.pptx", 0),
+  generated("shape-hyperlink-text-outline", "shape-hyperlink-text-outline.pptx", 0),
+  generated("charts-3d-fallback", "charts-3d-fallback.pptx", 0),
+  generated("color-transforms", "color-transforms.pptx", 0),
+  generated("table-complex-merge", "table-complex-merge.pptx", 0),
+  generated("multi-lang-font", "multi-lang-font.pptx", 0),
+  generated("placeholder-inheritance-extended", "placeholder-inheritance-extended.pptx", 0),
+  generated("table-style-border", "table-style-border.pptx", 0),
+  generated("placeholder-geometry-inheritance", "placeholder-geometry-inheritance.pptx", 0),
+  generated("placeholder-empty-on-slide", "placeholder-empty-on-slide.pptx", 0),
+  generated("interleaved-bullet-ppr", "interleaved-bullet-ppr.pptx", 0),
 ] as const satisfies readonly DocumentPathVrtCase[];
 
 export const DOCUMENT_PATH_VRT_CASES = [
@@ -143,7 +94,6 @@ function shared(
   name: string,
   fixture: string,
   mismatchTolerance: number,
-  blockerIssues: readonly number[],
   expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[] = [],
 ): DocumentPathVrtCase {
   return {
@@ -151,7 +101,6 @@ function shared(
     name,
     fixture,
     mismatchTolerance,
-    blockerIssues,
     expectedDiagnosticCodes,
   };
 }
@@ -160,7 +109,6 @@ function generated(
   name: string,
   fixture: string,
   mismatchTolerance: number,
-  blockerIssues: readonly number[],
   expectedDiagnosticCodes: readonly DocumentPathVrtDiagnosticCode[] = [],
 ): DocumentPathVrtCase {
   return {
@@ -168,7 +116,6 @@ function generated(
     name,
     fixture,
     mismatchTolerance,
-    blockerIssues,
     expectedDiagnosticCodes,
   };
 }

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -6,7 +6,6 @@ import { convertPptxToPngViaDocumentPath } from "../../packages/core/src/experim
 import { convertPptxToPngViaParserPath } from "../../packages/core/src/parser-path-oracle.js";
 import { compareImageBuffers } from "../compare-utils.js";
 import {
-  DOCUMENT_PATH_VRT_BLOCKER_ISSUES,
   DOCUMENT_PATH_VRT_CASES,
   DOCUMENT_PATH_VRT_GENERATED_CASES,
   DOCUMENT_PATH_VRT_RENDER_WIDTH,
@@ -45,21 +44,11 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
     );
   });
 
-  it("keeps every non-zero or diagnostic-emitting gap linked to a blocker issue", () => {
-    const blockerIssueNumbers = new Set(Object.values(DOCUMENT_PATH_VRT_BLOCKER_ISSUES));
-
+  it("keeps document-path parity cases at zero visual tolerance", () => {
     for (const testCase of DOCUMENT_PATH_VRT_CASES) {
-      for (const issue of testCase.blockerIssues) {
-        expect(blockerIssueNumbers.has(issue), `${testCase.name}: unknown blocker #${issue}`).toBe(
-          true,
-        );
-      }
-      if (testCase.mismatchTolerance > 0 || testCase.expectedDiagnosticCodes.length > 0) {
-        expect(
-          testCase.blockerIssues.length,
-          `${testCase.name}: expected blocker issue for residual gap`,
-        ).toBeGreaterThan(0);
-      }
+      expect(testCase.mismatchTolerance, `${testCase.name}: expected zero visual tolerance`).toBe(
+        0,
+      );
     }
   });
 
@@ -121,7 +110,7 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
             `[document-path-vrt] ${testCase.name} slide${documentResult.slideNumber}: ` +
               `${(comparison.mismatchPercentage * 100).toFixed(3)}% ` +
               `(tolerance ${(testCase.mismatchTolerance * 100).toFixed(1)}%)` +
-              blockerSuffix(testCase.blockerIssues),
+              diagnosticSuffix(testCase.expectedDiagnosticCodes),
           );
 
           expect(
@@ -129,8 +118,7 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
             `${testCase.name} slide ${documentResult.slideNumber}: ` +
               `${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ ` +
               `(${comparison.mismatchedPixels}/${comparison.totalPixels}). ` +
-              `Tolerance: ${testCase.mismatchTolerance * 100}%. ` +
-              `Blockers: ${formatBlockers(testCase.blockerIssues)}`,
+              `Tolerance: ${testCase.mismatchTolerance * 100}%.`,
           ).toBe(true);
         }
       });
@@ -146,11 +134,7 @@ function fixtureDir(group: DocumentPathVrtFixtureGroup): string {
   return group === "shared" ? SHARED_FIXTURE_DIR : GENERATED_FIXTURE_DIR;
 }
 
-function blockerSuffix(blockerIssues: readonly number[]): string {
-  if (blockerIssues.length === 0) return "";
-  return `; blockers ${formatBlockers(blockerIssues)}`;
-}
-
-function formatBlockers(blockerIssues: readonly number[]): string {
-  return blockerIssues.length === 0 ? "none" : blockerIssues.map((issue) => `#${issue}`).join(", ");
+function diagnosticSuffix(expectedDiagnosticCodes: readonly string[]): string {
+  if (expectedDiagnosticCodes.length === 0) return "";
+  return `; diagnostics ${expectedDiagnosticCodes.join(", ")}`;
 }

--- a/vrt/snapshot/document-path-regression.test.ts
+++ b/vrt/snapshot/document-path-regression.test.ts
@@ -78,9 +78,7 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
         expect(documentResults.slides.map((slide) => slide.slideNumber)).toEqual(
           currentResults.map((slide) => slide.slideNumber),
         );
-        expect(uniqueSortedCodes(documentResults.diagnostics)).toEqual(
-          [...testCase.expectedDiagnosticCodes].sort(),
-        );
+        expect(uniqueSortedCodes(documentResults.diagnostics)).toEqual([]);
 
         for (const documentResult of documentResults.slides) {
           const currentResult = currentResults.find(
@@ -109,8 +107,7 @@ describe("Document path Visual Regression Tests", { timeout: 60000 }, () => {
           console.log(
             `[document-path-vrt] ${testCase.name} slide${documentResult.slideNumber}: ` +
               `${(comparison.mismatchPercentage * 100).toFixed(3)}% ` +
-              `(tolerance ${(testCase.mismatchTolerance * 100).toFixed(1)}%)` +
-              diagnosticSuffix(testCase.expectedDiagnosticCodes),
+              `(tolerance ${(testCase.mismatchTolerance * 100).toFixed(1)}%)`,
           );
 
           expect(
@@ -132,9 +129,4 @@ function uniqueSortedCodes(diagnostics: readonly { readonly code: string }[]): s
 
 function fixtureDir(group: DocumentPathVrtFixtureGroup): string {
   return group === "shared" ? SHARED_FIXTURE_DIR : GENERATED_FIXTURE_DIR;
-}
-
-function diagnosticSuffix(expectedDiagnosticCodes: readonly string[]): string {
-  if (expectedDiagnosticCodes.length === 0) return "";
-  return `; diagnostics ${expectedDiagnosticCodes.join(", ")}`;
 }


### PR DESCRIPTION
close #512

## 概要

- CleanDoc dogfood migration 関連ドキュメントに、#481 完了後の現在状態と historical RFC として読むべき箇所を明記
- document path VRT の close 済み blocker issue metadata を削除し、zero-diff / zero-diagnostic gate として整理
- shared fixtures の document path VRT 運用説明を現在の parser path oracle 比較に更新

## 影響範囲

- docs/
- shared-fixtures/README.md
- vrt/snapshot/document-path-cases.ts
- vrt/snapshot/document-path-regression.test.ts

## 検証

- npm run lint
- npm run typecheck
- npm run format:check
- NODE_OPTIONS=--max-old-space-size=8192 npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-regression.test.ts

## 補足

- 通常 heap の VRT 単体実行はローカルで Node heap OOM になったため、heap を 8192MB に増やして CI 相当の設定で確認しています。
- docs/test metadata cleanup のため changeset は追加していません。