### PR TITLE
CleanDoc document path 実装を横断リファクタする

### DIFF
--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -78,6 +78,7 @@ export interface RendererAdapterDiagnostic {
 }
 
 type DiagnosticSink = RendererAdapterDiagnostic[];
+type RendererAdapterDiagnosticCode = RendererAdapterDiagnostic["code"];
 
 const ZERO_TRANSFORM: Transform = {
   offsetX: asEmu(0),
@@ -153,25 +154,27 @@ function adaptBackground(
   diagnostics: DiagnosticSink,
 ): Background | null {
   if (background === undefined) return null;
-  if (background.kind === "fill") {
-    return { fill: adaptFill(background.fill, slide, diagnostics) };
+  switch (background.kind) {
+    case "fill":
+      return { fill: adaptFill(background.fill, slide, diagnostics) };
+    case "styleReference":
+      return {
+        fill:
+          background.color !== undefined
+            ? { type: "solid", color: adaptColor(background.color) }
+            : null,
+      };
+    case "raw":
+      pushAdapterWarning(
+        diagnostics,
+        "pptx-computed-view-adapter.raw-background-ignored",
+        "Raw PptxSourceModel background is not supported by the renderer adapter.",
+        slide,
+      );
+      return null;
+    default:
+      return assertNever(background);
   }
-  if (background.kind === "styleReference") {
-    return {
-      fill:
-        background.color !== undefined
-          ? { type: "solid", color: adaptColor(background.color) }
-          : null,
-    };
-  }
-
-  diagnostics.push({
-    severity: "warning",
-    code: "pptx-computed-view-adapter.raw-background-ignored",
-    message: "Raw PptxSourceModel background is not supported by the renderer adapter.",
-    slideNumber: slide.slideNumber,
-  });
-  return null;
 }
 
 function adaptElement(
@@ -179,31 +182,39 @@ function adaptElement(
   slide: ComputedSlide,
   diagnostics: DiagnosticSink,
 ): SlideElement[] {
-  if (element.kind === "shape") return [adaptShape(element, slide, diagnostics)];
-  if (element.kind === "connector") return [adaptConnector(element, slide, diagnostics)];
-  if (element.kind === "group") return [adaptGroup(element, slide, diagnostics)];
-  if (element.kind === "image") {
-    const image = adaptImage(element, slide, diagnostics);
-    return image === undefined ? [] : [image];
+  switch (element.kind) {
+    case "shape":
+      return [adaptShape(element, slide, diagnostics)];
+    case "connector":
+      return [adaptConnector(element, slide, diagnostics)];
+    case "group":
+      return [adaptGroup(element, slide, diagnostics)];
+    case "image": {
+      const image = adaptImage(element, slide, diagnostics);
+      return image === undefined ? [] : [image];
+    }
+    case "table":
+      return [adaptTable(element, slide, diagnostics)];
+    case "chart": {
+      const chart = adaptChart(element, slide, diagnostics);
+      return chart === undefined ? [] : [chart];
+    }
+    case "smartArt": {
+      const smartArt = adaptSmartArt(element, slide, diagnostics);
+      return smartArt === undefined ? [] : [smartArt];
+    }
+    case "raw":
+      pushAdapterWarning(
+        diagnostics,
+        "pptx-computed-view-adapter.raw-element-skipped",
+        "Raw PptxSourceModel shape tree node is outside the renderer adapter subset.",
+        slide,
+        element.sourcePartPath,
+      );
+      return [];
+    default:
+      return assertNever(element);
   }
-  if (element.kind === "table") return [adaptTable(element, slide, diagnostics)];
-  if (element.kind === "chart") {
-    const chart = adaptChart(element, slide, diagnostics);
-    return chart === undefined ? [] : [chart];
-  }
-  if (element.kind === "smartArt") {
-    const smartArt = adaptSmartArt(element, slide, diagnostics);
-    return smartArt === undefined ? [] : [smartArt];
-  }
-
-  diagnostics.push({
-    severity: "warning",
-    code: "pptx-computed-view-adapter.raw-element-skipped",
-    message: "Raw PptxSourceModel shape tree node is outside the renderer adapter subset.",
-    slideNumber: slide.slideNumber,
-    sourcePartPath: element.sourcePartPath,
-  });
-  return [];
 }
 
 function adaptConnector(
@@ -255,25 +266,25 @@ function adaptChart(
   diagnostics: DiagnosticSink,
 ): ChartElement | undefined {
   if (chart.chartXml === undefined) {
-    diagnostics.push({
-      severity: "warning",
-      code: "pptx-computed-view-adapter.unresolved-chart-skipped",
-      message: "PptxSourceModel chart element has no resolved chart XML.",
-      slideNumber: slide.slideNumber,
-      sourcePartPath: chart.sourcePartPath,
-    });
+    pushAdapterWarning(
+      diagnostics,
+      "pptx-computed-view-adapter.unresolved-chart-skipped",
+      "PptxSourceModel chart element has no resolved chart XML.",
+      slide,
+      chart.sourcePartPath,
+    );
     return undefined;
   }
 
   const chartData = parseChart(chart.chartXml, createColorResolver(slide));
   if (chartData === null) {
-    diagnostics.push({
-      severity: "warning",
-      code: "pptx-computed-view-adapter.unresolved-chart-skipped",
-      message: "PptxSourceModel chart XML could not be parsed into the renderer chart model.",
-      slideNumber: slide.slideNumber,
-      sourcePartPath: chart.sourcePartPath,
-    });
+    pushAdapterWarning(
+      diagnostics,
+      "pptx-computed-view-adapter.unresolved-chart-skipped",
+      "PptxSourceModel chart XML could not be parsed into the renderer chart model.",
+      slide,
+      chart.sourcePartPath,
+    );
     return undefined;
   }
 
@@ -290,13 +301,13 @@ function adaptSmartArt(
   diagnostics: DiagnosticSink,
 ): GroupElement | undefined {
   if (smartArt.drawingXml === undefined || smartArt.drawingPartPath === undefined) {
-    diagnostics.push({
-      severity: "warning",
-      code: "pptx-computed-view-adapter.unresolved-smartart-skipped",
-      message: "PptxSourceModel SmartArt element has no resolved diagram drawing XML.",
-      slideNumber: slide.slideNumber,
-      sourcePartPath: smartArt.sourcePartPath,
-    });
+    pushAdapterWarning(
+      diagnostics,
+      "pptx-computed-view-adapter.unresolved-smartart-skipped",
+      "PptxSourceModel SmartArt element has no resolved diagram drawing XML.",
+      slide,
+      smartArt.sourcePartPath,
+    );
     return undefined;
   }
 
@@ -304,13 +315,13 @@ function adaptSmartArt(
   const drawing = parsed.drawing as XmlNode | undefined;
   const spTree = drawing?.spTree as XmlNode | undefined;
   if (spTree === undefined) {
-    diagnostics.push({
-      severity: "warning",
-      code: "pptx-computed-view-adapter.unresolved-smartart-skipped",
-      message: "PptxSourceModel SmartArt diagram drawing XML has no shape tree.",
-      slideNumber: slide.slideNumber,
-      sourcePartPath: smartArt.sourcePartPath,
-    });
+    pushAdapterWarning(
+      diagnostics,
+      "pptx-computed-view-adapter.unresolved-smartart-skipped",
+      "PptxSourceModel SmartArt diagram drawing XML has no shape tree.",
+      slide,
+      smartArt.sourcePartPath,
+    );
     return undefined;
   }
 
@@ -486,13 +497,13 @@ function adaptImage(
   diagnostics: DiagnosticSink,
 ): ImageElement | undefined {
   if (image.media === undefined) {
-    diagnostics.push({
-      severity: "warning",
-      code: "pptx-computed-view-adapter.unresolved-image-skipped",
-      message: "PptxSourceModel image element has no resolved media payload.",
-      slideNumber: slide.slideNumber,
-      sourcePartPath: image.sourcePartPath,
-    });
+    pushAdapterWarning(
+      diagnostics,
+      "pptx-computed-view-adapter.unresolved-image-skipped",
+      "PptxSourceModel image element has no resolved media payload.",
+      slide,
+      image.sourcePartPath,
+    );
     return undefined;
   }
 
@@ -560,13 +571,13 @@ function adaptTransform(
   sourcePartPath: string,
 ): Transform {
   if (transform === undefined) {
-    diagnostics.push({
-      severity: "warning",
-      code: "pptx-computed-view-adapter.missing-transform",
-      message: "PptxSourceModel element has no computed transform; using a zero-size fallback.",
-      slideNumber: slide.slideNumber,
+    pushAdapterWarning(
+      diagnostics,
+      "pptx-computed-view-adapter.missing-transform",
+      "PptxSourceModel element has no computed transform; using a zero-size fallback.",
+      slide,
       sourcePartPath,
-    });
+    );
     return ZERO_TRANSFORM;
   }
 
@@ -604,54 +615,67 @@ function adaptFill(
   slide: ComputedSlide,
   diagnostics: DiagnosticSink,
 ): Fill | null {
-  if (fill.kind === "none") return { type: "none" };
-  if (fill.kind === "solid") {
-    return { type: "solid", color: adaptColor(fill.color) };
+  switch (fill.kind) {
+    case "none":
+      return { type: "none" };
+    case "solid":
+      return { type: "solid", color: adaptColor(fill.color) };
+    case "gradient":
+      return {
+        type: "gradient",
+        stops: fill.stops.map((stop) => ({
+          position: stop.position,
+          color: adaptColor(stop.color),
+        })),
+        angle: fill.angle ?? 0,
+        gradientType: fill.gradientType,
+        ...(fill.centerX !== undefined ? { centerX: fill.centerX } : {}),
+        ...(fill.centerY !== undefined ? { centerY: fill.centerY } : {}),
+      };
+    case "pattern":
+      return {
+        type: "pattern",
+        preset: fill.preset,
+        foregroundColor: adaptColor(fill.foregroundColor),
+        backgroundColor: adaptColor(fill.backgroundColor),
+      };
+    case "image":
+      if (fill.media !== undefined) {
+        return {
+          type: "image",
+          imageData: uint8ArrayToBase64(fill.media.bytes),
+          mimeType: normalizeImageMimeType(fill.media.contentType),
+          tile:
+            fill.tile !== undefined
+              ? {
+                  tx: toRendererEmu(fill.tile.tx),
+                  ty: toRendererEmu(fill.tile.ty),
+                  sx: fill.tile.sx,
+                  sy: fill.tile.sy,
+                  flip: fill.tile.flip,
+                  align: fill.tile.align,
+                }
+              : null,
+        };
+      }
+      pushAdapterWarning(
+        diagnostics,
+        "pptx-computed-view-adapter.raw-fill-ignored",
+        "Raw PptxSourceModel fill is outside the renderer adapter subset.",
+        slide,
+      );
+      return null;
+    case "raw":
+      pushAdapterWarning(
+        diagnostics,
+        "pptx-computed-view-adapter.raw-fill-ignored",
+        "Raw PptxSourceModel fill is outside the renderer adapter subset.",
+        slide,
+      );
+      return null;
+    default:
+      return assertNever(fill);
   }
-  if (fill.kind === "gradient") {
-    return {
-      type: "gradient",
-      stops: fill.stops.map((stop) => ({ position: stop.position, color: adaptColor(stop.color) })),
-      angle: fill.angle ?? 0,
-      gradientType: fill.gradientType,
-      ...(fill.centerX !== undefined ? { centerX: fill.centerX } : {}),
-      ...(fill.centerY !== undefined ? { centerY: fill.centerY } : {}),
-    };
-  }
-  if (fill.kind === "pattern") {
-    return {
-      type: "pattern",
-      preset: fill.preset,
-      foregroundColor: adaptColor(fill.foregroundColor),
-      backgroundColor: adaptColor(fill.backgroundColor),
-    };
-  }
-  if (fill.kind === "image" && fill.media !== undefined) {
-    return {
-      type: "image",
-      imageData: uint8ArrayToBase64(fill.media.bytes),
-      mimeType: normalizeImageMimeType(fill.media.contentType),
-      tile:
-        fill.tile !== undefined
-          ? {
-              tx: toRendererEmu(fill.tile.tx),
-              ty: toRendererEmu(fill.tile.ty),
-              sx: fill.tile.sx,
-              sy: fill.tile.sy,
-              flip: fill.tile.flip,
-              align: fill.tile.align,
-            }
-          : null,
-    };
-  }
-
-  diagnostics.push({
-    severity: "warning",
-    code: "pptx-computed-view-adapter.raw-fill-ignored",
-    message: "Raw PptxSourceModel fill is outside the renderer adapter subset.",
-    slideNumber: slide.slideNumber,
-  });
-  return null;
 }
 
 function adaptOutline(
@@ -827,4 +851,24 @@ function normalizeImageMimeType(contentType: string): string {
   if (contentType === "image/x-emf") return "image/emf";
   if (contentType === "image/x-wmf") return "image/wmf";
   return contentType;
+}
+
+function pushAdapterWarning(
+  diagnostics: DiagnosticSink,
+  code: RendererAdapterDiagnosticCode,
+  message: string,
+  slide: ComputedSlide,
+  sourcePartPath?: string,
+): void {
+  diagnostics.push({
+    severity: "warning",
+    code,
+    message,
+    slideNumber: slide.slideNumber,
+    ...(sourcePartPath !== undefined ? { sourcePartPath } : {}),
+  });
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected computed view union member: ${JSON.stringify(value)}`);
 }

--- a/packages/document/src/computed/color.ts
+++ b/packages/document/src/computed/color.ts
@@ -1,0 +1,230 @@
+import type {
+  SourceColor,
+  SourceColorMap,
+  SourceColorTransform,
+  SourceTheme,
+} from "../source/index.js";
+import { assertNever } from "../utils/assert-never.js";
+import type { ComputedColor } from "./pptx-computed-view.js";
+
+const DEFAULT_COLOR_MAP: Readonly<Record<string, string>> = {
+  bg1: "lt1",
+  tx1: "dk1",
+  bg2: "lt2",
+  tx2: "dk2",
+  accent1: "accent1",
+  accent2: "accent2",
+  accent3: "accent3",
+  accent4: "accent4",
+  accent5: "accent5",
+  accent6: "accent6",
+  hlink: "hlink",
+  folHlink: "folHlink",
+};
+
+const FALLBACK_SCHEME_COLORS: Readonly<Record<string, string>> = {
+  dk1: "#000000",
+  lt1: "#ffffff",
+  dk2: "#44546a",
+  lt2: "#e7e6e6",
+  accent1: "#4472c4",
+  accent2: "#ed7d31",
+  accent3: "#a5a5a5",
+  accent4: "#ffc000",
+  accent5: "#5b9bd5",
+  accent6: "#70ad47",
+  hlink: "#0563c1",
+  folHlink: "#954f72",
+};
+
+export interface ColorResolutionContext {
+  readonly theme?: SourceTheme;
+  readonly colorMap: Readonly<Record<string, string>>;
+}
+
+export function buildEffectiveColorMap(
+  master?: SourceColorMap,
+  layoutOverride?: SourceColorMap,
+  slideOverride?: SourceColorMap,
+): Readonly<Record<string, string>> {
+  return {
+    ...DEFAULT_COLOR_MAP,
+    ...master?.mapping,
+    ...layoutOverride?.mapping,
+    ...slideOverride?.mapping,
+  };
+}
+
+export function buildComputedColorScheme(
+  context: ColorResolutionContext,
+): Readonly<Record<string, string>> {
+  const colors: Record<string, string> = { ...FALLBACK_SCHEME_COLORS };
+  for (const [name, color] of Object.entries(context.theme?.colorScheme?.colors ?? {})) {
+    const resolved = resolveColor(context, color);
+    if (resolved !== undefined) colors[name] = resolved.hex;
+  }
+  return colors;
+}
+
+export function resolveColor(
+  context: ColorResolutionContext,
+  color: SourceColor,
+  visited: ReadonlySet<string> = new Set(),
+): ComputedColor | undefined {
+  const hex = resolveBaseHex(context, color, visited);
+  if (hex === undefined) return undefined;
+
+  return applyColorTransforms(hex, color.transforms);
+}
+
+function resolveBaseHex(
+  context: ColorResolutionContext,
+  color: SourceColor,
+  visited: ReadonlySet<string>,
+): string | undefined {
+  switch (color.kind) {
+    case "srgb":
+      return normalizeHex(color.hex);
+    case "system":
+      return normalizeHex(color.lastColor ?? "000000");
+    case "scheme": {
+      const mappedName = context.colorMap[color.scheme] ?? color.scheme;
+      if (visited.has(mappedName)) return "#000000";
+      const schemeColor = context.theme?.colorScheme?.colors[mappedName];
+      return schemeColor !== undefined
+        ? resolveColor(context, schemeColor, new Set([...visited, mappedName]))?.hex
+        : FALLBACK_SCHEME_COLORS[mappedName];
+    }
+    default:
+      return assertNever(color);
+  }
+}
+
+function applyColorTransforms(
+  initialHex: string,
+  transforms: readonly SourceColorTransform[] | undefined,
+): ComputedColor {
+  let hex = initialHex;
+  let alpha = 1;
+  for (const transform of transforms ?? []) {
+    switch (transform.kind) {
+      case "lumMod": {
+        const lumOff = transforms?.find((candidate) => candidate.kind === "lumOff");
+        hex = applyLuminance(
+          hex,
+          Number(transform.value) / 100000,
+          Number(lumOff?.value ?? 0) / 100000,
+        );
+        break;
+      }
+      case "lumOff":
+        if (!transforms?.some((candidate) => candidate.kind === "lumMod")) {
+          hex = applyLuminance(hex, 1, Number(transform.value) / 100000);
+        }
+        break;
+      case "tint":
+        hex = applyTint(hex, Number(transform.value) / 100000);
+        break;
+      case "shade":
+        hex = applyShade(hex, Number(transform.value) / 100000);
+        break;
+      case "alpha":
+        alpha = Number(transform.value) / 100000;
+        break;
+      default:
+        assertNever(transform.kind);
+    }
+  }
+
+  return { hex, alpha };
+}
+
+function normalizeHex(hex: string): string {
+  const normalized = hex.replace(/^#/, "").toLowerCase();
+  return `#${normalized.padStart(6, "0").slice(0, 6)}`;
+}
+
+function applyLuminance(hex: string, lumMod: number, lumOff: number): string {
+  const { h, s, l } = hexToHsl(hex);
+  return hslToHex(h, s, Math.min(1, Math.max(0, l * lumMod + lumOff)));
+}
+
+function applyTint(hex: string, tintAmount: number): string {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex(
+    Math.round(r + (255 - r) * tintAmount),
+    Math.round(g + (255 - g) * tintAmount),
+    Math.round(b + (255 - b) * tintAmount),
+  );
+}
+
+function applyShade(hex: string, shadeAmount: number): string {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHex(
+    Math.round(r * shadeAmount),
+    Math.round(g * shadeAmount),
+    Math.round(b * shadeAmount),
+  );
+}
+
+function hexToRgb(hex: string): { readonly r: number; readonly g: number; readonly b: number } {
+  const normalized = hex.replace("#", "");
+  return {
+    r: parseInt(normalized.slice(0, 2), 16),
+    g: parseInt(normalized.slice(2, 4), 16),
+    b: parseInt(normalized.slice(4, 6), 16),
+  };
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (value: number) => Math.min(255, Math.max(0, value)).toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hexToHsl(hex: string): { readonly h: number; readonly s: number; readonly l: number } {
+  const { r: r255, g: g255, b: b255 } = hexToRgb(hex);
+  const r = r255 / 255;
+  const g = g255 / 255;
+  const b = b255 / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return { h: 0, s: 0, l };
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  const h =
+    max === r
+      ? ((g - b) / d + (g < b ? 6 : 0)) / 6
+      : max === g
+        ? ((b - r) / d + 2) / 6
+        : ((r - g) / d + 4) / 6;
+
+  return { h, s, l };
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+  if (s === 0) {
+    const value = Math.round(l * 255);
+    return rgbToHex(value, value, value);
+  }
+
+  const hue2rgb = (p: number, q: number, t: number): number => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return rgbToHex(
+    Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
+    Math.round(hue2rgb(p, q, h) * 255),
+    Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
+  );
+}

--- a/packages/document/src/computed/color.ts
+++ b/packages/document/src/computed/color.ts
@@ -37,7 +37,7 @@ const FALLBACK_SCHEME_COLORS: Readonly<Record<string, string>> = {
   folHlink: "#954f72",
 };
 
-export interface ColorResolutionContext {
+interface ColorResolutionContext {
   readonly theme?: SourceTheme;
   readonly colorMap: Readonly<Record<string, string>>;
 }

--- a/packages/document/src/computed/create-computed-view.ts
+++ b/packages/document/src/computed/create-computed-view.ts
@@ -3,8 +3,6 @@ import type {
   PptxSourceModel,
   SourceBlipEffects,
   SourceCellBorders,
-  SourceColor,
-  SourceColorMap,
   SourceEffectList,
   SourceFill,
   SourceImage,
@@ -25,13 +23,15 @@ import type {
   SourceTextStyle,
   SourceTheme,
 } from "../source/index.js";
-import { asEmu, asPartPath } from "../source/index.js";
+import { asEmu } from "../source/index.js";
+import { assertNever } from "../utils/assert-never.js";
+import { buildComputedColorScheme, buildEffectiveColorMap, resolveColor } from "./color.js";
+import { findPlaceholderMatch } from "./placeholders.js";
 import type {
   ComputedBackground,
   ComputedBlipEffects,
   ComputedCellBorders,
   ComputedChartElement,
-  ComputedColor,
   ComputedConnectorElement,
   ComputedEffectList,
   ComputedElement,
@@ -41,7 +41,6 @@ import type {
   ComputedImageElement,
   ComputedOutline,
   ComputedParagraph,
-  ComputedPlaceholderMatch,
   ComputedRelationship,
   ComputedRunProperties,
   ComputedShapeElement,
@@ -54,36 +53,7 @@ import type {
   CreateComputedViewOptions,
   PptxComputedView,
 } from "./pptx-computed-view.js";
-
-const DEFAULT_COLOR_MAP: Readonly<Record<string, string>> = {
-  bg1: "lt1",
-  tx1: "dk1",
-  bg2: "lt2",
-  tx2: "dk2",
-  accent1: "accent1",
-  accent2: "accent2",
-  accent3: "accent3",
-  accent4: "accent4",
-  accent5: "accent5",
-  accent6: "accent6",
-  hlink: "hlink",
-  folHlink: "folHlink",
-};
-
-const FALLBACK_SCHEME_COLORS: Readonly<Record<string, string>> = {
-  dk1: "#000000",
-  lt1: "#ffffff",
-  dk2: "#44546a",
-  lt2: "#e7e6e6",
-  accent1: "#4472c4",
-  accent2: "#ed7d31",
-  accent3: "#a5a5a5",
-  accent4: "#ffc000",
-  accent5: "#5b9bd5",
-  accent6: "#70ad47",
-  hlink: "#0563c1",
-  folHlink: "#954f72",
-};
+import { resolveComputedRelationships } from "./relationships.js";
 
 const IMAGE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
 const CHART_REL_TYPES: ReadonlySet<string> = new Set([
@@ -170,7 +140,7 @@ function computeSlide(
     layout?.colorMapOverride,
     slide.colorMapOverride,
   );
-  const relationships = resolveRelationships(source, slide.partPath);
+  const relationships = resolveComputedRelationships(source, slide.partPath);
   const context: ComputeContext = { source, layout, master, theme, colorMap, relationships };
   const colorScheme = buildComputedColorScheme(context);
 
@@ -229,59 +199,6 @@ type MutableRunProperties = {
   -readonly [K in keyof SourceRunProperties]?: SourceRunProperties[K];
 };
 
-function buildEffectiveColorMap(
-  master?: SourceColorMap,
-  layoutOverride?: SourceColorMap,
-  slideOverride?: SourceColorMap,
-): Readonly<Record<string, string>> {
-  return {
-    ...DEFAULT_COLOR_MAP,
-    ...master?.mapping,
-    ...layoutOverride?.mapping,
-    ...slideOverride?.mapping,
-  };
-}
-
-function buildComputedColorScheme(context: ComputeContext): Readonly<Record<string, string>> {
-  const colors: Record<string, string> = { ...FALLBACK_SCHEME_COLORS };
-  for (const [name, color] of Object.entries(context.theme?.colorScheme?.colors ?? {})) {
-    const resolved = resolveColor(context, color);
-    if (resolved !== undefined) colors[name] = resolved.hex;
-  }
-  return colors;
-}
-
-function resolveRelationships(
-  source: PptxSourceModel,
-  sourcePartPath: PartPath,
-): ComputedRelationship[] {
-  const rels =
-    source.packageGraph.relationships.find((entry) => entry.sourcePartPath === sourcePartPath)
-      ?.relationships ?? [];
-
-  return rels.map((relationship) => {
-    const external = relationship.targetMode === "External";
-    const target = external
-      ? relationship.target
-      : resolveRelationshipTarget(sourcePartPath, relationship.target);
-    const targetPartPath = external ? undefined : asPartPath(target);
-    const media =
-      targetPartPath !== undefined
-        ? source.packageGraph.media.find((part) => part.partPath === targetPartPath)
-        : undefined;
-
-    return {
-      id: relationship.id,
-      type: relationship.type,
-      source: relationship,
-      target,
-      ...(relationship.targetMode !== undefined ? { targetMode: relationship.targetMode } : {}),
-      ...(targetPartPath !== undefined ? { targetPartPath } : {}),
-      ...(media !== undefined ? { media } : {}),
-    };
-  });
-}
-
 function computeBackground(
   context: ComputeContext,
   slide: SourceSlide,
@@ -307,29 +224,33 @@ function computeBackground(
   if (picked === undefined) return undefined;
 
   const { background, sourceLayer } = picked;
-  if (background.kind === "fill") {
-    return {
-      background: {
-        kind: "fill",
-        source: background,
-        fill: computeFill(context, background.fill, picked.partPath),
-        sourceLayer,
-      },
-    };
+  switch (background.kind) {
+    case "fill":
+      return {
+        background: {
+          kind: "fill",
+          source: background,
+          fill: computeFill(context, background.fill, picked.partPath),
+          sourceLayer,
+        },
+      };
+    case "styleReference": {
+      const color = resolveColor(context, background.color);
+      return {
+        background: {
+          kind: "styleReference",
+          source: background,
+          index: background.index,
+          ...(color !== undefined ? { color } : {}),
+          sourceLayer,
+        },
+      };
+    }
+    case "raw":
+      return { background: { kind: "raw", source: background, sourceLayer } };
+    default:
+      return assertNever(background);
   }
-  if (background.kind === "styleReference") {
-    const color = resolveColor(context, background.color);
-    return {
-      background: {
-        kind: "styleReference",
-        source: background,
-        index: background.index,
-        ...(color !== undefined ? { color } : {}),
-        sourceLayer,
-      },
-    };
-  }
-  return { background: { kind: "raw", source: background, sourceLayer } };
 }
 
 function computeTemplateElements(
@@ -359,18 +280,26 @@ function computeElement(
   layer: ComputedElementLayer,
   partPath: PartPath,
 ): ComputedElement {
-  if (element.kind === "shape") return computeShapeElement(context, element, layer, partPath);
-  if (element.kind === "connector") {
-    return computeConnectorElement(context, element, layer, partPath);
+  switch (element.kind) {
+    case "shape":
+      return computeShapeElement(context, element, layer, partPath);
+    case "connector":
+      return computeConnectorElement(context, element, layer, partPath);
+    case "group":
+      return computeGroupElement(context, element, layer, partPath);
+    case "image":
+      return computeImageElement(context, element, layer, partPath);
+    case "table":
+      return computeTableElement(context, element, layer, partPath);
+    case "chart":
+      return computeChartElement(context, element, layer, partPath);
+    case "smartArt":
+      return computeSmartArtElement(context, element, layer, partPath);
+    case "raw":
+      return { kind: "raw", sourceLayer: layer, sourcePartPath: partPath, sourceNode: element };
+    default:
+      return assertNever(element);
   }
-  if (element.kind === "group") return computeGroupElement(context, element, layer, partPath);
-  if (element.kind === "image") return computeImageElement(context, element, layer, partPath);
-  if (element.kind === "table") return computeTableElement(context, element, layer, partPath);
-  if (element.kind === "chart") return computeChartElement(context, element, layer, partPath);
-  if (element.kind === "smartArt") {
-    return computeSmartArtElement(context, element, layer, partPath);
-  }
-  return { kind: "raw", sourceLayer: layer, sourcePartPath: partPath, sourceNode: element };
 }
 
 function computeConnectorElement(
@@ -427,7 +356,16 @@ function computeShapeElement(
   layer: ComputedElementLayer,
   partPath: PartPath,
 ): ComputedShapeElement {
-  const match = layer === "slide" ? findPlaceholderMatch(context, shape) : undefined;
+  const match =
+    layer === "slide"
+      ? findPlaceholderMatch(
+          {
+            layoutShapes: context.layout?.shapes ?? [],
+            masterShapes: context.master?.shapes ?? [],
+          },
+          shape,
+        )
+      : undefined;
   const placeholderType =
     shape.placeholder !== undefined ? (shape.placeholder.type ?? "body") : undefined;
   const transform = firstDefined(
@@ -481,7 +419,7 @@ function computeImageElement(
   layer: ComputedElementLayer,
   partPath: PartPath,
 ): ComputedImageElement {
-  const relationship = resolveRelationships(context.source, partPath).find(
+  const relationship = resolveComputedRelationships(context.source, partPath).find(
     (rel) => rel.id === image.blipRelationshipId && rel.type === IMAGE_REL_TYPE,
   );
   const effects =
@@ -556,7 +494,7 @@ function computeSmartArtElement(
   );
   const dataRelationships =
     dataRelationship?.targetPartPath !== undefined
-      ? resolveRelationships(context.source, dataRelationship.targetPartPath)
+      ? resolveComputedRelationships(context.source, dataRelationship.targetPartPath)
       : [];
   const drawingRelationship = dataRelationships.find((rel) =>
     DIAGRAM_DRAWING_REL_TYPES.has(rel.type),
@@ -576,7 +514,9 @@ function computeSmartArtElement(
     ...(drawingPartPath !== undefined ? { drawingPartPath } : {}),
     ...(drawingXml !== undefined ? { drawingXml } : {}),
     drawingRelationships:
-      drawingPartPath !== undefined ? resolveRelationships(context.source, drawingPartPath) : [],
+      drawingPartPath !== undefined
+        ? resolveComputedRelationships(context.source, drawingPartPath)
+        : [],
     media: context.source.packageGraph.media,
   };
 }
@@ -641,47 +581,58 @@ function computeCellBorders(
 }
 
 function computeFill(context: ComputeContext, fill: SourceFill, partPath: PartPath): ComputedFill {
-  if (fill.kind === "none") return { kind: "none", source: fill };
-  if (fill.kind === "raw") return { kind: "raw", source: fill };
-  if (fill.kind === "gradient") {
-    return {
-      kind: "gradient",
-      source: fill,
-      stops: fill.stops.map((stop) => ({
-        position: stop.position,
-        color: resolveColor(context, stop.color) ?? { hex: "#000000", alpha: 1 },
-      })),
-      gradientType: fill.gradientType,
-      ...(fill.gradientType === "linear" ? { angle: Number(fill.angle) / 60000 } : {}),
-      ...(fill.gradientType === "radial" ? { centerX: fill.centerX, centerY: fill.centerY } : {}),
-    };
+  switch (fill.kind) {
+    case "none":
+      return { kind: "none", source: fill };
+    case "raw":
+      return { kind: "raw", source: fill };
+    case "gradient":
+      return {
+        kind: "gradient",
+        source: fill,
+        stops: fill.stops.map((stop) => ({
+          position: stop.position,
+          color: resolveColor(context, stop.color) ?? { hex: "#000000", alpha: 1 },
+        })),
+        gradientType: fill.gradientType,
+        ...(fill.gradientType === "linear" ? { angle: Number(fill.angle) / 60000 } : {}),
+        ...(fill.gradientType === "radial" ? { centerX: fill.centerX, centerY: fill.centerY } : {}),
+      };
+    case "pattern":
+      return {
+        kind: "pattern",
+        source: fill,
+        preset: fill.preset,
+        foregroundColor: resolveColor(context, fill.foregroundColor) ?? {
+          hex: "#000000",
+          alpha: 1,
+        },
+        backgroundColor: resolveColor(context, fill.backgroundColor) ?? {
+          hex: "#ffffff",
+          alpha: 1,
+        },
+      };
+    case "image": {
+      const relationship = resolveComputedRelationships(context.source, partPath).find(
+        (rel) => rel.id === fill.blipRelationshipId && rel.type === IMAGE_REL_TYPE,
+      );
+      return {
+        kind: "image",
+        source: fill,
+        ...(relationship !== undefined ? { relationship } : {}),
+        ...(relationship?.media !== undefined ? { media: relationship.media } : {}),
+        ...(fill.tile !== undefined ? { tile: fill.tile } : {}),
+      };
+    }
+    case "solid":
+      return {
+        kind: "solid",
+        source: fill,
+        color: resolveColor(context, fill.color) ?? { hex: "#000000", alpha: 1 },
+      };
+    default:
+      return assertNever(fill);
   }
-  if (fill.kind === "pattern") {
-    return {
-      kind: "pattern",
-      source: fill,
-      preset: fill.preset,
-      foregroundColor: resolveColor(context, fill.foregroundColor) ?? { hex: "#000000", alpha: 1 },
-      backgroundColor: resolveColor(context, fill.backgroundColor) ?? { hex: "#ffffff", alpha: 1 },
-    };
-  }
-  if (fill.kind === "image") {
-    const relationship = resolveRelationships(context.source, partPath).find(
-      (rel) => rel.id === fill.blipRelationshipId && rel.type === IMAGE_REL_TYPE,
-    );
-    return {
-      kind: "image",
-      source: fill,
-      ...(relationship !== undefined ? { relationship } : {}),
-      ...(relationship?.media !== undefined ? { media: relationship.media } : {}),
-      ...(fill.tile !== undefined ? { tile: fill.tile } : {}),
-    };
-  }
-  return {
-    kind: "solid",
-    source: fill,
-    color: resolveColor(context, fill.color) ?? { hex: "#000000", alpha: 1 },
-  };
 }
 
 function computeOutline(
@@ -1125,145 +1076,11 @@ function resolveThemeTypeface(context: ComputeContext, typeface: string): string
   }
 }
 
-function findPlaceholderMatch(
-  context: ComputeContext,
-  shape: SourceShape,
-): ComputedPlaceholderMatch | undefined {
-  if (shape.placeholder === undefined) return undefined;
-  const type = shape.placeholder.type ?? "body";
-  const index = shape.placeholder.index;
-  const layout = findMatchingPlaceholder(type, index, context.layout?.shapes ?? []);
-  const master = findMatchingPlaceholder(type, index, context.master?.shapes ?? []);
-  if (layout === undefined && master === undefined) return undefined;
-  return {
-    ...(layout !== undefined ? { layout } : {}),
-    ...(master !== undefined ? { master } : {}),
-  };
-}
-
-function findMatchingPlaceholder(
-  type: string,
-  index: number | undefined,
-  shapes: readonly SourceShapeNode[],
-): SourceShape | undefined {
-  const placeholders = shapes.filter(
-    (shape): shape is SourceShape => shape.kind === "shape" && shape.placeholder !== undefined,
-  );
-
-  if (index !== undefined) {
-    const byIndexWithTransform = placeholders.find(
-      (shape) => shape.placeholder?.index === index && shape.transform !== undefined,
-    );
-    if (byIndexWithTransform !== undefined) return byIndexWithTransform;
-    const byIndex = placeholders.find((shape) => shape.placeholder?.index === index);
-    if (byIndex !== undefined) return byIndex;
-  }
-
-  const byTypeWithTransform = placeholders.find(
-    (shape) => (shape.placeholder?.type ?? "body") === type && shape.transform !== undefined,
-  );
-  if (byTypeWithTransform !== undefined) return byTypeWithTransform;
-
-  const fallbackType = getPlaceholderFallbackType(type);
-  if (fallbackType !== undefined) {
-    const byFallbackWithTransform = placeholders.find(
-      (shape) =>
-        (shape.placeholder?.type ?? "body") === fallbackType && shape.transform !== undefined,
-    );
-    if (byFallbackWithTransform !== undefined) return byFallbackWithTransform;
-  }
-
-  const byType = placeholders.find((shape) => (shape.placeholder?.type ?? "body") === type);
-  if (byType !== undefined) return byType;
-
-  if (fallbackType !== undefined) {
-    return placeholders.find((shape) => (shape.placeholder?.type ?? "body") === fallbackType);
-  }
-
-  return undefined;
-}
-
-function getPlaceholderFallbackType(type: string): string | undefined {
-  if (type === "ctrTitle") return "title";
-  if (type === "subTitle") return "body";
-  return undefined;
-}
-
 function isEmptyPlaceholder(shape: SourceShape): boolean {
   if (shape.placeholder === undefined) return false;
   const paragraphs = shape.textBody?.paragraphs;
   if (paragraphs === undefined || paragraphs.length === 0) return true;
   return !paragraphs.some((paragraph) => paragraph.runs.some((run) => run.text.length > 0));
-}
-
-function resolveColor(
-  context: ComputeContext,
-  color: SourceColor,
-  visited: ReadonlySet<string> = new Set(),
-): ComputedColor | undefined {
-  let hex: string | undefined;
-  if (color.kind === "srgb") {
-    hex = normalizeHex(color.hex);
-  } else if (color.kind === "system") {
-    hex = normalizeHex(color.lastColor ?? "000000");
-  } else {
-    const mappedName = context.colorMap[color.scheme] ?? color.scheme;
-    if (visited.has(mappedName)) return { hex: "#000000", alpha: 1 };
-    const schemeColor = context.theme?.colorScheme?.colors[mappedName];
-    hex =
-      schemeColor !== undefined
-        ? resolveColor(context, schemeColor, new Set([...visited, mappedName]))?.hex
-        : FALLBACK_SCHEME_COLORS[mappedName];
-  }
-  if (hex === undefined) return undefined;
-
-  let alpha = 1;
-  for (const transform of color.transforms ?? []) {
-    if (transform.kind === "lumMod") {
-      const lumOff = color.transforms?.find((candidate) => candidate.kind === "lumOff");
-      hex = applyLuminance(
-        hex,
-        Number(transform.value) / 100000,
-        Number(lumOff?.value ?? 0) / 100000,
-      );
-    } else if (transform.kind === "lumOff") {
-      if (!color.transforms?.some((candidate) => candidate.kind === "lumMod")) {
-        hex = applyLuminance(hex, 1, Number(transform.value) / 100000);
-      }
-    } else if (transform.kind === "tint") {
-      hex = applyTint(hex, Number(transform.value) / 100000);
-    } else if (transform.kind === "shade") {
-      hex = applyShade(hex, Number(transform.value) / 100000);
-    } else if (transform.kind === "alpha") {
-      alpha = Number(transform.value) / 100000;
-    }
-  }
-
-  return { hex, alpha };
-}
-
-function resolveRelationshipTarget(sourcePartPath: string, target: string): string {
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return target;
-
-  let combined: string;
-  if (target.startsWith("/")) {
-    combined = target.slice(1);
-  } else {
-    const slash = sourcePartPath.lastIndexOf("/");
-    const baseDir = slash === -1 ? "" : sourcePartPath.slice(0, slash);
-    combined = baseDir === "" ? target : `${baseDir}/${target}`;
-  }
-
-  const segments: string[] = [];
-  for (const segment of combined.split("/")) {
-    if (segment === "" || segment === ".") continue;
-    if (segment === "..") {
-      segments.pop();
-      continue;
-    }
-    segments.push(segment);
-  }
-  return segments.join("/");
 }
 
 function readRawPackageText(source: PptxSourceModel, partPath: PartPath): string | undefined {
@@ -1272,101 +1089,10 @@ function readRawPackageText(source: PptxSourceModel, partPath: PartPath): string
   return undefined;
 }
 
-function normalizeHex(hex: string): string {
-  // OOXML `srgbClr@val` / `sysClr@lastClr` は 6 桁 RRGGBB 前提。
-  const normalized = hex.replace(/^#/, "").toLowerCase();
-  return `#${normalized.padStart(6, "0").slice(0, 6)}`;
-}
-
 function omitColor(properties: SourceRunProperties): Omit<SourceRunProperties, "color"> {
   const withoutColor = { ...properties };
   delete withoutColor.color;
   return withoutColor;
-}
-
-function applyLuminance(hex: string, lumMod: number, lumOff: number): string {
-  const { h, s, l } = hexToHsl(hex);
-  return hslToHex(h, s, Math.min(1, Math.max(0, l * lumMod + lumOff)));
-}
-
-function applyTint(hex: string, tintAmount: number): string {
-  const { r, g, b } = hexToRgb(hex);
-  return rgbToHex(
-    Math.round(r + (255 - r) * tintAmount),
-    Math.round(g + (255 - g) * tintAmount),
-    Math.round(b + (255 - b) * tintAmount),
-  );
-}
-
-function applyShade(hex: string, shadeAmount: number): string {
-  const { r, g, b } = hexToRgb(hex);
-  return rgbToHex(
-    Math.round(r * shadeAmount),
-    Math.round(g * shadeAmount),
-    Math.round(b * shadeAmount),
-  );
-}
-
-function hexToRgb(hex: string): { readonly r: number; readonly g: number; readonly b: number } {
-  const normalized = hex.replace("#", "");
-  return {
-    r: parseInt(normalized.slice(0, 2), 16),
-    g: parseInt(normalized.slice(2, 4), 16),
-    b: parseInt(normalized.slice(4, 6), 16),
-  };
-}
-
-function rgbToHex(r: number, g: number, b: number): string {
-  const toHex = (value: number) => Math.min(255, Math.max(0, value)).toString(16).padStart(2, "0");
-  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-}
-
-function hexToHsl(hex: string): { readonly h: number; readonly s: number; readonly l: number } {
-  const { r: r255, g: g255, b: b255 } = hexToRgb(hex);
-  const r = r255 / 255;
-  const g = g255 / 255;
-  const b = b255 / 255;
-  const max = Math.max(r, g, b);
-  const min = Math.min(r, g, b);
-  const l = (max + min) / 2;
-
-  if (max === min) return { h: 0, s: 0, l };
-
-  const d = max - min;
-  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-  const h =
-    max === r
-      ? ((g - b) / d + (g < b ? 6 : 0)) / 6
-      : max === g
-        ? ((b - r) / d + 2) / 6
-        : ((r - g) / d + 4) / 6;
-
-  return { h, s, l };
-}
-
-function hslToHex(h: number, s: number, l: number): string {
-  if (s === 0) {
-    const value = Math.round(l * 255);
-    return rgbToHex(value, value, value);
-  }
-
-  const hue2rgb = (p: number, q: number, t: number): number => {
-    let tt = t;
-    if (tt < 0) tt += 1;
-    if (tt > 1) tt -= 1;
-    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
-    if (tt < 1 / 2) return q;
-    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
-    return p;
-  };
-
-  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-  const p = 2 * l - q;
-  return rgbToHex(
-    Math.round(hue2rgb(p, q, h + 1 / 3) * 255),
-    Math.round(hue2rgb(p, q, h) * 255),
-    Math.round(hue2rgb(p, q, h - 1 / 3) * 255),
-  );
 }
 
 function firstDefined<T>(...values: readonly (T | undefined)[]): T | undefined {

--- a/packages/document/src/computed/placeholders.ts
+++ b/packages/document/src/computed/placeholders.ts
@@ -1,7 +1,7 @@
 import type { SourceShape, SourceShapeNode } from "../source/index.js";
 import type { ComputedPlaceholderMatch } from "./pptx-computed-view.js";
 
-export interface PlaceholderMatchContext {
+interface PlaceholderMatchContext {
   readonly layoutShapes: readonly SourceShapeNode[];
   readonly masterShapes: readonly SourceShapeNode[];
 }

--- a/packages/document/src/computed/placeholders.ts
+++ b/packages/document/src/computed/placeholders.ts
@@ -1,0 +1,71 @@
+import type { SourceShape, SourceShapeNode } from "../source/index.js";
+import type { ComputedPlaceholderMatch } from "./pptx-computed-view.js";
+
+export interface PlaceholderMatchContext {
+  readonly layoutShapes: readonly SourceShapeNode[];
+  readonly masterShapes: readonly SourceShapeNode[];
+}
+
+export function findPlaceholderMatch(
+  context: PlaceholderMatchContext,
+  shape: SourceShape,
+): ComputedPlaceholderMatch | undefined {
+  if (shape.placeholder === undefined) return undefined;
+  const type = shape.placeholder.type ?? "body";
+  const index = shape.placeholder.index;
+  const layout = findMatchingPlaceholder(type, index, context.layoutShapes);
+  const master = findMatchingPlaceholder(type, index, context.masterShapes);
+  if (layout === undefined && master === undefined) return undefined;
+  return {
+    ...(layout !== undefined ? { layout } : {}),
+    ...(master !== undefined ? { master } : {}),
+  };
+}
+
+function findMatchingPlaceholder(
+  type: string,
+  index: number | undefined,
+  shapes: readonly SourceShapeNode[],
+): SourceShape | undefined {
+  const placeholders = shapes.filter(
+    (shape): shape is SourceShape => shape.kind === "shape" && shape.placeholder !== undefined,
+  );
+
+  if (index !== undefined) {
+    const byIndexWithTransform = placeholders.find(
+      (shape) => shape.placeholder?.index === index && shape.transform !== undefined,
+    );
+    if (byIndexWithTransform !== undefined) return byIndexWithTransform;
+    const byIndex = placeholders.find((shape) => shape.placeholder?.index === index);
+    if (byIndex !== undefined) return byIndex;
+  }
+
+  const byTypeWithTransform = placeholders.find(
+    (shape) => (shape.placeholder?.type ?? "body") === type && shape.transform !== undefined,
+  );
+  if (byTypeWithTransform !== undefined) return byTypeWithTransform;
+
+  const fallbackType = getPlaceholderFallbackType(type);
+  if (fallbackType !== undefined) {
+    const byFallbackWithTransform = placeholders.find(
+      (shape) =>
+        (shape.placeholder?.type ?? "body") === fallbackType && shape.transform !== undefined,
+    );
+    if (byFallbackWithTransform !== undefined) return byFallbackWithTransform;
+  }
+
+  const byType = placeholders.find((shape) => (shape.placeholder?.type ?? "body") === type);
+  if (byType !== undefined) return byType;
+
+  if (fallbackType !== undefined) {
+    return placeholders.find((shape) => (shape.placeholder?.type ?? "body") === fallbackType);
+  }
+
+  return undefined;
+}
+
+function getPlaceholderFallbackType(type: string): string | undefined {
+  if (type === "ctrTitle") return "title";
+  if (type === "subTitle") return "body";
+  return undefined;
+}

--- a/packages/document/src/computed/relationships.ts
+++ b/packages/document/src/computed/relationships.ts
@@ -1,0 +1,39 @@
+import type { MediaPart, PartPath, PptxSourceModel } from "../source/index.js";
+import { asPartPath } from "../source/index.js";
+import { resolveRelationshipTarget } from "../source/package-paths.js";
+import type { ComputedRelationship } from "./pptx-computed-view.js";
+
+export function resolveComputedRelationships(
+  source: PptxSourceModel,
+  sourcePartPath: PartPath,
+): ComputedRelationship[] {
+  const rels =
+    source.packageGraph.relationships.find((entry) => entry.sourcePartPath === sourcePartPath)
+      ?.relationships ?? [];
+
+  return rels.map((relationship) => {
+    const external = relationship.targetMode === "External";
+    const target = external
+      ? relationship.target
+      : resolveRelationshipTarget(sourcePartPath, relationship.target);
+    const targetPartPath = external ? undefined : asPartPath(target);
+    const media =
+      targetPartPath !== undefined
+        ? findMedia(source.packageGraph.media, targetPartPath)
+        : undefined;
+
+    return {
+      id: relationship.id,
+      type: relationship.type,
+      source: relationship,
+      target,
+      ...(relationship.targetMode !== undefined ? { targetMode: relationship.targetMode } : {}),
+      ...(targetPartPath !== undefined ? { targetPartPath } : {}),
+      ...(media !== undefined ? { media } : {}),
+    };
+  });
+}
+
+function findMedia(media: readonly MediaPart[], partPath: PartPath): MediaPart | undefined {
+  return media.find((part) => part.partPath === partPath);
+}

--- a/packages/document/src/reader/drawing.ts
+++ b/packages/document/src/reader/drawing.ts
@@ -31,6 +31,7 @@ import type {
   SourceTransform,
 } from "../source/index.js";
 import { asEmu, asOoxmlAngle, asOoxmlPercent, asRelationshipId } from "../source/index.js";
+import { parseEnumValue, parseEnumValueWithDefault } from "./ooxml-values.js";
 import { makeSidecar } from "./raw-node.js";
 import {
   getAttr,
@@ -42,7 +43,7 @@ import {
   type XmlNode,
 } from "./xml.js";
 
-const COLOR_TRANSFORM_KINDS: ReadonlySet<string> = new Set([
+const COLOR_TRANSFORM_KINDS: ReadonlySet<SourceColorTransform["kind"]> = new Set([
   "lumMod",
   "lumOff",
   "tint",
@@ -451,7 +452,8 @@ function withTransforms(base: SourceColor, colorNode: XmlNode): SourceColor {
   for (const key of Object.keys(colorNode)) {
     if (key.startsWith("@_")) continue;
     const kind = localName(key);
-    if (!COLOR_TRANSFORM_KINDS.has(kind)) continue;
+    const transformKind = parseEnumValue(kind, COLOR_TRANSFORM_KINDS);
+    if (transformKind === undefined) continue;
     const value = colorNode[key];
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
@@ -460,7 +462,7 @@ function withTransforms(base: SourceColor, colorNode: XmlNode): SourceColor {
       const numeric = Number(raw);
       if (!Number.isFinite(numeric)) continue;
       transforms.push({
-        kind: kind as SourceColorTransform["kind"],
+        kind: transformKind,
         value: asOoxmlPercent(numeric),
       });
     }
@@ -483,8 +485,7 @@ export function isTrue(value: string | undefined): boolean {
 
 function parseDashStyle(prstDash: XmlNode | undefined): SourceDashStyle | undefined {
   const value = getAttr(prstDash, "val");
-  if (value === undefined) return undefined;
-  return DASH_STYLES.has(value) ? (value as SourceDashStyle) : undefined;
+  return parseEnumValue(value, DASH_STYLES);
 }
 
 function parseCustomDash(ln: XmlNode): number[] | undefined {
@@ -516,19 +517,18 @@ function parseLineJoin(ln: XmlNode): SourceLineJoin | undefined {
 
 function parseArrowEndpoint(node: XmlNode | undefined): SourceArrowEndpoint | undefined {
   if (!node) return undefined;
-  const type = (getAttr(node, "type") ?? "none") as SourceArrowType | "none";
-  if (type === "none") return undefined;
-  if (!ARROW_TYPES.has(type)) return undefined;
+  const type = parseEnumValue(getAttr(node, "type"), ARROW_TYPES);
+  if (type === undefined) return undefined;
   const width = getAttr(node, "w") ?? "med";
   const length = getAttr(node, "len") ?? "med";
   return {
     type,
-    width: ARROW_SIZES.has(width) ? (width as SourceArrowSize) : "med",
-    length: ARROW_SIZES.has(length) ? (length as SourceArrowSize) : "med",
+    width: parseEnumValueWithDefault(width, ARROW_SIZES, "med"),
+    length: parseEnumValueWithDefault(length, ARROW_SIZES, "med"),
   };
 }
 
-const DASH_STYLES: ReadonlySet<string> = new Set([
+const DASH_STYLES: ReadonlySet<SourceDashStyle> = new Set([
   "solid",
   "dash",
   "dot",
@@ -539,7 +539,7 @@ const DASH_STYLES: ReadonlySet<string> = new Set([
   "sysDot",
 ]);
 
-const ARROW_TYPES: ReadonlySet<string> = new Set([
+const ARROW_TYPES: ReadonlySet<SourceArrowType> = new Set([
   "triangle",
   "stealth",
   "diamond",
@@ -547,4 +547,4 @@ const ARROW_TYPES: ReadonlySet<string> = new Set([
   "arrow",
 ]);
 
-const ARROW_SIZES: ReadonlySet<string> = new Set(["sm", "med", "lg"]);
+const ARROW_SIZES: ReadonlySet<SourceArrowSize> = new Set(["sm", "med", "lg"]);

--- a/packages/document/src/reader/ooxml-values.ts
+++ b/packages/document/src/reader/ooxml-values.ts
@@ -12,10 +12,3 @@ export function parseEnumValueWithDefault<const T extends string>(
 ): T {
   return parseEnumValue(value, allowed) ?? fallback;
 }
-
-export function isEnumValue<const T extends string>(
-  value: string | undefined,
-  allowed: ReadonlySet<T>,
-): value is T {
-  return value !== undefined && allowed.has(value as T);
-}

--- a/packages/document/src/reader/ooxml-values.ts
+++ b/packages/document/src/reader/ooxml-values.ts
@@ -1,0 +1,21 @@
+export function parseEnumValue<const T extends string>(
+  value: string | undefined,
+  allowed: ReadonlySet<T>,
+): T | undefined {
+  return value !== undefined && allowed.has(value as T) ? (value as T) : undefined;
+}
+
+export function parseEnumValueWithDefault<const T extends string>(
+  value: string | undefined,
+  allowed: ReadonlySet<T>,
+  fallback: T,
+): T {
+  return parseEnumValue(value, allowed) ?? fallback;
+}
+
+export function isEnumValue<const T extends string>(
+  value: string | undefined,
+  allowed: ReadonlySet<T>,
+): value is T {
+  return value !== undefined && allowed.has(value as T);
+}

--- a/packages/document/src/reader/read-pptx.ts
+++ b/packages/document/src/reader/read-pptx.ts
@@ -28,7 +28,6 @@ import type {
   PptxSourceModel,
   RawPackagePart,
   Relationship,
-  RelationshipTargetMode,
   SlideSize,
   SourcePresentation,
   SourceSlide,
@@ -37,6 +36,13 @@ import type {
   SourceTheme,
 } from "../source/index.js";
 import { asEmu, asPartPath, asRelationshipId } from "../source/index.js";
+import {
+  isRelationshipPart,
+  parseRelationshipTargetMode,
+  relationshipsSourcePartPath,
+  resolveInternalRelationshipTarget,
+  resolveRelationshipTarget,
+} from "../source/package-paths.js";
 import { createSidecarIdFactory } from "./raw-node.js";
 import { parseSlide, parseSlideLayout, parseSlideMaster, parseTheme } from "./slide-parts.js";
 import { parseTextStyle } from "./text.js";
@@ -56,7 +62,6 @@ import {
 export type ReadPptxInput = Uint8Array;
 
 const CONTENT_TYPES_PART = "[Content_Types].xml";
-const RELS_SUFFIX = ".rels";
 const PACKAGE_ROOT_PART = "";
 
 const OFFICE_DOCUMENT_REL_TYPE =
@@ -279,7 +284,7 @@ function resolveSingleRel(
   const rels = relationships.find((rel) => rel.sourcePartPath === sourcePart)?.relationships;
   const match = rels?.find((rel) => rel.type === relType && rel.targetMode !== "External");
   if (match === undefined) return undefined;
-  return asPartPath(resolveTarget(sourcePart, match.target));
+  return resolveInternalRelationshipTarget(sourcePart, match);
 }
 
 /** 指定 source part の relationship のうち、内部の該当 type をすべて解決する。 */
@@ -291,7 +296,10 @@ function resolveAllRels(
   const rels = relationships.find((rel) => rel.sourcePartPath === sourcePart)?.relationships ?? [];
   return rels
     .filter((rel) => rel.type === relType && rel.targetMode !== "External")
-    .map((rel) => asPartPath(resolveTarget(sourcePart, rel.target)));
+    .flatMap((rel) => {
+      const target = resolveInternalRelationshipTarget(sourcePart, rel);
+      return target === undefined ? [] : [target];
+    });
 }
 
 /** 挿入順を保ちつつ part path を重複排除する小さな集合。 */
@@ -364,16 +372,16 @@ function readRelationships(entries: Map<string, Uint8Array>): PartRelationships[
       const type = getAttr(node, "Type");
       const target = getAttr(node, "Target");
       if (id === undefined || type === undefined || target === undefined) continue;
-      const targetMode = getAttr(node, "TargetMode");
+      const targetMode = parseRelationshipTargetMode(getAttr(node, "TargetMode"));
       relationships.push({
         id: asRelationshipId(id),
         type,
         target,
-        ...(targetMode !== undefined ? { targetMode: targetMode as RelationshipTargetMode } : {}),
+        ...(targetMode !== undefined ? { targetMode } : {}),
       });
     }
 
-    result.push({ sourcePartPath: asPartPath(relsSourcePartPath(path)), relationships });
+    result.push({ sourcePartPath: relationshipsSourcePartPath(path), relationships });
   }
 
   return result;
@@ -440,7 +448,9 @@ function readPresentation(
       });
       continue;
     }
-    slidePartPaths.push(asPartPath(resolveTarget(presentationPath, relationship.target)));
+    slidePartPaths.push(
+      asPartPath(resolveRelationshipTarget(presentationPath, relationship.target)),
+    );
   }
 
   return {
@@ -478,7 +488,7 @@ function locatePresentationPart(
     (rel) => rel.type === OFFICE_DOCUMENT_REL_TYPE && rel.targetMode !== "External",
   );
   if (officeDocumentRel !== undefined) {
-    return resolveTarget(PACKAGE_ROOT_PART, officeDocumentRel.target);
+    return resolveRelationshipTarget(PACKAGE_ROOT_PART, officeDocumentRel.target);
   }
 
   const override = overrides.find((entry) => entry.contentType === PRESENTATION_CONTENT_TYPE);
@@ -489,10 +499,6 @@ const MEDIA_CONTENT_TYPE_PREFIXES = ["image/", "audio/", "video/"];
 
 function isMediaContentType(contentType: string): boolean {
   return MEDIA_CONTENT_TYPE_PREFIXES.some((prefix) => contentType.startsWith(prefix));
-}
-
-function isRelationshipPart(path: string): boolean {
-  return path.endsWith(RELS_SUFFIX) && path.includes("_rels/");
 }
 
 function resolveContentType(
@@ -523,46 +529,4 @@ function extensionOf(path: string): string | undefined {
 
 function stripLeadingSlash(path: string): string {
   return path.startsWith("/") ? path.slice(1) : path;
-}
-
-/**
- * `_rels/*.rels` part path から、その rels が属する source part path を求める。
- * 例: `ppt/_rels/presentation.xml.rels` → `ppt/presentation.xml`、
- * `_rels/.rels` → `""` (package root)。
- */
-function relsSourcePartPath(relsPath: string): string {
-  const marker = "_rels/";
-  const idx = relsPath.lastIndexOf(marker);
-  const dir = relsPath.slice(0, idx); // "" / "ppt/" / "ppt/slides/"
-  const file = relsPath.slice(idx + marker.length); // ".rels" / "presentation.xml.rels"
-  const base = file.endsWith(RELS_SUFFIX) ? file.slice(0, -RELS_SUFFIX.length) : file;
-  return dir + base;
-}
-
-/**
- * relationship target を source part path 基準で解決し、package 内の絶対 part
- * path (先頭スラッシュ無し) に正規化する。external (絶対 URI) はそのまま返す。
- */
-function resolveTarget(sourcePartPath: string, target: string): string {
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return target; // 絶対 URI (external)。
-
-  let combined: string;
-  if (target.startsWith("/")) {
-    combined = target.slice(1); // package root 起点。
-  } else {
-    const slash = sourcePartPath.lastIndexOf("/");
-    const baseDir = slash === -1 ? "" : sourcePartPath.slice(0, slash);
-    combined = baseDir === "" ? target : `${baseDir}/${target}`;
-  }
-
-  const segments: string[] = [];
-  for (const segment of combined.split("/")) {
-    if (segment === "" || segment === ".") continue;
-    if (segment === "..") {
-      segments.pop();
-      continue;
-    }
-    segments.push(segment);
-  }
-  return segments.join("/");
 }

--- a/packages/document/src/reader/text.ts
+++ b/packages/document/src/reader/text.ts
@@ -28,6 +28,7 @@ import type {
 import { asEmu, asHundredthPt, asPt, asSourceNodeId } from "../source/index.js";
 import { parseColorElement } from "./drawing.js";
 import { isTrue, numericAttr } from "./drawing.js";
+import { parseEnumValue, parseEnumValueWithDefault } from "./ooxml-values.js";
 import { collectUnknownSidecars } from "./raw-node.js";
 import {
   getAttr,
@@ -68,8 +69,8 @@ const ANCHOR_MAP: Readonly<Record<string, SourceVerticalAnchor>> = {
   b: "bottom",
 };
 
-const WRAP_VALUES = new Set(["square", "none"]);
-const VERTICAL_VALUES = new Set([
+const WRAP_VALUES: ReadonlySet<SourceTextWrap> = new Set(["square", "none"]);
+const VERTICAL_VALUES: ReadonlySet<SourceTextVerticalType> = new Set([
   "horz",
   "vert",
   "vert270",
@@ -78,7 +79,7 @@ const VERTICAL_VALUES = new Set([
   "mongolianVert",
 ]);
 
-const VALID_AUTO_NUM_SCHEMES = new Set([
+const VALID_AUTO_NUM_SCHEMES: ReadonlySet<SourceAutoNumScheme> = new Set([
   "arabicPeriod",
   "arabicParenR",
   "romanUcPeriod",
@@ -350,13 +351,11 @@ function parseBodyProperties(bodyPr: XmlNode | undefined): SourceTextBodyPropert
 }
 
 function parseWrap(value: string | undefined): SourceTextWrap | undefined {
-  return value !== undefined && WRAP_VALUES.has(value) ? (value as SourceTextWrap) : undefined;
+  return parseEnumValue(value, WRAP_VALUES);
 }
 
 function parseVerticalType(value: string | undefined): SourceTextVerticalType | undefined {
-  return value !== undefined && VERTICAL_VALUES.has(value)
-    ? (value as SourceTextVerticalType)
-    : undefined;
+  return parseEnumValue(value, VERTICAL_VALUES);
 }
 
 function parseParagraph(
@@ -548,7 +547,7 @@ function parseBullet(pPr: XmlNode | undefined): SourceParagraphProperties["bulle
     const scheme = getAttr(buAutoNum, "type") ?? "arabicPeriod";
     return {
       type: "autoNum",
-      scheme: VALID_AUTO_NUM_SCHEMES.has(scheme) ? (scheme as SourceAutoNumScheme) : "arabicPeriod",
+      scheme: parseEnumValueWithDefault(scheme, VALID_AUTO_NUM_SCHEMES, "arabicPeriod"),
       startAt: numericAttr(buAutoNum, "startAt") ?? 1,
     };
   }

--- a/packages/document/src/source/package-paths.test.ts
+++ b/packages/document/src/source/package-paths.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { asPartPath } from "./handles.js";
+import {
+  isRelationshipPart,
+  parseRelationshipTargetMode,
+  relationshipsPartPath,
+  relationshipsSourcePartPath,
+  resolveInternalRelationshipTarget,
+  resolveRelationshipTarget,
+} from "./package-paths.js";
+
+describe("package path helpers", () => {
+  it("relationship part path と owner part path を相互に解決する", () => {
+    expect(relationshipsPartPath(asPartPath(""))).toBe("_rels/.rels");
+    expect(relationshipsPartPath(asPartPath("ppt/presentation.xml"))).toBe(
+      "ppt/_rels/presentation.xml.rels",
+    );
+    expect(relationshipsPartPath(asPartPath("ppt/slides/slide1.xml"))).toBe(
+      "ppt/slides/_rels/slide1.xml.rels",
+    );
+
+    expect(relationshipsSourcePartPath("_rels/.rels")).toBe("");
+    expect(relationshipsSourcePartPath("ppt/_rels/presentation.xml.rels")).toBe(
+      "ppt/presentation.xml",
+    );
+    expect(relationshipsSourcePartPath("ppt/slides/_rels/slide1.xml.rels")).toBe(
+      "ppt/slides/slide1.xml",
+    );
+  });
+
+  it("relationship part を判定する", () => {
+    expect(isRelationshipPart("_rels/.rels")).toBe(true);
+    expect(isRelationshipPart("ppt/slides/_rels/slide1.xml.rels")).toBe(true);
+    expect(isRelationshipPart("ppt/slides/slide1.xml")).toBe(false);
+  });
+
+  it("relationship target を source part 基準で正規化する", () => {
+    expect(resolveRelationshipTarget("ppt/slides/slide1.xml", "../media/image1.png")).toBe(
+      "ppt/media/image1.png",
+    );
+    expect(resolveRelationshipTarget("ppt/presentation.xml", "/ppt/slides/slide1.xml")).toBe(
+      "ppt/slides/slide1.xml",
+    );
+    expect(resolveRelationshipTarget("", "ppt/presentation.xml")).toBe("ppt/presentation.xml");
+    expect(resolveRelationshipTarget("ppt/slides/slide1.xml", "https://example.com/a")).toBe(
+      "https://example.com/a",
+    );
+  });
+
+  it("internal relationship target と target mode を parse する", () => {
+    expect(
+      resolveInternalRelationshipTarget(asPartPath("ppt/slides/slide1.xml"), {
+        id: "rId1",
+        type: "image",
+        target: "../media/image1.png",
+      }),
+    ).toBe("ppt/media/image1.png");
+    expect(
+      resolveInternalRelationshipTarget(asPartPath("ppt/slides/slide1.xml"), {
+        id: "rId2",
+        type: "hyperlink",
+        target: "https://example.com/",
+        targetMode: "External",
+      }),
+    ).toBeUndefined();
+
+    expect(parseRelationshipTargetMode("External")).toBe("External");
+    expect(parseRelationshipTargetMode("Internal")).toBe("Internal");
+    expect(parseRelationshipTargetMode("Unexpected")).toBeUndefined();
+    expect(parseRelationshipTargetMode(undefined)).toBeUndefined();
+  });
+});

--- a/packages/document/src/source/package-paths.ts
+++ b/packages/document/src/source/package-paths.ts
@@ -1,0 +1,70 @@
+import { asPartPath, type PartPath } from "./handles.js";
+import type { Relationship, RelationshipTargetMode } from "./package-graph.js";
+
+const RELS_SUFFIX = ".rels";
+const RELS_MARKER = "_rels/";
+const ABSOLUTE_URI_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+export function isRelationshipPart(path: string): boolean {
+  return path.endsWith(RELS_SUFFIX) && path.includes(RELS_MARKER);
+}
+
+export function relationshipsPartPath(sourcePartPath: PartPath): string {
+  if (sourcePartPath === "") return "_rels/.rels";
+  const slash = sourcePartPath.lastIndexOf("/");
+  const dir = slash === -1 ? "" : sourcePartPath.slice(0, slash + 1);
+  const file = slash === -1 ? sourcePartPath : sourcePartPath.slice(slash + 1);
+  return `${dir}_rels/${file}.rels`;
+}
+
+export function relationshipsSourcePartPath(relsPath: string): PartPath {
+  const idx = relsPath.lastIndexOf(RELS_MARKER);
+  const dir = relsPath.slice(0, idx);
+  const file = relsPath.slice(idx + RELS_MARKER.length);
+  const base = file.endsWith(RELS_SUFFIX) ? file.slice(0, -RELS_SUFFIX.length) : file;
+  return asPartPath(dir + base);
+}
+
+export function resolveRelationshipTarget(sourcePartPath: string, target: string): string {
+  if (ABSOLUTE_URI_PATTERN.test(target)) return target;
+
+  const combined = target.startsWith("/")
+    ? target.slice(1)
+    : joinPackageRelativeTarget(sourcePartPath, target);
+
+  return normalizePackagePath(combined);
+}
+
+export function resolveInternalRelationshipTarget(
+  sourcePartPath: PartPath,
+  relationship: Relationship,
+): PartPath | undefined {
+  if (relationship.targetMode === "External") return undefined;
+  return asPartPath(resolveRelationshipTarget(sourcePartPath, relationship.target));
+}
+
+export function parseRelationshipTargetMode(
+  value: string | undefined,
+): RelationshipTargetMode | undefined {
+  if (value === "Internal" || value === "External") return value;
+  return undefined;
+}
+
+function joinPackageRelativeTarget(sourcePartPath: string, target: string): string {
+  const slash = sourcePartPath.lastIndexOf("/");
+  const baseDir = slash === -1 ? "" : sourcePartPath.slice(0, slash);
+  return baseDir === "" ? target : `${baseDir}/${target}`;
+}
+
+function normalizePackagePath(path: string): string {
+  const segments: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join("/");
+}

--- a/packages/document/src/utils/assert-never.ts
+++ b/packages/document/src/utils/assert-never.ts
@@ -1,0 +1,6 @@
+export function assertNever(
+  value: never,
+  message = "Unexpected discriminated union member",
+): never {
+  throw new Error(`${message}: ${JSON.stringify(value)}`);
+}

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -11,7 +11,14 @@
 import { XMLBuilder } from "fast-xml-parser";
 import { zipSync } from "fflate";
 
-import { parseXml, type XmlNode } from "../reader/xml.js";
+import {
+  getAttr,
+  getChild,
+  getChildArray,
+  localName,
+  parseXml,
+  type XmlNode,
+} from "../reader/xml.js";
 import type {
   PartPath,
   PartRelationships,
@@ -21,6 +28,7 @@ import type {
   RawOoxmlNode,
   RawPackagePart,
 } from "../source/index.js";
+import { isRelationshipPart, relationshipsPartPath } from "../source/package-paths.js";
 
 /** `writePptx` の出力。 */
 export type WritePptxOutput = Uint8Array;
@@ -202,40 +210,6 @@ function getShapeByOrderingSlot(
   return undefined;
 }
 
-function getChild(node: XmlNode | undefined, name: string): XmlNode | undefined {
-  if (!node) return undefined;
-  for (const key of Object.keys(node)) {
-    if (key.startsWith("@_")) continue;
-    if (localName(key) !== name) continue;
-    const value = node[key];
-    return Array.isArray(value)
-      ? (value[0] as XmlNode | undefined)
-      : (value as XmlNode | undefined);
-  }
-  return undefined;
-}
-
-function getChildArray(node: XmlNode | undefined, name: string): XmlNode[] {
-  if (!node) return [];
-  for (const key of Object.keys(node)) {
-    if (key.startsWith("@_")) continue;
-    if (localName(key) === name) {
-      const value = node[key];
-      if (value === undefined || value === null) return [];
-      return (Array.isArray(value) ? value : [value]) as XmlNode[];
-    }
-  }
-  return [];
-}
-
-function getAttr(node: XmlNode | undefined, name: string): string | undefined {
-  if (!node) return undefined;
-  const value = node[`@_${name}`];
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  return undefined;
-}
-
 function setChildText(node: XmlNode, name: string, text: string): void {
   for (const key of Object.keys(node)) {
     if (key.startsWith("@_")) continue;
@@ -265,11 +239,6 @@ function textElementValue(existing: unknown, text: string): unknown {
 
 function textRequiresPreserve(text: string): boolean {
   return text.startsWith(" ") || text.endsWith(" ");
-}
-
-function localName(key: string): string {
-  const colon = key.indexOf(":");
-  return colon === -1 ? key : key.slice(colon + 1);
 }
 
 function serializeContentTypes(
@@ -342,18 +311,6 @@ function serializeRawNode(node: RawOoxmlNode): string {
   }
   if (text === "" && children === "") return `<${node.name}${attributes}/>`;
   return `<${node.name}${attributes}>${text}${children}</${node.name}>`;
-}
-
-function relationshipsPartPath(sourcePartPath: PartPath): string {
-  if (sourcePartPath === "") return "_rels/.rels";
-  const slash = sourcePartPath.lastIndexOf("/");
-  const dir = slash === -1 ? "" : sourcePartPath.slice(0, slash + 1);
-  const file = slash === -1 ? sourcePartPath : sourcePartPath.slice(slash + 1);
-  return `${dir}_rels/${file}.rels`;
-}
-
-function isRelationshipPart(path: string): boolean {
-  return path.endsWith(".rels") && path.includes("_rels/");
 }
 
 function encodeXml(xml: string): Uint8Array {


### PR DESCRIPTION
close #514

## 概要

CleanDoc / PptxSourceModel document path 周辺の横断リファクタです。挙動変更ではなく、computed view / reader / writer / core adapter の分岐・helper・validation 境界を整理しました。

## 変更内容

- `create-computed-view.ts` から color / relationships / placeholders の責務を分離
- computed view と core adapter の主要 `kind` 分岐を `switch` + `assertNever` に変更
- relationship target / rels path 解決を `packages/document/src/source/package-paths.ts` に共通化し、単体テストを追加
- writer が reader の XML helper を利用する形にして重複 helper を削減
- OOXML enum parsing helper を追加し、`Set.has` + union cast の散在を削減
- adapter diagnostics を `pushAdapterWarning` に集約

## 検証

- `npm run knip`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test -- packages/document/src/source/package-paths.test.ts packages/document/src/reader/read-pptx.test.ts packages/document/src/computed/create-computed-view.test.ts packages/core/src/pptx-computed-view-renderer-adapter.test.ts`
- `npm run test`
- `npm run build`

`npm run build` では既存の `import.meta` CJS warning が表示されますが、build は成功しています。
