### PR TITLE
CleanDoc 名称を PptxSourceModel 系へ置き換える

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,15 +33,15 @@ CI consists of 4 jobs:
 
 ## Architecture
 
-Data flow: **PPTX binary → CleanDoc reader → Computed view → Renderer model adapter → Renderer (SVG generation) → PNG conversion (optional)**
+Data flow: **PPTX binary → PptxSourceModel reader → Computed view → Renderer model adapter → Renderer (SVG generation) → PNG conversion (optional)**
 
-The legacy parser path remains available internally as an explicit parser-path oracle for parity checks and VRT, but public `convertPptxToSvg` / `convertPptxToPng` default to the CleanDoc document path.
+The legacy parser path remains available internally as an explicit parser-path oracle for parity checks and VRT, but public `convertPptxToSvg` / `convertPptxToPng` default to the PptxSourceModel document path.
 
 ソースは pnpm workspaces (`packages/*`) で分割されている。root は private な workspace orchestration 専用で、公開 npm package `pptx-glimpse` は `packages/core` から publish する。`pptx-glimpse` パッケージは build-time workspace dependency として `@pptx-glimpse/document` / `@pptx-glimpse/renderer` を参照し、公開 tarball には bundle された成果物を含める。
 
-`@pptx-glimpse/document` / CleanDoc / writer / editor-core / pom 連携に関わる issue に着手する前に、責務境界と依存方向の決定記録である `docs/document-boundaries.md` と、そこからリンクされる派生決定記録を必ず読むこと。`document` は `core` / `editor-core` / renderer / pom を知らない下位基盤として扱う。
+`@pptx-glimpse/document` / PptxSourceModel / writer / editor-core / pom 連携に関わる issue に着手する前に、責務境界と依存方向の決定記録である `docs/document-boundaries.md` と、そこからリンクされる派生決定記録を必ず読むこと。`document` は `core` / `editor-core` / renderer / pom を知らない下位基盤として扱う。
 
-`packages/document/src/` — experimental `@pptx-glimpse/document` パッケージ。CleanDoc / OOXML document foundation の下位基盤として追加されており、public conversion path の default reader / computed view として参照される。`@pptx-glimpse/document/experimental` は後続の source model / reader / writer 実装を積むための experimental entry point。
+`packages/document/src/` — experimental `@pptx-glimpse/document` パッケージ。PptxSourceModel / OOXML document foundation の下位基盤として追加されており、public conversion path の default reader / computed view として参照される。`@pptx-glimpse/document/experimental` は後続の source model / reader / writer 実装を積むための experimental entry point。
 
 `packages/core/src/` — 公開パッケージ `pptx-glimpse` の実装（パーサー + 公開 API）
 

--- a/docs/core-document-dogfood-migration.md
+++ b/docs/core-document-dogfood-migration.md
@@ -7,9 +7,9 @@ This note records how the public `convertPptxToSvg` / `convertPptxToPng` path
 should eventually dogfood `@pptx-glimpse/document`. It feeds into
 [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445) and builds on
 the package boundary decision in
-[document-boundaries.md](./document-boundaries.md), the CleanDoc source/computed
+[document-boundaries.md](./document-boundaries.md), the PptxSourceModel source/computed
 view decision in
-[cleandoc-source-computed-view.md](./cleandoc-source-computed-view.md), and the
+[pptx-source-model-computed-view.md](./pptx-source-model-computed-view.md), and the
 raw OOXML round-trip policy in
 [raw-ooxml-round-trip.md](./raw-ooxml-round-trip.md).
 
@@ -18,7 +18,7 @@ moving reusable OOXML reading semantics into `@pptx-glimpse/document`.
 
 > Current-state note, 2026-06-27: the migration tracked by
 > [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481) is complete.
-> Public `convertPptxToSvg` / `convertPptxToPng` now default to the CleanDoc
+> Public `convertPptxToSvg` / `convertPptxToPng` now default to the PptxSourceModel
 > document path. This note remains a historical RFC for the migration plan and
 > should be read together with
 > [legacy-parser-semantics-audit.md](./legacy-parser-semantics-audit.md), which
@@ -43,7 +43,7 @@ PPTX Buffer | Uint8Array
 ```
 
 `parsePptxData` and `parseSlideWithLayout` were the effective core reader before
-the CleanDoc default switch. They unzip the package, parse XML, collect
+the PptxSourceModel default switch. They unzip the package, parse XML, collect
 relationships/theme data, and produce the renderer model consumed by
 `@pptx-glimpse/renderer`.
 
@@ -73,9 +73,9 @@ The public conversion path is now:
 ```text
 PPTX Buffer | Uint8Array
   -> @pptx-glimpse/document readPptx(input)
-  -> CleanDoc source model
+  -> PptxSourceModel source model
   -> createComputedView(source, options)
-  -> core-owned CleanDoc renderer adapter
+  -> core-owned PptxSourceModel renderer adapter
   -> existing @pptx-glimpse/renderer model
   -> renderSlideToSvg(slide, slideSize)
   -> svgToPng(svg, options) for PNG output
@@ -93,7 +93,7 @@ The final conversion flow should be:
 ```text
 PPTX Buffer | Uint8Array
   -> @pptx-glimpse/document readPptx(input)
-  -> CleanDoc source model
+  -> PptxSourceModel source model
   -> createComputedView(source, options)
   -> createRenderView(computed, renderOptions)
   -> existing @pptx-glimpse/renderer model
@@ -103,18 +103,18 @@ PPTX Buffer | Uint8Array
 
 The ownership boundary should be:
 
-- `@pptx-glimpse/document` owns OOXML package reading, CleanDoc source types,
+- `@pptx-glimpse/document` owns OOXML package reading, PptxSourceModel source types,
   relationship/package bookkeeping, source handles, raw preservation sidecars,
   and document-level computed view generation.
 - `@pptx-glimpse/core` owns the public conversion API, slide selection,
   compatibility options, warning behavior, font setup, and the
-  CleanDoc-computed-view-to-renderer-model adapter.
+  PptxSourceModel-computed-view-to-renderer-model adapter.
 - `@pptx-glimpse/renderer` keeps owning SVG/PNG rendering, font measurement,
   text-to-path behavior, visual fallbacks, and renderer-specific warnings.
 
 `@pptx-glimpse/document` must not import `core`, `editor-core`, the renderer, or
 pom. Core depends on `document`; the renderer consumes the adapter output and
-does not need to know CleanDoc directly.
+does not need to know PptxSourceModel directly.
 
 ## Historical Parallel Reader Period
 
@@ -125,7 +125,7 @@ tests still exist.
 The first `document` reader was introduced behind internal or experimental
 paths and compared against the then-current parser path. During that historical
 parallel period, the public `convertPptxToSvg` / `convertPptxToPng` default
-stayed on the parser path until the CleanDoc reader, computed view, and adapter
+stayed on the parser path until the PptxSourceModel reader, computed view, and adapter
 reached rendering parity for the supported fixture set.
 
 Recommended sequence during the parallel period:
@@ -136,7 +136,7 @@ Recommended sequence during the parallel period:
 3. Add computed view generation for slide size, slide order, relationships,
    theme resolution, background fallback, placeholder cascade, and text style
    inheritance, including slide and layout `showMasterSp` visibility.
-4. Add a CleanDoc computed view to current renderer model adapter in core.
+4. Add a PptxSourceModel computed view to current renderer model adapter in core.
 5. Run dual-reader comparison tests where both paths parse the same fixtures and
    the adapter output is compared against the current renderer model.
 6. Switch selected fixtures to render through the document path in tests.
@@ -150,8 +150,8 @@ renderer fallbacks and visual diagnostics should stay outside it.
 
 ## Adapter Policy
 
-The adapter should translate from CleanDoc computed view to the existing
-renderer model, not merge the renderer model into CleanDoc.
+The adapter should translate from PptxSourceModel computed view to the existing
+renderer model, not merge the renderer model into PptxSourceModel.
 
 Adapter responsibilities:
 
@@ -181,16 +181,16 @@ computed-view fields can be simplified in separate, rendering-focused PRs.
 
 Dogfood should be verified at multiple levels instead of relying on only VRT:
 
-| Level                      | Purpose                                                                     | Suggested checks                                                                                                                          |
-| -------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Document reader unit tests | Ensure OOXML parts become CleanDoc source nodes with stable references      | minimal PPTX fixtures, relationship graph assertions, raw sidecar preservation assertions                                                 |
-| Computed view unit tests   | Ensure document semantics are resolved outside the renderer                 | theme/color map resolution, background fallback, placeholder matching, text style cascade, unit conversion                                |
-| Adapter tests              | Ensure CleanDoc computed view maps to the current renderer contract         | compare adapter output with selected current parser model snapshots or focused structural assertions, including `showMasterSp` visibility |
-| Core dual-reader tests     | Ensure public conversion can dogfood `document` without changing behavior   | run both paths on shared fixtures and compare selected render model fields, slide selection, warnings, and result shapes                  |
-| Public API behavior tests  | Ensure public conversion options remain compatible                          | verify `slides` filtering, warning/log behavior, `convertPptxToPng` path-text forcing, and returned object shapes                         |
-| Snapshot VRT               | Catch visual regressions once fixtures are opted into the document path     | existing `vrt/snapshot` cases and shared real PPTX fixtures                                                                               |
-| LibreOffice VRT            | Compare generated output against external rendering references where useful | existing `vrt/libreoffice` cases after the document path affects rendering                                                                |
-| Package verification       | Ensure the published API shape remains compatible                           | existing build, typecheck, package verification, and API import smoke tests                                                               |
+| Level                      | Purpose                                                                       | Suggested checks                                                                                                                          |
+| -------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Document reader unit tests | Ensure OOXML parts become PptxSourceModel source nodes with stable references | minimal PPTX fixtures, relationship graph assertions, raw sidecar preservation assertions                                                 |
+| Computed view unit tests   | Ensure document semantics are resolved outside the renderer                   | theme/color map resolution, background fallback, placeholder matching, text style cascade, unit conversion                                |
+| Adapter tests              | Ensure PptxSourceModel computed view maps to the current renderer contract    | compare adapter output with selected current parser model snapshots or focused structural assertions, including `showMasterSp` visibility |
+| Core dual-reader tests     | Ensure public conversion can dogfood `document` without changing behavior     | run both paths on shared fixtures and compare selected render model fields, slide selection, warnings, and result shapes                  |
+| Public API behavior tests  | Ensure public conversion options remain compatible                            | verify `slides` filtering, warning/log behavior, `convertPptxToPng` path-text forcing, and returned object shapes                         |
+| Snapshot VRT               | Catch visual regressions once fixtures are opted into the document path       | existing `vrt/snapshot` cases and shared real PPTX fixtures                                                                               |
+| LibreOffice VRT            | Compare generated output against external rendering references where useful   | existing `vrt/libreoffice` cases after the document path affects rendering                                                                |
+| Package verification       | Ensure the published API shape remains compatible                             | existing build, typecheck, package verification, and API import smoke tests                                                               |
 
 For early PRs, unit and adapter tests are more important than snapshot churn.
 VRT snapshots should only be updated when the public render output intentionally
@@ -200,11 +200,11 @@ changes. The first dogfood milestone should aim for no visual output changes.
 
 Split the migration into small PRs with explicit compatibility checkpoints:
 
-1. Add `@pptx-glimpse/document` package skeleton, CleanDoc source types, and
+1. Add `@pptx-glimpse/document` package skeleton, PptxSourceModel source types, and
    package boundary tests.
 2. Implement minimal `readPptx(input)` that can read presentation metadata,
    slide list, relationships, and slide size while preserving raw package parts.
-3. Add CleanDoc source coverage for shapes, text, images, theme references,
+3. Add PptxSourceModel source coverage for shapes, text, images, theme references,
    layouts, and masters needed by the existing fixtures.
 4. Add `createComputedView(source, options)` for slide size, slide order,
    relationship resolution, theme/color map resolution, background fallback,
@@ -245,7 +245,7 @@ It also does not require:
 The historical conclusion to reflect in #445 was:
 
 `pptx-glimpse` core should dogfood `@pptx-glimpse/document` by routing the public
-SVG/PNG conversion path through CleanDoc source reading, computed document view
+SVG/PNG conversion path through PptxSourceModel source reading, computed document view
 generation, and a core-owned adapter into the existing renderer model.
 
 That migration used a temporary parallel reader period. The old parser served as
@@ -256,6 +256,6 @@ default to the document path, and reusable OOXML semantics now continue to move
 out of the old parser into `@pptx-glimpse/document`.
 
 The existing renderer model remains a render-specific adapter target during the
-migration. CleanDoc is the canonical source model, computed view resolves
+migration. PptxSourceModel is the canonical source model, computed view resolves
 document semantics, and renderer/core continue to own rendering-specific
 fallbacks and output behavior.

--- a/docs/document-boundaries.md
+++ b/docs/document-boundaries.md
@@ -11,24 +11,24 @@ will eventually depend on `@pptx-glimpse/document`, and pptx-glimpse will not
 depend on pom.**
 
 The related source/computed layering decision is recorded in
-[cleandoc-source-computed-view.md](./cleandoc-source-computed-view.md). In short,
-CleanDoc is the source model owned by `@pptx-glimpse/document`, and computed
+[pptx-source-model-computed-view.md](./pptx-source-model-computed-view.md). In short,
+PptxSourceModel is the source model owned by `@pptx-glimpse/document`, and computed
 views are generated projections for renderer, AI reading, and editor consumers.
 
 The related raw preservation and round-trip decision is recorded in
 [raw-ooxml-round-trip.md](./raw-ooxml-round-trip.md). In short,
 `@pptx-glimpse/document` should preserve raw OOXML for untouched or unsupported
-source material, while keeping typed CleanDoc operations as the normal editing
+source material, while keeping typed PptxSourceModel operations as the normal editing
 API.
 
 The related core dogfood migration decision is recorded in
 [core-document-dogfood-migration.md](./core-document-dogfood-migration.md). In
-short, public SVG/PNG conversion should eventually route through CleanDoc source
+short, public SVG/PNG conversion should eventually route through PptxSourceModel source
 reading, computed view generation, and a core-owned adapter into the existing
 renderer model.
 
 The related minimal implementation PoC scope is recorded in
-[cleandoc-minimal-poc-scope.md](./cleandoc-minimal-poc-scope.md). In short, the
+[pptx-source-model-minimal-poc-scope.md](./pptx-source-model-minimal-poc-scope.md). In short, the
 first slice should prove simple themed slide read, computed render view, current
 renderer adapter parity, no-edit structural round-trip, and one plain text-run
 edit round-trip.
@@ -42,11 +42,11 @@ the core role corresponds to the future `@pptx-glimpse/core` boundary.
 
 ## Dependency direction
 
-`@pptx-glimpse/document` is the lower-level OOXML / CleanDoc foundation. Higher
+`@pptx-glimpse/document` is the lower-level OOXML / PptxSourceModel foundation. Higher
 packages may consume it, but it must not know product-level APIs, preview APIs,
 editing workflows, or pom's authoring DSL.
 
-CleanDoc means the clean intermediate document model discussed in
+PptxSourceModel means the clean intermediate document model discussed in
 [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445): it keeps the
 semantic structure and round-trip preservation hooks needed for PPTX documents
 without exposing OOXML's package scattering as the primary authoring surface.
@@ -61,7 +61,7 @@ without exposing OOXML's package scattering as the primary authoring surface.
 @pptx-glimpse/core
   -> @pptx-glimpse/document
   -> @pptx-glimpse/renderer
-  (owns orchestration and the CleanDoc-to-render-view adapter)
+  (owns orchestration and the PptxSourceModel-to-render-view adapter)
 
 @pptx-glimpse/document
   -> OOXML package parts
@@ -94,16 +94,16 @@ editor-specific concepts.
 `@pptx-glimpse/document` owns the PPTX document domain model and the mechanics
 needed to read, write, validate, and preserve that domain model:
 
-- CleanDoc schema and TypeScript types.
+- PptxSourceModel schema and TypeScript types.
 - Presentation package structure: slides, layouts, masters, themes, media,
   relationships, and content types.
-- Reader-side conversion from OOXML package parts into CleanDoc.
-- Writer-side conversion from CleanDoc back into OOXML package parts.
+- Reader-side conversion from OOXML package parts into PptxSourceModel.
+- Writer-side conversion from PptxSourceModel back into OOXML package parts.
 - Stable IDs and relationship references that allow round-trip editing.
-- Normalized units and value types where CleanDoc intentionally hides OOXML
+- Normalized units and value types where PptxSourceModel intentionally hides OOXML
   encoding details.
 - Source-level values plus the metadata required to recover or preserve OOXML
-  constructs that CleanDoc does not model directly.
+  constructs that PptxSourceModel does not model directly.
 - Raw OOXML escape hatch for vendor extensions, uncommon DrawingML constructs,
   `mc:AlternateContent`, and other cases needed to keep round-trips lossless.
 - Validation and diagnostics that are about document correctness, not rendering
@@ -134,17 +134,17 @@ application-level packages that depend on `document`.
 
 ## Package roles
 
-| Package                     | Role                                               | Depends on `document`?                        | `document` may depend on it? |
-| --------------------------- | -------------------------------------------------- | --------------------------------------------- | ---------------------------- |
-| `@pptx-glimpse/document`    | CleanDoc, OOXML reader/writer, document validation | n/a                                           | n/a                          |
-| `@pptx-glimpse/core`        | Public preview/conversion API and orchestration    | Yes                                           | No                           |
-| `@pptx-glimpse/editor-core` | Headless editing commands and state machine        | Yes                                           | No                           |
-| `@pptx-glimpse/renderer`    | Render-oriented model and SVG/PNG generation       | No direct dependency; consumes adapter output | No                           |
-| `@hirokisakabe/pom`         | Authoring DSL and generation workflow              | Yes, eventually                               | No                           |
+| Package                     | Role                                                      | Depends on `document`?                        | `document` may depend on it? |
+| --------------------------- | --------------------------------------------------------- | --------------------------------------------- | ---------------------------- |
+| `@pptx-glimpse/document`    | PptxSourceModel, OOXML reader/writer, document validation | n/a                                           | n/a                          |
+| `@pptx-glimpse/core`        | Public preview/conversion API and orchestration           | Yes                                           | No                           |
+| `@pptx-glimpse/editor-core` | Headless editing commands and state machine               | Yes                                           | No                           |
+| `@pptx-glimpse/renderer`    | Render-oriented model and SVG/PNG generation              | No direct dependency; consumes adapter output | No                           |
+| `@hirokisakabe/pom`         | Authoring DSL and generation workflow                     | Yes, eventually                               | No                           |
 
-## Renderer model and CleanDoc
+## Renderer model and PptxSourceModel
 
-The existing renderer model should **not** be merged directly into CleanDoc.
+The existing renderer model should **not** be merged directly into PptxSourceModel.
 
 The renderer model is a computed, display-oriented view optimized for SVG/PNG
 generation. It can contain resolved values, fallback decisions, pixel-oriented
@@ -152,12 +152,12 @@ measurements, rendering warnings, and simplifications that are useful for
 preview output but too lossy or too presentation-specific to be the canonical
 document model.
 
-CleanDoc should instead be the source/semantic model. Rendering should use an
+PptxSourceModel should instead be the source/semantic model. Rendering should use an
 adapter:
 
 ```text
 OOXML package
-  -> CleanDoc
+  -> PptxSourceModel
   -> computed render view / renderer adapter
   -> SVG / PNG
 ```
@@ -166,14 +166,14 @@ This lets `document` preserve enough structure for writer/editor/round-trip
 work, while `renderer` keeps a purpose-built shape for visual output.
 
 Historical migration note: the short-term parser-to-renderer public path has
-been replaced by the CleanDoc document path as part of
+been replaced by the PptxSourceModel document path as part of
 [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481). The old parser
 path remains only as an explicit internal oracle for parity checks and targeted
 adapter fallbacks. The migration path was:
 
-1. Introduce CleanDoc types in `@pptx-glimpse/document`.
-2. Add a reader path that builds CleanDoc from OOXML.
-3. Add an adapter from CleanDoc to the current renderer model.
+1. Introduce PptxSourceModel types in `@pptx-glimpse/document`.
+2. Add a reader path that builds PptxSourceModel from OOXML.
+3. Add an adapter from PptxSourceModel to the current renderer model.
 4. Gradually move parser semantics that are not renderer-specific into
    `document`.
 5. Keep renderer-only fallbacks and visual diagnostics outside `document`.
@@ -185,14 +185,14 @@ Adopt `@pptx-glimpse/document` as a lower-level foundation. `core`,
 
 The package boundary should be:
 
-- `document`: canonical PPTX/CleanDoc data model, OOXML read/write mechanics,
+- `document`: canonical PPTX/PptxSourceModel data model, OOXML read/write mechanics,
   preservation hooks, validation.
 - `core`: public conversion orchestration and compatibility API.
-- `editor-core`: editing commands and headless editor state built on CleanDoc.
+- `editor-core`: editing commands and headless editor state built on PptxSourceModel.
 - renderer: computed display model and SVG/PNG output.
-- pom: authoring DSL that may emit or consume CleanDoc but is never known by
+- pom: authoring DSL that may emit or consume PptxSourceModel but is never known by
   pptx-glimpse packages.
 
-For #445, this means CleanDoc should be designed as the canonical
+For #445, this means PptxSourceModel should be designed as the canonical
 `@pptx-glimpse/document` model, with a generated computed render view rather than
 an in-place replacement of the existing renderer model.

--- a/docs/legacy-parser-semantics-audit.md
+++ b/docs/legacy-parser-semantics-audit.md
@@ -1,10 +1,10 @@
-# Legacy parser semantics audit after the CleanDoc default switch
+# Legacy parser semantics audit after the PptxSourceModel default switch
 
 - Status: implementation note for [#485](https://github.com/hirokisakabe/pptx-glimpse/issues/485)
 - Date: 2026-06-27
 
 This note records the first shrink pass after public SVG/PNG conversion moved to
-the CleanDoc document path. It complements
+the PptxSourceModel document path. It complements
 [core-document-dogfood-migration.md](./core-document-dogfood-migration.md) and
 [document-boundaries.md](./document-boundaries.md). For #485, this note
 supersedes the earlier "current state" and parallel-reader descriptions in the
@@ -26,7 +26,7 @@ convertPptxToSvg / convertPptxToPng
   -> convertPptxToSvgViaDocumentPath / convertPptxToPngViaDocumentPath
   -> @pptx-glimpse/document readPptx
   -> createComputedView
-  -> core-owned CleanDoc renderer adapter
+  -> core-owned PptxSourceModel renderer adapter
   -> renderer
 ```
 
@@ -40,16 +40,16 @@ an internal oracle for parity checks.
 These reusable OOXML semantics are now owned by `@pptx-glimpse/document` source
 or computed view code:
 
-| Semantics                                                 | Document owner                                                      | Previous parser overlap removed or reduced                                       |
-| --------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Package graph, slide order, relationships, media payloads | `reader/read-pptx.ts`, source package graph, computed relationships | Public conversion no longer calls `parsePptxData` for package traversal          |
-| Slide/layout/master chain resolution                      | `createComputedView`                                                | Public conversion no longer calls `parseSlideWithLayout` for cascade assembly    |
-| Background fallback                                       | `createComputedView`                                                | Public conversion uses computed `background` instead of parser-side fallback     |
-| Theme color and color map resolution                      | source theme data + computed color resolution                       | Public conversion uses computed colors through the adapter                       |
-| Placeholder filtering and effective element ordering      | `createComputedView`                                                | Core converter no longer owns parser-path `mergeElements`                        |
-| Text style cascade for rendering/inspection               | `createComputedView`                                                | `collectUsedFonts` now reads CleanDoc/computed text instead of parser slides     |
-| Theme font source data for rendering/inspection           | source theme data + core runtime helpers                            | `collectUsedFonts` and rendering setup no longer depend on parser slide assembly |
-| Table/chart/image relationship resolution for rendering   | `createComputedView` + adapter                                      | Parser path remains only as comparison oracle                                    |
+| Semantics                                                 | Document owner                                                      | Previous parser overlap removed or reduced                                          |
+| --------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Package graph, slide order, relationships, media payloads | `reader/read-pptx.ts`, source package graph, computed relationships | Public conversion no longer calls `parsePptxData` for package traversal             |
+| Slide/layout/master chain resolution                      | `createComputedView`                                                | Public conversion no longer calls `parseSlideWithLayout` for cascade assembly       |
+| Background fallback                                       | `createComputedView`                                                | Public conversion uses computed `background` instead of parser-side fallback        |
+| Theme color and color map resolution                      | source theme data + computed color resolution                       | Public conversion uses computed colors through the adapter                          |
+| Placeholder filtering and effective element ordering      | `createComputedView`                                                | Core converter no longer owns parser-path `mergeElements`                           |
+| Text style cascade for rendering/inspection               | `createComputedView`                                                | `collectUsedFonts` now reads PptxSourceModel/computed text instead of parser slides |
+| Theme font source data for rendering/inspection           | source theme data + core runtime helpers                            | `collectUsedFonts` and rendering setup no longer depend on parser slide assembly    |
+| Table/chart/image relationship resolution for rendering   | `createComputedView` + adapter                                      | Parser path remains only as comparison oracle                                       |
 
 ## Responsibilities left outside `document`
 
@@ -59,7 +59,7 @@ These remain in core or renderer by design:
 | ---------------------------------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | Public API options                                                           | `packages/core/src/converter.ts`, `packages/core/src/index.ts` | Stable API compatibility remains a core package concern                                                   |
 | Warning setup, font setup, SVG text-output mode, PNG sizing                  | `packages/core/src/experimental-document-renderer.ts`          | Renderer environment setup and runtime conversion options are core concerns                               |
-| CleanDoc computed view to renderer model mapping                             | `packages/core/src/cleandoc-renderer-adapter.ts`               | The renderer model is a display-oriented compatibility target, not the CleanDoc source model              |
+| PptxSourceModel computed view to renderer model mapping                      | `packages/core/src/pptx-computed-view-renderer-adapter.ts`     | The renderer model is a display-oriented compatibility target, not the PptxSourceModel source model       |
 | Chart XML to renderer chart model mapping                                    | Adapter calling parser `parseChart`                            | Chart rendering model is still renderer-specific; move only after a chart source/computed contract exists |
 | SmartArt drawing XML fallback to renderer shape tree                         | Adapter calling parser `parseShapeTree`                        | This is a rendering fallback for resolved diagram drawing XML, not canonical document semantics yet       |
 | Font discovery, font mapping, text measurement, text-to-path, SVG/PNG output | `@pptx-glimpse/renderer`                                       | Renderer-specific behavior per `document-boundaries.md`                                                   |
@@ -73,7 +73,7 @@ The old parser code still has three explicit roles:
 2. `dual-reader-structural-comparison.test.ts` compares a focused structural
    subset against the old parser while the migration still needs a readable
    model-level oracle.
-3. `cleandoc-renderer-adapter.ts` reuses `parseChart` and `parseShapeTree` for
+3. `pptx-computed-view-renderer-adapter.ts` reuses `parseChart` and `parseShapeTree` for
    renderer-specific chart and SmartArt fallbacks.
 
 No public API currently imports old parser render orchestration. `converter.ts`
@@ -97,7 +97,7 @@ Some duplication intentionally remains:
 - Parser unit tests under `packages/core/src/parser/` still protect the
   old oracle and adapter fallback helpers. Delete or narrow them only after the
   corresponding oracle role is removed.
-- `cleandoc-renderer-adapter.ts` still calls parser helpers for chart parsing
+- `pptx-computed-view-renderer-adapter.ts` still calls parser helpers for chart parsing
   and SmartArt fallback rendering. Split follow-up issues should define
   document-owned chart/diagram source contracts before moving this logic.
 - Comments in `packages/document/src/computed/create-computed-view.ts`

--- a/docs/pptx-source-model-computed-view.md
+++ b/docs/pptx-source-model-computed-view.md
@@ -1,17 +1,26 @@
-# CleanDoc source model and computed view
+# PptxSourceModel and computed view
 
 - Status: RFC decision for [#450](https://github.com/hirokisakabe/pptx-glimpse/issues/450)
 - Date: 2026-06-20
 
-This note records the CleanDoc layering decision that should feed into
+This note records the PptxSourceModel layering decision that should feed into
 [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445). It builds on
 the package boundary decision in
 [document-boundaries.md](./document-boundaries.md): `@pptx-glimpse/document` is
-the lower-level OOXML / CleanDoc foundation, and renderer / core / editor-core /
+the lower-level OOXML / PptxSourceModel foundation, and renderer / core / editor-core /
 pom are consumers of it.
 
+> Naming note, 2026-06-27: this concept was formerly called CleanDoc. The
+> current name is `PptxSourceModel` because the model is PPTX-domain source
+> material for reader / writer / computed-view workflows, including raw OOXML
+> preservation sidecars. `PptxSource` was rejected because it can sound like the
+> whole `@pptx-glimpse/document` package or an input stream rather than the
+> canonical in-memory source model. `PptxModel` was rejected because it is too
+> broad and blurs the source model with `PptxComputedView`, renderer adapter
+> models, and future editor projections.
+
 The related raw preservation and round-trip decision is recorded in
-[raw-ooxml-round-trip.md](./raw-ooxml-round-trip.md). In short, CleanDoc targets
+[raw-ooxml-round-trip.md](./raw-ooxml-round-trip.md). In short, PptxSourceModel targets
 structural preservation rather than byte equality, and raw OOXML is kept as
 source-model sidecars or untouched package parts instead of becoming the primary
 editing surface.
@@ -25,11 +34,11 @@ oracle and targeted fallback source.
 
 ## Decision
 
-Adopt a two-layer CleanDoc design:
+Adopt a two-layer PptxSourceModel design:
 
 ```text
 OOXML package parts
-  -> CleanDoc source model
+  -> PptxSourceModel source model
   -> computed document view
   -> renderer adapter / editor projections / AI-readable output
 ```
@@ -43,9 +52,9 @@ effective values. It resolves inheritance, relationships, theme references, and
 unit conversions into a deterministic, easy-to-consume view. It is derived data,
 not the editable source of truth.
 
-Do not merge the existing renderer model directly into CleanDoc. Treat it as the
+Do not merge the existing renderer model directly into PptxSourceModel. Treat it as the
 first rendering-oriented computed view shape, then migrate toward an explicit
-CleanDoc-to-renderer adapter.
+PptxSourceModel-to-renderer adapter.
 
 ## Source Model Responsibilities
 
@@ -60,7 +69,7 @@ It owns:
 - Element identity and ordering as authored in each source part.
 - Source-local values, including unresolved theme color references, style
   references, placeholder declarations, relationship IDs, and package part paths.
-- Raw or partially parsed OOXML for constructs CleanDoc does not model directly,
+- Raw or partially parsed OOXML for constructs PptxSourceModel does not model directly,
   such as vendor extensions, `mc:AlternateContent`, uncommon DrawingML nodes, and
   future features.
 - Lossless-preservation metadata where it matters for round-trip output:
@@ -116,9 +125,9 @@ parse.
 Recommended shape:
 
 ```text
-readPptx(input) -> CleanDocSource
+readPptx(input) -> PptxSourceModel
 
-createComputedView(source, options) -> CleanDocComputedView
+createComputedView(source, options) -> PptxComputedView
 
 createRenderView(computed, options) -> renderer model
 ```
@@ -223,7 +232,7 @@ like a render-oriented computed view:
 Migration direction:
 
 1. Keep the current renderer model as the SVG/PNG render view contract.
-2. Introduce CleanDoc source types separately in `@pptx-glimpse/document`.
+2. Introduce PptxSourceModel source types separately in `@pptx-glimpse/document`.
 3. Move source-preserving parse responsibility into `document`.
 4. Add a computed view generator that resolves cascade and references.
 5. Add an adapter from computed view to the current renderer model.
@@ -232,7 +241,7 @@ Migration direction:
 
 ## Historical Implementation Mapping Before #481
 
-Before the CleanDoc default switch, parser/core code already contained several
+Before the PptxSourceModel default switch, parser/core code already contained several
 computed-view behaviors:
 
 - `parseSlideWithLayout` resolves slide -> layout -> master chains.
@@ -251,13 +260,13 @@ the public default path.
 
 ## Schema Normalization Scope
 
-Normalize enough to make CleanDoc usable, but do not normalize away source
+Normalize enough to make PptxSourceModel usable, but do not normalize away source
 intent.
 
 Normalize:
 
 - Package paths and relationships into stable document references.
-- Namespaced OOXML names into CleanDoc field names.
+- Namespaced OOXML names into PptxSourceModel field names.
 - Common geometry, transform, fill, line, text, table, chart, and media
   structures.
 - Units into typed domain values.
@@ -282,7 +291,7 @@ Do not normalize source into:
 
 The conclusion to reflect in #445 is:
 
-CleanDoc should adopt a two-layer architecture. The canonical
+PptxSourceModel should adopt a two-layer architecture. The canonical
 `@pptx-glimpse/document` model is a source model that preserves document
 semantics, source references, typed OOXML-domain units, and raw escape hatches
 for writer/editor/round-trip work. A computed view is generated from that source
@@ -290,7 +299,7 @@ model to resolve theme, master, layout, slide, placeholder, relationship, and
 text-style cascades for renderer, AI reading, and editor projections.
 
 The existing renderer model should be treated as a render-specific computed view
-or adapter target, not as the CleanDoc schema itself. Unit normalization should
+or adapter target, not as the PptxSourceModel schema itself. Unit normalization should
 use typed PPTX-domain units in source and computed document views, with pixel
 conversion limited to renderer boundaries. If a future design rejects the
 two-layer approach, it must explain how one model can simultaneously preserve

--- a/docs/pptx-source-model-minimal-poc-scope.md
+++ b/docs/pptx-source-model-minimal-poc-scope.md
@@ -1,4 +1,4 @@
-# CleanDoc minimal PoC scope
+# PptxSourceModel minimal PoC scope
 
 - Status: RFC decision for [#453](https://github.com/hirokisakabe/pptx-glimpse/issues/453)
 - Date: 2026-06-20
@@ -7,11 +7,11 @@ This note records the first implementation slice for `@pptx-glimpse/document`.
 It builds on the package boundary decision in
 [document-boundaries.md](./document-boundaries.md), the source/computed layering
 decision in
-[cleandoc-source-computed-view.md](./cleandoc-source-computed-view.md), the raw
+[pptx-source-model-computed-view.md](./pptx-source-model-computed-view.md), the raw
 round-trip policy in [raw-ooxml-round-trip.md](./raw-ooxml-round-trip.md), and
 the core dogfood migration plan in
 [core-document-dogfood-migration.md](./core-document-dogfood-migration.md).
-Issue #453 is the PoC-scope child decision for the broader CleanDoc RFC in
+Issue #453 is the PoC-scope child decision for the broader PptxSourceModel RFC in
 [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445), so this note
 ends with a #445-ready conclusion.
 
@@ -26,13 +26,13 @@ prove the intended architecture end to end:
 
 ```text
 PPTX package
-  -> CleanDoc source model
+  -> PptxSourceModel source model
   -> computed document view
   -> current renderer model adapter
   -> SVG/PNG render verification
 
 PPTX package
-  -> CleanDoc source model
+  -> PptxSourceModel source model
   -> writer
   -> structurally preserved PPTX package
 ```
@@ -176,12 +176,12 @@ sidecars unless an explicit supported edit invalidates the owning node.
 
 ## Read to Computed View to Render Verification
 
-The PoC should verify the read -> CleanDoc -> computed view -> render path with
+The PoC should verify the read -> PptxSourceModel -> computed view -> render path with
 focused structural tests before relying on VRT.
 
 Recommended checks:
 
-1. Read a fixture PPTX into `CleanDocSource`.
+1. Read a fixture PPTX into `PptxSourceModel`.
 2. Assert package graph basics: slide count, slide order, slide size,
    slide/layout/master/theme references, relationship IDs, and media references.
 3. Assert typed source nodes for supported shapes, text runs, and images while
@@ -204,27 +204,27 @@ only when a specific inheritance or preservation case is not covered.
 VRT snapshot updates should not be part of the first PoC unless the public render
 output intentionally changes.
 
-## Read to CleanDoc to Write Verification
+## Read to PptxSourceModel to Write Verification
 
 The PoC writer should prove structural preservation, not byte equality.
 
 Recommended no-edit round-trip checks:
 
-1. Read a fixture PPTX into `CleanDocSource`.
+1. Read a fixture PPTX into `PptxSourceModel`.
 2. Write it without applying edits.
 3. Assert the result is a valid PPTX ZIP package with required content types and
    relationship parts.
 4. Assert slide count, slide size, slide order, slide/layout/master/theme
    references, relationship IDs, and media part bytes are preserved for
    unchanged material.
-5. Re-read the written PPTX and assert the supported CleanDoc source subset is
+5. Re-read the written PPTX and assert the supported PptxSourceModel source subset is
    equivalent to the original read.
 6. Render original and round-tripped PPTX through the current public conversion
    path and assert no meaningful output difference for the supported subset.
 
 Recommended one-text-edit checks:
 
-1. Read a fixture PPTX into `CleanDocSource`.
+1. Read a fixture PPTX into `PptxSourceModel`.
 2. Locate one existing text run by stable source handle.
 3. Replace only that run's plain text.
 4. Write the PPTX.
@@ -284,7 +284,7 @@ to:
 
 1. Add `@pptx-glimpse/document` workspace package skeleton, public experimental
    entry points, package-boundary tests, and build wiring.
-2. Define CleanDoc source model types for package graph, presentation, slides,
+2. Define PptxSourceModel source model types for package graph, presentation, slides,
    layouts, masters, themes, media, simple shapes, text, images, source handles,
    raw sidecars, and diagnostics.
 3. Implement `readPptx(input)` for package graph, presentation metadata, slide
@@ -296,7 +296,7 @@ to:
 5. Implement `createComputedView(source, options)` for slide size/order,
    relationship resolution, theme color resolution, background fallback,
    placeholder matching, text style inheritance, and `showMasterSp` visibility.
-6. Add a core-owned CleanDoc computed-view-to-current-renderer-model adapter for
+6. Add a core-owned PptxSourceModel computed-view-to-current-renderer-model adapter for
    the supported subset.
 7. Add dual-reader structural comparison tests against the current parser for
    selected shared fixtures.
@@ -315,7 +315,7 @@ to:
 The conclusion to reflect in #445 is:
 
 The first `@pptx-glimpse/document` PoC should be a narrow end-to-end slice, not a
-general OOXML rewrite. It should read simple themed PPTX slides into a CleanDoc
+general OOXML rewrite. It should read simple themed PPTX slides into a PptxSourceModel
 source model, generate a computed view that resolves slide/layout/master/theme
 semantics, adapt that view into the current renderer model for comparison, and
 write structurally preserved PPTX output for no-edit and one-plain-text-run edit

--- a/docs/raw-ooxml-round-trip.md
+++ b/docs/raw-ooxml-round-trip.md
@@ -8,17 +8,17 @@ feed into [#445](https://github.com/hirokisakabe/pptx-glimpse/issues/445). It
 builds on the package boundary decision in
 [document-boundaries.md](./document-boundaries.md) and the source/computed
 layering decision in
-[cleandoc-source-computed-view.md](./cleandoc-source-computed-view.md).
+[pptx-source-model-computed-view.md](./pptx-source-model-computed-view.md).
 
 The related core dogfood migration decision is recorded in
 [core-document-dogfood-migration.md](./core-document-dogfood-migration.md). In
-short, public SVG/PNG conversion now routes through CleanDoc source reading,
+short, public SVG/PNG conversion now routes through PptxSourceModel source reading,
 computed view generation, and a core-owned adapter into the existing renderer
 model after the [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481)
 default switch.
 
 The goal is to make `@pptx-glimpse/document` reliable for existing PPTX files
-without turning CleanDoc into a byte-level OOXML editor. CleanDoc should expose a
+without turning PptxSourceModel into a byte-level OOXML editor. PptxSourceModel should expose a
 clean document model for supported semantics, while retaining enough raw source
 material to write back unsupported or unedited content.
 
@@ -43,7 +43,7 @@ Do not target byte equality.
 Byte equality is intentionally out of scope because XML serialization can change
 attribute order, namespace prefix placement, insignificant whitespace, ZIP entry
 metadata, compression settings, relationship ID allocation, and defaulted OOXML
-values. Preserving those details would force CleanDoc to become a package patcher
+values. Preserving those details would force PptxSourceModel to become a package patcher
 first and a document model second.
 
 Do not claim full semantic equality for edited content.
@@ -60,7 +60,7 @@ Adopt a hybrid preservation model:
 
 ```text
 PPTX package part
-  -> parsed CleanDoc source nodes
+  -> parsed PptxSourceModel source nodes
   -> raw node sidecars for unsupported or partially supported XML
   -> raw package part fallback for untouched parts
 ```
@@ -72,13 +72,13 @@ Preserve raw data at the following levels:
 | Level              | Use case                                              | Policy                                                                                 |
 | ------------------ | ----------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | Package part       | Untouched slide/layout/master/theme/chart/media parts | Keep the original bytes or original XML tree and write them back unchanged.            |
-| XML node sidecar   | Unknown child elements, vendor extensions, `extLst`   | Attach raw XML to the nearest CleanDoc source node with ordering metadata.             |
+| XML node sidecar   | Unknown child elements, vendor extensions, `extLst`   | Attach raw XML to the nearest PptxSourceModel source node with ordering metadata.      |
 | Alternate branch   | `mc:AlternateContent`                                 | Preserve all choices/fallback branches unless the owning node is regenerated.          |
 | Relationship entry | `_rels/*.rels` references                             | Preserve existing relationship IDs and targets where the referenced part is unchanged. |
 | Content type entry | `[Content_Types].xml` overrides/defaults              | Preserve entries for existing parts; add/remove entries only for package edits.        |
 | Binary asset       | Images, media, embedded workbooks                     | Preserve bytes and part paths unless the asset is replaced or removed.                 |
 
-CleanDoc source nodes should carry stable source handles, for example original
+PptxSourceModel source nodes should carry stable source handles, for example original
 part path, relationship ID, element ID, child ordering slots, and raw sidecar
 references. These handles let the writer decide whether it can splice a generated
 node into an existing part or must regenerate a larger scope.
@@ -96,7 +96,7 @@ Reject element-property raw storage as the default.
 
 Storing raw XML beside every property would make the public model noisy and would
 still not solve child ordering, namespace declarations, `mc:AlternateContent`,
-or relationship updates. Properties should become typed CleanDoc fields when they
+or relationship updates. Properties should become typed PptxSourceModel fields when they
 are supported; unsupported material should stay as raw node sidecars.
 
 Reject a single opaque raw XML string per slide as the only escape hatch.
@@ -105,7 +105,7 @@ That approach preserves untouched slides, but it cannot support precise edits or
 diagnostics. It also prevents editor-core from knowing which unsupported content
 is attached to which shape, table, chart, or text node.
 
-Reject full normalization into CleanDoc without raw sidecars.
+Reject full normalization into PptxSourceModel without raw sidecars.
 
 That would produce the cleanest model, but it would drop unsupported OOXML and
 make existing-file editing unsafe.
@@ -130,7 +130,7 @@ Policy:
 - If a part is dirty but contains mostly supported edits, regenerate only the
   dirty XML elements and splice preserved raw sidecars back into their original
   order.
-- If node-level splicing is unsafe, regenerate the whole XML part from CleanDoc
+- If node-level splicing is unsafe, regenerate the whole XML part from PptxSourceModel
   source plus preserved raw sidecars.
 - If an edit invalidates an unsupported node that cannot be preserved, drop that
   raw node only with an explicit diagnostic.
@@ -201,16 +201,16 @@ Keep the raw OOXML escape hatch primarily as an internal source-model mechanism
 for the first implementation.
 
 Public APIs should expose raw material cautiously through explicit expert-level
-handles, not as the default editing surface. The default CleanDoc API should stay
+handles, not as the default editing surface. The default PptxSourceModel API should stay
 semantic and typed.
 
 Recommended public shape:
 
 ```text
-readPptx(input, { preserveRaw: true }) -> CleanDocSource
+readPptx(input, { preserveRaw: true }) -> PptxSourceModel
 
 source.getRaw(handle) -> RawOoxmlNode | RawPackagePart | undefined
-source.replaceRaw(handle, raw, options) -> CleanDocSource
+source.replaceRaw(handle, raw, options) -> PptxSourceModel
 source.listDiagnostics() -> Diagnostic[]
 ```
 
@@ -219,7 +219,7 @@ API principles:
 - Raw handles are stable source references, not direct mutable object pointers.
 - Raw replacement is opt-in and should require namespace-aware XML validation.
 - Raw access should be available for advanced tools, migrations, and emergency
-  preservation workflows, but ordinary editor commands should use typed CleanDoc
+  preservation workflows, but ordinary editor commands should use typed PptxSourceModel
   operations.
 - Computed views may expose provenance back to raw handles for diagnostics, but
   they should not expose raw XML as their primary data.
@@ -231,7 +231,7 @@ schema and could encourage consumers to depend on OOXML internals that
 
 ## Conclusion for #445
 
-For #445, CleanDoc should define lossless behavior as structural preservation,
+For #445, PptxSourceModel should define lossless behavior as structural preservation,
 not byte equality. `@pptx-glimpse/document` should preserve raw OOXML at package
 part and XML-node sidecar granularity, keep relationships/content types/assets as
 source-model data, and use edit tracking so unedited parts can be written back
@@ -244,6 +244,6 @@ by default and are only dropped when an explicit edit invalidates them, with a
 diagnostic.
 
 The raw escape hatch should remain mostly internal at first, with a narrow
-expert-level public API based on stable raw handles. CleanDoc remains the normal
+expert-level public API based on stable raw handles. PptxSourceModel remains the normal
 semantic editing API; raw OOXML is a preservation and emergency escape mechanism,
 not the primary programming model.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,7 +63,7 @@ export default tseslint.config(
                 "./scripts",
               ],
               message:
-                "@pptx-glimpse/document is the lower-level OOXML/CleanDoc foundation and must not import higher-level packages or app/script code.",
+                "@pptx-glimpse/document is the lower-level OOXML/PptxSourceModel foundation and must not import higher-level packages or app/script code.",
             },
           ],
         },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Patch Changes
 
 - 0a9a8e9: Improve experimental document path rendering parity with the parser path under default snapshot VRT font conditions.
-- 436d171: Fix CleanDoc document-path text font and autofit parity with the current parser path.
+- 436d171: Fix PptxSourceModel document-path text font and autofit parity with the current parser path.
 - e588f05: Move the published package metadata and build output to the core workspace package.
-- 29e9f8c: Switch the public conversion default for `convertPptxToSvg` and `convertPptxToPng` to the CleanDoc document path while keeping an explicit parser-path oracle for parity checks.
-- 5a7498a: Move remaining public font collection to the CleanDoc path and keep legacy parser rendering scoped to the internal parity oracle.
+- 29e9f8c: Switch the public conversion default for `convertPptxToSvg` and `convertPptxToPng` to the PptxSourceModel document path while keeping an explicit parser-path oracle for parity checks.
+- 5a7498a: Move remaining public font collection to the PptxSourceModel path and keep legacy parser rendering scoped to the internal parity oracle.

--- a/packages/core/src/dual-reader-structural-comparison.test.ts
+++ b/packages/core/src/dual-reader-structural-comparison.test.ts
@@ -19,8 +19,8 @@ import type {
 } from "@pptx-glimpse/renderer";
 import { describe, expect, it } from "vitest";
 
-import { adaptComputedViewToRendererModel } from "./cleandoc-renderer-adapter.js";
 import { buildEffectiveSlideElements } from "./parser-path-oracle.js";
+import { adaptComputedViewToRendererModel } from "./pptx-computed-view-renderer-adapter.js";
 import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 
 const CASES = [
@@ -51,7 +51,7 @@ const OUT_OF_SCOPE_FIELDS = [
 ] as const;
 
 describe("dual-reader structural comparison", () => {
-  it("comparison scope is intentionally limited to the CleanDoc PoC supported subset", () => {
+  it("comparison scope is intentionally limited to the PptxSourceModel PoC supported subset", () => {
     expect(COMPARISON_SCOPE).toMatchInlineSnapshot(`
       [
         "slide size",
@@ -77,7 +77,7 @@ describe("dual-reader structural comparison", () => {
   });
 
   it.each(CASES)(
-    "$fixtureName matches between current parser and CleanDoc document path for supported fields",
+    "$fixtureName matches between current parser and PptxSourceModel document path for supported fields",
     ({ fixtureName, includeRunProperties }) => {
       const input = readFixture(fixtureName);
       const options = { includeRunProperties };
@@ -87,7 +87,7 @@ describe("dual-reader structural comparison", () => {
       for (const diagnostic of document.diagnostics) {
         expect(diagnostic).toMatchObject({
           severity: "warning",
-          code: "cleandoc-adapter.raw-element-skipped",
+          code: "pptx-computed-view-adapter.raw-element-skipped",
         });
       }
       expect(document.presentation).toEqual(current);

--- a/packages/core/src/experimental-document-renderer.test.ts
+++ b/packages/core/src/experimental-document-renderer.test.ts
@@ -4,26 +4,26 @@ import { fileURLToPath } from "node:url";
 import * as documentExperimental from "@pptx-glimpse/document/experimental";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import * as adapterModule from "./cleandoc-renderer-adapter.js";
 import { convertPptxToPng, convertPptxToSvg } from "./converter.js";
 import {
   convertPptxToPngViaDocumentPath,
   convertPptxToSvgViaDocumentPath,
 } from "./experimental-document-renderer.js";
+import * as adapterModule from "./pptx-computed-view-renderer-adapter.js";
 
 const SELECTED_SHARED_FIXTURES = ["real-basic-theme.pptx", "real-product-page.pptx"] as const;
 
 const DOCUMENT_RENDER_TEST_SCOPE = [
   "readPptx source model",
   "createComputedView cascade projection",
-  "CleanDoc computed-view to current renderer model adapter",
+  "PptxSourceModel computed-view to current renderer model adapter",
   "existing SVG renderer",
   "existing SVG to PNG conversion",
 ] as const;
 
 const DOCUMENT_RENDER_UNSUPPORTED_SUBSET = [
   "raw shape-tree nodes such as groups and unsupported graphicFrame content",
-  "raw background and fill variants outside the CleanDoc adapter subset",
+  "raw background and fill variants outside the PptxSourceModel adapter subset",
   "unresolved images without a package media payload",
   "elements missing computed transforms",
 ] as const;
@@ -38,7 +38,7 @@ describe("experimental document render path", () => {
       [
         "readPptx source model",
         "createComputedView cascade projection",
-        "CleanDoc computed-view to current renderer model adapter",
+        "PptxSourceModel computed-view to current renderer model adapter",
         "existing SVG renderer",
         "existing SVG to PNG conversion",
       ]
@@ -46,7 +46,7 @@ describe("experimental document render path", () => {
     expect(DOCUMENT_RENDER_UNSUPPORTED_SUBSET).toMatchInlineSnapshot(`
       [
         "raw shape-tree nodes such as groups and unsupported graphicFrame content",
-        "raw background and fill variants outside the CleanDoc adapter subset",
+        "raw background and fill variants outside the PptxSourceModel adapter subset",
         "unresolved images without a package media payload",
         "elements missing computed transforms",
       ]
@@ -151,5 +151,5 @@ function expectUnsupportedDiagnosticsToStayInScope(
 }
 
 function isExpectedDocumentRenderDiagnosticCode(code: string): boolean {
-  return code === "cleandoc-adapter.raw-element-skipped";
+  return code === "pptx-computed-view-adapter.raw-element-skipped";
 }

--- a/packages/core/src/experimental-document-renderer.ts
+++ b/packages/core/src/experimental-document-renderer.ts
@@ -25,11 +25,11 @@ import {
   warn,
 } from "@pptx-glimpse/renderer";
 
+import type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
 import {
   adaptComputedViewToRendererModel,
   type RendererAdapterDiagnostic,
-} from "./cleandoc-renderer-adapter.js";
-import type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
+} from "./pptx-computed-view-renderer-adapter.js";
 
 type DocumentRenderDiagnostic = RendererAdapterDiagnostic;
 
@@ -44,7 +44,7 @@ interface DocumentPathPngResult {
 }
 
 /**
- * CleanDoc document-path render orchestration used by the public converter
+ * PptxSourceModel document-path render orchestration used by the public converter
  * default. Parser-path helpers remain available for parity checks.
  */
 export async function convertPptxToSvgViaDocumentPath(
@@ -127,7 +127,7 @@ function findScriptFontScheme(source: ReturnType<typeof readPptx>) {
 }
 
 /**
- * Internal / experimental PNG path layered on top of the CleanDoc SVG path and
+ * Internal / experimental PNG path layered on top of the PptxSourceModel SVG path and
  * the existing renderer PNG conversion.
  */
 export async function convertPptxToPngViaDocumentPath(

--- a/packages/core/src/font/font-collector.ts
+++ b/packages/core/src/font/font-collector.ts
@@ -2,10 +2,10 @@
  * PPTX から使用フォント名を収集する API。
  */
 import {
-  type CleanDocSource,
   type ComputedElement,
   type ComputedTextBody,
   createComputedView,
+  type PptxSourceModel,
   readPptx,
   type SourceThemeFontScheme,
 } from "@pptx-glimpse/document/experimental";
@@ -86,7 +86,7 @@ export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
   };
 }
 
-function findDefaultThemeFontScheme(source: CleanDocSource): ResolvedThemeFontScheme {
+function findDefaultThemeFontScheme(source: PptxSourceModel): ResolvedThemeFontScheme {
   const firstThemePartPath = source.slideMasters.find(
     (master) => master.themePartPath !== undefined,
   )?.themePartPath;
@@ -95,7 +95,7 @@ function findDefaultThemeFontScheme(source: CleanDocSource): ResolvedThemeFontSc
 }
 
 function findThemeFontScheme(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   themePartPath: string | undefined,
 ): ResolvedThemeFontScheme | undefined {
   if (themePartPath === undefined) return undefined;

--- a/packages/core/src/parser-path-oracle.ts
+++ b/packages/core/src/parser-path-oracle.ts
@@ -33,7 +33,7 @@ import { parsePptxData, parseSlideWithLayout } from "./pptx-data-parser.js";
 /**
  * Explicit old-parser render oracle for document-path parity checks.
  *
- * Public conversion defaults to the CleanDoc document path. Keep this module
+ * Public conversion defaults to the PptxSourceModel document path. Keep this module
  * internal so old parser semantics do not leak back into core orchestration.
  */
 async function convertPptxToSvgViaParserPath(

--- a/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
@@ -1,4 +1,8 @@
-import type { CleanDocSource, SourceShape, SourceTable } from "@pptx-glimpse/document/experimental";
+import type {
+  PptxSourceModel,
+  SourceShape,
+  SourceTable,
+} from "@pptx-glimpse/document/experimental";
 import {
   asEmu,
   asOoxmlAngle,
@@ -12,7 +16,7 @@ import {
 import type { SlideElement } from "@pptx-glimpse/renderer";
 import { describe, expect, it } from "vitest";
 
-import { adaptComputedViewToRendererModel } from "./cleandoc-renderer-adapter.js";
+import { adaptComputedViewToRendererModel } from "./pptx-computed-view-renderer-adapter.js";
 
 describe("adaptComputedViewToRendererModel", () => {
   it("slide size / background / effective element ordering を renderer model に変換する", () => {
@@ -498,7 +502,7 @@ describe("adaptComputedViewToRendererModel", () => {
         }),
       ],
     });
-    const sourceWithEmfMedia: CleanDocSource = {
+    const sourceWithEmfMedia: PptxSourceModel = {
       ...source,
       packageGraph: {
         ...source.packageGraph,
@@ -585,7 +589,7 @@ describe("adaptComputedViewToRendererModel", () => {
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({
         severity: "warning",
-        code: "cleandoc-adapter.raw-element-skipped",
+        code: "pptx-computed-view-adapter.raw-element-skipped",
         slideNumber: 1,
         sourcePartPath: "ppt/slides/slide1.xml",
       }),
@@ -627,10 +631,10 @@ describe("adaptComputedViewToRendererModel", () => {
     expect(result.slides[0]?.elements.map(getAltText)).not.toContain("Missing media");
     expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
       expect.arrayContaining([
-        "cleandoc-adapter.raw-background-ignored",
-        "cleandoc-adapter.missing-transform",
-        "cleandoc-adapter.raw-fill-ignored",
-        "cleandoc-adapter.unresolved-image-skipped",
+        "pptx-computed-view-adapter.raw-background-ignored",
+        "pptx-computed-view-adapter.missing-transform",
+        "pptx-computed-view-adapter.raw-fill-ignored",
+        "pptx-computed-view-adapter.unresolved-image-skipped",
       ]),
     );
   });
@@ -647,11 +651,11 @@ function getAltText(element: SlideElement): string | undefined {
 }
 
 interface BuildSourceOptions {
-  readonly extraSlideShapes?: CleanDocSource["slides"][number]["shapes"];
-  readonly slideBackground?: CleanDocSource["slides"][number]["background"];
+  readonly extraSlideShapes?: PptxSourceModel["slides"][number]["shapes"];
+  readonly slideBackground?: PptxSourceModel["slides"][number]["background"];
 }
 
-function buildSource(options: BuildSourceOptions = {}): CleanDocSource {
+function buildSource(options: BuildSourceOptions = {}): PptxSourceModel {
   const slidePath = asPartPath("ppt/slides/slide1.xml");
   const layoutPath = asPartPath("ppt/slideLayouts/layout1.xml");
   const masterPath = asPartPath("ppt/slideMasters/master1.xml");
@@ -804,7 +808,7 @@ function buildSource(options: BuildSourceOptions = {}): CleanDocSource {
   };
 }
 
-function buildSourceWithChartAndSmartArt(): CleanDocSource {
+function buildSourceWithChartAndSmartArt(): PptxSourceModel {
   const source = buildSource({
     extraSlideShapes: [
       {

--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -1,5 +1,4 @@
 import type {
-  CleanDocComputedView,
   ComputedBackground,
   ComputedBlipEffects,
   ComputedChartElement,
@@ -19,6 +18,7 @@ import type {
   ComputedSmartArtElement,
   ComputedTableElement,
   ComputedTextBody,
+  PptxComputedView,
 } from "@pptx-glimpse/document/experimental";
 import type {
   Background,
@@ -65,13 +65,13 @@ interface RendererAdapterResult {
 export interface RendererAdapterDiagnostic {
   readonly severity: "warning";
   readonly code:
-    | "cleandoc-adapter.missing-transform"
-    | "cleandoc-adapter.raw-element-skipped"
-    | "cleandoc-adapter.raw-background-ignored"
-    | "cleandoc-adapter.raw-fill-ignored"
-    | "cleandoc-adapter.unresolved-chart-skipped"
-    | "cleandoc-adapter.unresolved-smartart-skipped"
-    | "cleandoc-adapter.unresolved-image-skipped";
+    | "pptx-computed-view-adapter.missing-transform"
+    | "pptx-computed-view-adapter.raw-element-skipped"
+    | "pptx-computed-view-adapter.raw-background-ignored"
+    | "pptx-computed-view-adapter.raw-fill-ignored"
+    | "pptx-computed-view-adapter.unresolved-chart-skipped"
+    | "pptx-computed-view-adapter.unresolved-smartart-skipped"
+    | "pptx-computed-view-adapter.unresolved-image-skipped";
   readonly message: string;
   readonly slideNumber?: number;
   readonly sourcePartPath?: string;
@@ -120,7 +120,7 @@ const DEFAULT_COLOR_MAP: ColorMap = {
 };
 
 export function adaptComputedViewToRendererModel(
-  computed: CleanDocComputedView,
+  computed: PptxComputedView,
 ): RendererAdapterResult {
   const diagnostics: DiagnosticSink = [];
 
@@ -167,8 +167,8 @@ function adaptBackground(
 
   diagnostics.push({
     severity: "warning",
-    code: "cleandoc-adapter.raw-background-ignored",
-    message: "Raw CleanDoc background is not supported by the renderer adapter.",
+    code: "pptx-computed-view-adapter.raw-background-ignored",
+    message: "Raw PptxSourceModel background is not supported by the renderer adapter.",
     slideNumber: slide.slideNumber,
   });
   return null;
@@ -198,8 +198,8 @@ function adaptElement(
 
   diagnostics.push({
     severity: "warning",
-    code: "cleandoc-adapter.raw-element-skipped",
-    message: "Raw CleanDoc shape tree node is outside the renderer adapter subset.",
+    code: "pptx-computed-view-adapter.raw-element-skipped",
+    message: "Raw PptxSourceModel shape tree node is outside the renderer adapter subset.",
     slideNumber: slide.slideNumber,
     sourcePartPath: element.sourcePartPath,
   });
@@ -257,8 +257,8 @@ function adaptChart(
   if (chart.chartXml === undefined) {
     diagnostics.push({
       severity: "warning",
-      code: "cleandoc-adapter.unresolved-chart-skipped",
-      message: "CleanDoc chart element has no resolved chart XML.",
+      code: "pptx-computed-view-adapter.unresolved-chart-skipped",
+      message: "PptxSourceModel chart element has no resolved chart XML.",
       slideNumber: slide.slideNumber,
       sourcePartPath: chart.sourcePartPath,
     });
@@ -269,8 +269,8 @@ function adaptChart(
   if (chartData === null) {
     diagnostics.push({
       severity: "warning",
-      code: "cleandoc-adapter.unresolved-chart-skipped",
-      message: "CleanDoc chart XML could not be parsed into the renderer chart model.",
+      code: "pptx-computed-view-adapter.unresolved-chart-skipped",
+      message: "PptxSourceModel chart XML could not be parsed into the renderer chart model.",
       slideNumber: slide.slideNumber,
       sourcePartPath: chart.sourcePartPath,
     });
@@ -292,8 +292,8 @@ function adaptSmartArt(
   if (smartArt.drawingXml === undefined || smartArt.drawingPartPath === undefined) {
     diagnostics.push({
       severity: "warning",
-      code: "cleandoc-adapter.unresolved-smartart-skipped",
-      message: "CleanDoc SmartArt element has no resolved diagram drawing XML.",
+      code: "pptx-computed-view-adapter.unresolved-smartart-skipped",
+      message: "PptxSourceModel SmartArt element has no resolved diagram drawing XML.",
       slideNumber: slide.slideNumber,
       sourcePartPath: smartArt.sourcePartPath,
     });
@@ -306,8 +306,8 @@ function adaptSmartArt(
   if (spTree === undefined) {
     diagnostics.push({
       severity: "warning",
-      code: "cleandoc-adapter.unresolved-smartart-skipped",
-      message: "CleanDoc SmartArt diagram drawing XML has no shape tree.",
+      code: "pptx-computed-view-adapter.unresolved-smartart-skipped",
+      message: "PptxSourceModel SmartArt diagram drawing XML has no shape tree.",
       slideNumber: slide.slideNumber,
       sourcePartPath: smartArt.sourcePartPath,
     });
@@ -488,8 +488,8 @@ function adaptImage(
   if (image.media === undefined) {
     diagnostics.push({
       severity: "warning",
-      code: "cleandoc-adapter.unresolved-image-skipped",
-      message: "CleanDoc image element has no resolved media payload.",
+      code: "pptx-computed-view-adapter.unresolved-image-skipped",
+      message: "PptxSourceModel image element has no resolved media payload.",
       slideNumber: slide.slideNumber,
       sourcePartPath: image.sourcePartPath,
     });
@@ -562,8 +562,8 @@ function adaptTransform(
   if (transform === undefined) {
     diagnostics.push({
       severity: "warning",
-      code: "cleandoc-adapter.missing-transform",
-      message: "CleanDoc element has no computed transform; using a zero-size fallback.",
+      code: "pptx-computed-view-adapter.missing-transform",
+      message: "PptxSourceModel element has no computed transform; using a zero-size fallback.",
       slideNumber: slide.slideNumber,
       sourcePartPath,
     });
@@ -647,8 +647,8 @@ function adaptFill(
 
   diagnostics.push({
     severity: "warning",
-    code: "cleandoc-adapter.raw-fill-ignored",
-    message: "Raw CleanDoc fill is outside the renderer adapter subset.",
+    code: "pptx-computed-view-adapter.raw-fill-ignored",
+    message: "Raw PptxSourceModel fill is outside the renderer adapter subset.",
     slideNumber: slide.slideNumber,
   });
   return null;

--- a/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
+++ b/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
@@ -2,10 +2,10 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import {
-  type CleanDocSource,
   createComputedView,
   findTextRunBySourceHandle,
   type MediaPart,
+  type PptxSourceModel,
   readPptx,
   replaceTextRunPlainText,
   type SourceParagraph,
@@ -17,13 +17,13 @@ import { renderSlideToSvg } from "@pptx-glimpse/renderer";
 import { unzipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 
-import { adaptComputedViewToRendererModel } from "./cleandoc-renderer-adapter.js";
 import { convertPptxToPng, convertPptxToSvg } from "./converter.js";
+import { adaptComputedViewToRendererModel } from "./pptx-computed-view-renderer-adapter.js";
 
 const SHARED_FIXTURES = ["real-basic-theme.pptx", "real-product-page.pptx"] as const;
 const EDITED_TEXT = "Edited 470";
 
-describe("CleanDoc PoC end-to-end round-trip", () => {
+describe("PptxSourceModel PoC end-to-end round-trip", () => {
   it.each(SHARED_FIXTURES)(
     "renders %s through read -> computed view -> adapter -> SVG",
     (fixtureName) => {
@@ -44,7 +44,7 @@ describe("CleanDoc PoC end-to-end round-trip", () => {
       for (const diagnostic of rendered.adapted.diagnostics) {
         expect(diagnostic).toMatchObject({
           severity: "warning",
-          code: "cleandoc-adapter.raw-element-skipped",
+          code: "pptx-computed-view-adapter.raw-element-skipped",
         });
       }
     },
@@ -156,7 +156,7 @@ describe("CleanDoc PoC end-to-end round-trip", () => {
 const textDecoder = new TextDecoder();
 
 interface RenderedDocumentPath {
-  readonly source: CleanDocSource;
+  readonly source: PptxSourceModel;
   readonly computed: ReturnType<typeof createComputedView>;
   readonly adapted: ReturnType<typeof adaptComputedViewToRendererModel>;
   readonly svgs: readonly { readonly slideNumber: number; readonly svg: string }[];
@@ -172,7 +172,7 @@ function renderDocumentPath(input: Uint8Array): RenderedDocumentPath {
   const adapted = adaptComputedViewToRendererModel(computed);
   const slideSize = adapted.slideSize;
   if (slideSize === undefined) {
-    throw new Error("CleanDoc render path requires a slide size for selected fixtures");
+    throw new Error("PptxSourceModel render path requires a slide size for selected fixtures");
   }
 
   return {
@@ -204,7 +204,7 @@ function mediaBytesByPath(media: readonly MediaPart[]): Record<string, readonly 
   return Object.fromEntries(media.map((part) => [part.partPath, [...part.bytes]]));
 }
 
-function selectedPreservedPartPaths(source: CleanDocSource): string[] {
+function selectedPreservedPartPaths(source: PptxSourceModel): string[] {
   return [
     ...source.presentation.slidePartPaths,
     ...source.slideLayouts.map((layout) => layout.partPath),
@@ -213,7 +213,7 @@ function selectedPreservedPartPaths(source: CleanDocSource): string[] {
   ];
 }
 
-function firstEditableRun(source: CleanDocSource): {
+function firstEditableRun(source: PptxSourceModel): {
   readonly slideNumber: number;
   readonly paragraph: SourceParagraph;
   readonly run: EditableTextRun;
@@ -229,7 +229,7 @@ function firstEditableRun(source: CleanDocSource): {
       }
     }
   }
-  throw new Error("No editable text run found in selected CleanDoc fixture");
+  throw new Error("No editable text run found in selected PptxSourceModel fixture");
 }
 
 type EditableTextRun = SourceTextRun & {
@@ -241,7 +241,7 @@ function isEditableTextRun(run: SourceTextRun): run is EditableTextRun {
 }
 
 function firstParagraphForRun(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   handle: SourceTextRun["handle"],
 ): SourceParagraph | undefined {
   if (handle === undefined) return undefined;

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -2,7 +2,7 @@
   "name": "@pptx-glimpse/document",
   "version": "0.0.0",
   "private": true,
-  "description": "Experimental CleanDoc and OOXML document foundation for pptx-glimpse.",
+  "description": "Experimental PptxSourceModel and OOXML document foundation for pptx-glimpse.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/document/src/computed/create-computed-view.test.ts
+++ b/packages/document/src/computed/create-computed-view.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import type {
-  CleanDocSource,
   ComputedConnectorElement,
   ComputedElement,
   ComputedGroupElement,
@@ -9,6 +8,7 @@ import type {
   ComputedShapeElement,
   ComputedSlide,
   ComputedTableElement,
+  PptxSourceModel,
   SourceRunProperties,
   SourceShape,
   SourceShapeNode,
@@ -210,7 +210,7 @@ describe("createComputedView", () => {
 
   it("local sp/no autofit で inherited normAutofit の scale 値をリセットする", () => {
     const source = buildSource();
-    const sourceWithAutofitPlaceholders: CleanDocSource = {
+    const sourceWithAutofitPlaceholders: PptxSourceModel = {
       ...source,
       slides: source.slides.map((slide) =>
         slide.partPath === asPartPath("ppt/slides/slide2.xml")
@@ -360,7 +360,7 @@ describe("createComputedView", () => {
         },
       }),
     ]);
-    const sourceWithFormatScheme: CleanDocSource = {
+    const sourceWithFormatScheme: PptxSourceModel = {
       ...source,
       themes: source.themes.map((theme) => ({
         ...theme,
@@ -484,7 +484,7 @@ describe("createComputedView", () => {
         },
       },
     ]);
-    const sourceWithStyleEffect: CleanDocSource = {
+    const sourceWithStyleEffect: PptxSourceModel = {
       ...source,
       themes: source.themes.map((theme) => ({
         ...theme,
@@ -581,7 +581,7 @@ describe("createComputedView", () => {
   it("connector / group / custom geometry を computed element として保持する", () => {
     const source = buildSource();
     const slidePath = asPartPath("ppt/slides/slide2.xml");
-    const extended: CleanDocSource = {
+    const extended: PptxSourceModel = {
       ...source,
       slides: source.slides.map((slide) =>
         slide.partPath === slidePath
@@ -709,9 +709,9 @@ function elementNames(elements: readonly ComputedElement[]): (string | undefined
 }
 
 function withSlide2Shapes(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   extraShapes: readonly SourceShapeNode[],
-): CleanDocSource {
+): PptxSourceModel {
   return {
     ...source,
     slides: source.slides.map((slide) =>
@@ -722,7 +722,7 @@ function withSlide2Shapes(
   };
 }
 
-function buildSource(): CleanDocSource {
+function buildSource(): PptxSourceModel {
   const masterTitle = placeholder("Master title", "title", 1, {
     transform: transform(100, 200, 300, 400),
     geometry: { preset: "rect" },
@@ -937,7 +937,7 @@ function buildSourceWithChartAndSmartArt(
   options: {
     readonly chartRelationshipType?: string;
   } = {},
-): CleanDocSource {
+): PptxSourceModel {
   const source = buildSource();
   const slidePath = asPartPath("ppt/slides/slide2.xml");
   const dataPath = asPartPath("ppt/diagrams/data1.xml");

--- a/packages/document/src/computed/create-computed-view.ts
+++ b/packages/document/src/computed/create-computed-view.ts
@@ -1,6 +1,6 @@
 import type {
-  CleanDocSource,
   PartPath,
+  PptxSourceModel,
   SourceBlipEffects,
   SourceCellBorders,
   SourceColor,
@@ -27,7 +27,6 @@ import type {
 } from "../source/index.js";
 import { asEmu, asPartPath } from "../source/index.js";
 import type {
-  CleanDocComputedView,
   ComputedBackground,
   ComputedBlipEffects,
   ComputedCellBorders,
@@ -53,7 +52,8 @@ import type {
   ComputedTableRow,
   ComputedTextBody,
   CreateComputedViewOptions,
-} from "./clean-doc-computed-view.js";
+  PptxComputedView,
+} from "./pptx-computed-view.js";
 
 const DEFAULT_COLOR_MAP: Readonly<Record<string, string>> = {
   bg1: "lt1",
@@ -124,9 +124,9 @@ const DEFAULT_TABLE_STYLE_BORDERS: SourceCellBorders = {
 };
 
 export function createComputedView(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   options: CreateComputedViewOptions = {},
-): CleanDocComputedView {
+): PptxComputedView {
   const slidesByPath = new Map(source.slides.map((slide) => [slide.partPath, slide]));
   const selectedSlideNumbers = options.slides !== undefined ? new Set(options.slides) : undefined;
 
@@ -149,7 +149,7 @@ export function createComputedView(
 }
 
 function computeSlide(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   slide: SourceSlide,
   slideNumber: number,
   options: CreateComputedViewOptions,
@@ -207,7 +207,7 @@ function computeSlide(
 }
 
 interface ComputeContext {
-  readonly source: CleanDocSource;
+  readonly source: PptxSourceModel;
   readonly layout?: SourceSlideLayout;
   readonly master?: SourceSlideMaster;
   readonly theme?: SourceTheme;
@@ -252,7 +252,7 @@ function buildComputedColorScheme(context: ComputeContext): Readonly<Record<stri
 }
 
 function resolveRelationships(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   sourcePartPath: PartPath,
 ): ComputedRelationship[] {
   const rels =
@@ -1266,7 +1266,7 @@ function resolveRelationshipTarget(sourcePartPath: string, target: string): stri
   return segments.join("/");
 }
 
-function readRawPackageText(source: CleanDocSource, partPath: PartPath): string | undefined {
+function readRawPackageText(source: PptxSourceModel, partPath: PartPath): string | undefined {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
   if (rawPart?.kind === "binary") return textDecoder.decode(rawPart.bytes);
   return undefined;

--- a/packages/document/src/computed/index.ts
+++ b/packages/document/src/computed/index.ts
@@ -1,5 +1,5 @@
+export { createComputedView } from "./create-computed-view.js";
 export type {
-  CleanDocComputedView,
   ComputedBackground,
   ComputedBlipEffects,
   ComputedCellBorders,
@@ -31,5 +31,5 @@ export type {
   ComputedTextBody,
   ComputedTextRun,
   CreateComputedViewOptions,
-} from "./clean-doc-computed-view.js";
-export { createComputedView } from "./create-computed-view.js";
+  PptxComputedView,
+} from "./pptx-computed-view.js";

--- a/packages/document/src/computed/pptx-computed-view.ts
+++ b/packages/document/src/computed/pptx-computed-view.ts
@@ -1,5 +1,5 @@
 /**
- * CleanDoc computed view の型。
+ * PptxSourceModel computed view の型。
  *
  * source model を mutation せず、slide / layout / master / theme cascade から
  * 消費しやすい effective value を派生させる。renderer 固有の pixel conversion
@@ -43,7 +43,7 @@ export interface CreateComputedViewOptions {
   readonly applyMasterVisibility?: boolean;
 }
 
-export interface CleanDocComputedView {
+export interface PptxComputedView {
   readonly slideSize?: ComputedSlideSize;
   readonly slides: readonly ComputedSlide[];
 }

--- a/packages/document/src/experimental.ts
+++ b/packages/document/src/experimental.ts
@@ -8,18 +8,18 @@ export const documentExperimentalApi: DocumentExperimentalApi = {
   status: "experimental",
 };
 
-// CleanDoc source model 型 (experimental)。後続の reader / writer / computed
+// PptxSourceModel source model 型 (experimental)。後続の reader / writer / computed
 // view 実装が参照する source of truth の最小 contract。
 export * from "./source/index.js";
 
-// CleanDoc source reader (experimental)。PPTX package を読み、package graph と
-// presentation metadata を含む CleanDoc source を返す。
+// PptxSourceModel source reader (experimental)。PPTX package を読み、package graph と
+// presentation metadata を含む PptxSourceModel source を返す。
 export * from "./reader/index.js";
 
-// CleanDoc computed view generator (experimental)。source model を mutation せず、
+// PptxSourceModel computed view generator (experimental)。source model を mutation せず、
 // slide/layout/master/theme cascade と relationship を解決した derived view を返す。
 export * from "./computed/index.js";
 
-// CleanDoc source writer (experimental)。まずは no-edit structural round-trip
+// PptxSourceModel source writer (experimental)。まずは no-edit structural round-trip
 // 用に、保持済み package material を PPTX ZIP として書き戻す。
 export * from "./writer/index.js";

--- a/packages/document/src/reader/drawing.ts
+++ b/packages/document/src/reader/drawing.ts
@@ -1,8 +1,8 @@
 /**
- * DrawingML の色・塗り・線・座標変換を CleanDoc source 型へ読み取るヘルパー。
+ * DrawingML の色・塗り・線・座標変換を PptxSourceModel source 型へ読み取るヘルパー。
  *
  * source では theme color / relationship を未解決のまま保持する
- * (`docs/cleandoc-source-computed-view.md`)。lumMod / tint 等の変換は適用せず
+ * (`docs/pptx-source-model-computed-view.md`)。lumMod / tint 等の変換は適用せず
  * そのまま保存し、解決は computed view の責務とする。未対応の塗り (gradient /
  * pattern / picture fill) は raw sidecar として保存する。
  */

--- a/packages/document/src/reader/index.ts
+++ b/packages/document/src/reader/index.ts
@@ -1,5 +1,5 @@
 /**
- * CleanDoc source reader の barrel re-export。
+ * PptxSourceModel source reader の barrel re-export。
  */
 
 export type { ReadPptxInput } from "./read-pptx.js";

--- a/packages/document/src/reader/raw-node.ts
+++ b/packages/document/src/reader/raw-node.ts
@@ -1,7 +1,7 @@
 /**
  * Raw OOXML escape hatch のための変換ヘルパー。
  *
- * CleanDoc が typed に表現しない要素 (未対応の fill / effect / extension 等) を
+ * PptxSourceModel が typed に表現しない要素 (未対応の fill / effect / extension 等) を
  * `RawOoxmlNode` / `RawSidecar` として保存し、structural round-trip を成立させる
  * (`docs/raw-ooxml-round-trip.md`)。fast-xml-parser が生成した plain object を
  * qualified name を保ったまま raw tree へ写し取る。

--- a/packages/document/src/reader/read-pptx.test.ts
+++ b/packages/document/src/reader/read-pptx.test.ts
@@ -69,7 +69,7 @@ function buildSyntheticPptx(): Uint8Array {
 describe("readPptx — package graph と presentation metadata", () => {
   const source = readPptx(buildSyntheticPptx());
 
-  it("presentation metadata を含む CleanDoc source を返す", () => {
+  it("presentation metadata を含む PptxSourceModel source を返す", () => {
     expect(source.presentation.partPath).toBe("ppt/presentation.xml");
     expect(source.presentation.handle?.partPath).toBe("ppt/presentation.xml");
     // slide は presentation order どおり typed に読まれる (cSld が空なので shapes は空)。

--- a/packages/document/src/reader/read-pptx.ts
+++ b/packages/document/src/reader/read-pptx.ts
@@ -1,8 +1,8 @@
 /**
- * `readPptx(input)` — CleanDoc source reader の最初の slice。
+ * `readPptx(input)` — PptxSourceModel source reader の最初の slice。
  *
  * PPTX ZIP package を読み、package graph (content types / relationships /
- * media) と presentation metadata (slide size / slide order) を CleanDoc source
+ * media) と presentation metadata (slide size / slide order) を PptxSourceModel source
  * として返す。さらに presentation order の各 slide から layout → master → theme
  * の chain を辿り、simple shape / text / image を typed source node として読む。
  * 未編集・未対応の part / 子要素は raw package material / raw sidecar として
@@ -18,7 +18,6 @@
 import { unzipSync } from "fflate";
 
 import type {
-  CleanDocSource,
   ContentTypeDefault,
   ContentTypeOverride,
   Diagnostic,
@@ -26,6 +25,7 @@ import type {
   PackagePartRef,
   PartPath,
   PartRelationships,
+  PptxSourceModel,
   RawPackagePart,
   Relationship,
   RelationshipTargetMode,
@@ -73,11 +73,11 @@ const PRESENTATION_CONTENT_TYPE =
 const textDecoder = new TextDecoder();
 
 /**
- * PPTX バイト列を読み、CleanDoc source を返す。
+ * PPTX バイト列を読み、PptxSourceModel source を返す。
  *
  * @throws presentation part が見つからない (= 有効な PPTX ではない) 場合。
  */
-export function readPptx(input: ReadPptxInput): CleanDocSource {
+export function readPptx(input: ReadPptxInput): PptxSourceModel {
   const entries = unzipPackage(input);
   const diagnostics: Diagnostic[] = [];
 

--- a/packages/document/src/reader/shape-tree.ts
+++ b/packages/document/src/reader/shape-tree.ts
@@ -1,5 +1,5 @@
 /**
- * `p:spTree` を CleanDoc source の shape node 列へ読み取る。
+ * `p:spTree` を PptxSourceModel source の shape node 列へ読み取る。
  *
  * simple autoshape (`p:sp`), embedded raster image (`p:pic`), connector
  * (`p:cxnSp`), and group (`p:grpSp`) を typed に表す。graphicFrame は table /

--- a/packages/document/src/reader/slide-parts.ts
+++ b/packages/document/src/reader/slide-parts.ts
@@ -1,9 +1,9 @@
 /**
- * slide / slideLayout / slideMaster / theme part を CleanDoc source の typed
+ * slide / slideLayout / slideMaster / theme part を PptxSourceModel source の typed
  * node へ読み取る。
  *
  * 各 part は分離したまま保持し、cascade (master → layout → slide) の解決は
- * computed view の責務とする (`docs/cleandoc-source-computed-view.md`)。本
+ * computed view の責務とする (`docs/pptx-source-model-computed-view.md`)。本
  * モジュールは解決に必要な素材 (背景 / clrMap / clrMapOvr / theme scheme /
  * showMasterSp) と shape tree を source-local に読み出す。
  */

--- a/packages/document/src/reader/text.ts
+++ b/packages/document/src/reader/text.ts
@@ -1,9 +1,9 @@
 /**
- * `p:txBody` を CleanDoc source の text body / paragraph / run へ読み取る。
+ * `p:txBody` を PptxSourceModel source の text body / paragraph / run へ読み取る。
  *
  * PoC scope は plain run text と basic run properties (太字 / 斜体 / 下線 /
  * フォントサイズ / typeface / solid color) のみを typed に表す
- * (`docs/cleandoc-minimal-poc-scope.md`)。bullet / field / line break 等の
+ * (`docs/pptx-source-model-minimal-poc-scope.md`)。bullet / field / line break 等の
  * 未対応ノードは raw sidecar として保持する。
  */
 

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1,5 +1,5 @@
 import type {
-  CleanDocSource,
+  PptxSourceModel,
   SourceHandle,
   SourceParagraph,
   SourceShape,
@@ -7,7 +7,7 @@ import type {
 } from "./index.js";
 
 export function findTextRunBySourceHandle(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   handle: SourceHandle,
 ): SourceTextRun | undefined {
   for (const slide of source.slides) {
@@ -21,10 +21,10 @@ export function findTextRunBySourceHandle(
 }
 
 export function replaceTextRunPlainText(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   handle: SourceHandle,
   text: string,
-): CleanDocSource {
+): PptxSourceModel {
   let replaced = false;
 
   const slides = source.slides.map((slide) => ({
@@ -57,7 +57,9 @@ export function replaceTextRunPlainText(
   }));
 
   if (!replaced) {
-    throw new Error("replaceTextRunPlainText: text run handle was not found in CleanDoc source");
+    throw new Error(
+      "replaceTextRunPlainText: text run handle was not found in PptxSourceModel source",
+    );
   }
 
   return {

--- a/packages/document/src/source/handles.ts
+++ b/packages/document/src/source/handles.ts
@@ -1,7 +1,7 @@
 /**
  * Source handle 関連の型。
  *
- * CleanDoc source node は、書き戻し (writer) / 編集 (editor) / round-trip の
+ * PptxSourceModel source node は、書き戻し (writer) / 編集 (editor) / round-trip の
  * ために「どの package part のどのノードから来たか」を stable な handle として
  * 保持する。handle は直接の mutable pointer ではなく、安定した参照
  * (part path / relationship id / node id / 兄弟内の順序 / raw sidecar 参照) で

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -1,8 +1,7 @@
 /**
- * CleanDoc source model 型の barrel re-export。
+ * PptxSourceModel source model 型の barrel re-export。
  */
 
-export type { CleanDocEdit, CleanDocSource, CleanDocTextRunEdit } from "./clean-doc-source.js";
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
 export { findTextRunBySourceHandle, replaceTextRunPlainText } from "./editing.js";
 export type {
@@ -24,6 +23,11 @@ export type {
   Relationship,
   RelationshipTargetMode,
 } from "./package-graph.js";
+export type {
+  PptxSourceModel,
+  PptxSourceModelEdit,
+  PptxSourceModelTextRunEdit,
+} from "./pptx-source-model.js";
 export type {
   SlideSize,
   SourceBackground,

--- a/packages/document/src/source/pptx-source-model.test.ts
+++ b/packages/document/src/source/pptx-source-model.test.ts
@@ -11,14 +11,14 @@ import {
   asRawSidecarId,
   asRelationshipId,
   asSourceNodeId,
-  type CleanDocSource,
+  type PptxSourceModel,
   type SourceImage,
   type SourceShape,
   type SourceTextRun,
 } from "../experimental.js";
 
-describe("CleanDoc source model types", () => {
-  it("can build a minimal CleanDocSource value", () => {
+describe("PptxSourceModel source model types", () => {
+  it("can build a minimal PptxSourceModel value", () => {
     const slidePath = asPartPath("ppt/slides/slide1.xml");
     const layoutPath = asPartPath("ppt/slideLayouts/slideLayout1.xml");
     const masterPath = asPartPath("ppt/slideMasters/slideMaster1.xml");
@@ -73,7 +73,7 @@ describe("CleanDoc source model types", () => {
       handle: { partPath: slidePath, relationshipId: asRelationshipId("rId2") },
     };
 
-    const source: CleanDocSource = {
+    const source: PptxSourceModel = {
       packageGraph: {
         contentTypes: {
           defaults: [{ extension: "png", contentType: "image/png" }],

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -1,10 +1,10 @@
 /**
- * CleanDoc source model のトップレベル型。
+ * PptxSourceModel source model のトップレベル型。
  *
  * `@pptx-glimpse/document` が所有する canonical な document 表現で、writer /
  * editor / round-trip の source of truth となる。renderer-specific fallback や
  * pixel output 固有の値は含まない (`docs/document-boundaries.md` /
- * `docs/cleandoc-source-computed-view.md`)。computed view はこの source から
+ * `docs/pptx-source-model-computed-view.md`)。computed view はこの source から
  * 派生して生成する derived projection であり、本型には含めない。
  */
 
@@ -19,7 +19,7 @@ import type {
   SourceTheme,
 } from "./presentation.js";
 
-export interface CleanDocSource {
+export interface PptxSourceModel {
   /** package part / relationship / content type / media の構造。 */
   readonly packageGraph: PackageGraph;
   readonly presentation: SourcePresentation;
@@ -29,13 +29,13 @@ export interface CleanDocSource {
   readonly themes: readonly SourceTheme[];
   /** document 正しさに関する診断。 */
   readonly diagnostics: readonly Diagnostic[];
-  /** typed CleanDoc operation と dirty scope。writer はここから最小更新範囲を判断する。 */
-  readonly edits?: readonly CleanDocEdit[];
+  /** typed PptxSourceModel operation と dirty scope。writer はここから最小更新範囲を判断する。 */
+  readonly edits?: readonly PptxSourceModelEdit[];
 }
 
-export type CleanDocEdit = CleanDocTextRunEdit;
+export type PptxSourceModelEdit = PptxSourceModelTextRunEdit;
 
-export interface CleanDocTextRunEdit {
+export interface PptxSourceModelTextRunEdit {
   readonly kind: "replaceTextRunPlainText";
   readonly handle: SourceHandle;
   readonly text: string;

--- a/packages/document/src/source/presentation.ts
+++ b/packages/document/src/source/presentation.ts
@@ -2,10 +2,10 @@
  * Presentation hierarchy の source 型。slide / layout / master / theme の参照
  * 関係を part path で表す。各 part は分離したまま保持し、cascade (master →
  * layout → slide) の **解決** は computed view の責務とする
- * (`docs/cleandoc-source-computed-view.md`)。ただし解決に必要な素材
+ * (`docs/pptx-source-model-computed-view.md`)。ただし解決に必要な素材
  * (background / clrMap / clrMapOvr / theme scheme / showMasterSp) は、source が
  * raw XML に戻らず保持できるよう source-local に置く
- * (`docs/cleandoc-minimal-poc-scope.md` の Included PPTX Subset)。
+ * (`docs/pptx-source-model-minimal-poc-scope.md` の Included PPTX Subset)。
  */
 
 import type { PartPath, SourceHandle } from "./handles.js";

--- a/packages/document/src/source/raw.ts
+++ b/packages/document/src/source/raw.ts
@@ -1,7 +1,7 @@
 /**
  * Raw OOXML escape hatch 関連の型 (`docs/raw-ooxml-round-trip.md`)。
  *
- * CleanDoc は supported semantics を typed field で表しつつ、未対応・部分対応の
+ * PptxSourceModel は supported semantics を typed field で表しつつ、未対応・部分対応の
  * XML を raw sidecar として、未編集の part を raw package part として保持し、
  * structural round-trip を成立させる。byte 一致は目標にしない。
  */
@@ -10,7 +10,7 @@ import type { PartPath, RawSidecarId } from "./handles.js";
 
 /**
  * 部分的にパースされた raw OOXML ノード。namespace prefix 付きの qualified name、
- * 属性、子ノード、テキストを保持する。CleanDoc が typed に表現しない要素
+ * 属性、子ノード、テキストを保持する。PptxSourceModel が typed に表現しない要素
  * (vendor extension / `mc:AlternateContent` / 未知の DrawingML 等) の保存に使う。
  */
 export interface RawOoxmlNode {
@@ -23,7 +23,7 @@ export interface RawOoxmlNode {
 }
 
 /**
- * CleanDoc source node に付随する raw XML sidecar。最も近い source node に
+ * PptxSourceModel source node に付随する raw XML sidecar。最も近い source node に
  * 紐づけ、親要素内での順序メタデータを保持して書き戻し時の順序を復元する。
  */
 export interface RawSidecar {

--- a/packages/document/src/source/shapes.ts
+++ b/packages/document/src/source/shapes.ts
@@ -3,7 +3,7 @@
  *
  * PoC scope の最小 subset (simple shapes / text / images) のみを typed に表す。
  * theme color や relationship は source では未解決の参照のまま保持し
- * (`docs/cleandoc-source-computed-view.md`)、cascade 解決は computed view の
+ * (`docs/pptx-source-model-computed-view.md`)、cascade 解決は computed view の
  * 責務とする。未対応ノードは raw escape hatch で保存する。
  */
 

--- a/packages/document/src/source/units.ts
+++ b/packages/document/src/source/units.ts
@@ -1,5 +1,5 @@
 /**
- * CleanDoc source model が使う PPTX-native な typed units。
+ * PptxSourceModel source model が使う PPTX-native な typed units。
  *
  * source model は pixel 変換を持たず、OOXML が定義する単位系をそのまま
  * 型として保持する。renderer 側の単位型 (`@pptx-glimpse/renderer`) は

--- a/packages/document/src/writer/index.ts
+++ b/packages/document/src/writer/index.ts
@@ -1,5 +1,5 @@
 /**
- * CleanDoc source writer の barrel re-export。
+ * PptxSourceModel source writer の barrel re-export。
  */
 
 export type { WritePptxOutput } from "./write-pptx.js";

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -127,7 +127,7 @@ function getEntry(output: Uint8Array, path: string): Uint8Array {
 }
 
 describe("writePptx — no-edit round-trip", () => {
-  it("CleanDoc source から no-edit PPTX を write し、再読込できる", () => {
+  it("PptxSourceModel source から no-edit PPTX を write し、再読込できる", () => {
     const input = buildRoundTripFixture();
     const original = readPptx(input);
 
@@ -292,7 +292,7 @@ describe("writePptx — one plain text-run edit", () => {
     expect(findTextRunBySourceHandle(source, run.handle!)).toBe(run);
   });
 
-  it("plain text 置換を CleanDoc source に適用し、write 後の PPTX に反映する", () => {
+  it("plain text 置換を PptxSourceModel source に適用し、write 後の PPTX に反映する", () => {
     const input = buildTextEditFixture();
     const source = readPptx(input);
     const run = firstRun(source);

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -1,5 +1,5 @@
 /**
- * `writePptx(source)` — CleanDoc source writer の最初の round-trip slice。
+ * `writePptx(source)` — PptxSourceModel source writer の最初の round-trip slice。
  *
  * この writer は structural round-trip を目的に、reader が保持した raw package
  * material / media bytes / package bookkeeping を PPTX ZIP として再構成する。
@@ -13,11 +13,11 @@ import { zipSync } from "fflate";
 
 import { parseXml, type XmlNode } from "../reader/xml.js";
 import type {
-  CleanDocEdit,
-  CleanDocSource,
-  CleanDocTextRunEdit,
   PartPath,
   PartRelationships,
+  PptxSourceModel,
+  PptxSourceModelEdit,
+  PptxSourceModelTextRunEdit,
   RawOoxmlNode,
   RawPackagePart,
 } from "../source/index.js";
@@ -40,14 +40,14 @@ const xmlBuilder = new XMLBuilder({
 });
 
 /**
- * CleanDoc source を PPTX package bytes に書き戻す。
+ * PptxSourceModel source を PPTX package bytes に書き戻す。
  *
  * round-trip 用の初期 writer であり、未編集 package material を優先して
  * preserved output を作る。dirty part の patch に必要な raw bytes が無い場合や
  * 必要な raw bytes が無い non-bookkeeping part は、
  * 暗黙に再生成せずエラーにする。
  */
-export function writePptx(source: CleanDocSource): WritePptxOutput {
+export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const textRunEdits = source.edits?.filter(isTextRunEdit) ?? [];
   const dirtyPartPaths = new Set(textRunEdits.map((edit) => edit.handle.partPath));
   const files: Record<string, Uint8Array> = {
@@ -90,14 +90,14 @@ export function writePptx(source: CleanDocSource): WritePptxOutput {
   return zipSync(files);
 }
 
-function isTextRunEdit(edit: CleanDocEdit): edit is CleanDocTextRunEdit {
+function isTextRunEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelTextRunEdit {
   return edit.kind === "replaceTextRunPlainText";
 }
 
 function serializeDirtyXmlPart(
-  source: CleanDocSource,
+  source: PptxSourceModel,
   partPath: PartPath,
-  textRunEdits: readonly CleanDocTextRunEdit[],
+  textRunEdits: readonly PptxSourceModelTextRunEdit[],
 ): Uint8Array {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
   if (rawPart === undefined) {
@@ -115,7 +115,7 @@ function serializeDirtyXmlPart(
   return encodeXml(XML_DECLARATION + xmlBuilder.build(root));
 }
 
-function applyTextRunEdit(root: XmlNode, edit: CleanDocTextRunEdit): void {
+function applyTextRunEdit(root: XmlNode, edit: PptxSourceModelTextRunEdit): void {
   const locator = parseTextRunLocator(edit.handle.nodeId);
   const slide = getChild(root, "sld");
   const cSld = getChild(slide, "cSld");
@@ -141,7 +141,9 @@ interface TextRunLocator {
   readonly runIndex: number;
 }
 
-function parseTextRunLocator(nodeId: CleanDocTextRunEdit["handle"]["nodeId"]): TextRunLocator {
+function parseTextRunLocator(
+  nodeId: PptxSourceModelTextRunEdit["handle"]["nodeId"],
+): TextRunLocator {
   const value = String(nodeId ?? "");
   const byShapeId = /^text:shape:(.+):p:(\d+):r:(\d+)$/.exec(value);
   if (byShapeId !== null) {
@@ -271,7 +273,7 @@ function localName(key: string): string {
 }
 
 function serializeContentTypes(
-  contentTypes: CleanDocSource["packageGraph"]["contentTypes"],
+  contentTypes: PptxSourceModel["packageGraph"]["contentTypes"],
 ): string {
   const defaults = contentTypes.defaults
     .map(

--- a/shared-fixtures/README.md
+++ b/shared-fixtures/README.md
@@ -6,11 +6,11 @@
 
 このディレクトリのファイルは複数のテストスイートから共有される:
 
-| テスト                   | ファイル                                        | 目的                                                                             |
-| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------------- |
-| E2E スモークテスト       | `e2e/smoke.test.ts`                             | エラーなく変換できること・主要要素の SVG 出力確認                                |
-| スナップショット VRT     | `vrt/snapshot/regression.test.ts`               | レンダリング結果のリグレッション検出                                             |
-| document path parity VRT | `vrt/snapshot/document-path-regression.test.ts` | CleanDoc document path と parser path oracle の zero-diff / zero-diagnostic 確認 |
+| テスト                   | ファイル                                        | 目的                                                                                    |
+| ------------------------ | ----------------------------------------------- | --------------------------------------------------------------------------------------- |
+| E2E スモークテスト       | `e2e/smoke.test.ts`                             | エラーなく変換できること・主要要素の SVG 出力確認                                       |
+| スナップショット VRT     | `vrt/snapshot/regression.test.ts`               | レンダリング結果のリグレッション検出                                                    |
+| document path parity VRT | `vrt/snapshot/document-path-regression.test.ts` | PptxSourceModel document path と parser path oracle の zero-diff / zero-diagnostic 確認 |
 
 ## プログラム合成フィクスチャとの違い
 

--- a/vrt/snapshot/document-path-cases.ts
+++ b/vrt/snapshot/document-path-cases.ts
@@ -2,7 +2,7 @@
  * Document path VRT は public snapshot を更新せず、明示的な parser path の PNG を
  * 参照画像としてその場で比較する full parity harness。
  *
- * CleanDoc default switch 後も parser path oracle との zero-diff gate として残す。
+ * PptxSourceModel default switch 後も parser path oracle との zero-diff gate として残す。
  * 以前の migration blocker issue はすべて解消済みなので、ケースごとの issue 番号は
  * ここでは保持しない。
  */


### PR DESCRIPTION
close #515

## 目的

`@pptx-glimpse/document` の内部概念名として残っていた `CleanDoc` を、PPTX domain / source model の責務が伝わる `PptxSourceModel` / `PptxComputedView` 系の名称へ置き換えます。

## 変更内容

- `CleanDocSource` / `CleanDocComputedView` / 編集系型を `PptxSourceModel` / `PptxComputedView` / `PptxSourceModel*` に rename
- core の computed-view adapter ファイル名と diagnostic code prefix を `pptx-computed-view-*` 系へ rename
- docs / AGENTS / package metadata / tests / diagnostic message から現在状態としての `CleanDoc` 参照を置換
- `docs/pptx-source-model-computed-view.md` に `PptxSourceModel` 採用理由と `PptxSource` / `PptxModel` を採らない理由を記録

## 影響範囲

- `packages/document/src/`
- `packages/core/src/` の document path / computed-view adapter 周辺
- `docs/`, `AGENTS.md`, `shared-fixtures/README.md`, `vrt/snapshot/document-path-cases.ts`

## 検証

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test -- packages/document/src packages/core/src/experimental-document-renderer.test.ts packages/core/src/pptx-computed-view-renderer-adapter.test.ts`
- `npm run build`
- acceptance-check: 全項目 ✓
- cross-review: critical 0 / warning 0 / info 0

## 補足

`CleanDoc` 文字列は historical alias の説明として `docs/pptx-source-model-computed-view.md` に 1 箇所だけ残しています。
