### PR TITLE
TypeScript type assertion の lint 方針を導入する

### DIFF
--- a/docs/type-assertion-policy.md
+++ b/docs/type-assertion-policy.md
@@ -21,12 +21,15 @@ linted TypeScript sources. The main buckets are:
 | Category | Count | Policy |
 | --- | ---: | --- |
 | XML / external input boundary (`XmlNode`, `XmlOrderedNode`, parsed JSON) | 443 | Allowed at parser boundaries. Prefer shared XML helpers such as `getNode`, `getNodeArray`, `getAttr`, and enum parsers when touching nearby code. |
-| Test fixture / mock construction | 96 | Allowed when constructing narrow fixtures. Prefer factory helpers when the same assertion repeats. |
+| Test fixture / mock construction | 95 | Allowed when constructing narrow fixtures. Prefer factory helpers when the same assertion repeats. |
 | `as const` literal preservation | 55 | Allowed. Prefer `satisfies` when shape validation is also needed. |
 | Branded unit / handle constructors (`Emu`, `Pt`, `PartPath`, etc.) | 12 | Allowed only inside constructor helpers such as `asEmu`, `asPt`, source unit helpers, and handle helpers. Callers should use the helper, not assert the brand directly. |
 | Double assertion (`as unknown as X`) | 8 | Avoid in new implementation code. Existing uses are limited to external library gaps and test fixtures; replace with focused adapter helpers when edited. |
-| Object literal assertion | 2 | New direct object/array literal assertions are banned by ESLint. Use typed variables, `satisfies`, or fixture factories instead. |
-| Other narrow assertions | 131 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules. |
+| Object literal assertion | 2 | New direct object/array literal assertions to concrete types are banned by ESLint. Existing broad/double assertions are tracked and should move to typed variables, `satisfies`, or fixture factories when edited. |
+| Array literal assertion | 0 | New direct array literal assertions to concrete types are banned by ESLint. |
+| `as any` | 0 | Not allowed in normal implementation code. |
+| External library / platform interop | 4 | Allowed inside the adapter module that owns the integration. |
+| Other narrow assertions | 132 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules. |
 
 No `as any` assertions were found in linted TypeScript sources during this
 audit.
@@ -42,7 +45,7 @@ rules:
 - `@typescript-eslint/no-unsafe-type-assertion`: `warn`
 
 `no-unsafe-type-assertion` is intentionally a warning for now. A trial run on
-2026-06-27 reported 676 warnings, mostly from XML parser boundaries and
+2026-06-27 reported 675 warnings, mostly from XML parser boundaries and
 fixture narrowing. Turning it into an error should be done package-by-package
 after the repeated XML access patterns have been moved behind helpers.
 

--- a/docs/type-assertion-policy.md
+++ b/docs/type-assertion-policy.md
@@ -1,0 +1,67 @@
+# Type Assertion Policy
+
+This repository allows type assertions only when the type system cannot model a
+boundary without a local helper. Normal implementation code should prefer
+control-flow narrowing, discriminated unions, typed parser helpers, or branded
+constructors.
+
+## Current Inventory
+
+Audit date: 2026-06-27.
+
+Command used for the broad inventory:
+
+```bash
+node -e '/* TypeScript AST walk over packages/, vrt/, scripts/, bench/, e2e/ */'
+```
+
+The current source tree contains 751 `as` / angle-bracket type assertions in
+linted TypeScript sources. The main buckets are:
+
+| Category | Count | Policy |
+| --- | ---: | --- |
+| XML / external input boundary (`XmlNode`, `XmlOrderedNode`, parsed JSON) | 443 | Allowed at parser boundaries. Prefer shared XML helpers such as `getNode`, `getNodeArray`, `getAttr`, and enum parsers when touching nearby code. |
+| Test fixture / mock construction | 95 | Allowed when constructing narrow fixtures. Prefer factory helpers when the same assertion repeats. |
+| `as const` literal preservation | 54 | Allowed. Prefer `satisfies` when shape validation is also needed. |
+| Branded unit / handle constructors (`Emu`, `Pt`, `PartPath`, etc.) | 12 | Allowed only inside constructor helpers such as `asEmu`, `asPt`, source unit helpers, and handle helpers. Callers should use the helper, not assert the brand directly. |
+| Double assertion (`as unknown as X`) | 8 | Avoid in new implementation code. Existing uses are limited to external library gaps and test fixtures; replace with focused adapter helpers when edited. |
+| Object literal assertion | 3 before this policy change | New direct object/array literal assertions are banned by ESLint. Use typed variables, `satisfies`, or fixture factories instead. |
+| Other narrow assertions | 132 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules. |
+
+No `as any` assertions were found in linted TypeScript sources during this
+audit.
+
+## ESLint Policy
+
+The CI lint path (`npm run lint`) now explicitly runs these type assertion
+rules:
+
+- `@typescript-eslint/no-unnecessary-type-assertion`: `error`
+- `@typescript-eslint/consistent-type-assertions`: `error`, with direct
+  object/array literal assertions disallowed
+- `@typescript-eslint/no-unsafe-type-assertion`: `warn`
+
+`no-unsafe-type-assertion` is intentionally a warning for now. A trial run on
+2026-06-27 reported 676 warnings, mostly from XML parser boundaries and
+fixture narrowing. Turning it into an error should be done package-by-package
+after the repeated XML access patterns have been moved behind helpers.
+
+Rule references:
+
+- [`@typescript-eslint/no-unnecessary-type-assertion`](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/)
+- [`@typescript-eslint/no-unsafe-type-assertion`](https://typescript-eslint.io/rules/no-unsafe-type-assertion/)
+- [`@typescript-eslint/consistent-type-assertions`](https://typescript-eslint.io/rules/consistent-type-assertions/)
+
+## Allowed Exceptions
+
+- XML and OOXML input parsing may assert from `unknown`/record-shaped values at
+  the boundary, but new code should use the shared parser helpers before adding
+  another inline assertion.
+- Branded numeric/string values must be created through local constructor
+  helpers. Direct brand assertions are allowed inside those constructors only.
+- Tests may use assertions for fixture narrowing, but repeated patterns should
+  become fixture builders or assertion helper functions.
+- External library type gaps may use assertions inside the adapter module that
+  owns the integration.
+- `as any`, new `as unknown as X`, and broad object literal assertions are not
+  allowed in normal implementation code.

--- a/docs/type-assertion-policy.md
+++ b/docs/type-assertion-policy.md
@@ -12,7 +12,7 @@ Audit date: 2026-06-27.
 Command used for the broad inventory:
 
 ```bash
-npx tsx scripts/audit-type-assertions.ts
+npm run audit:type-assertions
 ```
 
 The current source tree contains 751 `as` / angle-bracket type assertions in

--- a/docs/type-assertion-policy.md
+++ b/docs/type-assertion-policy.md
@@ -12,7 +12,7 @@ Audit date: 2026-06-27.
 Command used for the broad inventory:
 
 ```bash
-node -e '/* TypeScript AST walk over packages/, vrt/, scripts/, bench/, e2e/ */'
+npx tsx scripts/audit-type-assertions.ts
 ```
 
 The current source tree contains 751 `as` / angle-bracket type assertions in
@@ -21,12 +21,12 @@ linted TypeScript sources. The main buckets are:
 | Category | Count | Policy |
 | --- | ---: | --- |
 | XML / external input boundary (`XmlNode`, `XmlOrderedNode`, parsed JSON) | 443 | Allowed at parser boundaries. Prefer shared XML helpers such as `getNode`, `getNodeArray`, `getAttr`, and enum parsers when touching nearby code. |
-| Test fixture / mock construction | 95 | Allowed when constructing narrow fixtures. Prefer factory helpers when the same assertion repeats. |
-| `as const` literal preservation | 54 | Allowed. Prefer `satisfies` when shape validation is also needed. |
+| Test fixture / mock construction | 96 | Allowed when constructing narrow fixtures. Prefer factory helpers when the same assertion repeats. |
+| `as const` literal preservation | 55 | Allowed. Prefer `satisfies` when shape validation is also needed. |
 | Branded unit / handle constructors (`Emu`, `Pt`, `PartPath`, etc.) | 12 | Allowed only inside constructor helpers such as `asEmu`, `asPt`, source unit helpers, and handle helpers. Callers should use the helper, not assert the brand directly. |
 | Double assertion (`as unknown as X`) | 8 | Avoid in new implementation code. Existing uses are limited to external library gaps and test fixtures; replace with focused adapter helpers when edited. |
-| Object literal assertion | 3 before this policy change | New direct object/array literal assertions are banned by ESLint. Use typed variables, `satisfies`, or fixture factories instead. |
-| Other narrow assertions | 132 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules. |
+| Object literal assertion | 2 | New direct object/array literal assertions are banned by ESLint. Use typed variables, `satisfies`, or fixture factories instead. |
+| Other narrow assertions | 131 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules. |
 
 No `as any` assertions were found in linted TypeScript sources during this
 audit.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,6 +77,20 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-return": "error",
+      // Type assertions are allowed at explicit boundaries (XML parsing,
+      // branded constructors, and test fixtures), but unnecessary assertions
+      // must fail CI and unsafe narrowing stays visible while the boundary
+      // helpers are consolidated.
+      "@typescript-eslint/no-unnecessary-type-assertion": "error",
+      "@typescript-eslint/no-unsafe-type-assertion": "warn",
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        {
+          assertionStyle: "as",
+          objectLiteralTypeAssertions: "never",
+          arrayLiteralTypeAssertions: "never",
+        },
+      ],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter @pptx-glimpse/document build && pnpm --filter @pptx-glimpse/renderer build && pnpm --filter pptx-glimpse build",
+    "audit:type-assertions": "tsx scripts/audit-type-assertions.ts",
     "bench": "vitest bench",
     "lint": "eslint packages/*/src/ vrt/ scripts/ bench/ e2e/",
     "lint:fix": "eslint packages/*/src/ vrt/ scripts/ bench/ e2e/ --fix",

--- a/packages/document/src/computed/create-computed-view.ts
+++ b/packages/document/src/computed/create-computed-view.ts
@@ -1024,9 +1024,13 @@ function mergeDefaultRunProperties(
 function pickInherited<K extends keyof SourceParagraphProperties>(
   inherited: readonly (SourceParagraphProperties | undefined)[],
   key: K,
-): Pick<SourceParagraphProperties, K> | Record<string, never> {
+): Partial<Pick<SourceParagraphProperties, K>> {
   const value = pickInheritedValue(inherited, key);
-  return value !== undefined ? ({ [key]: value } as Pick<SourceParagraphProperties, K>) : {};
+  const picked: Partial<Pick<SourceParagraphProperties, K>> = {};
+  if (value !== undefined) {
+    picked[key] = value;
+  }
+  return picked;
 }
 
 function pickInheritedValue<K extends keyof SourceParagraphProperties>(

--- a/scripts/audit-type-assertions.ts
+++ b/scripts/audit-type-assertions.ts
@@ -1,0 +1,183 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import ts from "typescript";
+
+const CATEGORIES = [
+  "xmlOrExternalInput",
+  "testFixture",
+  "asConst",
+  "brandedConstructor",
+  "doubleUnknown",
+  "objectLiteral",
+  "arrayLiteral",
+  "asAny",
+  "externalInterop",
+  "other",
+] as const;
+
+type Category = (typeof CATEGORIES)[number];
+
+interface CategoryBucket {
+  readonly description: string;
+  count: number;
+  readonly examples: string[];
+}
+
+const buckets: Record<Category, CategoryBucket> = {
+  xmlOrExternalInput: {
+    description: "XML / external input boundary",
+    count: 0,
+    examples: [],
+  },
+  testFixture: {
+    description: "Test fixture / mock construction",
+    count: 0,
+    examples: [],
+  },
+  asConst: {
+    description: "`as const` literal preservation",
+    count: 0,
+    examples: [],
+  },
+  brandedConstructor: {
+    description: "Branded unit / handle constructors",
+    count: 0,
+    examples: [],
+  },
+  doubleUnknown: {
+    description: "Double assertion (`as unknown as X`)",
+    count: 0,
+    examples: [],
+  },
+  objectLiteral: {
+    description: "Object literal assertion",
+    count: 0,
+    examples: [],
+  },
+  arrayLiteral: {
+    description: "Array literal assertion",
+    count: 0,
+    examples: [],
+  },
+  asAny: {
+    description: "`as any`",
+    count: 0,
+    examples: [],
+  },
+  externalInterop: {
+    description: "External library / platform interop",
+    count: 0,
+    examples: [],
+  },
+  other: {
+    description: "Other narrow assertions",
+    count: 0,
+    examples: [],
+  },
+};
+
+const lintedRoots = ["packages", "vrt", "scripts", "bench", "e2e"];
+
+function listSourceFiles(): string[] {
+  return execFileSync("rg", ["--files", "-g", "*.ts", "-g", "*.tsx", ...lintedRoots], {
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter((file) => file.length > 0);
+}
+
+function classify(file: string, sourceFile: ts.SourceFile, node: AssertionNode): Category {
+  const typeText = node.type.getText(sourceFile);
+  const expressionText = node.expression.getText(sourceFile);
+  const assertionText = node.getText(sourceFile);
+
+  if (typeText === "const") return "asConst";
+  if (typeText === "any") return "asAny";
+  if (assertionText.includes("as unknown as")) return "doubleUnknown";
+  if (ts.isObjectLiteralExpression(node.expression)) return "objectLiteral";
+  if (ts.isArrayLiteralExpression(node.expression)) return "arrayLiteral";
+  if (isXmlOrExternalInput(typeText)) return "xmlOrExternalInput";
+  if (isBrandedConstructor(typeText)) return "brandedConstructor";
+  if (isTestOrVrtFile(file)) return "testFixture";
+  if (isExternalInterop(typeText, expressionText)) return "externalInterop";
+  return "other";
+}
+
+function isXmlOrExternalInput(typeText: string): boolean {
+  return /\b(XmlNode|XmlOrderedNode|Record<string, unknown>|PackageJson)\b/.test(typeText);
+}
+
+function isBrandedConstructor(typeText: string): boolean {
+  return /\b(Emu|Pt|HundredthPt|OoxmlPercent|OoxmlAngle|PartPath|RelationshipId|SourceNodeId|RawSidecarId)\b/.test(
+    typeText,
+  );
+}
+
+function isTestOrVrtFile(file: string): boolean {
+  return /\.(test|e2e\.test)\.ts$/.test(file) || file.startsWith("vrt/");
+}
+
+function isExternalInterop(typeText: string, expressionText: string): boolean {
+  return (
+    /\b(ArrayBuffer|OpentypeFullFont|SubsettableFont|ReturnType<typeof crypto\.randomUUID>|Error|VitestBenchOutput|SlideSvg)\b/.test(
+      typeText,
+    ) || expressionText.startsWith("JSON.parse(")
+  );
+}
+
+function record(
+  category: Category,
+  file: string,
+  sourceFile: ts.SourceFile,
+  node: AssertionNode,
+): void {
+  const bucket = buckets[category];
+  const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+  bucket.count += 1;
+  if (bucket.examples.length < 3) {
+    bucket.examples.push(`${file}:${line}: ${node.getText(sourceFile).replace(/\s+/g, " ")}`);
+  }
+}
+
+type AssertionNode = ts.AsExpression | ts.TypeAssertion;
+
+function isAssertionNode(node: ts.Node): node is AssertionNode {
+  return ts.isAsExpression(node) || ts.isTypeAssertionExpression(node);
+}
+
+function visit(file: string, sourceFile: ts.SourceFile, node: ts.Node): void {
+  if (isAssertionNode(node)) {
+    record(classify(file, sourceFile, node), file, sourceFile, node);
+  }
+  ts.forEachChild(node, (child) => visit(file, sourceFile, child));
+}
+
+for (const file of listSourceFiles()) {
+  const source = readFileSync(file, "utf8");
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+  visit(file, sourceFile, sourceFile);
+}
+
+const total = CATEGORIES.reduce((sum, category) => sum + buckets[category].count, 0);
+
+console.log(`# Type assertion audit\n`);
+console.log(`Total assertions: ${total}\n`);
+console.log("| Category | Count |");
+console.log("| --- | ---: |");
+for (const category of CATEGORIES) {
+  console.log(`| ${buckets[category].description} | ${buckets[category].count} |`);
+}
+console.log("\n## Examples\n");
+for (const category of CATEGORIES) {
+  const bucket = buckets[category];
+  console.log(`### ${bucket.description}\n`);
+  if (bucket.examples.length === 0) {
+    console.log("- none\n");
+    continue;
+  }
+  for (const example of bucket.examples) {
+    console.log(`- ${example}`);
+  }
+  console.log("");
+}

--- a/scripts/audit-type-assertions.ts
+++ b/scripts/audit-type-assertions.ts
@@ -77,12 +77,18 @@ const buckets: Record<Category, CategoryBucket> = {
   },
 };
 
-const lintedRoots = ["packages", "vrt", "scripts", "bench", "e2e"];
+const lintedFileGlobs = [
+  "packages/*/src/**/*.ts",
+  "packages/*/src/**/*.tsx",
+  "vrt/**/*.ts",
+  "scripts/**/*.ts",
+  "bench/**/*.ts",
+  "e2e/**/*.ts",
+];
 
 function listSourceFiles(): string[] {
-  return execFileSync("rg", ["--files", "-g", "*.ts", "-g", "*.tsx", ...lintedRoots], {
-    encoding: "utf8",
-  })
+  const globArgs = lintedFileGlobs.flatMap((glob) => ["-g", glob]);
+  return execFileSync("rg", ["--files", ...globArgs, "."], { encoding: "utf8" })
     .split("\n")
     .filter((file) => file.length > 0);
 }


### PR DESCRIPTION
close #517

## 目的

TypeScript の type assertion 使用方針を明文化し、不要な assertion と広い object/array literal assertion を CI の lint 経路で検出できるようにします。unsafe narrowing assertion は現状の件数が多いため warn として可視化し、段階的に helper へ閉じ込める方針にします。

## 変更内容

- `eslint.config.mjs` に `no-unnecessary-type-assertion` / `no-unsafe-type-assertion` / `consistent-type-assertions` を明示追加
- `docs/type-assertion-policy.md` を追加し、`as` usage の用途別棚卸しと例外方針を記録
- `scripts/audit-type-assertions.ts` と `audit:type-assertions` script を追加し、lint 対象 TypeScript source の assertion 分類を再実行可能にした
- `packages/document/src/computed/create-computed-view.ts` の object literal assertion 1 件を型付き変数代入へ置換

## 影響範囲

- `eslint.config.mjs`
- `docs/type-assertion-policy.md`
- `scripts/audit-type-assertions.ts`
- `package.json`
- `packages/document/src/computed/create-computed-view.ts`

## 検証

- `npm run audit:type-assertions`
- `npm run knip`
- `npm run lint`（0 errors / 675 warnings）
- `npm run typecheck`
- `npm run format:check`
- `npm run test -- packages/document/src/computed/create-computed-view.test.ts`

## 参考

- [@typescript-eslint/no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/)
- [@typescript-eslint/no-unsafe-type-assertion](https://typescript-eslint.io/rules/no-unsafe-type-assertion/)
- [@typescript-eslint/consistent-type-assertions](https://typescript-eslint.io/rules/consistent-type-assertions/)
