### PR TITLE
no-unsafe-type-assertion を error 化する

### DIFF
--- a/docs/type-assertion-policy.md
+++ b/docs/type-assertion-policy.md
@@ -15,7 +15,7 @@ Command used for the broad inventory:
 npm run audit:type-assertions
 ```
 
-The current source tree contains 77 `as` / angle-bracket type assertions in
+The current source tree contains 84 `as` / angle-bracket type assertions in
 linted TypeScript sources. The main buckets are:
 
 | Category | Count | Policy |
@@ -29,7 +29,7 @@ linted TypeScript sources. The main buckets are:
 | Array literal assertion | 0 | New direct array literal assertions to concrete types are banned by ESLint. |
 | `as any` | 0 | Not allowed in normal implementation code. |
 | External library / platform interop | 0 | Allowed inside the adapter module that owns the integration, preferably via a boundary helper. |
-| Other narrow assertions | 7 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules or purpose-specific `unsafe*Assertion` helpers. |
+| Other narrow assertions | 14 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules or purpose-specific `unsafe*Assertion` helpers. |
 
 No `as any` assertions were found in linted TypeScript sources during this
 audit.
@@ -52,6 +52,8 @@ boundary purpose (`unsafeXmlBoundaryAssertion`,
 `unsafeBrandAssertion`, external interop helpers, and adapter/script/VRT
 variants), each with a reasoned `eslint-disable-next-line` at the actual
 assertion boundary.
+`unsafeFixtureAssertion` is test-only; ESLint rejects importing it from
+production package sources.
 
 Rule references:
 

--- a/docs/type-assertion-policy.md
+++ b/docs/type-assertion-policy.md
@@ -20,7 +20,7 @@ linted TypeScript sources. The main buckets are:
 
 | Category | Count | Policy |
 | --- | ---: | --- |
-| XML / external input boundary (`XmlNode`, `XmlOrderedNode`, parsed JSON) | 11 | Allowed at parser boundaries. Prefer shared XML helpers such as `getNode`, `getNodeArray`, `getAttr`, and enum parsers when touching nearby code. Unsafe narrowing belongs in `unsafeTypeAssertion` boundary helpers, not inline parser code. |
+| XML / external input boundary (`XmlNode`, `XmlOrderedNode`, parsed JSON) | 11 | Allowed at parser boundaries. Prefer shared XML helpers such as `getNode`, `getNodeArray`, `getAttr`, and enum parsers when touching nearby code. Unsafe narrowing belongs in purpose-specific `unsafe*Assertion` boundary helpers, not inline parser code. |
 | Test fixture / mock construction | 0 | Prefer fixture builders or boundary helpers when constructing narrow fixtures. |
 | `as const` literal preservation | 59 | Allowed. Prefer `satisfies` when shape validation is also needed. |
 | Branded unit / handle constructors (`Emu`, `Pt`, `PartPath`, etc.) | 0 | Callers should use constructor helpers such as `asEmu`, `asPt`, source unit helpers, and handle helpers. |
@@ -29,7 +29,7 @@ linted TypeScript sources. The main buckets are:
 | Array literal assertion | 0 | New direct array literal assertions to concrete types are banned by ESLint. |
 | `as any` | 0 | Not allowed in normal implementation code. |
 | External library / platform interop | 0 | Allowed inside the adapter module that owns the integration, preferably via a boundary helper. |
-| Other narrow assertions | 7 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules or `unsafeTypeAssertion` helpers. |
+| Other narrow assertions | 7 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules or purpose-specific `unsafe*Assertion` helpers. |
 
 No `as any` assertions were found in linted TypeScript sources during this
 audit.
@@ -46,8 +46,11 @@ rules:
 
 `no-unsafe-type-assertion` is enforced as an error. Existing unsafe narrowing
 from XML/OOXML parser boundaries, fixture narrowing, branded values, and
-external-library gaps has been moved behind local `unsafeTypeAssertion`
-helpers, each with a reasoned `eslint-disable-next-line` at the actual
+external-library gaps has been moved behind local helper functions grouped by
+boundary purpose (`unsafeXmlBoundaryAssertion`,
+`unsafeOoxmlBoundaryAssertion`, `unsafeFixtureAssertion`,
+`unsafeBrandAssertion`, external interop helpers, and adapter/script/VRT
+variants), each with a reasoned `eslint-disable-next-line` at the actual
 assertion boundary.
 
 Rule references:
@@ -60,7 +63,8 @@ Rule references:
 
 - XML and OOXML input parsing may narrow from `unknown`/record-shaped values at
   the boundary, but new code should use shared parser helpers or
-  `unsafeTypeAssertion` before adding another inline assertion.
+  purpose-specific `unsafe*Assertion` helpers before adding another inline
+  assertion.
 - Branded numeric/string values must be created through local constructor
   helpers. Direct brand assertions are allowed inside those constructors only.
 - Tests may use boundary helpers for fixture narrowing, but repeated patterns

--- a/docs/type-assertion-policy.md
+++ b/docs/type-assertion-policy.md
@@ -15,21 +15,21 @@ Command used for the broad inventory:
 npm run audit:type-assertions
 ```
 
-The current source tree contains 751 `as` / angle-bracket type assertions in
+The current source tree contains 77 `as` / angle-bracket type assertions in
 linted TypeScript sources. The main buckets are:
 
 | Category | Count | Policy |
 | --- | ---: | --- |
-| XML / external input boundary (`XmlNode`, `XmlOrderedNode`, parsed JSON) | 443 | Allowed at parser boundaries. Prefer shared XML helpers such as `getNode`, `getNodeArray`, `getAttr`, and enum parsers when touching nearby code. |
-| Test fixture / mock construction | 95 | Allowed when constructing narrow fixtures. Prefer factory helpers when the same assertion repeats. |
-| `as const` literal preservation | 55 | Allowed. Prefer `satisfies` when shape validation is also needed. |
-| Branded unit / handle constructors (`Emu`, `Pt`, `PartPath`, etc.) | 12 | Allowed only inside constructor helpers such as `asEmu`, `asPt`, source unit helpers, and handle helpers. Callers should use the helper, not assert the brand directly. |
-| Double assertion (`as unknown as X`) | 8 | Avoid in new implementation code. Existing uses are limited to external library gaps and test fixtures; replace with focused adapter helpers when edited. |
-| Object literal assertion | 2 | New direct object/array literal assertions to concrete types are banned by ESLint. Existing broad/double assertions are tracked and should move to typed variables, `satisfies`, or fixture factories when edited. |
+| XML / external input boundary (`XmlNode`, `XmlOrderedNode`, parsed JSON) | 11 | Allowed at parser boundaries. Prefer shared XML helpers such as `getNode`, `getNodeArray`, `getAttr`, and enum parsers when touching nearby code. Unsafe narrowing belongs in `unsafeTypeAssertion` boundary helpers, not inline parser code. |
+| Test fixture / mock construction | 0 | Prefer fixture builders or boundary helpers when constructing narrow fixtures. |
+| `as const` literal preservation | 59 | Allowed. Prefer `satisfies` when shape validation is also needed. |
+| Branded unit / handle constructors (`Emu`, `Pt`, `PartPath`, etc.) | 0 | Callers should use constructor helpers such as `asEmu`, `asPt`, source unit helpers, and handle helpers. |
+| Double assertion (`as unknown as X`) | 0 | Not allowed in new implementation code. Replace with focused adapter helpers when needed. |
+| Object literal assertion | 0 | Direct object/array literal assertions to concrete types are banned by ESLint. Use typed variables, `satisfies`, or fixture factories. |
 | Array literal assertion | 0 | New direct array literal assertions to concrete types are banned by ESLint. |
 | `as any` | 0 | Not allowed in normal implementation code. |
-| External library / platform interop | 4 | Allowed inside the adapter module that owns the integration. |
-| Other narrow assertions | 132 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules. |
+| External library / platform interop | 0 | Allowed inside the adapter module that owns the integration, preferably via a boundary helper. |
+| Other narrow assertions | 7 | Treat case-by-case. Enum/string-literal narrowing should move toward parser helpers such as `parseEnum`. External library gaps should stay inside adapter modules or `unsafeTypeAssertion` helpers. |
 
 No `as any` assertions were found in linted TypeScript sources during this
 audit.
@@ -40,14 +40,15 @@ The CI lint path (`npm run lint`) now explicitly runs these type assertion
 rules:
 
 - `@typescript-eslint/no-unnecessary-type-assertion`: `error`
+- `@typescript-eslint/no-unsafe-type-assertion`: `error`
 - `@typescript-eslint/consistent-type-assertions`: `error`, with direct
   object/array literal assertions disallowed
-- `@typescript-eslint/no-unsafe-type-assertion`: `warn`
 
-`no-unsafe-type-assertion` is intentionally a warning for now. A trial run on
-2026-06-27 reported 675 warnings, mostly from XML parser boundaries and
-fixture narrowing. Turning it into an error should be done package-by-package
-after the repeated XML access patterns have been moved behind helpers.
+`no-unsafe-type-assertion` is enforced as an error. Existing unsafe narrowing
+from XML/OOXML parser boundaries, fixture narrowing, branded values, and
+external-library gaps has been moved behind local `unsafeTypeAssertion`
+helpers, each with a reasoned `eslint-disable-next-line` at the actual
+assertion boundary.
 
 Rule references:
 
@@ -57,13 +58,13 @@ Rule references:
 
 ## Allowed Exceptions
 
-- XML and OOXML input parsing may assert from `unknown`/record-shaped values at
-  the boundary, but new code should use the shared parser helpers before adding
-  another inline assertion.
+- XML and OOXML input parsing may narrow from `unknown`/record-shaped values at
+  the boundary, but new code should use shared parser helpers or
+  `unsafeTypeAssertion` before adding another inline assertion.
 - Branded numeric/string values must be created through local constructor
   helpers. Direct brand assertions are allowed inside those constructors only.
-- Tests may use assertions for fixture narrowing, but repeated patterns should
-  become fixture builders or assertion helper functions.
+- Tests may use boundary helpers for fixture narrowing, but repeated patterns
+  should become fixture builders or assertion helper functions.
 - External library type gaps may use assertions inside the adapter module that
   owns the integration.
 - `as any`, new `as unknown as X`, and broad object literal assertions are not

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,6 +99,32 @@ export default tseslint.config(
     },
   },
   {
+    files: ["packages/*/src/**/*.ts"],
+    ignores: [
+      "packages/*/src/**/*.test.ts",
+      "packages/*/src/**/*.e2e.test.ts",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "./unsafe-type-assertion.js",
+              importNames: ["unsafeFixtureAssertion"],
+              message: "unsafeFixtureAssertion is test-only; production code must use a boundary-specific helper.",
+            },
+            {
+              name: "../unsafe-type-assertion.js",
+              importNames: ["unsafeFixtureAssertion"],
+              message: "unsafeFixtureAssertion is test-only; production code must use a boundary-specific helper.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["scripts/**/*.ts", "vrt/**/*.ts", "bench/**/*.ts", "e2e/**/*.ts"],
     rules: {
       "@typescript-eslint/no-unsafe-argument": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,16 +108,12 @@ export default tseslint.config(
       "no-restricted-imports": [
         "error",
         {
-          paths: [
+          patterns: [
             {
-              name: "./unsafe-type-assertion.js",
+              group: ["**/unsafe-type-assertion.js"],
               importNames: ["unsafeFixtureAssertion"],
-              message: "unsafeFixtureAssertion is test-only; production code must use a boundary-specific helper.",
-            },
-            {
-              name: "../unsafe-type-assertion.js",
-              importNames: ["unsafeFixtureAssertion"],
-              message: "unsafeFixtureAssertion is test-only; production code must use a boundary-specific helper.",
+              message:
+                "unsafeFixtureAssertion is test-only; production code must use a boundary-specific helper.",
             },
           ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,12 +77,11 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-call": "error",
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-return": "error",
-      // Type assertions are allowed at explicit boundaries (XML parsing,
-      // branded constructors, and test fixtures), but unnecessary assertions
-      // must fail CI and unsafe narrowing stays visible while the boundary
-      // helpers are consolidated.
+      // Type assertions are allowed at explicit boundaries only. Unsafe
+      // narrowing must stay inside boundary helpers or a reasoned local
+      // eslint-disable-next-line directive.
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
-      "@typescript-eslint/no-unsafe-type-assertion": "warn",
+      "@typescript-eslint/no-unsafe-type-assertion": "error",
       "@typescript-eslint/consistent-type-assertions": [
         "error",
         {

--- a/packages/core/src/color/color-resolver.ts
+++ b/packages/core/src/color/color-resolver.ts
@@ -10,7 +10,7 @@ import type { ColorMap, ColorScheme, ColorSchemeKey } from "@pptx-glimpse/render
 import { debug } from "@pptx-glimpse/renderer";
 
 import type { XmlNode } from "../parser/xml-parser.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { applyColorTransforms } from "./color-transforms.js";
 
 export class ColorResolver {
@@ -23,13 +23,13 @@ export class ColorResolver {
     if (!colorNode) return null;
 
     if (colorNode.srgbClr) {
-      return this.resolveSrgbClr(unsafeTypeAssertion<XmlNode>(colorNode.srgbClr));
+      return this.resolveSrgbClr(unsafeXmlBoundaryAssertion<XmlNode>(colorNode.srgbClr));
     }
     if (colorNode.schemeClr) {
-      return this.resolveSchemeClr(unsafeTypeAssertion<XmlNode>(colorNode.schemeClr));
+      return this.resolveSchemeClr(unsafeXmlBoundaryAssertion<XmlNode>(colorNode.schemeClr));
     }
     if (colorNode.sysClr) {
-      return this.resolveSysClr(unsafeTypeAssertion<XmlNode>(colorNode.sysClr));
+      return this.resolveSysClr(unsafeXmlBoundaryAssertion<XmlNode>(colorNode.sysClr));
     }
 
     const keys = Object.keys(colorNode).filter((k) => !k.startsWith("@_"));
@@ -41,20 +41,20 @@ export class ColorResolver {
   }
 
   private resolveSrgbClr(node: XmlNode): ResolvedColor {
-    const hex = `#${unsafeTypeAssertion<string>(node["@_val"])}`;
+    const hex = `#${unsafeXmlBoundaryAssertion<string>(node["@_val"])}`;
     const alpha = extractAlpha(node);
     return applyColorTransforms({ hex, alpha }, node);
   }
 
   private resolveSchemeClr(node: XmlNode): ResolvedColor {
-    const schemeName = unsafeTypeAssertion<string>(node["@_val"]);
+    const schemeName = unsafeXmlBoundaryAssertion<string>(node["@_val"]);
     const hex = this.resolveSchemeColorName(schemeName);
     const alpha = extractAlpha(node);
     return applyColorTransforms({ hex, alpha }, node);
   }
 
   private resolveSysClr(node: XmlNode): ResolvedColor {
-    const hex = `#${unsafeTypeAssertion<string | undefined>(node["@_lastClr"]) ?? "000000"}`;
+    const hex = `#${unsafeXmlBoundaryAssertion<string | undefined>(node["@_lastClr"]) ?? "000000"}`;
     const alpha = extractAlpha(node);
     return applyColorTransforms({ hex, alpha }, node);
   }
@@ -66,17 +66,17 @@ export class ColorResolver {
 
   private mapColorName(name: string): ColorSchemeKey {
     if (name in this.colorMap) {
-      return this.colorMap[unsafeTypeAssertion<keyof ColorMap>(name)];
+      return this.colorMap[unsafeXmlBoundaryAssertion<keyof ColorMap>(name)];
     }
     if (name in this.colorScheme) {
-      return unsafeTypeAssertion<ColorSchemeKey>(name);
+      return unsafeXmlBoundaryAssertion<ColorSchemeKey>(name);
     }
     return "dk1";
   }
 }
 
 function extractAlpha(node: XmlNode): number {
-  const alphaNode = unsafeTypeAssertion<XmlNode | undefined>(node.alpha);
+  const alphaNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.alpha);
   if (alphaNode) {
     return Number(alphaNode["@_val"]) / 100000;
   }

--- a/packages/core/src/color/color-resolver.ts
+++ b/packages/core/src/color/color-resolver.ts
@@ -10,6 +10,7 @@ import type { ColorMap, ColorScheme, ColorSchemeKey } from "@pptx-glimpse/render
 import { debug } from "@pptx-glimpse/renderer";
 
 import type { XmlNode } from "../parser/xml-parser.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { applyColorTransforms } from "./color-transforms.js";
 
 export class ColorResolver {
@@ -22,13 +23,13 @@ export class ColorResolver {
     if (!colorNode) return null;
 
     if (colorNode.srgbClr) {
-      return this.resolveSrgbClr(colorNode.srgbClr as XmlNode);
+      return this.resolveSrgbClr(unsafeTypeAssertion<XmlNode>(colorNode.srgbClr));
     }
     if (colorNode.schemeClr) {
-      return this.resolveSchemeClr(colorNode.schemeClr as XmlNode);
+      return this.resolveSchemeClr(unsafeTypeAssertion<XmlNode>(colorNode.schemeClr));
     }
     if (colorNode.sysClr) {
-      return this.resolveSysClr(colorNode.sysClr as XmlNode);
+      return this.resolveSysClr(unsafeTypeAssertion<XmlNode>(colorNode.sysClr));
     }
 
     const keys = Object.keys(colorNode).filter((k) => !k.startsWith("@_"));
@@ -40,20 +41,20 @@ export class ColorResolver {
   }
 
   private resolveSrgbClr(node: XmlNode): ResolvedColor {
-    const hex = `#${node["@_val"] as string}`;
+    const hex = `#${unsafeTypeAssertion<string>(node["@_val"])}`;
     const alpha = extractAlpha(node);
     return applyColorTransforms({ hex, alpha }, node);
   }
 
   private resolveSchemeClr(node: XmlNode): ResolvedColor {
-    const schemeName = node["@_val"] as string;
+    const schemeName = unsafeTypeAssertion<string>(node["@_val"]);
     const hex = this.resolveSchemeColorName(schemeName);
     const alpha = extractAlpha(node);
     return applyColorTransforms({ hex, alpha }, node);
   }
 
   private resolveSysClr(node: XmlNode): ResolvedColor {
-    const hex = `#${(node["@_lastClr"] as string | undefined) ?? "000000"}`;
+    const hex = `#${unsafeTypeAssertion<string | undefined>(node["@_lastClr"]) ?? "000000"}`;
     const alpha = extractAlpha(node);
     return applyColorTransforms({ hex, alpha }, node);
   }
@@ -65,17 +66,17 @@ export class ColorResolver {
 
   private mapColorName(name: string): ColorSchemeKey {
     if (name in this.colorMap) {
-      return this.colorMap[name as keyof ColorMap];
+      return this.colorMap[unsafeTypeAssertion<keyof ColorMap>(name)];
     }
     if (name in this.colorScheme) {
-      return name as ColorSchemeKey;
+      return unsafeTypeAssertion<ColorSchemeKey>(name);
     }
     return "dk1";
   }
 }
 
 function extractAlpha(node: XmlNode): number {
-  const alphaNode = node.alpha as XmlNode | undefined;
+  const alphaNode = unsafeTypeAssertion<XmlNode | undefined>(node.alpha);
   if (alphaNode) {
     return Number(alphaNode["@_val"]) / 100000;
   }

--- a/packages/core/src/color/color-transforms.ts
+++ b/packages/core/src/color/color-transforms.ts
@@ -8,31 +8,32 @@
 import type { ResolvedColor } from "@pptx-glimpse/renderer";
 
 import type { XmlNode } from "../parser/xml-parser.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 
 export function applyColorTransforms(color: ResolvedColor, node: XmlNode): ResolvedColor {
   let { hex, alpha } = color;
 
-  const lumMod = node.lumMod as XmlNode | undefined;
-  const lumOff = node.lumOff as XmlNode | undefined;
+  const lumMod = unsafeTypeAssertion<XmlNode | undefined>(node.lumMod);
+  const lumOff = unsafeTypeAssertion<XmlNode | undefined>(node.lumOff);
   if (lumMod || lumOff) {
     hex = applyLuminance(
       hex,
-      lumMod?.["@_val"] as string | undefined,
-      lumOff?.["@_val"] as string | undefined,
+      unsafeTypeAssertion<string | undefined>(lumMod?.["@_val"]),
+      unsafeTypeAssertion<string | undefined>(lumOff?.["@_val"]),
     );
   }
 
-  const tintNode = node.tint as XmlNode | undefined;
+  const tintNode = unsafeTypeAssertion<XmlNode | undefined>(node.tint);
   if (tintNode) {
     hex = applyTint(hex, Number(tintNode["@_val"]) / 100000);
   }
 
-  const shadeNode = node.shade as XmlNode | undefined;
+  const shadeNode = unsafeTypeAssertion<XmlNode | undefined>(node.shade);
   if (shadeNode) {
     hex = applyShade(hex, Number(shadeNode["@_val"]) / 100000);
   }
 
-  const alphaNode = node.alpha as XmlNode | undefined;
+  const alphaNode = unsafeTypeAssertion<XmlNode | undefined>(node.alpha);
   if (alphaNode) {
     alpha = Number(alphaNode["@_val"]) / 100000;
   }

--- a/packages/core/src/color/color-transforms.ts
+++ b/packages/core/src/color/color-transforms.ts
@@ -8,32 +8,32 @@
 import type { ResolvedColor } from "@pptx-glimpse/renderer";
 
 import type { XmlNode } from "../parser/xml-parser.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 
 export function applyColorTransforms(color: ResolvedColor, node: XmlNode): ResolvedColor {
   let { hex, alpha } = color;
 
-  const lumMod = unsafeTypeAssertion<XmlNode | undefined>(node.lumMod);
-  const lumOff = unsafeTypeAssertion<XmlNode | undefined>(node.lumOff);
+  const lumMod = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.lumMod);
+  const lumOff = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.lumOff);
   if (lumMod || lumOff) {
     hex = applyLuminance(
       hex,
-      unsafeTypeAssertion<string | undefined>(lumMod?.["@_val"]),
-      unsafeTypeAssertion<string | undefined>(lumOff?.["@_val"]),
+      unsafeXmlBoundaryAssertion<string | undefined>(lumMod?.["@_val"]),
+      unsafeXmlBoundaryAssertion<string | undefined>(lumOff?.["@_val"]),
     );
   }
 
-  const tintNode = unsafeTypeAssertion<XmlNode | undefined>(node.tint);
+  const tintNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.tint);
   if (tintNode) {
     hex = applyTint(hex, Number(tintNode["@_val"]) / 100000);
   }
 
-  const shadeNode = unsafeTypeAssertion<XmlNode | undefined>(node.shade);
+  const shadeNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.shade);
   if (shadeNode) {
     hex = applyShade(hex, Number(shadeNode["@_val"]) / 100000);
   }
 
-  const alphaNode = unsafeTypeAssertion<XmlNode | undefined>(node.alpha);
+  const alphaNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.alpha);
   if (alphaNode) {
     alpha = Number(alphaNode["@_val"]) / 100000;
   }

--- a/packages/core/src/parse-render.integration.test.ts
+++ b/packages/core/src/parse-render.integration.test.ts
@@ -9,7 +9,7 @@ import type { Relationship } from "./parser/relationship-parser.js";
 import { parseShapeTree } from "./parser/slide-parser.js";
 import type { XmlNode } from "./parser/xml-parser.js";
 import { parseXml } from "./parser/xml-parser.js";
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "./unsafe-type-assertion.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -89,7 +89,7 @@ function parseAndRenderShape(
 ): { shape: ShapeElement; svg: string; defs: string[] } {
   const parsed = parseXml(xml);
   const elements = parseShapeTree(
-    unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+    unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
     rels ?? new Map<string, Relationship>(),
     "ppt/slides/slide1.xml",
     createEmptyArchive(),
@@ -97,7 +97,7 @@ function parseAndRenderShape(
   );
   expect(elements).toHaveLength(1);
   expect(elements[0].type).toBe("shape");
-  const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+  const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
   const result = renderShape(shape);
   const svg = result.content;
   return { shape, svg, defs: result.defs };

--- a/packages/core/src/parse-render.integration.test.ts
+++ b/packages/core/src/parse-render.integration.test.ts
@@ -9,6 +9,7 @@ import type { Relationship } from "./parser/relationship-parser.js";
 import { parseShapeTree } from "./parser/slide-parser.js";
 import type { XmlNode } from "./parser/xml-parser.js";
 import { parseXml } from "./parser/xml-parser.js";
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -88,7 +89,7 @@ function parseAndRenderShape(
 ): { shape: ShapeElement; svg: string; defs: string[] } {
   const parsed = parseXml(xml);
   const elements = parseShapeTree(
-    parsed.spTree as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
     rels ?? new Map<string, Relationship>(),
     "ppt/slides/slide1.xml",
     createEmptyArchive(),
@@ -96,7 +97,7 @@ function parseAndRenderShape(
   );
   expect(elements).toHaveLength(1);
   expect(elements[0].type).toBe("shape");
-  const shape = elements[0] as ShapeElement;
+  const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
   const result = renderShape(shape);
   const svg = result.content;
   return { shape, svg, defs: result.defs };

--- a/packages/core/src/parser-path-oracle.test.ts
+++ b/packages/core/src/parser-path-oracle.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildEffectiveSlideElements } from "./parser-path-oracle.js";
 import type { ParsedSlide } from "./pptx-data-parser.js";
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
 
 describe("buildEffectiveSlideElements", () => {
   it("omits master elements when the slide hides master shapes", () => {
@@ -103,10 +104,10 @@ function shape(
           paragraphs: [{ runs: [{ text: options.text }] }],
         };
 
-  return {
+  return unsafeTypeAssertion<ShapeElement>({
     type: "shape",
     id,
     placeholderType: options.placeholderType,
     textBody,
-  } as unknown as ShapeElement;
+  });
 }

--- a/packages/core/src/parser-path-oracle.test.ts
+++ b/packages/core/src/parser-path-oracle.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { buildEffectiveSlideElements } from "./parser-path-oracle.js";
 import type { ParsedSlide } from "./pptx-data-parser.js";
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "./unsafe-type-assertion.js";
 
 describe("buildEffectiveSlideElements", () => {
   it("omits master elements when the slide hides master shapes", () => {
@@ -104,7 +104,7 @@ function shape(
           paragraphs: [{ runs: [{ text: options.text }] }],
         };
 
-  return unsafeTypeAssertion<ShapeElement>({
+  return unsafeFixtureAssertion<ShapeElement>({
     type: "shape",
     id,
     placeholderType: options.placeholderType,

--- a/packages/core/src/parser/blip-effect-parser.ts
+++ b/packages/core/src/parser/blip-effect-parser.ts
@@ -10,7 +10,7 @@ import type { ResolvedColor } from "@pptx-glimpse/renderer";
 import { asEmu } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 const PRESET_COLORS: Record<string, string> = {
@@ -31,15 +31,15 @@ export function parseBlipEffects(
   if (!blipNode) return null;
 
   const grayscale = blipNode.grayscl !== undefined;
-  const biLevel = parseBiLevel(unsafeTypeAssertion<XmlNode | undefined>(blipNode.biLevel));
-  const blur = parseBlur(unsafeTypeAssertion<XmlNode | undefined>(blipNode.blur));
-  const lum = parseLum(unsafeTypeAssertion<XmlNode | undefined>(blipNode.lum));
+  const biLevel = parseBiLevel(unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipNode.biLevel));
+  const blur = parseBlur(unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipNode.blur));
+  const lum = parseLum(unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipNode.lum));
   const duotone = parseDuotone(
-    unsafeTypeAssertion<XmlNode | undefined>(blipNode.duotone),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipNode.duotone),
     colorResolver,
   );
   const clrChange = parseClrChange(
-    unsafeTypeAssertion<XmlNode | undefined>(blipNode.clrChange),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipNode.clrChange),
     colorResolver,
   );
 
@@ -85,7 +85,11 @@ function parseDuotone(
     if (!colorNodes) continue;
     const nodes = Array.isArray(colorNodes) ? colorNodes : [colorNodes];
     for (const cn of nodes) {
-      const resolved = resolveColorNode(key, unsafeTypeAssertion<XmlNode>(cn), colorResolver);
+      const resolved = resolveColorNode(
+        key,
+        unsafeXmlBoundaryAssertion<XmlNode>(cn),
+        colorResolver,
+      );
       if (resolved) colors.push(resolved);
     }
   }
@@ -100,8 +104,8 @@ function parseClrChange(
 ): ClrChangeEffect | null {
   if (!node) return null;
 
-  const clrFrom = unsafeTypeAssertion<XmlNode | undefined>(node.clrFrom);
-  const clrTo = unsafeTypeAssertion<XmlNode | undefined>(node.clrTo);
+  const clrFrom = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.clrFrom);
+  const clrTo = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.clrTo);
   if (!clrFrom || !clrTo) return null;
 
   const from = colorResolver.resolve(clrFrom);
@@ -117,7 +121,7 @@ function resolveColorNode(
   colorResolver: ColorResolver,
 ): ResolvedColor | null {
   if (key === "prstClr") {
-    const val = unsafeTypeAssertion<string | undefined>(node["@_val"]);
+    const val = unsafeXmlBoundaryAssertion<string | undefined>(node["@_val"]);
     const hex = val ? PRESET_COLORS[val] : undefined;
     if (!hex) return null;
     return { hex, alpha: 1 };

--- a/packages/core/src/parser/blip-effect-parser.ts
+++ b/packages/core/src/parser/blip-effect-parser.ts
@@ -10,6 +10,7 @@ import type { ResolvedColor } from "@pptx-glimpse/renderer";
 import { asEmu } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 const PRESET_COLORS: Record<string, string> = {
@@ -30,11 +31,17 @@ export function parseBlipEffects(
   if (!blipNode) return null;
 
   const grayscale = blipNode.grayscl !== undefined;
-  const biLevel = parseBiLevel(blipNode.biLevel as XmlNode | undefined);
-  const blur = parseBlur(blipNode.blur as XmlNode | undefined);
-  const lum = parseLum(blipNode.lum as XmlNode | undefined);
-  const duotone = parseDuotone(blipNode.duotone as XmlNode | undefined, colorResolver);
-  const clrChange = parseClrChange(blipNode.clrChange as XmlNode | undefined, colorResolver);
+  const biLevel = parseBiLevel(unsafeTypeAssertion<XmlNode | undefined>(blipNode.biLevel));
+  const blur = parseBlur(unsafeTypeAssertion<XmlNode | undefined>(blipNode.blur));
+  const lum = parseLum(unsafeTypeAssertion<XmlNode | undefined>(blipNode.lum));
+  const duotone = parseDuotone(
+    unsafeTypeAssertion<XmlNode | undefined>(blipNode.duotone),
+    colorResolver,
+  );
+  const clrChange = parseClrChange(
+    unsafeTypeAssertion<XmlNode | undefined>(blipNode.clrChange),
+    colorResolver,
+  );
 
   if (!grayscale && !biLevel && !blur && !lum && !duotone && !clrChange) {
     return null;
@@ -78,7 +85,7 @@ function parseDuotone(
     if (!colorNodes) continue;
     const nodes = Array.isArray(colorNodes) ? colorNodes : [colorNodes];
     for (const cn of nodes) {
-      const resolved = resolveColorNode(key, cn as XmlNode, colorResolver);
+      const resolved = resolveColorNode(key, unsafeTypeAssertion<XmlNode>(cn), colorResolver);
       if (resolved) colors.push(resolved);
     }
   }
@@ -93,8 +100,8 @@ function parseClrChange(
 ): ClrChangeEffect | null {
   if (!node) return null;
 
-  const clrFrom = node.clrFrom as XmlNode | undefined;
-  const clrTo = node.clrTo as XmlNode | undefined;
+  const clrFrom = unsafeTypeAssertion<XmlNode | undefined>(node.clrFrom);
+  const clrTo = unsafeTypeAssertion<XmlNode | undefined>(node.clrTo);
   if (!clrFrom || !clrTo) return null;
 
   const from = colorResolver.resolve(clrFrom);
@@ -110,7 +117,7 @@ function resolveColorNode(
   colorResolver: ColorResolver,
 ): ResolvedColor | null {
   if (key === "prstClr") {
-    const val = node["@_val"] as string | undefined;
+    const val = unsafeTypeAssertion<string | undefined>(node["@_val"]);
     const hex = val ? PRESET_COLORS[val] : undefined;
     if (!hex) return null;
     return { hex, alpha: 1 };

--- a/packages/core/src/parser/custom-geometry-parser.ts
+++ b/packages/core/src/parser/custom-geometry-parser.ts
@@ -1,22 +1,23 @@
 import type { CustomGeometryPath } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { evaluateGuides, type GuideDefinition, resolveValue } from "./geometry-formula.js";
 import type { XmlNode } from "./xml-parser.js";
 
 /** custGeom ノードをパースして CustomGeometryPath[] を返す */
 export function parseCustomGeometry(custGeom: XmlNode): CustomGeometryPath[] | null {
-  const pathLst = custGeom.pathLst as XmlNode | undefined;
+  const pathLst = unsafeTypeAssertion<XmlNode | undefined>(custGeom.pathLst);
   if (!pathLst?.path) return null;
 
-  const avLst = custGeom.avLst as XmlNode | undefined;
-  const gdLst = custGeom.gdLst as XmlNode | undefined;
-  const avGd = parseGuideList(avLst?.gd as XmlNode);
-  const gdGd = parseGuideList(gdLst?.gd as XmlNode);
+  const avLst = unsafeTypeAssertion<XmlNode | undefined>(custGeom.avLst);
+  const gdLst = unsafeTypeAssertion<XmlNode | undefined>(custGeom.gdLst);
+  const avGd = parseGuideList(unsafeTypeAssertion<XmlNode>(avLst?.gd));
+  const gdGd = parseGuideList(unsafeTypeAssertion<XmlNode>(gdLst?.gd));
 
   const paths = Array.isArray(pathLst.path)
-    ? (pathLst.path as XmlNode[])
-    : [pathLst.path as XmlNode];
+    ? unsafeTypeAssertion<XmlNode[]>(pathLst.path)
+    : [unsafeTypeAssertion<XmlNode>(pathLst.path)];
   const result: CustomGeometryPath[] = [];
 
   for (const path of paths) {
@@ -45,8 +46,8 @@ function parseGuideList(gd: XmlNode): GuideDefinition[] {
   const list = Array.isArray(gd) ? (gd as XmlNode[]) : [gd];
   return list
     .map((g) => ({
-      name: (g["@_name"] as string | undefined) ?? "",
-      fmla: (g["@_fmla"] as string | undefined) ?? "",
+      name: unsafeTypeAssertion<string | undefined>(g["@_name"]) ?? "",
+      fmla: unsafeTypeAssertion<string | undefined>(g["@_fmla"]) ?? "",
     }))
     .filter((g: GuideDefinition) => g.name && g.fmla);
 }
@@ -63,12 +64,14 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
     if (key.startsWith("@_")) continue;
 
     const value = path[key];
-    const items = Array.isArray(value) ? (value as XmlNode[]) : [value as XmlNode];
+    const items = Array.isArray(value)
+      ? unsafeTypeAssertion<XmlNode[]>(value)
+      : [unsafeTypeAssertion<XmlNode>(value)];
 
     for (const item of items) {
       switch (key) {
         case "moveTo": {
-          const pt = resolveFirstPoint(item.pt as XmlNode, vars);
+          const pt = resolveFirstPoint(unsafeTypeAssertion<XmlNode>(item.pt), vars);
           if (pt) {
             parts.push(`M ${pt.x} ${pt.y}`);
             curX = pt.x;
@@ -79,7 +82,7 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
           break;
         }
         case "lnTo": {
-          const pt = resolveFirstPoint(item.pt as XmlNode, vars);
+          const pt = resolveFirstPoint(unsafeTypeAssertion<XmlNode>(item.pt), vars);
           if (pt) {
             parts.push(`L ${pt.x} ${pt.y}`);
             curX = pt.x;
@@ -88,7 +91,7 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
           break;
         }
         case "cubicBezTo": {
-          const pts = resolvePoints(item.pt as XmlNode, vars);
+          const pts = resolvePoints(unsafeTypeAssertion<XmlNode>(item.pt), vars);
           if (pts.length >= 3) {
             parts.push(`C ${pts.map((p) => `${p.x} ${p.y}`).join(", ")}`);
             curX = pts[pts.length - 1].x;
@@ -97,7 +100,7 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
           break;
         }
         case "quadBezTo": {
-          const pts = resolvePoints(item.pt as XmlNode, vars);
+          const pts = resolvePoints(unsafeTypeAssertion<XmlNode>(item.pt), vars);
           if (pts.length >= 2) {
             parts.push(`Q ${pts.map((p) => `${p.x} ${p.y}`).join(", ")}`);
             curX = pts[pts.length - 1].x;
@@ -132,11 +135,11 @@ function resolveFirstPoint(
   vars: Record<string, number>,
 ): { x: number; y: number } | null {
   if (!pt) return null;
-  const p = Array.isArray(pt) ? (pt[0] as XmlNode) : pt;
+  const p = Array.isArray(pt) ? unsafeTypeAssertion<XmlNode>(pt[0]) : pt;
   if (!p) return null;
   return {
-    x: resolveValue(p["@_x"] as string, vars),
-    y: resolveValue(p["@_y"] as string, vars),
+    x: resolveValue(unsafeTypeAssertion<string>(p["@_x"]), vars),
+    y: resolveValue(unsafeTypeAssertion<string>(p["@_y"]), vars),
   };
 }
 
@@ -144,8 +147,8 @@ function resolvePoints(pt: XmlNode, vars: Record<string, number>): Array<{ x: nu
   if (!pt) return [];
   const pts = Array.isArray(pt) ? (pt as XmlNode[]) : [pt];
   return pts.map((p) => ({
-    x: resolveValue(p["@_x"] as string, vars),
-    y: resolveValue(p["@_y"] as string, vars),
+    x: resolveValue(unsafeTypeAssertion<string>(p["@_x"]), vars),
+    y: resolveValue(unsafeTypeAssertion<string>(p["@_y"]), vars),
   }));
 }
 
@@ -156,10 +159,10 @@ function convertArcTo(
   curY: number,
   vars: Record<string, number>,
 ): { svg: string; endX: number; endY: number } | null {
-  const wR = resolveValue((arc["@_wR"] as string | undefined) ?? "0", vars);
-  const hR = resolveValue((arc["@_hR"] as string | undefined) ?? "0", vars);
-  const stAng = resolveValue((arc["@_stAng"] as string | undefined) ?? "0", vars);
-  const swAng = resolveValue((arc["@_swAng"] as string | undefined) ?? "0", vars);
+  const wR = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_wR"]) ?? "0", vars);
+  const hR = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_hR"]) ?? "0", vars);
+  const stAng = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_stAng"]) ?? "0", vars);
+  const swAng = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_swAng"]) ?? "0", vars);
 
   if (wR === 0 && hR === 0) return null;
   if (swAng === 0) return null;

--- a/packages/core/src/parser/custom-geometry-parser.ts
+++ b/packages/core/src/parser/custom-geometry-parser.ts
@@ -1,23 +1,23 @@
 import type { CustomGeometryPath } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { evaluateGuides, type GuideDefinition, resolveValue } from "./geometry-formula.js";
 import type { XmlNode } from "./xml-parser.js";
 
 /** custGeom ノードをパースして CustomGeometryPath[] を返す */
 export function parseCustomGeometry(custGeom: XmlNode): CustomGeometryPath[] | null {
-  const pathLst = unsafeTypeAssertion<XmlNode | undefined>(custGeom.pathLst);
+  const pathLst = unsafeXmlBoundaryAssertion<XmlNode | undefined>(custGeom.pathLst);
   if (!pathLst?.path) return null;
 
-  const avLst = unsafeTypeAssertion<XmlNode | undefined>(custGeom.avLst);
-  const gdLst = unsafeTypeAssertion<XmlNode | undefined>(custGeom.gdLst);
-  const avGd = parseGuideList(unsafeTypeAssertion<XmlNode>(avLst?.gd));
-  const gdGd = parseGuideList(unsafeTypeAssertion<XmlNode>(gdLst?.gd));
+  const avLst = unsafeXmlBoundaryAssertion<XmlNode | undefined>(custGeom.avLst);
+  const gdLst = unsafeXmlBoundaryAssertion<XmlNode | undefined>(custGeom.gdLst);
+  const avGd = parseGuideList(unsafeXmlBoundaryAssertion<XmlNode>(avLst?.gd));
+  const gdGd = parseGuideList(unsafeXmlBoundaryAssertion<XmlNode>(gdLst?.gd));
 
   const paths = Array.isArray(pathLst.path)
-    ? unsafeTypeAssertion<XmlNode[]>(pathLst.path)
-    : [unsafeTypeAssertion<XmlNode>(pathLst.path)];
+    ? unsafeXmlBoundaryAssertion<XmlNode[]>(pathLst.path)
+    : [unsafeXmlBoundaryAssertion<XmlNode>(pathLst.path)];
   const result: CustomGeometryPath[] = [];
 
   for (const path of paths) {
@@ -46,8 +46,8 @@ function parseGuideList(gd: XmlNode): GuideDefinition[] {
   const list = Array.isArray(gd) ? (gd as XmlNode[]) : [gd];
   return list
     .map((g) => ({
-      name: unsafeTypeAssertion<string | undefined>(g["@_name"]) ?? "",
-      fmla: unsafeTypeAssertion<string | undefined>(g["@_fmla"]) ?? "",
+      name: unsafeXmlBoundaryAssertion<string | undefined>(g["@_name"]) ?? "",
+      fmla: unsafeXmlBoundaryAssertion<string | undefined>(g["@_fmla"]) ?? "",
     }))
     .filter((g: GuideDefinition) => g.name && g.fmla);
 }
@@ -65,13 +65,13 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
 
     const value = path[key];
     const items = Array.isArray(value)
-      ? unsafeTypeAssertion<XmlNode[]>(value)
-      : [unsafeTypeAssertion<XmlNode>(value)];
+      ? unsafeXmlBoundaryAssertion<XmlNode[]>(value)
+      : [unsafeXmlBoundaryAssertion<XmlNode>(value)];
 
     for (const item of items) {
       switch (key) {
         case "moveTo": {
-          const pt = resolveFirstPoint(unsafeTypeAssertion<XmlNode>(item.pt), vars);
+          const pt = resolveFirstPoint(unsafeXmlBoundaryAssertion<XmlNode>(item.pt), vars);
           if (pt) {
             parts.push(`M ${pt.x} ${pt.y}`);
             curX = pt.x;
@@ -82,7 +82,7 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
           break;
         }
         case "lnTo": {
-          const pt = resolveFirstPoint(unsafeTypeAssertion<XmlNode>(item.pt), vars);
+          const pt = resolveFirstPoint(unsafeXmlBoundaryAssertion<XmlNode>(item.pt), vars);
           if (pt) {
             parts.push(`L ${pt.x} ${pt.y}`);
             curX = pt.x;
@@ -91,7 +91,7 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
           break;
         }
         case "cubicBezTo": {
-          const pts = resolvePoints(unsafeTypeAssertion<XmlNode>(item.pt), vars);
+          const pts = resolvePoints(unsafeXmlBoundaryAssertion<XmlNode>(item.pt), vars);
           if (pts.length >= 3) {
             parts.push(`C ${pts.map((p) => `${p.x} ${p.y}`).join(", ")}`);
             curX = pts[pts.length - 1].x;
@@ -100,7 +100,7 @@ function buildPathCommands(path: XmlNode, vars: Record<string, number>): string 
           break;
         }
         case "quadBezTo": {
-          const pts = resolvePoints(unsafeTypeAssertion<XmlNode>(item.pt), vars);
+          const pts = resolvePoints(unsafeXmlBoundaryAssertion<XmlNode>(item.pt), vars);
           if (pts.length >= 2) {
             parts.push(`Q ${pts.map((p) => `${p.x} ${p.y}`).join(", ")}`);
             curX = pts[pts.length - 1].x;
@@ -135,11 +135,11 @@ function resolveFirstPoint(
   vars: Record<string, number>,
 ): { x: number; y: number } | null {
   if (!pt) return null;
-  const p = Array.isArray(pt) ? unsafeTypeAssertion<XmlNode>(pt[0]) : pt;
+  const p = Array.isArray(pt) ? unsafeXmlBoundaryAssertion<XmlNode>(pt[0]) : pt;
   if (!p) return null;
   return {
-    x: resolveValue(unsafeTypeAssertion<string>(p["@_x"]), vars),
-    y: resolveValue(unsafeTypeAssertion<string>(p["@_y"]), vars),
+    x: resolveValue(unsafeXmlBoundaryAssertion<string>(p["@_x"]), vars),
+    y: resolveValue(unsafeXmlBoundaryAssertion<string>(p["@_y"]), vars),
   };
 }
 
@@ -147,8 +147,8 @@ function resolvePoints(pt: XmlNode, vars: Record<string, number>): Array<{ x: nu
   if (!pt) return [];
   const pts = Array.isArray(pt) ? (pt as XmlNode[]) : [pt];
   return pts.map((p) => ({
-    x: resolveValue(unsafeTypeAssertion<string>(p["@_x"]), vars),
-    y: resolveValue(unsafeTypeAssertion<string>(p["@_y"]), vars),
+    x: resolveValue(unsafeXmlBoundaryAssertion<string>(p["@_x"]), vars),
+    y: resolveValue(unsafeXmlBoundaryAssertion<string>(p["@_y"]), vars),
   }));
 }
 
@@ -159,10 +159,16 @@ function convertArcTo(
   curY: number,
   vars: Record<string, number>,
 ): { svg: string; endX: number; endY: number } | null {
-  const wR = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_wR"]) ?? "0", vars);
-  const hR = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_hR"]) ?? "0", vars);
-  const stAng = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_stAng"]) ?? "0", vars);
-  const swAng = resolveValue(unsafeTypeAssertion<string | undefined>(arc["@_swAng"]) ?? "0", vars);
+  const wR = resolveValue(unsafeXmlBoundaryAssertion<string | undefined>(arc["@_wR"]) ?? "0", vars);
+  const hR = resolveValue(unsafeXmlBoundaryAssertion<string | undefined>(arc["@_hR"]) ?? "0", vars);
+  const stAng = resolveValue(
+    unsafeXmlBoundaryAssertion<string | undefined>(arc["@_stAng"]) ?? "0",
+    vars,
+  );
+  const swAng = resolveValue(
+    unsafeXmlBoundaryAssertion<string | undefined>(arc["@_swAng"]) ?? "0",
+    vars,
+  );
 
   if (wR === 0 && hR === 0) return null;
   if (swAng === 0) return null;

--- a/packages/core/src/parser/effect-parser.ts
+++ b/packages/core/src/parser/effect-parser.ts
@@ -2,6 +2,7 @@ import type { EffectList, Glow, InnerShadow, OuterShadow, SoftEdge } from "@pptx
 import { asEmu } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 export function parseEffectList(
@@ -10,10 +11,16 @@ export function parseEffectList(
 ): EffectList | null {
   if (!effectLstNode) return null;
 
-  const outerShadow = parseOuterShadow(effectLstNode.outerShdw as XmlNode, colorResolver);
-  const innerShadow = parseInnerShadow(effectLstNode.innerShdw as XmlNode, colorResolver);
-  const glow = parseGlow(effectLstNode.glow as XmlNode, colorResolver);
-  const softEdge = parseSoftEdge(effectLstNode.softEdge as XmlNode);
+  const outerShadow = parseOuterShadow(
+    unsafeTypeAssertion<XmlNode>(effectLstNode.outerShdw),
+    colorResolver,
+  );
+  const innerShadow = parseInnerShadow(
+    unsafeTypeAssertion<XmlNode>(effectLstNode.innerShdw),
+    colorResolver,
+  );
+  const glow = parseGlow(unsafeTypeAssertion<XmlNode>(effectLstNode.glow), colorResolver);
+  const softEdge = parseSoftEdge(unsafeTypeAssertion<XmlNode>(effectLstNode.softEdge));
 
   if (!outerShadow && !innerShadow && !glow && !softEdge) {
     return null;
@@ -33,7 +40,7 @@ function parseOuterShadow(node: XmlNode, colorResolver: ColorResolver): OuterSha
     distance: asEmu(Number(node["@_dist"] ?? 0)),
     direction: Number(node["@_dir"] ?? 0) / 60000,
     color,
-    alignment: (node["@_algn"] as string | undefined) ?? "b",
+    alignment: unsafeTypeAssertion<string | undefined>(node["@_algn"]) ?? "b",
     rotateWithShape: node["@_rotWithShape"] !== "0",
   };
 }

--- a/packages/core/src/parser/effect-parser.ts
+++ b/packages/core/src/parser/effect-parser.ts
@@ -2,7 +2,7 @@ import type { EffectList, Glow, InnerShadow, OuterShadow, SoftEdge } from "@pptx
 import { asEmu } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 export function parseEffectList(
@@ -12,15 +12,15 @@ export function parseEffectList(
   if (!effectLstNode) return null;
 
   const outerShadow = parseOuterShadow(
-    unsafeTypeAssertion<XmlNode>(effectLstNode.outerShdw),
+    unsafeXmlBoundaryAssertion<XmlNode>(effectLstNode.outerShdw),
     colorResolver,
   );
   const innerShadow = parseInnerShadow(
-    unsafeTypeAssertion<XmlNode>(effectLstNode.innerShdw),
+    unsafeXmlBoundaryAssertion<XmlNode>(effectLstNode.innerShdw),
     colorResolver,
   );
-  const glow = parseGlow(unsafeTypeAssertion<XmlNode>(effectLstNode.glow), colorResolver);
-  const softEdge = parseSoftEdge(unsafeTypeAssertion<XmlNode>(effectLstNode.softEdge));
+  const glow = parseGlow(unsafeXmlBoundaryAssertion<XmlNode>(effectLstNode.glow), colorResolver);
+  const softEdge = parseSoftEdge(unsafeXmlBoundaryAssertion<XmlNode>(effectLstNode.softEdge));
 
   if (!outerShadow && !innerShadow && !glow && !softEdge) {
     return null;
@@ -40,7 +40,7 @@ function parseOuterShadow(node: XmlNode, colorResolver: ColorResolver): OuterSha
     distance: asEmu(Number(node["@_dist"] ?? 0)),
     direction: Number(node["@_dir"] ?? 0) / 60000,
     color,
-    alignment: unsafeTypeAssertion<string | undefined>(node["@_algn"]) ?? "b",
+    alignment: unsafeXmlBoundaryAssertion<string | undefined>(node["@_algn"]) ?? "b",
     rotateWithShape: node["@_rotWithShape"] !== "0",
   };
 }

--- a/packages/core/src/parser/fill-parser.ts
+++ b/packages/core/src/parser/fill-parser.ts
@@ -21,6 +21,7 @@ import { asEmu } from "@pptx-glimpse/renderer";
 import { debug, warn } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import type { Relationship } from "./relationship-parser.js";
 import { resolveRelationshipTarget } from "./relationship-parser.js";
@@ -45,22 +46,22 @@ export function parseFillFromNode(
   }
 
   if (node.solidFill) {
-    const color = colorResolver.resolve(node.solidFill as XmlNode);
+    const color = colorResolver.resolve(unsafeTypeAssertion<XmlNode>(node.solidFill));
     if (color) {
       return { type: "solid", color };
     }
   }
 
   if (node.gradFill) {
-    return parseGradientFill(node.gradFill as XmlNode, colorResolver);
+    return parseGradientFill(unsafeTypeAssertion<XmlNode>(node.gradFill), colorResolver);
   }
 
   if (node.blipFill && context) {
-    return parseBlipFill(node.blipFill as XmlNode, context);
+    return parseBlipFill(unsafeTypeAssertion<XmlNode>(node.blipFill), context);
   }
 
   if (node.pattFill) {
-    return parsePatternFill(node.pattFill as XmlNode, colorResolver);
+    return parsePatternFill(unsafeTypeAssertion<XmlNode>(node.pattFill), colorResolver);
   }
 
   if (node.grpFill !== undefined && context?.groupFill) {
@@ -71,9 +72,10 @@ export function parseFillFromNode(
 }
 
 function parseBlipFill(blipFillNode: XmlNode, context: FillParseContext): ImageFill | null {
-  const blip = blipFillNode?.blip as XmlNode | undefined;
+  const blip = unsafeTypeAssertion<XmlNode | undefined>(blipFillNode?.blip);
   const rId =
-    (blip?.["@_r:embed"] as string | undefined) ?? (blip?.["@_embed"] as string | undefined);
+    unsafeTypeAssertion<string | undefined>(blip?.["@_r:embed"]) ??
+    unsafeTypeAssertion<string | undefined>(blip?.["@_embed"]);
   if (!rId) return null;
 
   const rel = context.rels.get(rId);
@@ -96,15 +98,17 @@ function parseBlipFill(blipFillNode: XmlNode, context: FillParseContext): ImageF
   const mimeType = mimeMap[ext] ?? "image/png";
   const imageData = uint8ArrayToBase64(mediaData);
 
-  const tileNode = blipFillNode.tile as XmlNode | undefined;
+  const tileNode = unsafeTypeAssertion<XmlNode | undefined>(blipFillNode.tile);
   const tile = tileNode
     ? {
         tx: asEmu(Number(tileNode["@_tx"] ?? 0)),
         ty: asEmu(Number(tileNode["@_ty"] ?? 0)),
         sx: Number(tileNode["@_sx"] ?? 100000) / 100000,
         sy: Number(tileNode["@_sy"] ?? 100000) / 100000,
-        flip: ((tileNode["@_flip"] as string) ?? "none") as ImageFillTile["flip"],
-        align: (tileNode["@_algn"] as string) ?? "tl",
+        flip: unsafeTypeAssertion<ImageFillTile["flip"]>(
+          unsafeTypeAssertion<string>(tileNode["@_flip"]) ?? "none",
+        ),
+        align: unsafeTypeAssertion<string>(tileNode["@_algn"]) ?? "tl",
       }
     : null;
 
@@ -112,8 +116,8 @@ function parseBlipFill(blipFillNode: XmlNode, context: FillParseContext): ImageF
 }
 
 function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fill | null {
-  const gsLst = gradNode.gsLst as XmlNode | undefined;
-  const gsArr = gsLst?.gs as XmlNode[] | undefined;
+  const gsLst = unsafeTypeAssertion<XmlNode | undefined>(gradNode.gsLst);
+  const gsArr = unsafeTypeAssertion<XmlNode[] | undefined>(gsLst?.gs);
   if (!gsArr) {
     debug("gradientFill.gsLst", "GradientFill: gsLst not found, skipping gradient");
     return null;
@@ -128,9 +132,9 @@ function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fil
     }
   }
 
-  const pathNode = gradNode.path as XmlNode | undefined;
+  const pathNode = unsafeTypeAssertion<XmlNode | undefined>(gradNode.path);
   if (pathNode) {
-    const fillToRect = pathNode.fillToRect as XmlNode | undefined;
+    const fillToRect = unsafeTypeAssertion<XmlNode | undefined>(pathNode.fillToRect);
     let centerX = 0.5;
     let centerY = 0.5;
     if (fillToRect) {
@@ -145,7 +149,7 @@ function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fil
   }
 
   let angle = 0;
-  const lin = gradNode.lin as XmlNode | undefined;
+  const lin = unsafeTypeAssertion<XmlNode | undefined>(gradNode.lin);
   if (lin) {
     angle = Number(lin["@_ang"] ?? 0) / 60000;
   }
@@ -154,9 +158,13 @@ function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fil
 }
 
 function parsePatternFill(pattNode: XmlNode, colorResolver: ColorResolver): PatternFill | null {
-  const preset = (pattNode["@_prst"] as string | undefined) ?? "ltDnDiag";
-  const fgColor = pattNode.fgClr ? colorResolver.resolve(pattNode.fgClr as XmlNode) : null;
-  const bgColor = pattNode.bgClr ? colorResolver.resolve(pattNode.bgClr as XmlNode) : null;
+  const preset = unsafeTypeAssertion<string | undefined>(pattNode["@_prst"]) ?? "ltDnDiag";
+  const fgColor = pattNode.fgClr
+    ? colorResolver.resolve(unsafeTypeAssertion<XmlNode>(pattNode.fgClr))
+    : null;
+  const bgColor = pattNode.bgClr
+    ? colorResolver.resolve(unsafeTypeAssertion<XmlNode>(pattNode.bgClr))
+    : null;
 
   if (!fgColor || !bgColor) return null;
 
@@ -175,12 +183,15 @@ export function parseOutline(lnNode: XmlNode, colorResolver: ColorResolver): Out
 
   let fill: SolidFill | GradientFill | null = null;
   if (lnNode.solidFill) {
-    const color = colorResolver.resolve(lnNode.solidFill as XmlNode);
+    const color = colorResolver.resolve(unsafeTypeAssertion<XmlNode>(lnNode.solidFill));
     if (color) {
       fill = { type: "solid", color };
     }
   } else if (lnNode.gradFill) {
-    const gradFill = parseGradientFill(lnNode.gradFill as XmlNode, colorResolver);
+    const gradFill = parseGradientFill(
+      unsafeTypeAssertion<XmlNode>(lnNode.gradFill),
+      colorResolver,
+    );
     if (gradFill && gradFill.type === "gradient") {
       fill = gradFill;
     }
@@ -190,24 +201,26 @@ export function parseOutline(lnNode: XmlNode, colorResolver: ColorResolver): Out
     return null;
   }
 
-  const prstDash = lnNode.prstDash as XmlNode | undefined;
-  const dashStyle = ((prstDash?.["@_val"] as string | undefined) ?? "solid") as DashStyle;
+  const prstDash = unsafeTypeAssertion<XmlNode | undefined>(lnNode.prstDash);
+  const dashStyle = unsafeTypeAssertion<DashStyle>(
+    unsafeTypeAssertion<string | undefined>(prstDash?.["@_val"]) ?? "solid",
+  );
 
   const customDash = parseCustomDash(lnNode);
 
-  const lineCap = parseLineCap(lnNode["@_cap"] as string | undefined);
+  const lineCap = parseLineCap(unsafeTypeAssertion<string | undefined>(lnNode["@_cap"]));
   const lineJoin = parseLineJoin(lnNode);
 
-  const headEnd = parseArrowEndpoint(lnNode.headEnd as XmlNode);
-  const tailEnd = parseArrowEndpoint(lnNode.tailEnd as XmlNode);
+  const headEnd = parseArrowEndpoint(unsafeTypeAssertion<XmlNode>(lnNode.headEnd));
+  const tailEnd = parseArrowEndpoint(unsafeTypeAssertion<XmlNode>(lnNode.tailEnd));
 
   return { width, fill, dashStyle, customDash, lineCap, lineJoin, headEnd, tailEnd };
 }
 
 function parseCustomDash(lnNode: XmlNode): number[] | undefined {
-  const custDash = lnNode.custDash as XmlNode | undefined;
+  const custDash = unsafeTypeAssertion<XmlNode | undefined>(lnNode.custDash);
   if (!custDash) return undefined;
-  const dsArr = custDash.ds as XmlNode[] | undefined;
+  const dsArr = unsafeTypeAssertion<XmlNode[] | undefined>(custDash.ds);
   if (!dsArr || dsArr.length === 0) return undefined;
 
   const result: number[] = [];
@@ -239,11 +252,17 @@ function parseLineJoin(lnNode: XmlNode): LineJoin | undefined {
 
 function parseArrowEndpoint(node: XmlNode): ArrowEndpoint | null {
   if (!node) return null;
-  const type = ((node["@_type"] as string | undefined) ?? "none") as ArrowType;
+  const type = unsafeTypeAssertion<ArrowType>(
+    unsafeTypeAssertion<string | undefined>(node["@_type"]) ?? "none",
+  );
   if (type === "none") return null;
   return {
     type,
-    width: ((node["@_w"] as string | undefined) ?? "med") as ArrowSize,
-    length: ((node["@_len"] as string | undefined) ?? "med") as ArrowSize,
+    width: unsafeTypeAssertion<ArrowSize>(
+      unsafeTypeAssertion<string | undefined>(node["@_w"]) ?? "med",
+    ),
+    length: unsafeTypeAssertion<ArrowSize>(
+      unsafeTypeAssertion<string | undefined>(node["@_len"]) ?? "med",
+    ),
   };
 }

--- a/packages/core/src/parser/fill-parser.ts
+++ b/packages/core/src/parser/fill-parser.ts
@@ -21,7 +21,7 @@ import { asEmu } from "@pptx-glimpse/renderer";
 import { debug, warn } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import type { Relationship } from "./relationship-parser.js";
 import { resolveRelationshipTarget } from "./relationship-parser.js";
@@ -46,22 +46,22 @@ export function parseFillFromNode(
   }
 
   if (node.solidFill) {
-    const color = colorResolver.resolve(unsafeTypeAssertion<XmlNode>(node.solidFill));
+    const color = colorResolver.resolve(unsafeXmlBoundaryAssertion<XmlNode>(node.solidFill));
     if (color) {
       return { type: "solid", color };
     }
   }
 
   if (node.gradFill) {
-    return parseGradientFill(unsafeTypeAssertion<XmlNode>(node.gradFill), colorResolver);
+    return parseGradientFill(unsafeXmlBoundaryAssertion<XmlNode>(node.gradFill), colorResolver);
   }
 
   if (node.blipFill && context) {
-    return parseBlipFill(unsafeTypeAssertion<XmlNode>(node.blipFill), context);
+    return parseBlipFill(unsafeXmlBoundaryAssertion<XmlNode>(node.blipFill), context);
   }
 
   if (node.pattFill) {
-    return parsePatternFill(unsafeTypeAssertion<XmlNode>(node.pattFill), colorResolver);
+    return parsePatternFill(unsafeXmlBoundaryAssertion<XmlNode>(node.pattFill), colorResolver);
   }
 
   if (node.grpFill !== undefined && context?.groupFill) {
@@ -72,10 +72,10 @@ export function parseFillFromNode(
 }
 
 function parseBlipFill(blipFillNode: XmlNode, context: FillParseContext): ImageFill | null {
-  const blip = unsafeTypeAssertion<XmlNode | undefined>(blipFillNode?.blip);
+  const blip = unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipFillNode?.blip);
   const rId =
-    unsafeTypeAssertion<string | undefined>(blip?.["@_r:embed"]) ??
-    unsafeTypeAssertion<string | undefined>(blip?.["@_embed"]);
+    unsafeXmlBoundaryAssertion<string | undefined>(blip?.["@_r:embed"]) ??
+    unsafeXmlBoundaryAssertion<string | undefined>(blip?.["@_embed"]);
   if (!rId) return null;
 
   const rel = context.rels.get(rId);
@@ -98,17 +98,17 @@ function parseBlipFill(blipFillNode: XmlNode, context: FillParseContext): ImageF
   const mimeType = mimeMap[ext] ?? "image/png";
   const imageData = uint8ArrayToBase64(mediaData);
 
-  const tileNode = unsafeTypeAssertion<XmlNode | undefined>(blipFillNode.tile);
+  const tileNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipFillNode.tile);
   const tile = tileNode
     ? {
         tx: asEmu(Number(tileNode["@_tx"] ?? 0)),
         ty: asEmu(Number(tileNode["@_ty"] ?? 0)),
         sx: Number(tileNode["@_sx"] ?? 100000) / 100000,
         sy: Number(tileNode["@_sy"] ?? 100000) / 100000,
-        flip: unsafeTypeAssertion<ImageFillTile["flip"]>(
-          unsafeTypeAssertion<string>(tileNode["@_flip"]) ?? "none",
+        flip: unsafeXmlBoundaryAssertion<ImageFillTile["flip"]>(
+          unsafeXmlBoundaryAssertion<string>(tileNode["@_flip"]) ?? "none",
         ),
-        align: unsafeTypeAssertion<string>(tileNode["@_algn"]) ?? "tl",
+        align: unsafeXmlBoundaryAssertion<string>(tileNode["@_algn"]) ?? "tl",
       }
     : null;
 
@@ -116,8 +116,8 @@ function parseBlipFill(blipFillNode: XmlNode, context: FillParseContext): ImageF
 }
 
 function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fill | null {
-  const gsLst = unsafeTypeAssertion<XmlNode | undefined>(gradNode.gsLst);
-  const gsArr = unsafeTypeAssertion<XmlNode[] | undefined>(gsLst?.gs);
+  const gsLst = unsafeXmlBoundaryAssertion<XmlNode | undefined>(gradNode.gsLst);
+  const gsArr = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(gsLst?.gs);
   if (!gsArr) {
     debug("gradientFill.gsLst", "GradientFill: gsLst not found, skipping gradient");
     return null;
@@ -132,9 +132,9 @@ function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fil
     }
   }
 
-  const pathNode = unsafeTypeAssertion<XmlNode | undefined>(gradNode.path);
+  const pathNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(gradNode.path);
   if (pathNode) {
-    const fillToRect = unsafeTypeAssertion<XmlNode | undefined>(pathNode.fillToRect);
+    const fillToRect = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pathNode.fillToRect);
     let centerX = 0.5;
     let centerY = 0.5;
     if (fillToRect) {
@@ -149,7 +149,7 @@ function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fil
   }
 
   let angle = 0;
-  const lin = unsafeTypeAssertion<XmlNode | undefined>(gradNode.lin);
+  const lin = unsafeXmlBoundaryAssertion<XmlNode | undefined>(gradNode.lin);
   if (lin) {
     angle = Number(lin["@_ang"] ?? 0) / 60000;
   }
@@ -158,12 +158,12 @@ function parseGradientFill(gradNode: XmlNode, colorResolver: ColorResolver): Fil
 }
 
 function parsePatternFill(pattNode: XmlNode, colorResolver: ColorResolver): PatternFill | null {
-  const preset = unsafeTypeAssertion<string | undefined>(pattNode["@_prst"]) ?? "ltDnDiag";
+  const preset = unsafeXmlBoundaryAssertion<string | undefined>(pattNode["@_prst"]) ?? "ltDnDiag";
   const fgColor = pattNode.fgClr
-    ? colorResolver.resolve(unsafeTypeAssertion<XmlNode>(pattNode.fgClr))
+    ? colorResolver.resolve(unsafeXmlBoundaryAssertion<XmlNode>(pattNode.fgClr))
     : null;
   const bgColor = pattNode.bgClr
-    ? colorResolver.resolve(unsafeTypeAssertion<XmlNode>(pattNode.bgClr))
+    ? colorResolver.resolve(unsafeXmlBoundaryAssertion<XmlNode>(pattNode.bgClr))
     : null;
 
   if (!fgColor || !bgColor) return null;
@@ -183,13 +183,13 @@ export function parseOutline(lnNode: XmlNode, colorResolver: ColorResolver): Out
 
   let fill: SolidFill | GradientFill | null = null;
   if (lnNode.solidFill) {
-    const color = colorResolver.resolve(unsafeTypeAssertion<XmlNode>(lnNode.solidFill));
+    const color = colorResolver.resolve(unsafeXmlBoundaryAssertion<XmlNode>(lnNode.solidFill));
     if (color) {
       fill = { type: "solid", color };
     }
   } else if (lnNode.gradFill) {
     const gradFill = parseGradientFill(
-      unsafeTypeAssertion<XmlNode>(lnNode.gradFill),
+      unsafeXmlBoundaryAssertion<XmlNode>(lnNode.gradFill),
       colorResolver,
     );
     if (gradFill && gradFill.type === "gradient") {
@@ -201,26 +201,26 @@ export function parseOutline(lnNode: XmlNode, colorResolver: ColorResolver): Out
     return null;
   }
 
-  const prstDash = unsafeTypeAssertion<XmlNode | undefined>(lnNode.prstDash);
-  const dashStyle = unsafeTypeAssertion<DashStyle>(
-    unsafeTypeAssertion<string | undefined>(prstDash?.["@_val"]) ?? "solid",
+  const prstDash = unsafeXmlBoundaryAssertion<XmlNode | undefined>(lnNode.prstDash);
+  const dashStyle = unsafeXmlBoundaryAssertion<DashStyle>(
+    unsafeXmlBoundaryAssertion<string | undefined>(prstDash?.["@_val"]) ?? "solid",
   );
 
   const customDash = parseCustomDash(lnNode);
 
-  const lineCap = parseLineCap(unsafeTypeAssertion<string | undefined>(lnNode["@_cap"]));
+  const lineCap = parseLineCap(unsafeXmlBoundaryAssertion<string | undefined>(lnNode["@_cap"]));
   const lineJoin = parseLineJoin(lnNode);
 
-  const headEnd = parseArrowEndpoint(unsafeTypeAssertion<XmlNode>(lnNode.headEnd));
-  const tailEnd = parseArrowEndpoint(unsafeTypeAssertion<XmlNode>(lnNode.tailEnd));
+  const headEnd = parseArrowEndpoint(unsafeXmlBoundaryAssertion<XmlNode>(lnNode.headEnd));
+  const tailEnd = parseArrowEndpoint(unsafeXmlBoundaryAssertion<XmlNode>(lnNode.tailEnd));
 
   return { width, fill, dashStyle, customDash, lineCap, lineJoin, headEnd, tailEnd };
 }
 
 function parseCustomDash(lnNode: XmlNode): number[] | undefined {
-  const custDash = unsafeTypeAssertion<XmlNode | undefined>(lnNode.custDash);
+  const custDash = unsafeXmlBoundaryAssertion<XmlNode | undefined>(lnNode.custDash);
   if (!custDash) return undefined;
-  const dsArr = unsafeTypeAssertion<XmlNode[] | undefined>(custDash.ds);
+  const dsArr = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(custDash.ds);
   if (!dsArr || dsArr.length === 0) return undefined;
 
   const result: number[] = [];
@@ -252,17 +252,17 @@ function parseLineJoin(lnNode: XmlNode): LineJoin | undefined {
 
 function parseArrowEndpoint(node: XmlNode): ArrowEndpoint | null {
   if (!node) return null;
-  const type = unsafeTypeAssertion<ArrowType>(
-    unsafeTypeAssertion<string | undefined>(node["@_type"]) ?? "none",
+  const type = unsafeXmlBoundaryAssertion<ArrowType>(
+    unsafeXmlBoundaryAssertion<string | undefined>(node["@_type"]) ?? "none",
   );
   if (type === "none") return null;
   return {
     type,
-    width: unsafeTypeAssertion<ArrowSize>(
-      unsafeTypeAssertion<string | undefined>(node["@_w"]) ?? "med",
+    width: unsafeXmlBoundaryAssertion<ArrowSize>(
+      unsafeXmlBoundaryAssertion<string | undefined>(node["@_w"]) ?? "med",
     ),
-    length: unsafeTypeAssertion<ArrowSize>(
-      unsafeTypeAssertion<string | undefined>(node["@_len"]) ?? "med",
+    length: unsafeXmlBoundaryAssertion<ArrowSize>(
+      unsafeXmlBoundaryAssertion<string | undefined>(node["@_len"]) ?? "med",
     ),
   };
 }

--- a/packages/core/src/parser/presentation-parser.ts
+++ b/packages/core/src/parser/presentation-parser.ts
@@ -3,6 +3,7 @@ import type { DefaultTextStyle } from "@pptx-glimpse/renderer";
 import { asEmu } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseListStyle } from "./text-style-parser.js";
 import { parseXml, type XmlNode } from "./xml-parser.js";
 
@@ -19,7 +20,7 @@ const DEFAULT_SLIDE_HEIGHT = asEmu(5143500);
 
 export function parsePresentation(xml: string): PresentationInfo {
   const parsed = parseXml(xml);
-  const pres = parsed.presentation as XmlNode | undefined;
+  const pres = unsafeTypeAssertion<XmlNode | undefined>(parsed.presentation);
 
   if (!pres) {
     debug("presentation.missing", `missing root element "presentation" in XML`);
@@ -29,7 +30,7 @@ export function parsePresentation(xml: string): PresentationInfo {
     };
   }
 
-  const sldSz = pres.sldSz as XmlNode | undefined;
+  const sldSz = unsafeTypeAssertion<XmlNode | undefined>(pres.sldSz);
   let slideSize: SlideSize;
   if (!sldSz || sldSz["@_cx"] === undefined || sldSz["@_cy"] === undefined) {
     debug(
@@ -44,10 +45,14 @@ export function parsePresentation(xml: string): PresentationInfo {
     };
   }
 
-  const sldIdLst = pres.sldIdLst as XmlNode | undefined;
-  const sldIdArr = (sldIdLst?.sldId as XmlNode[] | undefined) ?? [];
+  const sldIdLst = unsafeTypeAssertion<XmlNode | undefined>(pres.sldIdLst);
+  const sldIdArr = unsafeTypeAssertion<XmlNode[] | undefined>(sldIdLst?.sldId) ?? [];
   const slideRIds: string[] = sldIdArr
-    .map((s) => (s["@_r:id"] as string | undefined) ?? (s["@_id"] as string | undefined))
+    .map(
+      (s) =>
+        unsafeTypeAssertion<string | undefined>(s["@_r:id"]) ??
+        unsafeTypeAssertion<string | undefined>(s["@_id"]),
+    )
     .filter((id): id is string => {
       if (id === undefined) {
         debug("presentation.slideRId", "undefined slide relationship ID found, skipping");
@@ -56,9 +61,11 @@ export function parsePresentation(xml: string): PresentationInfo {
       return true;
     });
 
-  const defaultTextStyle = parseListStyle(pres.defaultTextStyle as XmlNode);
-  const embeddedFonts = parseEmbeddedFontList(pres.embeddedFontLst as XmlNode | undefined);
-  const protection = parseProtection(pres.modifyVerifier as XmlNode | undefined);
+  const defaultTextStyle = parseListStyle(unsafeTypeAssertion<XmlNode>(pres.defaultTextStyle));
+  const embeddedFonts = parseEmbeddedFontList(
+    unsafeTypeAssertion<XmlNode | undefined>(pres.embeddedFontLst),
+  );
+  const protection = parseProtection(unsafeTypeAssertion<XmlNode | undefined>(pres.modifyVerifier));
 
   return {
     slideSize,
@@ -73,16 +80,18 @@ function parseEmbeddedFontList(node: XmlNode | undefined): EmbeddedFont[] | unde
   if (!node) return undefined;
   const fonts = node.embeddedFont;
   if (!fonts) return undefined;
-  const fontArr = (Array.isArray(fonts) ? fonts : [fonts]) as XmlNode[];
+  const fontArr = unsafeTypeAssertion<XmlNode[]>(Array.isArray(fonts) ? fonts : [fonts]);
   const result: EmbeddedFont[] = [];
   for (const f of fontArr) {
     const fontRaw = f.font;
-    const fontNode = (Array.isArray(fontRaw) ? fontRaw[0] : fontRaw) as XmlNode | undefined;
+    const fontNode = unsafeTypeAssertion<XmlNode | undefined>(
+      Array.isArray(fontRaw) ? fontRaw[0] : fontRaw,
+    );
     if (!fontNode) continue;
     const font: EmbeddedFont = {
-      typeface: (fontNode["@_typeface"] as string | undefined) ?? "",
+      typeface: unsafeTypeAssertion<string | undefined>(fontNode["@_typeface"]) ?? "",
     };
-    if (fontNode["@_panose"]) font.panose = fontNode["@_panose"] as string;
+    if (fontNode["@_panose"]) font.panose = unsafeTypeAssertion<string>(fontNode["@_panose"]);
     if (fontNode["@_pitchFamily"] !== undefined)
       font.pitchFamily = Number(fontNode["@_pitchFamily"]);
     if (fontNode["@_charset"] !== undefined) font.charset = Number(fontNode["@_charset"]);
@@ -94,9 +103,10 @@ function parseEmbeddedFontList(node: XmlNode | undefined): EmbeddedFont[] | unde
 function parseProtection(node: XmlNode | undefined): Protection | undefined {
   if (!node) return undefined;
   const verifier: NonNullable<Protection["modifyVerifier"]> = {};
-  if (node["@_algorithmName"]) verifier.algorithmName = node["@_algorithmName"] as string;
-  if (node["@_hashValue"]) verifier.hashValue = node["@_hashValue"] as string;
-  if (node["@_saltValue"]) verifier.saltValue = node["@_saltValue"] as string;
+  if (node["@_algorithmName"])
+    verifier.algorithmName = unsafeTypeAssertion<string>(node["@_algorithmName"]);
+  if (node["@_hashValue"]) verifier.hashValue = unsafeTypeAssertion<string>(node["@_hashValue"]);
+  if (node["@_saltValue"]) verifier.saltValue = unsafeTypeAssertion<string>(node["@_saltValue"]);
   if (node["@_spinCount"] !== undefined) verifier.spinCount = Number(node["@_spinCount"]);
   return { modifyVerifier: verifier };
 }

--- a/packages/core/src/parser/presentation-parser.ts
+++ b/packages/core/src/parser/presentation-parser.ts
@@ -3,7 +3,7 @@ import type { DefaultTextStyle } from "@pptx-glimpse/renderer";
 import { asEmu } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseListStyle } from "./text-style-parser.js";
 import { parseXml, type XmlNode } from "./xml-parser.js";
 
@@ -20,7 +20,7 @@ const DEFAULT_SLIDE_HEIGHT = asEmu(5143500);
 
 export function parsePresentation(xml: string): PresentationInfo {
   const parsed = parseXml(xml);
-  const pres = unsafeTypeAssertion<XmlNode | undefined>(parsed.presentation);
+  const pres = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.presentation);
 
   if (!pres) {
     debug("presentation.missing", `missing root element "presentation" in XML`);
@@ -30,7 +30,7 @@ export function parsePresentation(xml: string): PresentationInfo {
     };
   }
 
-  const sldSz = unsafeTypeAssertion<XmlNode | undefined>(pres.sldSz);
+  const sldSz = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pres.sldSz);
   let slideSize: SlideSize;
   if (!sldSz || sldSz["@_cx"] === undefined || sldSz["@_cy"] === undefined) {
     debug(
@@ -45,13 +45,13 @@ export function parsePresentation(xml: string): PresentationInfo {
     };
   }
 
-  const sldIdLst = unsafeTypeAssertion<XmlNode | undefined>(pres.sldIdLst);
-  const sldIdArr = unsafeTypeAssertion<XmlNode[] | undefined>(sldIdLst?.sldId) ?? [];
+  const sldIdLst = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pres.sldIdLst);
+  const sldIdArr = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(sldIdLst?.sldId) ?? [];
   const slideRIds: string[] = sldIdArr
     .map(
       (s) =>
-        unsafeTypeAssertion<string | undefined>(s["@_r:id"]) ??
-        unsafeTypeAssertion<string | undefined>(s["@_id"]),
+        unsafeXmlBoundaryAssertion<string | undefined>(s["@_r:id"]) ??
+        unsafeXmlBoundaryAssertion<string | undefined>(s["@_id"]),
     )
     .filter((id): id is string => {
       if (id === undefined) {
@@ -61,11 +61,15 @@ export function parsePresentation(xml: string): PresentationInfo {
       return true;
     });
 
-  const defaultTextStyle = parseListStyle(unsafeTypeAssertion<XmlNode>(pres.defaultTextStyle));
-  const embeddedFonts = parseEmbeddedFontList(
-    unsafeTypeAssertion<XmlNode | undefined>(pres.embeddedFontLst),
+  const defaultTextStyle = parseListStyle(
+    unsafeXmlBoundaryAssertion<XmlNode>(pres.defaultTextStyle),
   );
-  const protection = parseProtection(unsafeTypeAssertion<XmlNode | undefined>(pres.modifyVerifier));
+  const embeddedFonts = parseEmbeddedFontList(
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(pres.embeddedFontLst),
+  );
+  const protection = parseProtection(
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(pres.modifyVerifier),
+  );
 
   return {
     slideSize,
@@ -80,18 +84,19 @@ function parseEmbeddedFontList(node: XmlNode | undefined): EmbeddedFont[] | unde
   if (!node) return undefined;
   const fonts = node.embeddedFont;
   if (!fonts) return undefined;
-  const fontArr = unsafeTypeAssertion<XmlNode[]>(Array.isArray(fonts) ? fonts : [fonts]);
+  const fontArr = unsafeXmlBoundaryAssertion<XmlNode[]>(Array.isArray(fonts) ? fonts : [fonts]);
   const result: EmbeddedFont[] = [];
   for (const f of fontArr) {
     const fontRaw = f.font;
-    const fontNode = unsafeTypeAssertion<XmlNode | undefined>(
+    const fontNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(
       Array.isArray(fontRaw) ? fontRaw[0] : fontRaw,
     );
     if (!fontNode) continue;
     const font: EmbeddedFont = {
-      typeface: unsafeTypeAssertion<string | undefined>(fontNode["@_typeface"]) ?? "",
+      typeface: unsafeXmlBoundaryAssertion<string | undefined>(fontNode["@_typeface"]) ?? "",
     };
-    if (fontNode["@_panose"]) font.panose = unsafeTypeAssertion<string>(fontNode["@_panose"]);
+    if (fontNode["@_panose"])
+      font.panose = unsafeXmlBoundaryAssertion<string>(fontNode["@_panose"]);
     if (fontNode["@_pitchFamily"] !== undefined)
       font.pitchFamily = Number(fontNode["@_pitchFamily"]);
     if (fontNode["@_charset"] !== undefined) font.charset = Number(fontNode["@_charset"]);
@@ -104,9 +109,11 @@ function parseProtection(node: XmlNode | undefined): Protection | undefined {
   if (!node) return undefined;
   const verifier: NonNullable<Protection["modifyVerifier"]> = {};
   if (node["@_algorithmName"])
-    verifier.algorithmName = unsafeTypeAssertion<string>(node["@_algorithmName"]);
-  if (node["@_hashValue"]) verifier.hashValue = unsafeTypeAssertion<string>(node["@_hashValue"]);
-  if (node["@_saltValue"]) verifier.saltValue = unsafeTypeAssertion<string>(node["@_saltValue"]);
+    verifier.algorithmName = unsafeXmlBoundaryAssertion<string>(node["@_algorithmName"]);
+  if (node["@_hashValue"])
+    verifier.hashValue = unsafeXmlBoundaryAssertion<string>(node["@_hashValue"]);
+  if (node["@_saltValue"])
+    verifier.saltValue = unsafeXmlBoundaryAssertion<string>(node["@_saltValue"]);
   if (node["@_spinCount"] !== undefined) verifier.spinCount = Number(node["@_spinCount"]);
   return { modifyVerifier: verifier };
 }

--- a/packages/core/src/parser/relationship-parser.ts
+++ b/packages/core/src/parser/relationship-parser.ts
@@ -1,6 +1,6 @@
 import { debug } from "@pptx-glimpse/renderer";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseXml, type XmlNode } from "./xml-parser.js";
 
 export interface Relationship {
@@ -14,21 +14,21 @@ export function parseRelationships(xml: string): Map<string, Relationship> {
   const parsed = parseXml(xml);
   const rels = new Map<string, Relationship>();
 
-  const root = unsafeTypeAssertion<XmlNode | undefined>(parsed.Relationships);
+  const root = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.Relationships);
 
   if (!root) {
     debug("relationship.missing", `missing root element "Relationships" in XML`);
     return rels;
   }
 
-  const relationships = unsafeTypeAssertion<XmlNode[] | undefined>(root.Relationship);
+  const relationships = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(root.Relationship);
   if (!relationships) return rels;
 
   for (const rel of relationships) {
-    const id = unsafeTypeAssertion<string | undefined>(rel["@_Id"]);
-    const type = unsafeTypeAssertion<string | undefined>(rel["@_Type"]);
-    const target = unsafeTypeAssertion<string | undefined>(rel["@_Target"]);
-    const targetMode = unsafeTypeAssertion<string | undefined>(rel["@_TargetMode"]);
+    const id = unsafeXmlBoundaryAssertion<string | undefined>(rel["@_Id"]);
+    const type = unsafeXmlBoundaryAssertion<string | undefined>(rel["@_Type"]);
+    const target = unsafeXmlBoundaryAssertion<string | undefined>(rel["@_Target"]);
+    const targetMode = unsafeXmlBoundaryAssertion<string | undefined>(rel["@_TargetMode"]);
 
     if (!id || !type || !target) {
       debug("relationship.attribute", "entry missing required attribute, skipping");

--- a/packages/core/src/parser/relationship-parser.ts
+++ b/packages/core/src/parser/relationship-parser.ts
@@ -1,5 +1,6 @@
 import { debug } from "@pptx-glimpse/renderer";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseXml, type XmlNode } from "./xml-parser.js";
 
 export interface Relationship {
@@ -13,21 +14,21 @@ export function parseRelationships(xml: string): Map<string, Relationship> {
   const parsed = parseXml(xml);
   const rels = new Map<string, Relationship>();
 
-  const root = parsed.Relationships as XmlNode | undefined;
+  const root = unsafeTypeAssertion<XmlNode | undefined>(parsed.Relationships);
 
   if (!root) {
     debug("relationship.missing", `missing root element "Relationships" in XML`);
     return rels;
   }
 
-  const relationships = root.Relationship as XmlNode[] | undefined;
+  const relationships = unsafeTypeAssertion<XmlNode[] | undefined>(root.Relationship);
   if (!relationships) return rels;
 
   for (const rel of relationships) {
-    const id = rel["@_Id"] as string | undefined;
-    const type = rel["@_Type"] as string | undefined;
-    const target = rel["@_Target"] as string | undefined;
-    const targetMode = rel["@_TargetMode"] as string | undefined;
+    const id = unsafeTypeAssertion<string | undefined>(rel["@_Id"]);
+    const type = unsafeTypeAssertion<string | undefined>(rel["@_Type"]);
+    const target = unsafeTypeAssertion<string | undefined>(rel["@_Target"]);
+    const targetMode = unsafeTypeAssertion<string | undefined>(rel["@_TargetMode"]);
 
     if (!id || !type || !target) {
       debug("relationship.attribute", "entry missing required attribute, skipping");

--- a/packages/core/src/parser/slide-layout-parser.test.ts
+++ b/packages/core/src/parser/slide-layout-parser.test.ts
@@ -3,7 +3,7 @@ import { initWarningLogger } from "@pptx-glimpse/renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import {
   parseSlideLayoutBackground,
@@ -114,9 +114,9 @@ describe("parseSlideLayoutElements", () => {
     );
 
     expect(elements).toHaveLength(2);
-    expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
-    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).placeholderType).toBe("ftr");
-    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).placeholderIdx).toBe(10);
+    expect(unsafeFixtureAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
+    expect(unsafeFixtureAssertion<ShapeElement>(elements[1]).placeholderType).toBe("ftr");
+    expect(unsafeFixtureAssertion<ShapeElement>(elements[1]).placeholderIdx).toBe(10);
   });
 
   it("returns empty array when no spTree", () => {
@@ -172,7 +172,7 @@ describe("parseSlideLayoutElements", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBeUndefined();
     expect(shape.fill).toEqual({ type: "solid", color: { hex: "#FF0000", alpha: 1 } });
   });

--- a/packages/core/src/parser/slide-layout-parser.test.ts
+++ b/packages/core/src/parser/slide-layout-parser.test.ts
@@ -3,6 +3,7 @@ import { initWarningLogger } from "@pptx-glimpse/renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import {
   parseSlideLayoutBackground,
@@ -113,9 +114,9 @@ describe("parseSlideLayoutElements", () => {
     );
 
     expect(elements).toHaveLength(2);
-    expect((elements[0] as ShapeElement).placeholderType).toBe("title");
-    expect((elements[1] as ShapeElement).placeholderType).toBe("ftr");
-    expect((elements[1] as ShapeElement).placeholderIdx).toBe(10);
+    expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
+    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).placeholderType).toBe("ftr");
+    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).placeholderIdx).toBe(10);
   });
 
   it("returns empty array when no spTree", () => {
@@ -171,7 +172,7 @@ describe("parseSlideLayoutElements", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBeUndefined();
     expect(shape.fill).toEqual({ type: "solid", color: { hex: "#FF0000", alpha: 1 } });
   });

--- a/packages/core/src/parser/slide-layout-parser.ts
+++ b/packages/core/src/parser/slide-layout-parser.ts
@@ -5,7 +5,7 @@ import type { FontScheme, FormatScheme } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import type { FillParseContext } from "./fill-parser.js";
 import { parseFillFromNode } from "./fill-parser.js";
 import type { PptxArchive } from "./pptx-reader.js";
@@ -21,17 +21,17 @@ export function parseSlideLayoutBackground(
 ): Background | null {
   const parsed = parseXml(xml);
 
-  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
+  const sldLayout = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldLayout);
   if (!sldLayout) {
     debug("slideLayout.missing", `missing root element "sldLayout" in XML`);
     return null;
   }
 
-  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldLayout.cSld);
-  const bg = unsafeTypeAssertion<XmlNode | undefined>(cSld?.bg);
+  const cSld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldLayout.cSld);
+  const bg = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.bg);
   if (!bg) return null;
 
-  const bgPr = unsafeTypeAssertion<XmlNode | undefined>(bg.bgPr);
+  const bgPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(bg.bgPr);
   if (!bgPr) return null;
 
   const fill = parseFillFromNode(bgPr, colorResolver, context);
@@ -48,14 +48,14 @@ export function parseSlideLayoutElements(
 ): SlideElement[] {
   const parsed = parseXml(xml);
 
-  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
+  const sldLayout = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldLayout);
   if (!sldLayout) {
     debug("slideLayout.missing", `missing root element "sldLayout" in XML`);
     return [];
   }
 
-  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldLayout.cSld);
-  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
+  const cSld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldLayout.cSld);
+  const spTree = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const relsPath = buildRelsPath(layoutPath);
@@ -81,7 +81,7 @@ export function parseSlideLayoutElements(
 
 export function parseSlideLayoutShowMasterSp(xml: string): boolean {
   const parsed = parseXml(xml);
-  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
+  const sldLayout = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldLayout);
   const attr = sldLayout?.["@_showMasterSp"];
   return attr !== "0" && attr !== "false";
 }
@@ -92,32 +92,32 @@ export function parseSlideLayoutPlaceholderStyles(
 ): PlaceholderStyleInfo[] {
   const parsed = parseXml(xml);
 
-  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
+  const sldLayout = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldLayout);
   if (!sldLayout) return [];
 
-  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldLayout.cSld);
-  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
+  const cSld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldLayout.cSld);
+  const spTree = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const results: PlaceholderStyleInfo[] = [];
-  const shapes = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
+  const shapes = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
 
   for (const sp of shapes) {
-    const nvSpPr = unsafeTypeAssertion<XmlNode | undefined>(sp.nvSpPr);
-    const nvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
-    const ph = unsafeTypeAssertion<XmlNode | undefined>(nvPr?.ph);
+    const nvSpPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.nvSpPr);
+    const nvPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
+    const ph = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvPr?.ph);
     if (!ph) continue;
 
-    const placeholderType: string = unsafeTypeAssertion<string>(ph["@_type"]) ?? "body";
+    const placeholderType: string = unsafeXmlBoundaryAssertion<string>(ph["@_type"]) ?? "body";
     const placeholderIdx = ph["@_idx"] !== undefined ? Number(ph["@_idx"]) : undefined;
-    const txBody = unsafeTypeAssertion<XmlNode | undefined>(sp.txBody);
-    const lstStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txBody?.lstStyle);
+    const txBody = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.txBody);
+    const lstStyleNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(txBody?.lstStyle);
     const lstStyle = lstStyleNode ? parseListStyle(lstStyleNode, colorResolver) : undefined;
 
-    const spPr = unsafeTypeAssertion<XmlNode | undefined>(sp.spPr);
+    const spPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.spPr);
     const transform =
       spPr && typeof spPr === "object"
-        ? parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm))
+        ? parseTransform(unsafeXmlBoundaryAssertion<XmlNode | undefined>(spPr.xfrm))
         : null;
     const geometry = spPr && typeof spPr === "object" ? parseGeometry(spPr) : undefined;
 

--- a/packages/core/src/parser/slide-layout-parser.ts
+++ b/packages/core/src/parser/slide-layout-parser.ts
@@ -5,6 +5,7 @@ import type { FontScheme, FormatScheme } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { FillParseContext } from "./fill-parser.js";
 import { parseFillFromNode } from "./fill-parser.js";
 import type { PptxArchive } from "./pptx-reader.js";
@@ -20,17 +21,17 @@ export function parseSlideLayoutBackground(
 ): Background | null {
   const parsed = parseXml(xml);
 
-  const sldLayout = parsed.sldLayout as XmlNode | undefined;
+  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
   if (!sldLayout) {
     debug("slideLayout.missing", `missing root element "sldLayout" in XML`);
     return null;
   }
 
-  const cSld = sldLayout.cSld as XmlNode | undefined;
-  const bg = cSld?.bg as XmlNode | undefined;
+  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldLayout.cSld);
+  const bg = unsafeTypeAssertion<XmlNode | undefined>(cSld?.bg);
   if (!bg) return null;
 
-  const bgPr = bg.bgPr as XmlNode | undefined;
+  const bgPr = unsafeTypeAssertion<XmlNode | undefined>(bg.bgPr);
   if (!bgPr) return null;
 
   const fill = parseFillFromNode(bgPr, colorResolver, context);
@@ -47,14 +48,14 @@ export function parseSlideLayoutElements(
 ): SlideElement[] {
   const parsed = parseXml(xml);
 
-  const sldLayout = parsed.sldLayout as XmlNode | undefined;
+  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
   if (!sldLayout) {
     debug("slideLayout.missing", `missing root element "sldLayout" in XML`);
     return [];
   }
 
-  const cSld = sldLayout.cSld as XmlNode | undefined;
-  const spTree = cSld?.spTree as XmlNode | undefined;
+  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldLayout.cSld);
+  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const relsPath = buildRelsPath(layoutPath);
@@ -80,7 +81,7 @@ export function parseSlideLayoutElements(
 
 export function parseSlideLayoutShowMasterSp(xml: string): boolean {
   const parsed = parseXml(xml);
-  const sldLayout = parsed.sldLayout as XmlNode | undefined;
+  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
   const attr = sldLayout?.["@_showMasterSp"];
   return attr !== "0" && attr !== "false";
 }
@@ -91,31 +92,33 @@ export function parseSlideLayoutPlaceholderStyles(
 ): PlaceholderStyleInfo[] {
   const parsed = parseXml(xml);
 
-  const sldLayout = parsed.sldLayout as XmlNode | undefined;
+  const sldLayout = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldLayout);
   if (!sldLayout) return [];
 
-  const cSld = sldLayout.cSld as XmlNode | undefined;
-  const spTree = cSld?.spTree as XmlNode | undefined;
+  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldLayout.cSld);
+  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const results: PlaceholderStyleInfo[] = [];
-  const shapes = (spTree.sp as XmlNode[] | undefined) ?? [];
+  const shapes = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
 
   for (const sp of shapes) {
-    const nvSpPr = sp.nvSpPr as XmlNode | undefined;
-    const nvPr = nvSpPr?.nvPr as XmlNode | undefined;
-    const ph = nvPr?.ph as XmlNode | undefined;
+    const nvSpPr = unsafeTypeAssertion<XmlNode | undefined>(sp.nvSpPr);
+    const nvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
+    const ph = unsafeTypeAssertion<XmlNode | undefined>(nvPr?.ph);
     if (!ph) continue;
 
-    const placeholderType: string = (ph["@_type"] as string) ?? "body";
+    const placeholderType: string = unsafeTypeAssertion<string>(ph["@_type"]) ?? "body";
     const placeholderIdx = ph["@_idx"] !== undefined ? Number(ph["@_idx"]) : undefined;
-    const txBody = sp.txBody as XmlNode | undefined;
-    const lstStyleNode = txBody?.lstStyle as XmlNode | undefined;
+    const txBody = unsafeTypeAssertion<XmlNode | undefined>(sp.txBody);
+    const lstStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txBody?.lstStyle);
     const lstStyle = lstStyleNode ? parseListStyle(lstStyleNode, colorResolver) : undefined;
 
-    const spPr = sp.spPr as XmlNode | undefined;
+    const spPr = unsafeTypeAssertion<XmlNode | undefined>(sp.spPr);
     const transform =
-      spPr && typeof spPr === "object" ? parseTransform(spPr.xfrm as XmlNode | undefined) : null;
+      spPr && typeof spPr === "object"
+        ? parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm))
+        : null;
     const geometry = spPr && typeof spPr === "object" ? parseGeometry(spPr) : undefined;
 
     results.push({

--- a/packages/core/src/parser/slide-master-parser.test.ts
+++ b/packages/core/src/parser/slide-master-parser.test.ts
@@ -3,6 +3,7 @@ import { initWarningLogger } from "@pptx-glimpse/renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import {
   parseSlideMasterBackground,
@@ -174,9 +175,9 @@ describe("parseSlideMasterElements", () => {
     );
 
     expect(elements).toHaveLength(2);
-    expect((elements[0] as ShapeElement).placeholderType).toBe("title");
-    expect((elements[1] as ShapeElement).placeholderType).toBeUndefined();
-    expect((elements[1] as ShapeElement).fill).toEqual({
+    expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
+    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).placeholderType).toBeUndefined();
+    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).fill).toEqual({
       type: "solid",
       color: { hex: "#4472C4", alpha: 1 },
     });

--- a/packages/core/src/parser/slide-master-parser.test.ts
+++ b/packages/core/src/parser/slide-master-parser.test.ts
@@ -3,7 +3,7 @@ import { initWarningLogger } from "@pptx-glimpse/renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import {
   parseSlideMasterBackground,
@@ -175,9 +175,9 @@ describe("parseSlideMasterElements", () => {
     );
 
     expect(elements).toHaveLength(2);
-    expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
-    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).placeholderType).toBeUndefined();
-    expect(unsafeTypeAssertion<ShapeElement>(elements[1]).fill).toEqual({
+    expect(unsafeFixtureAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
+    expect(unsafeFixtureAssertion<ShapeElement>(elements[1]).placeholderType).toBeUndefined();
+    expect(unsafeFixtureAssertion<ShapeElement>(elements[1]).fill).toEqual({
       type: "solid",
       color: { hex: "#4472C4", alpha: 1 },
     });

--- a/packages/core/src/parser/slide-master-parser.ts
+++ b/packages/core/src/parser/slide-master-parser.ts
@@ -6,6 +6,7 @@ import type { FontScheme } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { FillParseContext } from "./fill-parser.js";
 import { parseFillFromNode } from "./fill-parser.js";
 import type { PptxArchive } from "./pptx-reader.js";
@@ -32,23 +33,23 @@ const DEFAULT_COLOR_MAP: ColorMap = {
 export function parseSlideMasterColorMap(xml: string): ColorMap {
   const parsed = parseXml(xml);
 
-  const sldMaster = parsed.sldMaster as XmlNode | undefined;
+  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return { ...DEFAULT_COLOR_MAP };
   }
 
-  const clrMap = sldMaster.clrMap as XmlNode | undefined;
+  const clrMap = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.clrMap);
 
   if (!clrMap) return { ...DEFAULT_COLOR_MAP };
 
   const result: Record<string, string> = {};
   for (const key of Object.keys(DEFAULT_COLOR_MAP)) {
-    const val = clrMap[`@_${key}`] as string | undefined;
-    result[key] = val ?? DEFAULT_COLOR_MAP[key as keyof ColorMap];
+    const val = unsafeTypeAssertion<string | undefined>(clrMap[`@_${key}`]);
+    result[key] = val ?? DEFAULT_COLOR_MAP[unsafeTypeAssertion<keyof ColorMap>(key)];
   }
 
-  return result as unknown as ColorMap;
+  return unsafeTypeAssertion<ColorMap>(result);
 }
 
 export function parseSlideMasterBackground(
@@ -58,17 +59,17 @@ export function parseSlideMasterBackground(
 ): Background | null {
   const parsed = parseXml(xml);
 
-  const sldMaster = parsed.sldMaster as XmlNode | undefined;
+  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return null;
   }
 
-  const cSld = sldMaster.cSld as XmlNode | undefined;
-  const bg = cSld?.bg as XmlNode | undefined;
+  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.cSld);
+  const bg = unsafeTypeAssertion<XmlNode | undefined>(cSld?.bg);
   if (!bg) return null;
 
-  const bgPr = bg.bgPr as XmlNode | undefined;
+  const bgPr = unsafeTypeAssertion<XmlNode | undefined>(bg.bgPr);
   if (!bgPr) return null;
 
   const fill = parseFillFromNode(bgPr, colorResolver, context);
@@ -85,14 +86,14 @@ export function parseSlideMasterElements(
 ): SlideElement[] {
   const parsed = parseXml(xml);
 
-  const sldMaster = parsed.sldMaster as XmlNode | undefined;
+  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return [];
   }
 
-  const cSld = sldMaster.cSld as XmlNode | undefined;
-  const spTree = cSld?.spTree as XmlNode | undefined;
+  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.cSld);
+  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const relsPath = buildRelsPath(masterPath);
@@ -122,18 +123,18 @@ export function parseSlideMasterTxStyles(
 ): TxStyles | undefined {
   const parsed = parseXml(xml);
 
-  const sldMaster = parsed.sldMaster as XmlNode | undefined;
+  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return undefined;
   }
 
-  const txStyles = sldMaster.txStyles as XmlNode | undefined;
+  const txStyles = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.txStyles);
   if (!txStyles) return undefined;
 
-  const titleStyleNode = txStyles.titleStyle as XmlNode | undefined;
-  const bodyStyleNode = txStyles.bodyStyle as XmlNode | undefined;
-  const otherStyleNode = txStyles.otherStyle as XmlNode | undefined;
+  const titleStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txStyles.titleStyle);
+  const bodyStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txStyles.bodyStyle);
+  const otherStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txStyles.otherStyle);
   const titleStyle = titleStyleNode ? parseListStyle(titleStyleNode, colorResolver) : undefined;
   const bodyStyle = bodyStyleNode ? parseListStyle(bodyStyleNode, colorResolver) : undefined;
   const otherStyle = otherStyleNode ? parseListStyle(otherStyleNode, colorResolver) : undefined;
@@ -148,31 +149,33 @@ export function parseSlideMasterPlaceholderStyles(
   colorResolver?: ColorResolver,
 ): PlaceholderStyleInfo[] {
   const parsed = parseXml(xml);
-  const sldMaster = parsed.sldMaster as XmlNode | undefined;
+  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) return [];
 
-  const cSld = sldMaster.cSld as XmlNode | undefined;
-  const spTree = cSld?.spTree as XmlNode | undefined;
+  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.cSld);
+  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const results: PlaceholderStyleInfo[] = [];
-  const shapes = (spTree.sp as XmlNode[] | undefined) ?? [];
+  const shapes = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
 
   for (const sp of shapes) {
-    const nvSpPr = sp.nvSpPr as XmlNode | undefined;
-    const nvPr = nvSpPr?.nvPr as XmlNode | undefined;
-    const ph = nvPr?.ph as XmlNode | undefined;
+    const nvSpPr = unsafeTypeAssertion<XmlNode | undefined>(sp.nvSpPr);
+    const nvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
+    const ph = unsafeTypeAssertion<XmlNode | undefined>(nvPr?.ph);
     if (!ph) continue;
 
-    const placeholderType: string = (ph["@_type"] as string) ?? "body";
+    const placeholderType: string = unsafeTypeAssertion<string>(ph["@_type"]) ?? "body";
     const placeholderIdx = ph["@_idx"] !== undefined ? Number(ph["@_idx"]) : undefined;
-    const txBody = sp.txBody as XmlNode | undefined;
-    const lstStyleNode = txBody?.lstStyle as XmlNode | undefined;
+    const txBody = unsafeTypeAssertion<XmlNode | undefined>(sp.txBody);
+    const lstStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txBody?.lstStyle);
     const lstStyle = lstStyleNode ? parseListStyle(lstStyleNode, colorResolver) : undefined;
 
-    const spPr = sp.spPr as XmlNode | undefined;
+    const spPr = unsafeTypeAssertion<XmlNode | undefined>(sp.spPr);
     const transform =
-      spPr && typeof spPr === "object" ? parseTransform(spPr.xfrm as XmlNode | undefined) : null;
+      spPr && typeof spPr === "object"
+        ? parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm))
+        : null;
     const geometry = spPr && typeof spPr === "object" ? parseGeometry(spPr) : undefined;
 
     results.push({

--- a/packages/core/src/parser/slide-master-parser.ts
+++ b/packages/core/src/parser/slide-master-parser.ts
@@ -6,7 +6,7 @@ import type { FontScheme } from "@pptx-glimpse/renderer";
 import { debug } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import type { FillParseContext } from "./fill-parser.js";
 import { parseFillFromNode } from "./fill-parser.js";
 import type { PptxArchive } from "./pptx-reader.js";
@@ -33,23 +33,23 @@ const DEFAULT_COLOR_MAP: ColorMap = {
 export function parseSlideMasterColorMap(xml: string): ColorMap {
   const parsed = parseXml(xml);
 
-  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
+  const sldMaster = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return { ...DEFAULT_COLOR_MAP };
   }
 
-  const clrMap = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.clrMap);
+  const clrMap = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldMaster.clrMap);
 
   if (!clrMap) return { ...DEFAULT_COLOR_MAP };
 
   const result: Record<string, string> = {};
   for (const key of Object.keys(DEFAULT_COLOR_MAP)) {
-    const val = unsafeTypeAssertion<string | undefined>(clrMap[`@_${key}`]);
-    result[key] = val ?? DEFAULT_COLOR_MAP[unsafeTypeAssertion<keyof ColorMap>(key)];
+    const val = unsafeXmlBoundaryAssertion<string | undefined>(clrMap[`@_${key}`]);
+    result[key] = val ?? DEFAULT_COLOR_MAP[unsafeXmlBoundaryAssertion<keyof ColorMap>(key)];
   }
 
-  return unsafeTypeAssertion<ColorMap>(result);
+  return unsafeXmlBoundaryAssertion<ColorMap>(result);
 }
 
 export function parseSlideMasterBackground(
@@ -59,17 +59,17 @@ export function parseSlideMasterBackground(
 ): Background | null {
   const parsed = parseXml(xml);
 
-  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
+  const sldMaster = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return null;
   }
 
-  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.cSld);
-  const bg = unsafeTypeAssertion<XmlNode | undefined>(cSld?.bg);
+  const cSld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldMaster.cSld);
+  const bg = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.bg);
   if (!bg) return null;
 
-  const bgPr = unsafeTypeAssertion<XmlNode | undefined>(bg.bgPr);
+  const bgPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(bg.bgPr);
   if (!bgPr) return null;
 
   const fill = parseFillFromNode(bgPr, colorResolver, context);
@@ -86,14 +86,14 @@ export function parseSlideMasterElements(
 ): SlideElement[] {
   const parsed = parseXml(xml);
 
-  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
+  const sldMaster = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return [];
   }
 
-  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.cSld);
-  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
+  const cSld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldMaster.cSld);
+  const spTree = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const relsPath = buildRelsPath(masterPath);
@@ -123,18 +123,18 @@ export function parseSlideMasterTxStyles(
 ): TxStyles | undefined {
   const parsed = parseXml(xml);
 
-  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
+  const sldMaster = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) {
     debug("slideMaster.missing", `missing root element "sldMaster" in XML`);
     return undefined;
   }
 
-  const txStyles = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.txStyles);
+  const txStyles = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldMaster.txStyles);
   if (!txStyles) return undefined;
 
-  const titleStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txStyles.titleStyle);
-  const bodyStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txStyles.bodyStyle);
-  const otherStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txStyles.otherStyle);
+  const titleStyleNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(txStyles.titleStyle);
+  const bodyStyleNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(txStyles.bodyStyle);
+  const otherStyleNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(txStyles.otherStyle);
   const titleStyle = titleStyleNode ? parseListStyle(titleStyleNode, colorResolver) : undefined;
   const bodyStyle = bodyStyleNode ? parseListStyle(bodyStyleNode, colorResolver) : undefined;
   const otherStyle = otherStyleNode ? parseListStyle(otherStyleNode, colorResolver) : undefined;
@@ -149,32 +149,32 @@ export function parseSlideMasterPlaceholderStyles(
   colorResolver?: ColorResolver,
 ): PlaceholderStyleInfo[] {
   const parsed = parseXml(xml);
-  const sldMaster = unsafeTypeAssertion<XmlNode | undefined>(parsed.sldMaster);
+  const sldMaster = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sldMaster);
   if (!sldMaster) return [];
 
-  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sldMaster.cSld);
-  const spTree = unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree);
+  const cSld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sldMaster.cSld);
+  const spTree = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.spTree);
   if (!spTree) return [];
 
   const results: PlaceholderStyleInfo[] = [];
-  const shapes = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
+  const shapes = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
 
   for (const sp of shapes) {
-    const nvSpPr = unsafeTypeAssertion<XmlNode | undefined>(sp.nvSpPr);
-    const nvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
-    const ph = unsafeTypeAssertion<XmlNode | undefined>(nvPr?.ph);
+    const nvSpPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.nvSpPr);
+    const nvPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
+    const ph = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvPr?.ph);
     if (!ph) continue;
 
-    const placeholderType: string = unsafeTypeAssertion<string>(ph["@_type"]) ?? "body";
+    const placeholderType: string = unsafeXmlBoundaryAssertion<string>(ph["@_type"]) ?? "body";
     const placeholderIdx = ph["@_idx"] !== undefined ? Number(ph["@_idx"]) : undefined;
-    const txBody = unsafeTypeAssertion<XmlNode | undefined>(sp.txBody);
-    const lstStyleNode = unsafeTypeAssertion<XmlNode | undefined>(txBody?.lstStyle);
+    const txBody = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.txBody);
+    const lstStyleNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(txBody?.lstStyle);
     const lstStyle = lstStyleNode ? parseListStyle(lstStyleNode, colorResolver) : undefined;
 
-    const spPr = unsafeTypeAssertion<XmlNode | undefined>(sp.spPr);
+    const spPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.spPr);
     const transform =
       spPr && typeof spPr === "object"
-        ? parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm))
+        ? parseTransform(unsafeXmlBoundaryAssertion<XmlNode | undefined>(spPr.xfrm))
         : null;
     const geometry = spPr && typeof spPr === "object" ? parseGeometry(spPr) : undefined;
 

--- a/packages/core/src/parser/slide-parser.test.ts
+++ b/packages/core/src/parser/slide-parser.test.ts
@@ -3,6 +3,7 @@ import { initWarningLogger } from "@pptx-glimpse/renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import type { Relationship } from "./relationship-parser.js";
 import { navigateOrdered, parseShapeTree, parseSlide, parseTextBody } from "./slide-parser.js";
@@ -71,7 +72,7 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -80,7 +81,7 @@ describe("parseShapeTree", () => {
 
     expect(elements).toHaveLength(1);
     expect(elements[0].type).toBe("shape");
-    expect((elements[0] as ShapeElement).placeholderType).toBe("title");
+    expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
   });
 
   it("defaults placeholder type to body when type is not specified", () => {
@@ -107,7 +108,7 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -115,7 +116,7 @@ describe("parseShapeTree", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBe("body");
     expect(shape.placeholderIdx).toBe(1);
   });
@@ -142,7 +143,7 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -150,7 +151,7 @@ describe("parseShapeTree", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBeUndefined();
     expect(shape.placeholderIdx).toBeUndefined();
   });
@@ -188,14 +189,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody).not.toBeNull();
     expect(shape.textBody!.bodyProperties.autoFit).toBe("normAutofit");
     expect(shape.textBody!.bodyProperties.fontScale).toBe(0.625);
@@ -235,14 +236,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.bodyProperties.autoFit).toBe("normAutofit");
     expect(shape.textBody!.bodyProperties.fontScale).toBe(1);
     expect(shape.textBody!.bodyProperties.lnSpcReduction).toBe(0);
@@ -279,14 +280,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.bodyProperties.autoFit).toBe("noAutofit");
     expect(shape.textBody!.bodyProperties.fontScale).toBe(1);
     expect(shape.textBody!.bodyProperties.lnSpcReduction).toBe(0);
@@ -323,14 +324,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(30);
   });
 
@@ -365,14 +366,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(-25);
   });
 
@@ -407,14 +408,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(0);
   });
 
@@ -444,13 +445,13 @@ describe("parseShapeTree", () => {
       `;
       const parsed = parseXml(xml);
       const elements = parseShapeTree(
-        parsed.spTree as XmlNode | undefined,
+        unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
         new Map(),
         "ppt/slides/slide1.xml",
         createEmptyArchive(),
         createColorResolver(),
       );
-      expect((elements[0] as ShapeElement).placeholderType).toBe(phType);
+      expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe(phType);
     }
   });
 });
@@ -490,14 +491,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toEqual({ type: "char", char: "\u2022" });
     expect(para.properties.marginLeft).toBe(342900);
@@ -538,14 +539,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toEqual({
       type: "autoNum",
@@ -588,14 +589,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toEqual({ type: "none" });
   });
@@ -635,14 +636,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bulletFont).toBe("Wingdings");
     expect(para.properties.bullet).toEqual({ type: "char", char: "v" });
@@ -679,14 +680,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toBeNull();
     expect(para.properties.marginLeft).toBeNull();
@@ -733,7 +734,7 @@ describe("structural validation warnings", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -773,7 +774,7 @@ describe("structural validation warnings", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide2.xml",
       createEmptyArchive(),
@@ -813,7 +814,7 @@ describe("structural validation warnings", () => {
     `;
     const parsed = parseXml(xml);
     parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -872,7 +873,7 @@ describe("structural validation warnings", () => {
       minorFontEa: "Yu Mincho",
     };
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -883,7 +884,7 @@ describe("structural validation warnings", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const runs = shape.textBody!.paragraphs[0].runs;
 
     expect(runs[0].properties.fontFamily).toBe("Calibri Light");
@@ -932,7 +933,7 @@ describe("structural validation warnings", () => {
       minorFontEa: "Yu Mincho",
     };
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -943,7 +944,7 @@ describe("structural validation warnings", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const runs = shape.textBody!.paragraphs[0].runs;
 
     expect(runs[0].properties.fontFamily).toBe("Arial");
@@ -990,14 +991,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     // lstStyle の段落プロパティが適用される
     expect(para.properties.alignment).toBe("ctr");
@@ -1044,14 +1045,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     expect(run.properties.fontSize).toBe(18);
     expect(run.properties.italic).toBe(true);
@@ -1104,14 +1105,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     // rPr が最優先
     expect(run.properties.fontSize).toBe(12);
@@ -1163,14 +1164,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     // pPr.defRPr > lstStyle.lvl.defRPr
     expect(run.properties.fontSize).toBe(24);
@@ -1211,14 +1212,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.marginLeft).toBe(342900);
     expect(para.properties.indent).toBe(-342900);
@@ -1272,14 +1273,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.fontSize).toBe(24);
     expect(shape.textBody!.paragraphs[1].runs[0].properties.fontSize).toBe(18);
   });
@@ -1319,14 +1320,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     expect(run.properties.fontSize).toBe(20);
     expect(run.properties.bold).toBe(true);
@@ -1378,7 +1379,7 @@ describe("lstStyle and defRPr parsing", () => {
       minorFontEa: "Yu Mincho",
     };
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -1388,7 +1389,7 @@ describe("lstStyle and defRPr parsing", () => {
       fontScheme,
     );
 
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     expect(run.properties.fontFamily).toBe("Calibri Light");
     expect(run.properties.fontFamilyEa).toBe("Yu Mincho");
@@ -1431,7 +1432,7 @@ describe("Z-order across element types", () => {
     const orderedSpTree = navigateOrdered(orderedParsed, ["spTree"]);
 
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -1473,7 +1474,7 @@ describe("Z-order across element types", () => {
 
     // orderedChildren なし → タイプ別イテレーション（sp が先）
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -1500,7 +1501,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.paragraphs).toHaveLength(1);
     // フォールバック: ordered data なしでも fld テキストが含まれる
@@ -1522,7 +1526,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     const runs = result!.paragraphs[0].runs;
     const allText = runs.map((r) => r.text).join("");
@@ -1547,7 +1554,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     const tabStops = result!.paragraphs[0].properties.tabStops;
     expect(tabStops).toHaveLength(2);
@@ -1568,7 +1578,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.paragraphs[0].properties.lineSpacing).toEqual({ type: "pts", value: 2100 });
   });
@@ -1586,7 +1599,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.paragraphs[0].properties.lineSpacing).toEqual({ type: "pct", value: 150000 });
   });
@@ -1601,7 +1617,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.paragraphs[0].properties.lineSpacing).toBeNull();
   });
@@ -1616,7 +1635,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.bodyProperties.numCol).toBe(2);
   });
@@ -1631,7 +1653,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.bodyProperties.numCol).toBe(1);
   });
@@ -1654,7 +1679,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     const allText = result!.paragraphs[0].runs.map((r) => r.text).join("");
     expect(allText).toContain("x");
@@ -1680,12 +1708,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? (spChildren as Record<string, unknown>[]).find((c) => "txBody" in c)
+      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = txBodyEntry?.txBody as Record<string, unknown>[] | undefined;
+    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+      txBodyEntry?.txBody,
+    );
 
     const result = parseTextBody(
-      parsed.txBody as XmlNode,
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -1708,7 +1738,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.bodyProperties.vert).toBe("vert");
   });
@@ -1723,7 +1756,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.bodyProperties.vert).toBe("vert270");
   });
@@ -1738,7 +1774,10 @@ describe("parseTextBody", () => {
         </a:p>
       </txBody>`;
     const parsed = parseXml(xml);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver());
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+    );
     expect(result).not.toBeNull();
     expect(result!.bodyProperties.vert).toBe("horz");
   });
@@ -1762,7 +1801,11 @@ describe("parseTextBody", () => {
     const rels = new Map<string, Relationship>([
       ["rId1", { id: "rId1", type: "hyperlink", target: "https://example.com" }],
     ]);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver(), rels);
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+      rels,
+    );
     expect(result).not.toBeNull();
     const run = result!.paragraphs[0].runs[0];
     expect(run.properties.hyperlink).toEqual({ url: "https://example.com" });
@@ -1790,7 +1833,11 @@ describe("parseTextBody", () => {
     const rels = new Map<string, Relationship>([
       ["rId1", { id: "rId1", type: "hyperlink", target: "https://example.com" }],
     ]);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver(), rels);
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+      rels,
+    );
     expect(result).not.toBeNull();
     const run = result!.paragraphs[0].runs[0];
     expect(run.properties.color).toEqual({ hex: "#FF0000", alpha: 1 });
@@ -1815,7 +1862,11 @@ describe("parseTextBody", () => {
     const rels = new Map<string, Relationship>([
       ["rId1", { id: "rId1", type: "hyperlink", target: "https://example.com" }],
     ]);
-    const result = parseTextBody(parsed.txBody as XmlNode, createColorResolver(), rels);
+    const result = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      createColorResolver(),
+      rels,
+    );
     expect(result).not.toBeNull();
     const run = result!.paragraphs[0].runs[0];
     expect(run.properties.underline).toBe(false);
@@ -1854,12 +1905,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? (spChildren as Record<string, unknown>[]).find((c) => "txBody" in c)
+      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = txBodyEntry?.txBody as Record<string, unknown>[] | undefined;
+    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+      txBodyEntry?.txBody,
+    );
 
     const result = parseTextBody(
-      parsed.txBody as XmlNode,
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -1911,12 +1964,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? (spChildren as Record<string, unknown>[]).find((c) => "txBody" in c)
+      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = txBodyEntry?.txBody as Record<string, unknown>[] | undefined;
+    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+      txBodyEntry?.txBody,
+    );
 
     const result = parseTextBody(
-      parsed.txBody as XmlNode,
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -1951,12 +2006,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? (spChildren as Record<string, unknown>[]).find((c) => "txBody" in c)
+      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = txBodyEntry?.txBody as Record<string, unknown>[] | undefined;
+    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+      txBodyEntry?.txBody,
+    );
 
     const result = parseTextBody(
-      parsed.txBody as XmlNode,
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -1990,12 +2047,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? (spChildren as Record<string, unknown>[]).find((c) => "txBody" in c)
+      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = txBodyEntry?.txBody as Record<string, unknown>[] | undefined;
+    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+      txBodyEntry?.txBody,
+    );
 
     const result = parseTextBody(
-      parsed.txBody as XmlNode,
+      unsafeTypeAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -2032,7 +2091,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2046,10 +2105,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "ctrTitle",
           transform: {
-            offsetX: 1000 as never,
-            offsetY: 2000 as never,
-            extentWidth: 5000 as never,
-            extentHeight: 3000 as never,
+            offsetX: unsafeTypeAssertion<never>(1000),
+            offsetY: unsafeTypeAssertion<never>(2000),
+            extentWidth: unsafeTypeAssertion<never>(5000),
+            extentHeight: unsafeTypeAssertion<never>(3000),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2059,7 +2118,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBe("ctrTitle");
     expect(shape.transform.offsetX).toBe(1000);
     expect(shape.transform.extentWidth).toBe(5000);
@@ -2085,7 +2144,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2099,10 +2158,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: 500 as never,
-            offsetY: 600 as never,
-            extentWidth: 8000 as never,
-            extentHeight: 1200 as never,
+            offsetX: unsafeTypeAssertion<never>(500),
+            offsetY: unsafeTypeAssertion<never>(600),
+            extentWidth: unsafeTypeAssertion<never>(8000),
+            extentHeight: unsafeTypeAssertion<never>(1200),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2113,7 +2172,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.geometry).toEqual({ type: "preset", preset: "roundRect", adjustValues: {} });
   });
 
@@ -2137,7 +2196,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2151,10 +2210,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: 100 as never,
-            offsetY: 200 as never,
-            extentWidth: 9000 as never,
-            extentHeight: 1500 as never,
+            offsetX: unsafeTypeAssertion<never>(100),
+            offsetY: unsafeTypeAssertion<never>(200),
+            extentWidth: unsafeTypeAssertion<never>(9000),
+            extentHeight: unsafeTypeAssertion<never>(1500),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2164,7 +2223,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.transform.extentWidth).toBe(9000);
   });
 
@@ -2185,7 +2244,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2220,7 +2279,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2234,10 +2293,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: 9999 as never,
-            offsetY: 9999 as never,
-            extentWidth: 9999 as never,
-            extentHeight: 9999 as never,
+            offsetX: unsafeTypeAssertion<never>(9999),
+            offsetY: unsafeTypeAssertion<never>(9999),
+            extentWidth: unsafeTypeAssertion<never>(9999),
+            extentHeight: unsafeTypeAssertion<never>(9999),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2247,7 +2306,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.transform.offsetX).toBe(111);
     expect(shape.transform.offsetY).toBe(222);
   });
@@ -2272,7 +2331,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2289,10 +2348,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: 500 as never,
-            offsetY: 600 as never,
-            extentWidth: 7000 as never,
-            extentHeight: 1000 as never,
+            offsetX: unsafeTypeAssertion<never>(500),
+            offsetY: unsafeTypeAssertion<never>(600),
+            extentWidth: unsafeTypeAssertion<never>(7000),
+            extentHeight: unsafeTypeAssertion<never>(1000),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2302,7 +2361,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = elements[0] as ShapeElement;
+    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
     expect(shape.transform.offsetX).toBe(500);
     expect(shape.transform.extentWidth).toBe(7000);
   });
@@ -2329,7 +2388,7 @@ describe("OOXML Strict compatibility", () => {
     `;
     const parsed = parseXml(xml);
     parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2366,7 +2425,7 @@ describe("OOXML Strict compatibility", () => {
     `;
     const parsed = parseXml(xml);
     parseShapeTree(
-      parsed.spTree as XmlNode | undefined,
+      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),

--- a/packages/core/src/parser/slide-parser.test.ts
+++ b/packages/core/src/parser/slide-parser.test.ts
@@ -3,7 +3,7 @@ import { initWarningLogger } from "@pptx-glimpse/renderer";
 import { describe, expect, it, vi } from "vitest";
 
 import { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import type { PptxArchive } from "./pptx-reader.js";
 import type { Relationship } from "./relationship-parser.js";
 import { navigateOrdered, parseShapeTree, parseSlide, parseTextBody } from "./slide-parser.js";
@@ -72,7 +72,7 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -81,7 +81,7 @@ describe("parseShapeTree", () => {
 
     expect(elements).toHaveLength(1);
     expect(elements[0].type).toBe("shape");
-    expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
+    expect(unsafeFixtureAssertion<ShapeElement>(elements[0]).placeholderType).toBe("title");
   });
 
   it("defaults placeholder type to body when type is not specified", () => {
@@ -108,7 +108,7 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -116,7 +116,7 @@ describe("parseShapeTree", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBe("body");
     expect(shape.placeholderIdx).toBe(1);
   });
@@ -143,7 +143,7 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -151,7 +151,7 @@ describe("parseShapeTree", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBeUndefined();
     expect(shape.placeholderIdx).toBeUndefined();
   });
@@ -189,14 +189,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody).not.toBeNull();
     expect(shape.textBody!.bodyProperties.autoFit).toBe("normAutofit");
     expect(shape.textBody!.bodyProperties.fontScale).toBe(0.625);
@@ -236,14 +236,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.bodyProperties.autoFit).toBe("normAutofit");
     expect(shape.textBody!.bodyProperties.fontScale).toBe(1);
     expect(shape.textBody!.bodyProperties.lnSpcReduction).toBe(0);
@@ -280,14 +280,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.bodyProperties.autoFit).toBe("noAutofit");
     expect(shape.textBody!.bodyProperties.fontScale).toBe(1);
     expect(shape.textBody!.bodyProperties.lnSpcReduction).toBe(0);
@@ -324,14 +324,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(30);
   });
 
@@ -366,14 +366,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(-25);
   });
 
@@ -408,14 +408,14 @@ describe("parseShapeTree", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.baseline).toBe(0);
   });
 
@@ -445,13 +445,13 @@ describe("parseShapeTree", () => {
       `;
       const parsed = parseXml(xml);
       const elements = parseShapeTree(
-        unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+        unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
         new Map(),
         "ppt/slides/slide1.xml",
         createEmptyArchive(),
         createColorResolver(),
       );
-      expect(unsafeTypeAssertion<ShapeElement>(elements[0]).placeholderType).toBe(phType);
+      expect(unsafeFixtureAssertion<ShapeElement>(elements[0]).placeholderType).toBe(phType);
     }
   });
 });
@@ -491,14 +491,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toEqual({ type: "char", char: "\u2022" });
     expect(para.properties.marginLeft).toBe(342900);
@@ -539,14 +539,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toEqual({
       type: "autoNum",
@@ -589,14 +589,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toEqual({ type: "none" });
   });
@@ -636,14 +636,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bulletFont).toBe("Wingdings");
     expect(para.properties.bullet).toEqual({ type: "char", char: "v" });
@@ -680,14 +680,14 @@ describe("bullet parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.bullet).toBeNull();
     expect(para.properties.marginLeft).toBeNull();
@@ -734,7 +734,7 @@ describe("structural validation warnings", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -774,7 +774,7 @@ describe("structural validation warnings", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide2.xml",
       createEmptyArchive(),
@@ -814,7 +814,7 @@ describe("structural validation warnings", () => {
     `;
     const parsed = parseXml(xml);
     parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -873,7 +873,7 @@ describe("structural validation warnings", () => {
       minorFontEa: "Yu Mincho",
     };
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -884,7 +884,7 @@ describe("structural validation warnings", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const runs = shape.textBody!.paragraphs[0].runs;
 
     expect(runs[0].properties.fontFamily).toBe("Calibri Light");
@@ -933,7 +933,7 @@ describe("structural validation warnings", () => {
       minorFontEa: "Yu Mincho",
     };
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -944,7 +944,7 @@ describe("structural validation warnings", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const runs = shape.textBody!.paragraphs[0].runs;
 
     expect(runs[0].properties.fontFamily).toBe("Arial");
@@ -991,14 +991,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     // lstStyle の段落プロパティが適用される
     expect(para.properties.alignment).toBe("ctr");
@@ -1045,14 +1045,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     expect(run.properties.fontSize).toBe(18);
     expect(run.properties.italic).toBe(true);
@@ -1105,14 +1105,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     // rPr が最優先
     expect(run.properties.fontSize).toBe(12);
@@ -1164,14 +1164,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     // pPr.defRPr > lstStyle.lvl.defRPr
     expect(run.properties.fontSize).toBe(24);
@@ -1212,14 +1212,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const para = shape.textBody!.paragraphs[0];
     expect(para.properties.marginLeft).toBe(342900);
     expect(para.properties.indent).toBe(-342900);
@@ -1273,14 +1273,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.textBody!.paragraphs[0].runs[0].properties.fontSize).toBe(24);
     expect(shape.textBody!.paragraphs[1].runs[0].properties.fontSize).toBe(18);
   });
@@ -1320,14 +1320,14 @@ describe("lstStyle and defRPr parsing", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
       createColorResolver(),
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     expect(run.properties.fontSize).toBe(20);
     expect(run.properties.bold).toBe(true);
@@ -1379,7 +1379,7 @@ describe("lstStyle and defRPr parsing", () => {
       minorFontEa: "Yu Mincho",
     };
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -1389,7 +1389,7 @@ describe("lstStyle and defRPr parsing", () => {
       fontScheme,
     );
 
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     const run = shape.textBody!.paragraphs[0].runs[0];
     expect(run.properties.fontFamily).toBe("Calibri Light");
     expect(run.properties.fontFamilyEa).toBe("Yu Mincho");
@@ -1432,7 +1432,7 @@ describe("Z-order across element types", () => {
     const orderedSpTree = navigateOrdered(orderedParsed, ["spTree"]);
 
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -1474,7 +1474,7 @@ describe("Z-order across element types", () => {
 
     // orderedChildren なし → タイプ別イテレーション（sp が先）
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -1502,7 +1502,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1527,7 +1527,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1555,7 +1555,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1579,7 +1579,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1600,7 +1600,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1618,7 +1618,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1636,7 +1636,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1654,7 +1654,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1680,7 +1680,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1708,14 +1708,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
+      ? unsafeFixtureAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+    const orderedTxBody = unsafeFixtureAssertion<Record<string, unknown>[] | undefined>(
       txBodyEntry?.txBody,
     );
 
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -1739,7 +1739,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1757,7 +1757,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1775,7 +1775,7 @@ describe("parseTextBody", () => {
       </txBody>`;
     const parsed = parseXml(xml);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
     );
     expect(result).not.toBeNull();
@@ -1802,7 +1802,7 @@ describe("parseTextBody", () => {
       ["rId1", { id: "rId1", type: "hyperlink", target: "https://example.com" }],
     ]);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       rels,
     );
@@ -1834,7 +1834,7 @@ describe("parseTextBody", () => {
       ["rId1", { id: "rId1", type: "hyperlink", target: "https://example.com" }],
     ]);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       rels,
     );
@@ -1863,7 +1863,7 @@ describe("parseTextBody", () => {
       ["rId1", { id: "rId1", type: "hyperlink", target: "https://example.com" }],
     ]);
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       rels,
     );
@@ -1905,14 +1905,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
+      ? unsafeFixtureAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+    const orderedTxBody = unsafeFixtureAssertion<Record<string, unknown>[] | undefined>(
       txBodyEntry?.txBody,
     );
 
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -1964,14 +1964,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
+      ? unsafeFixtureAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+    const orderedTxBody = unsafeFixtureAssertion<Record<string, unknown>[] | undefined>(
       txBodyEntry?.txBody,
     );
 
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -2006,14 +2006,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
+      ? unsafeFixtureAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+    const orderedTxBody = unsafeFixtureAssertion<Record<string, unknown>[] | undefined>(
       txBodyEntry?.txBody,
     );
 
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -2047,14 +2047,14 @@ describe("parseTextBody", () => {
     const orderedFull = parseXmlOrdered(fullXml);
     const spChildren = orderedFull[0]?.sp;
     const txBodyEntry = Array.isArray(spChildren)
-      ? unsafeTypeAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
+      ? unsafeFixtureAssertion<Record<string, unknown>[]>(spChildren).find((c) => "txBody" in c)
       : null;
-    const orderedTxBody = unsafeTypeAssertion<Record<string, unknown>[] | undefined>(
+    const orderedTxBody = unsafeFixtureAssertion<Record<string, unknown>[] | undefined>(
       txBodyEntry?.txBody,
     );
 
     const result = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(parsed.txBody),
+      unsafeFixtureAssertion<XmlNode>(parsed.txBody),
       createColorResolver(),
       undefined,
       undefined,
@@ -2091,7 +2091,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2105,10 +2105,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "ctrTitle",
           transform: {
-            offsetX: unsafeTypeAssertion<never>(1000),
-            offsetY: unsafeTypeAssertion<never>(2000),
-            extentWidth: unsafeTypeAssertion<never>(5000),
-            extentHeight: unsafeTypeAssertion<never>(3000),
+            offsetX: unsafeFixtureAssertion<never>(1000),
+            offsetY: unsafeFixtureAssertion<never>(2000),
+            extentWidth: unsafeFixtureAssertion<never>(5000),
+            extentHeight: unsafeFixtureAssertion<never>(3000),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2118,7 +2118,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.placeholderType).toBe("ctrTitle");
     expect(shape.transform.offsetX).toBe(1000);
     expect(shape.transform.extentWidth).toBe(5000);
@@ -2144,7 +2144,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2158,10 +2158,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: unsafeTypeAssertion<never>(500),
-            offsetY: unsafeTypeAssertion<never>(600),
-            extentWidth: unsafeTypeAssertion<never>(8000),
-            extentHeight: unsafeTypeAssertion<never>(1200),
+            offsetX: unsafeFixtureAssertion<never>(500),
+            offsetY: unsafeFixtureAssertion<never>(600),
+            extentWidth: unsafeFixtureAssertion<never>(8000),
+            extentHeight: unsafeFixtureAssertion<never>(1200),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2172,7 +2172,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.geometry).toEqual({ type: "preset", preset: "roundRect", adjustValues: {} });
   });
 
@@ -2196,7 +2196,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2210,10 +2210,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: unsafeTypeAssertion<never>(100),
-            offsetY: unsafeTypeAssertion<never>(200),
-            extentWidth: unsafeTypeAssertion<never>(9000),
-            extentHeight: unsafeTypeAssertion<never>(1500),
+            offsetX: unsafeFixtureAssertion<never>(100),
+            offsetY: unsafeFixtureAssertion<never>(200),
+            extentWidth: unsafeFixtureAssertion<never>(9000),
+            extentHeight: unsafeFixtureAssertion<never>(1500),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2223,7 +2223,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.transform.extentWidth).toBe(9000);
   });
 
@@ -2244,7 +2244,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2279,7 +2279,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2293,10 +2293,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: unsafeTypeAssertion<never>(9999),
-            offsetY: unsafeTypeAssertion<never>(9999),
-            extentWidth: unsafeTypeAssertion<never>(9999),
-            extentHeight: unsafeTypeAssertion<never>(9999),
+            offsetX: unsafeFixtureAssertion<never>(9999),
+            offsetY: unsafeFixtureAssertion<never>(9999),
+            extentWidth: unsafeFixtureAssertion<never>(9999),
+            extentHeight: unsafeFixtureAssertion<never>(9999),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2306,7 +2306,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.transform.offsetX).toBe(111);
     expect(shape.transform.offsetY).toBe(222);
   });
@@ -2331,7 +2331,7 @@ describe("placeholder geometry inheritance", () => {
     `;
     const parsed = parseXml(xml);
     const elements = parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2348,10 +2348,10 @@ describe("placeholder geometry inheritance", () => {
         {
           placeholderType: "title",
           transform: {
-            offsetX: unsafeTypeAssertion<never>(500),
-            offsetY: unsafeTypeAssertion<never>(600),
-            extentWidth: unsafeTypeAssertion<never>(7000),
-            extentHeight: unsafeTypeAssertion<never>(1000),
+            offsetX: unsafeFixtureAssertion<never>(500),
+            offsetY: unsafeFixtureAssertion<never>(600),
+            extentWidth: unsafeFixtureAssertion<never>(7000),
+            extentHeight: unsafeFixtureAssertion<never>(1000),
             rotation: 0,
             flipH: false,
             flipV: false,
@@ -2361,7 +2361,7 @@ describe("placeholder geometry inheritance", () => {
     );
 
     expect(elements).toHaveLength(1);
-    const shape = unsafeTypeAssertion<ShapeElement>(elements[0]);
+    const shape = unsafeFixtureAssertion<ShapeElement>(elements[0]);
     expect(shape.transform.offsetX).toBe(500);
     expect(shape.transform.extentWidth).toBe(7000);
   });
@@ -2388,7 +2388,7 @@ describe("OOXML Strict compatibility", () => {
     `;
     const parsed = parseXml(xml);
     parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),
@@ -2425,7 +2425,7 @@ describe("OOXML Strict compatibility", () => {
     `;
     const parsed = parseXml(xml);
     parseShapeTree(
-      unsafeTypeAssertion<XmlNode | undefined>(parsed.spTree),
+      unsafeFixtureAssertion<XmlNode | undefined>(parsed.spTree),
       new Map(),
       "ppt/slides/slide1.xml",
       createEmptyArchive(),

--- a/packages/core/src/parser/slide-parser.ts
+++ b/packages/core/src/parser/slide-parser.ts
@@ -33,7 +33,7 @@ import { asEmu, asHundredthPt } from "@pptx-glimpse/renderer";
 import { debug, warn } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseBlipEffects } from "./blip-effect-parser.js";
 import { parseChart } from "./chart-parser.js";
 import { parseCustomGeometry } from "./custom-geometry-parser.js";
@@ -73,7 +73,7 @@ export function navigateOrdered(
   for (const key of path) {
     const entry = current.find((item: XmlOrderedNode) => key in item);
     if (!entry) return null;
-    current = unsafeTypeAssertion<XmlOrderedNode[]>(entry[key]);
+    current = unsafeXmlBoundaryAssertion<XmlOrderedNode[]>(entry[key]);
     if (!Array.isArray(current)) return null;
   }
   return current;
@@ -90,7 +90,7 @@ export function parseSlide(
   placeholderStyles?: PlaceholderStyleInfo[],
 ): Slide {
   const parsed = parseXml(slideXml);
-  const sld = unsafeTypeAssertion<XmlNode | undefined>(parsed.sld);
+  const sld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sld);
   if (!sld) {
     debug("slide.missing", `missing root element "sld" in XML`, `Slide ${slideNumber}`);
   }
@@ -100,9 +100,9 @@ export function parseSlide(
   const rels = relsXml ? parseRelationships(relsXml) : new Map<string, Relationship>();
 
   const fillContext: FillParseContext = { rels, archive, basePath: slidePath };
-  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sld?.cSld) ?? undefined;
+  const cSld = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sld?.cSld) ?? undefined;
   const background = parseBackground(
-    unsafeTypeAssertion<XmlNode | undefined>(cSld?.bg),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.bg),
     colorResolver,
     fillContext,
   );
@@ -112,7 +112,7 @@ export function parseSlide(
   const orderedSpTree = navigateOrdered(orderedParsed, ["sld", "cSld", "spTree"]);
 
   const elements = parseShapeTree(
-    unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(cSld?.spTree),
     rels,
     slidePath,
     archive,
@@ -138,7 +138,7 @@ function parseBackground(
 ): Background | null {
   if (!bgNode) return null;
 
-  const bgPr = unsafeTypeAssertion<XmlNode | undefined>(bgNode.bgPr);
+  const bgPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(bgNode.bgPr);
   if (!bgPr) return null;
 
   const fill = parseFillFromNode(bgPr, colorResolver, context);
@@ -155,7 +155,7 @@ function mergeChildElements(spTree: XmlNode, source: XmlNode): void {
     }
     const arr = Array.isArray(items) ? items : [items];
     for (const item of arr) {
-      unsafeTypeAssertion<unknown[]>(spTree[tag]).push(item);
+      unsafeXmlBoundaryAssertion<unknown[]>(spTree[tag]).push(item);
     }
   }
 }
@@ -195,18 +195,18 @@ export function parseShapeTree(
   // フォールバック: タイプ別イテレーション（後方互換）
   // mc:AlternateContent の処理: Choice 内の要素を spTree にマージ
   const alternateContents =
-    unsafeTypeAssertion<XmlNode[] | undefined>(spTree.AlternateContent) ?? [];
+    unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.AlternateContent) ?? [];
   for (const ac of alternateContents) {
     const choices = Array.isArray(ac.Choice) ? ac.Choice : ac.Choice ? [ac.Choice] : [];
     for (const choice of choices) {
-      mergeChildElements(spTree, unsafeTypeAssertion<XmlNode>(choice));
+      mergeChildElements(spTree, unsafeXmlBoundaryAssertion<XmlNode>(choice));
     }
   }
 
   const ctx = context ?? slidePath;
   const elements: SlideElement[] = [];
 
-  const shapes = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
+  const shapes = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
   for (const sp of shapes) {
     const shape = parseShape(
       sp,
@@ -225,7 +225,7 @@ export function parseShapeTree(
     }
   }
 
-  const pics = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.pic) ?? [];
+  const pics = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.pic) ?? [];
   for (const pic of pics) {
     const img = parseImage(pic, rels, slidePath, archive, colorResolver);
     if (img) {
@@ -235,7 +235,7 @@ export function parseShapeTree(
     }
   }
 
-  const cxnSps = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.cxnSp) ?? [];
+  const cxnSps = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.cxnSp) ?? [];
   for (const cxn of cxnSps) {
     const connector = parseConnector(cxn, colorResolver, fmtScheme);
     if (connector) {
@@ -245,7 +245,7 @@ export function parseShapeTree(
     }
   }
 
-  const grpSps = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.grpSp) ?? [];
+  const grpSps = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.grpSp) ?? [];
   for (const grp of grpSps) {
     const group = parseGroup(
       grp,
@@ -265,7 +265,8 @@ export function parseShapeTree(
     }
   }
 
-  const graphicFrames = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.graphicFrame) ?? [];
+  const graphicFrames =
+    unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.graphicFrame) ?? [];
   for (const gf of graphicFrames) {
     const chart = parseGraphicFrame(gf, rels, slidePath, archive, colorResolver, fontScheme);
     if (chart) {
@@ -305,7 +306,8 @@ function parseShapeTreeOrdered(
       const acIndex = tagCounters["AlternateContent"] ?? 0;
       tagCounters["AlternateContent"] = acIndex + 1;
 
-      const acList = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.AlternateContent) ?? [];
+      const acList =
+        unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree.AlternateContent) ?? [];
       const acData = acList[acIndex] as XmlNode | undefined;
       if (!acData) continue;
 
@@ -314,18 +316,18 @@ function parseShapeTreeOrdered(
         : acData.Choice
           ? [acData.Choice]
           : [];
-      const firstChoice = unsafeTypeAssertion<XmlNode | undefined>(choices[0]);
+      const firstChoice = unsafeXmlBoundaryAssertion<XmlNode | undefined>(choices[0]);
       if (!firstChoice) continue;
 
       // ordered 結果から Choice の子要素を取得
-      const acOrderedChildren = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(
+      const acOrderedChildren = unsafeXmlBoundaryAssertion<XmlOrderedNode[] | undefined>(
         child.AlternateContent,
       );
 
       const choiceOrdered = Array.isArray(acOrderedChildren)
         ? acOrderedChildren.find((c: XmlOrderedNode) => "Choice" in c)
         : null;
-      const choiceChildren = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(
+      const choiceChildren = unsafeXmlBoundaryAssertion<XmlOrderedNode[] | undefined>(
         choiceOrdered?.Choice,
       );
 
@@ -341,7 +343,7 @@ function parseShapeTreeOrdered(
 
           const items = firstChoice[choiceTag];
           const arr = Array.isArray(items) ? items : items ? [items] : [];
-          const element = unsafeTypeAssertion<XmlNode | undefined>(arr[choiceIdx]);
+          const element = unsafeXmlBoundaryAssertion<XmlNode | undefined>(arr[choiceIdx]);
           if (!element) continue;
 
           parseAndPushElement(
@@ -369,7 +371,7 @@ function parseShapeTreeOrdered(
     const index = tagCounters[tag] ?? 0;
     tagCounters[tag] = index + 1;
 
-    const tagArray = unsafeTypeAssertion<XmlNode[] | undefined>(spTree[tag]);
+    const tagArray = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(spTree[tag]);
     const element = tagArray?.[index];
     if (!element) continue;
 
@@ -449,7 +451,7 @@ function parseAndPushElement(
     case "grpSp": {
       // ordered 結果からグループの子要素順序を取得
       const grpOrderedChildren =
-        unsafeTypeAssertion<XmlOrderedNode[] | undefined>(orderedNode[tag]) ?? null;
+        unsafeXmlBoundaryAssertion<XmlOrderedNode[] | undefined>(orderedNode[tag]) ?? null;
       const group = parseGroup(
         element,
         rels,
@@ -497,15 +499,15 @@ function parseShape(
   fmtScheme?: FormatScheme,
   placeholderStyles?: PlaceholderStyleInfo[],
 ): ShapeElement | null {
-  const spPr = unsafeTypeAssertion<XmlNode | undefined>(sp.spPr);
+  const spPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.spPr);
   const spPrIsObject = spPr != null && typeof spPr === "object";
 
   // プレースホルダー情報を先に抽出（transform フォールバックに必要）
-  const nvSpPr = unsafeTypeAssertion<XmlNode | undefined>(sp.nvSpPr);
-  const nvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
-  const ph = unsafeTypeAssertion<XmlNode | undefined>(nvPr?.ph);
+  const nvSpPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.nvSpPr);
+  const nvPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
+  const ph = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvPr?.ph);
   const placeholderType = ph
-    ? (unsafeTypeAssertion<string | undefined>(ph["@_type"]) ?? "body")
+    ? (unsafeXmlBoundaryAssertion<string | undefined>(ph["@_type"]) ?? "body")
     : undefined;
   const placeholderIdx = ph?.["@_idx"] !== undefined ? Number(ph["@_idx"]) : undefined;
 
@@ -514,7 +516,7 @@ function parseShape(
   let geometry: Geometry;
 
   if (spPrIsObject) {
-    transform = parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm));
+    transform = parseTransform(unsafeXmlBoundaryAssertion<XmlNode | undefined>(spPr.xfrm));
     geometry = parseGeometry(spPr);
   } else {
     geometry = { type: "preset", preset: "rect", adjustValues: {} };
@@ -543,7 +545,7 @@ function parseShape(
 
   // Resolve style references (sp.style) as fallback for direct attributes
   const styleRef = resolveShapeStyle(
-    unsafeTypeAssertion<XmlNode | undefined>(sp.style),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.style),
     fmtScheme,
     colorResolver,
   );
@@ -552,22 +554,22 @@ function parseShape(
   const fill = directFill ?? styleRef?.fill ?? null;
 
   const directOutline = spPrIsObject
-    ? parseOutline(unsafeTypeAssertion<XmlNode>(spPr.ln), colorResolver)
+    ? parseOutline(unsafeXmlBoundaryAssertion<XmlNode>(spPr.ln), colorResolver)
     : null;
   const outline = directOutline ?? styleRef?.outline ?? null;
 
   // ordered ノードから txBody の ordered children を抽出
   let orderedTxBody: XmlOrderedNode[] | undefined;
   if (orderedNode) {
-    const spChildren = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(orderedNode.sp);
+    const spChildren = unsafeXmlBoundaryAssertion<XmlOrderedNode[] | undefined>(orderedNode.sp);
     if (Array.isArray(spChildren)) {
       const txBodyEntry = spChildren.find((c: XmlOrderedNode) => "txBody" in c);
-      orderedTxBody = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(txBodyEntry?.txBody);
+      orderedTxBody = unsafeXmlBoundaryAssertion<XmlOrderedNode[] | undefined>(txBodyEntry?.txBody);
     }
   }
 
   const textBody = parseTextBody(
-    unsafeTypeAssertion<XmlNode | undefined>(sp.txBody),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(sp.txBody),
     colorResolver,
     rels,
     fontScheme,
@@ -576,14 +578,14 @@ function parseShape(
   );
 
   const directEffects = spPrIsObject
-    ? parseEffectList(unsafeTypeAssertion<XmlNode>(spPr.effectLst), colorResolver)
+    ? parseEffectList(unsafeXmlBoundaryAssertion<XmlNode>(spPr.effectLst), colorResolver)
     : null;
   const effects = directEffects ?? styleRef?.effects ?? null;
 
-  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.cNvPr);
-  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
+  const cNvPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvSpPr?.cNvPr);
+  const altText = unsafeXmlBoundaryAssertion<string | undefined>(cNvPr?.["@_descr"]);
   const hyperlink = parseHyperlink(
-    unsafeTypeAssertion<XmlNode | undefined>(cNvPr?.hlinkClick),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(cNvPr?.hlinkClick),
     rels,
   );
 
@@ -609,17 +611,17 @@ function parseImage(
   archive: PptxArchive,
   colorResolver: ColorResolver,
 ): ImageElement | null {
-  const spPr = unsafeTypeAssertion<XmlNode | undefined>(pic.spPr);
+  const spPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pic.spPr);
   if (!spPr) return null;
 
-  const transform = parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm));
+  const transform = parseTransform(unsafeXmlBoundaryAssertion<XmlNode | undefined>(spPr.xfrm));
   if (!transform) return null;
 
-  const blipFill = unsafeTypeAssertion<XmlNode | undefined>(pic.blipFill);
-  const blip = unsafeTypeAssertion<XmlNode | undefined>(blipFill?.blip);
+  const blipFill = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pic.blipFill);
+  const blip = unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipFill?.blip);
   const rId =
-    unsafeTypeAssertion<string | undefined>(blip?.["@_r:embed"]) ??
-    unsafeTypeAssertion<string | undefined>(blip?.["@_embed"]);
+    unsafeXmlBoundaryAssertion<string | undefined>(blip?.["@_r:embed"]) ??
+    unsafeXmlBoundaryAssertion<string | undefined>(blip?.["@_embed"]);
   if (!rId) return null;
 
   const rel = rels.get(rId);
@@ -644,15 +646,20 @@ function parseImage(
   };
   const mimeType = mimeMap[ext] ?? "image/png";
   const imageData = uint8ArrayToBase64(mediaData);
-  const effects = parseEffectList(unsafeTypeAssertion<XmlNode>(spPr.effectLst), colorResolver);
-  const blipEffects = parseBlipEffects(unsafeTypeAssertion<XmlNode>(blip), colorResolver);
-  const srcRect = parseSrcRect(unsafeTypeAssertion<XmlNode | undefined>(blipFill?.srcRect));
-  const stretch = parseStretchFillRect(unsafeTypeAssertion<XmlNode | undefined>(blipFill?.stretch));
-  const tile = parseTileInfo(unsafeTypeAssertion<XmlNode | undefined>(blipFill?.tile));
+  const effects = parseEffectList(
+    unsafeXmlBoundaryAssertion<XmlNode>(spPr.effectLst),
+    colorResolver,
+  );
+  const blipEffects = parseBlipEffects(unsafeXmlBoundaryAssertion<XmlNode>(blip), colorResolver);
+  const srcRect = parseSrcRect(unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipFill?.srcRect));
+  const stretch = parseStretchFillRect(
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipFill?.stretch),
+  );
+  const tile = parseTileInfo(unsafeXmlBoundaryAssertion<XmlNode | undefined>(blipFill?.tile));
 
-  const nvPicPr = unsafeTypeAssertion<XmlNode | undefined>(pic.nvPicPr);
-  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvPicPr?.cNvPr);
-  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
+  const nvPicPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pic.nvPicPr);
+  const cNvPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvPicPr?.cNvPr);
+  const altText = unsafeXmlBoundaryAssertion<string | undefined>(cNvPr?.["@_descr"]);
 
   return {
     type: "image",
@@ -680,7 +687,7 @@ function parseSrcRect(node: XmlNode | undefined): SrcRect | null {
 
 function parseStretchFillRect(stretchNode: XmlNode | undefined): StretchFillRect | null {
   if (!stretchNode) return null;
-  const fillRect = unsafeTypeAssertion<XmlNode | undefined>(stretchNode.fillRect);
+  const fillRect = unsafeXmlBoundaryAssertion<XmlNode | undefined>(stretchNode.fillRect);
   if (!fillRect) return null;
   const l = Number(fillRect["@_l"] ?? 0) / 100000;
   const t = Number(fillRect["@_t"] ?? 0) / 100000;
@@ -697,8 +704,8 @@ function parseTileInfo(node: XmlNode | undefined): TileInfo | null {
     ty: asEmu(Number(node["@_ty"] ?? 0)),
     sx: Number(node["@_sx"] ?? 100000) / 100000,
     sy: Number(node["@_sy"] ?? 100000) / 100000,
-    flip: unsafeTypeAssertion<TileInfo["flip"]>(node["@_flip"] ?? "none"),
-    align: unsafeTypeAssertion<string>(node["@_algn"]) ?? "tl",
+    flip: unsafeXmlBoundaryAssertion<TileInfo["flip"]>(node["@_flip"] ?? "none"),
+    align: unsafeXmlBoundaryAssertion<string>(node["@_algn"]) ?? "tl",
   };
 }
 
@@ -707,30 +714,30 @@ function parseConnector(
   colorResolver: ColorResolver,
   fmtScheme?: FormatScheme,
 ): ConnectorElement | null {
-  const spPr = unsafeTypeAssertion<XmlNode | undefined>(cxn.spPr);
+  const spPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cxn.spPr);
   if (!spPr) return null;
 
-  const transform = parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm));
+  const transform = parseTransform(unsafeXmlBoundaryAssertion<XmlNode | undefined>(spPr.xfrm));
   if (!transform) return null;
 
   const geometry = parseGeometry(spPr);
 
   const styleRef = resolveShapeStyle(
-    unsafeTypeAssertion<XmlNode | undefined>(cxn.style),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(cxn.style),
     fmtScheme,
     colorResolver,
   );
-  const directOutline = parseOutline(unsafeTypeAssertion<XmlNode>(spPr.ln), colorResolver);
+  const directOutline = parseOutline(unsafeXmlBoundaryAssertion<XmlNode>(spPr.ln), colorResolver);
   const outline = directOutline ?? styleRef?.outline ?? null;
   const directEffects = parseEffectList(
-    unsafeTypeAssertion<XmlNode>(spPr.effectLst),
+    unsafeXmlBoundaryAssertion<XmlNode>(spPr.effectLst),
     colorResolver,
   );
   const effects = directEffects ?? styleRef?.effects ?? null;
 
-  const nvCxnSpPr = unsafeTypeAssertion<XmlNode | undefined>(cxn.nvCxnSpPr);
-  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvCxnSpPr?.cNvPr);
-  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
+  const nvCxnSpPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cxn.nvCxnSpPr);
+  const cNvPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvCxnSpPr?.cNvPr);
+  const altText = unsafeXmlBoundaryAssertion<string | undefined>(cNvPr?.["@_descr"]);
 
   return { type: "connector", transform, geometry, outline, effects, ...(altText && { altText }) };
 }
@@ -746,15 +753,15 @@ function parseGroup(
   orderedChildren?: XmlOrderedNode[] | null,
   fmtScheme?: FormatScheme,
 ): GroupElement | null {
-  const grpSpPr = unsafeTypeAssertion<XmlNode | undefined>(grp.grpSpPr);
+  const grpSpPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(grp.grpSpPr);
   if (!grpSpPr) return null;
 
-  const xfrm = unsafeTypeAssertion<XmlNode | undefined>(grpSpPr.xfrm);
+  const xfrm = unsafeXmlBoundaryAssertion<XmlNode | undefined>(grpSpPr.xfrm);
   const transform = parseTransform(xfrm);
   if (!transform) return null;
 
-  const childOff = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chOff);
-  const childExt = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chExt);
+  const childOff = unsafeXmlBoundaryAssertion<XmlNode | undefined>(xfrm?.chOff);
+  const childExt = unsafeXmlBoundaryAssertion<XmlNode | undefined>(xfrm?.chExt);
   const childTransform: Transform = {
     offsetX: asEmu(Number(childOff?.["@_x"] ?? 0)),
     offsetY: asEmu(Number(childOff?.["@_y"] ?? 0)),
@@ -785,11 +792,14 @@ function parseGroup(
     orderedChildren,
     fmtScheme,
   );
-  const effects = parseEffectList(unsafeTypeAssertion<XmlNode>(grpSpPr.effectLst), colorResolver);
+  const effects = parseEffectList(
+    unsafeXmlBoundaryAssertion<XmlNode>(grpSpPr.effectLst),
+    colorResolver,
+  );
 
-  const nvGrpSpPr = unsafeTypeAssertion<XmlNode | undefined>(grp.nvGrpSpPr);
-  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvGrpSpPr?.cNvPr);
-  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
+  const nvGrpSpPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(grp.nvGrpSpPr);
+  const cNvPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(nvGrpSpPr?.cNvPr);
+  const altText = unsafeXmlBoundaryAssertion<string | undefined>(cNvPr?.["@_descr"]);
 
   return {
     type: "group",
@@ -809,20 +819,20 @@ function parseGraphicFrame(
   colorResolver: ColorResolver,
   fontScheme?: FontScheme | null,
 ): ChartElement | TableElement | GroupElement | null {
-  const xfrm = unsafeTypeAssertion<XmlNode | undefined>(gf.xfrm);
+  const xfrm = unsafeXmlBoundaryAssertion<XmlNode | undefined>(gf.xfrm);
   const transform = parseTransform(xfrm);
   if (!transform) return null;
 
-  const graphic = unsafeTypeAssertion<XmlNode | undefined>(gf.graphic);
-  const graphicData = unsafeTypeAssertion<XmlNode | undefined>(graphic?.graphicData);
+  const graphic = unsafeXmlBoundaryAssertion<XmlNode | undefined>(gf.graphic);
+  const graphicData = unsafeXmlBoundaryAssertion<XmlNode | undefined>(graphic?.graphicData);
   if (!graphicData) return null;
 
   // Chart
-  const chartRef = unsafeTypeAssertion<XmlNode | undefined>(graphicData.chart);
+  const chartRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(graphicData.chart);
   if (chartRef) {
     const rId =
-      unsafeTypeAssertion<string | undefined>(chartRef["@_r:id"]) ??
-      unsafeTypeAssertion<string | undefined>(chartRef["@_id"]);
+      unsafeXmlBoundaryAssertion<string | undefined>(chartRef["@_r:id"]) ??
+      unsafeXmlBoundaryAssertion<string | undefined>(chartRef["@_id"]);
     if (!rId) return null;
 
     const rel = rels.get(rId);
@@ -839,7 +849,7 @@ function parseGraphicFrame(
   }
 
   // Table
-  const tblNode = unsafeTypeAssertion<XmlNode | undefined>(graphicData.tbl);
+  const tblNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(graphicData.tbl);
   if (tblNode) {
     const tableData = parseTable(tblNode, colorResolver, fontScheme);
     if (!tableData) return null;
@@ -848,7 +858,7 @@ function parseGraphicFrame(
   }
 
   // SmartArt (Diagram) — Transitional and Strict URIs
-  if (SMARTART_DIAGRAM_URIS.has(unsafeTypeAssertion<string>(graphicData["@_uri"]))) {
+  if (SMARTART_DIAGRAM_URIS.has(unsafeXmlBoundaryAssertion<string>(graphicData["@_uri"]))) {
     return parseSmartArt(
       graphicData,
       transform,
@@ -860,7 +870,7 @@ function parseGraphicFrame(
     );
   }
 
-  const uri = unsafeTypeAssertion<string | undefined>(graphicData["@_uri"]) ?? "unknown";
+  const uri = unsafeXmlBoundaryAssertion<string | undefined>(graphicData["@_uri"]) ?? "unknown";
   warn("graphicFrame.unsupported", `unsupported graphicFrame content (uri: ${uri})`);
 
   return null;
@@ -876,13 +886,13 @@ function parseSmartArt(
   fontScheme?: FontScheme | null,
 ): GroupElement | null {
   // dgm:relIds → removeNSPrefix → relIds
-  const relIds = unsafeTypeAssertion<XmlNode | undefined>(graphicData.relIds);
+  const relIds = unsafeXmlBoundaryAssertion<XmlNode | undefined>(graphicData.relIds);
   if (!relIds) return null;
 
   // r:dm 属性 (data model relationship ID)
   const dmRId =
-    unsafeTypeAssertion<string | undefined>(relIds["@_r:dm"]) ??
-    unsafeTypeAssertion<string | undefined>(relIds["@_dm"]);
+    unsafeXmlBoundaryAssertion<string | undefined>(relIds["@_r:dm"]) ??
+    unsafeXmlBoundaryAssertion<string | undefined>(relIds["@_dm"]);
   if (!dmRId) return null;
 
   const dmRel = rels.get(dmRId);
@@ -928,8 +938,8 @@ function parseSmartArt(
   }
 
   const parsed = parseXml(drawingXml);
-  const drawing = unsafeTypeAssertion<XmlNode | undefined>(parsed.drawing);
-  const spTree = unsafeTypeAssertion<XmlNode | undefined>(drawing?.spTree);
+  const drawing = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.drawing);
+  const spTree = unsafeXmlBoundaryAssertion<XmlNode | undefined>(drawing?.spTree);
   if (!spTree) return null;
 
   // drawing XML 用のリレーションシップを取得
@@ -940,10 +950,10 @@ function parseSmartArt(
     : new Map<string, Relationship>();
 
   // grpSpPr から childTransform を取得
-  const grpSpPr = unsafeTypeAssertion<XmlNode | undefined>(spTree.grpSpPr);
-  const grpXfrm = unsafeTypeAssertion<XmlNode | undefined>(grpSpPr?.xfrm);
-  const childOff = unsafeTypeAssertion<XmlNode | undefined>(grpXfrm?.chOff);
-  const childExt = unsafeTypeAssertion<XmlNode | undefined>(grpXfrm?.chExt);
+  const grpSpPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(spTree.grpSpPr);
+  const grpXfrm = unsafeXmlBoundaryAssertion<XmlNode | undefined>(grpSpPr?.xfrm);
+  const childOff = unsafeXmlBoundaryAssertion<XmlNode | undefined>(grpXfrm?.chOff);
+  const childExt = unsafeXmlBoundaryAssertion<XmlNode | undefined>(grpXfrm?.chExt);
   const childTransform: Transform = {
     offsetX: asEmu(Number(childOff?.["@_x"] ?? 0)),
     offsetY: asEmu(Number(childOff?.["@_y"] ?? 0)),
@@ -990,8 +1000,8 @@ function parseSmartArt(
 export function parseTransform(xfrm: XmlNode | undefined): Transform | null {
   if (!xfrm) return null;
 
-  const off = unsafeTypeAssertion<XmlNode | undefined>(xfrm.off);
-  const ext = unsafeTypeAssertion<XmlNode | undefined>(xfrm.ext);
+  const off = unsafeXmlBoundaryAssertion<XmlNode | undefined>(xfrm.off);
+  const ext = unsafeXmlBoundaryAssertion<XmlNode | undefined>(xfrm.ext);
   if (!off || !ext) return null;
 
   let offsetX = asEmu(Number(off["@_x"] ?? 0));
@@ -1034,17 +1044,17 @@ export function parseTransform(xfrm: XmlNode | undefined): Transform | null {
 
 export function parseGeometry(spPr: XmlNode): Geometry {
   if (spPr.prstGeom) {
-    const prstGeom = unsafeTypeAssertion<XmlNode>(spPr.prstGeom);
-    const preset = unsafeTypeAssertion<string | undefined>(prstGeom["@_prst"]) ?? "rect";
-    const avLst = unsafeTypeAssertion<XmlNode | undefined>(prstGeom.avLst);
+    const prstGeom = unsafeXmlBoundaryAssertion<XmlNode>(spPr.prstGeom);
+    const preset = unsafeXmlBoundaryAssertion<string | undefined>(prstGeom["@_prst"]) ?? "rect";
+    const avLst = unsafeXmlBoundaryAssertion<XmlNode | undefined>(prstGeom.avLst);
     const adjustValues: Record<string, number> = {};
 
     if (avLst?.gd) {
       const guides = Array.isArray(avLst.gd) ? avLst.gd : [avLst.gd];
       for (const gd of guides) {
-        const gdNode = unsafeTypeAssertion<XmlNode>(gd);
-        const name = unsafeTypeAssertion<string>(gdNode["@_name"]);
-        const fmla = unsafeTypeAssertion<string>(gdNode["@_fmla"]);
+        const gdNode = unsafeXmlBoundaryAssertion<XmlNode>(gd);
+        const name = unsafeXmlBoundaryAssertion<string>(gdNode["@_name"]);
+        const fmla = unsafeXmlBoundaryAssertion<string>(gdNode["@_fmla"]);
         const match = fmla?.match(/val\s+(\d+)/);
         if (name && match) {
           adjustValues[name] = Number(match[1]);
@@ -1056,7 +1066,7 @@ export function parseGeometry(spPr: XmlNode): Geometry {
   }
 
   if (spPr.custGeom) {
-    const paths = parseCustomGeometry(unsafeTypeAssertion<XmlNode>(spPr.custGeom));
+    const paths = parseCustomGeometry(unsafeXmlBoundaryAssertion<XmlNode>(spPr.custGeom));
     if (paths) {
       return { type: "custom", paths };
     }
@@ -1113,9 +1123,9 @@ function findMatchingPlaceholder(
 function hasMultipleBulletPPr(p: XmlNode, orderedChildren: XmlOrderedNode[]): boolean {
   const rawPPr = p.pPr;
   const pPrList: XmlNode[] = Array.isArray(rawPPr)
-    ? unsafeTypeAssertion<XmlNode[]>(rawPPr)
+    ? unsafeXmlBoundaryAssertion<XmlNode[]>(rawPPr)
     : rawPPr
-      ? [unsafeTypeAssertion<XmlNode>(rawPPr)]
+      ? [unsafeXmlBoundaryAssertion<XmlNode>(rawPPr)]
       : [];
 
   let bulletPPrCount = 0;
@@ -1155,14 +1165,14 @@ function splitInterleavedParagraph(
 ): Paragraph[] {
   const rawPPr = p.pPr;
   const pPrList: XmlNode[] = Array.isArray(rawPPr)
-    ? unsafeTypeAssertion<XmlNode[]>(rawPPr)
+    ? unsafeXmlBoundaryAssertion<XmlNode[]>(rawPPr)
     : rawPPr
-      ? [unsafeTypeAssertion<XmlNode>(rawPPr)]
+      ? [unsafeXmlBoundaryAssertion<XmlNode>(rawPPr)]
       : [];
 
-  const rList: XmlNode[] = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
-  const fldList: XmlNode[] = unsafeTypeAssertion<XmlNode[] | undefined>(p.fld) ?? [];
-  const brList: XmlNode[] = unsafeTypeAssertion<XmlNode[] | undefined>(p.br) ?? [];
+  const rList: XmlNode[] = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.r) ?? [];
+  const fldList: XmlNode[] = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.fld) ?? [];
+  const brList: XmlNode[] = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.br) ?? [];
 
   interface Group {
     pPrIdx: number;
@@ -1285,10 +1295,10 @@ export function parseTextBody(
 ): TextBody | null {
   if (!txBody) return null;
 
-  const bodyPr = unsafeTypeAssertion<XmlNode | undefined>(txBody.bodyPr);
+  const bodyPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(txBody.bodyPr);
 
   const vert =
-    unsafeTypeAssertion<BodyProperties["vert"] | undefined>(bodyPr?.["@_vert"]) ?? "horz";
+    unsafeXmlBoundaryAssertion<BodyProperties["vert"] | undefined>(bodyPr?.["@_vert"]) ?? "horz";
 
   const numCol = bodyPr?.["@_numCol"] ? Math.max(1, Number(bodyPr["@_numCol"])) : 1;
 
@@ -1299,7 +1309,7 @@ export function parseTextBody(
     autoFit = "normAutofit";
     const normAutofit = bodyPr.normAutofit;
     if (typeof normAutofit === "object" && normAutofit !== null) {
-      const normNode = unsafeTypeAssertion<XmlNode>(normAutofit);
+      const normNode = unsafeXmlBoundaryAssertion<XmlNode>(normAutofit);
       fontScale = normNode["@_fontScale"] ? Number(normNode["@_fontScale"]) / 100000 : 1;
       lnSpcReduction = normNode["@_lnSpcReduction"]
         ? Number(normNode["@_lnSpcReduction"]) / 100000
@@ -1310,12 +1320,12 @@ export function parseTextBody(
   }
 
   const bodyProperties: BodyProperties = {
-    anchor: unsafeTypeAssertion<"t" | "ctr" | "b">(bodyPr?.["@_anchor"]) ?? "t",
+    anchor: unsafeXmlBoundaryAssertion<"t" | "ctr" | "b">(bodyPr?.["@_anchor"]) ?? "t",
     marginLeft: asEmu(Number(bodyPr?.["@_lIns"] ?? 91440)),
     marginRight: asEmu(Number(bodyPr?.["@_rIns"] ?? 91440)),
     marginTop: asEmu(Number(bodyPr?.["@_tIns"] ?? 45720)),
     marginBottom: asEmu(Number(bodyPr?.["@_bIns"] ?? 45720)),
-    wrap: unsafeTypeAssertion<"square" | "none">(bodyPr?.["@_wrap"]) ?? "square",
+    wrap: unsafeXmlBoundaryAssertion<"square" | "none">(bodyPr?.["@_wrap"]) ?? "square",
     autoFit,
     fontScale,
     lnSpcReduction,
@@ -1324,20 +1334,20 @@ export function parseTextBody(
   };
 
   const lstStyle =
-    lstStyleOverride ?? parseListStyle(unsafeTypeAssertion<XmlNode>(txBody.lstStyle));
+    lstStyleOverride ?? parseListStyle(unsafeXmlBoundaryAssertion<XmlNode>(txBody.lstStyle));
 
   // ordered data から各段落の ordered children を抽出
   const orderedParagraphs: (XmlOrderedNode[] | undefined)[] = [];
   if (orderedTxBody) {
     for (const child of orderedTxBody) {
       if ("p" in child) {
-        orderedParagraphs.push(unsafeTypeAssertion<XmlOrderedNode[]>(child.p));
+        orderedParagraphs.push(unsafeXmlBoundaryAssertion<XmlOrderedNode[]>(child.p));
       }
     }
   }
 
   const paragraphs: Paragraph[] = [];
-  const pList = unsafeTypeAssertion<XmlNode[] | undefined>(txBody.p) ?? [];
+  const pList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(txBody.p) ?? [];
   for (let i = 0; i < pList.length; i++) {
     const orderedChildren = orderedParagraphs[i];
     // 単一 <a:p> 内に bullet pPr が複数回交互配置されている非標準XMLを検出して分割
@@ -1380,35 +1390,36 @@ const VALID_AUTO_NUM_SCHEMES = new Set([
 function parseBullet(pPr: XmlNode | undefined, colorResolver: ColorResolver) {
   let bullet: BulletType | null = null;
   let bulletFont: string | null = null;
-  const buClr = unsafeTypeAssertion<XmlNode | undefined>(pPr?.buClr);
-  let bulletColor = colorResolver.resolve(unsafeTypeAssertion<XmlNode>(buClr));
+  const buClr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pPr?.buClr);
+  let bulletColor = colorResolver.resolve(unsafeXmlBoundaryAssertion<XmlNode>(buClr));
   if (!buClr) bulletColor = null;
-  const buSzPct = unsafeTypeAssertion<XmlNode | undefined>(pPr?.buSzPct);
+  const buSzPct = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pPr?.buSzPct);
   const bulletSizePct: number | null = buSzPct ? Number(buSzPct["@_val"]) : null;
 
   if (pPr?.buNone !== undefined) {
     bullet = { type: "none" };
   } else if (pPr?.buChar) {
-    const buChar = unsafeTypeAssertion<XmlNode>(pPr.buChar);
+    const buChar = unsafeXmlBoundaryAssertion<XmlNode>(pPr.buChar);
     bullet = {
       type: "char",
-      char: unsafeTypeAssertion<string | undefined>(buChar["@_char"]) ?? "\u2022",
+      char: unsafeXmlBoundaryAssertion<string | undefined>(buChar["@_char"]) ?? "\u2022",
     };
   } else if (pPr?.buAutoNum) {
-    const buAutoNum = unsafeTypeAssertion<XmlNode>(pPr.buAutoNum);
-    const scheme = unsafeTypeAssertion<string | undefined>(buAutoNum["@_type"]) ?? "arabicPeriod";
+    const buAutoNum = unsafeXmlBoundaryAssertion<XmlNode>(pPr.buAutoNum);
+    const scheme =
+      unsafeXmlBoundaryAssertion<string | undefined>(buAutoNum["@_type"]) ?? "arabicPeriod";
     bullet = {
       type: "autoNum",
       scheme: VALID_AUTO_NUM_SCHEMES.has(scheme)
-        ? unsafeTypeAssertion<AutoNumScheme>(scheme)
+        ? unsafeXmlBoundaryAssertion<AutoNumScheme>(scheme)
         : "arabicPeriod",
       startAt: Number(buAutoNum["@_startAt"] ?? 1),
     };
   }
 
   if (pPr?.buFont) {
-    const buFont = unsafeTypeAssertion<XmlNode>(pPr.buFont);
-    bulletFont = unsafeTypeAssertion<string | undefined>(buFont["@_typeface"]) ?? null;
+    const buFont = unsafeXmlBoundaryAssertion<XmlNode>(pPr.buFont);
+    bulletFont = unsafeXmlBoundaryAssertion<string | undefined>(buFont["@_typeface"]) ?? null;
   }
 
   return { bullet, bulletFont, bulletColor, bulletSizePct };
@@ -1416,29 +1427,29 @@ function parseBullet(pPr: XmlNode | undefined, colorResolver: ColorResolver) {
 
 function parseSpacing(spc: XmlNode | undefined): SpacingValue {
   if (spc?.spcPts) {
-    const spcPts = unsafeTypeAssertion<XmlNode>(spc.spcPts);
+    const spcPts = unsafeXmlBoundaryAssertion<XmlNode>(spc.spcPts);
     return { type: "pts", value: asHundredthPt(Number(spcPts["@_val"])) };
   }
   if (spc?.spcPct) {
-    const spcPct = unsafeTypeAssertion<XmlNode>(spc.spcPct);
+    const spcPct = unsafeXmlBoundaryAssertion<XmlNode>(spc.spcPct);
     return { type: "pct", value: Number(spcPct["@_val"]) };
   }
   return { type: "pts", value: asHundredthPt(0) };
 }
 
 function parseTabStops(pPr: XmlNode | undefined): TabStop[] {
-  const tabLst = unsafeTypeAssertion<XmlNode | undefined>(pPr?.tabLst);
+  const tabLst = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pPr?.tabLst);
   if (!tabLst) return [];
 
   const tabs = tabLst.tab;
   if (!tabs) return [];
 
   const tabArr = Array.isArray(tabs)
-    ? unsafeTypeAssertion<XmlNode[]>(tabs)
-    : [unsafeTypeAssertion<XmlNode>(tabs)];
+    ? unsafeXmlBoundaryAssertion<XmlNode[]>(tabs)
+    : [unsafeXmlBoundaryAssertion<XmlNode>(tabs)];
   return tabArr.map((tab) => ({
     position: asEmu(Number(tab["@_pos"] ?? 0)),
-    alignment: unsafeTypeAssertion<TabStop["alignment"]>(tab["@_algn"]) ?? "l",
+    alignment: unsafeXmlBoundaryAssertion<TabStop["alignment"]>(tab["@_algn"]) ?? "l",
   }));
 }
 
@@ -1449,7 +1460,9 @@ function extractMathText(node: XmlNode): string {
     if (key.startsWith("@_")) continue;
     if (key === "t") {
       if (typeof value === "object" && value !== null) {
-        text += unsafeTypeAssertion<string>(unsafeTypeAssertion<XmlNode>(value)["#text"]) ?? "";
+        text +=
+          unsafeXmlBoundaryAssertion<string>(unsafeXmlBoundaryAssertion<XmlNode>(value)["#text"]) ??
+          "";
       } else if (
         typeof value === "string" ||
         typeof value === "number" ||
@@ -1461,7 +1474,7 @@ function extractMathText(node: XmlNode): string {
       const items = Array.isArray(value) ? value : [value];
       for (const item of items) {
         if (typeof item === "object" && item !== null) {
-          text += extractMathText(unsafeTypeAssertion<XmlNode>(item));
+          text += extractMathText(unsafeXmlBoundaryAssertion<XmlNode>(item));
         }
       }
     }
@@ -1472,7 +1485,9 @@ function extractMathText(node: XmlNode): string {
 function extractTextContent(node: XmlNode): string {
   const text = node.t;
   if (typeof text === "object") {
-    return unsafeTypeAssertion<string>(unsafeTypeAssertion<XmlNode>(text)["#text"]) ?? "";
+    return (
+      unsafeXmlBoundaryAssertion<string>(unsafeXmlBoundaryAssertion<XmlNode>(text)["#text"]) ?? ""
+    );
   }
   return typeof text === "string" || typeof text === "number" || typeof text === "boolean"
     ? String(text)
@@ -1487,23 +1502,23 @@ function parseParagraph(
   lstStyle?: DefaultTextStyle,
   orderedPChildren?: XmlOrderedNode[],
 ): Paragraph {
-  const pPr = unsafeTypeAssertion<XmlNode | undefined>(p.pPr);
+  const pPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(p.pPr);
   const level = Number(pPr?.["@_lvl"] ?? 0);
 
   // lstStyle からレベル対応のデフォルト段落プロパティを取得
   const lstLevelProps = lstStyle?.levels[level];
 
   const { bullet, bulletFont, bulletColor, bulletSizePct } = parseBullet(pPr, colorResolver);
-  const lnSpc = unsafeTypeAssertion<XmlNode | undefined>(pPr?.lnSpc);
+  const lnSpc = unsafeXmlBoundaryAssertion<XmlNode | undefined>(pPr?.lnSpc);
   const tabStops = parseTabStops(pPr);
   const properties = {
     alignment:
-      unsafeTypeAssertion<"l" | "ctr" | "r" | "just">(pPr?.["@_algn"]) ??
+      unsafeXmlBoundaryAssertion<"l" | "ctr" | "r" | "just">(pPr?.["@_algn"]) ??
       lstLevelProps?.alignment ??
       null,
     lineSpacing: lnSpc?.spcPts || lnSpc?.spcPct ? parseSpacing(lnSpc) : null,
-    spaceBefore: parseSpacing(unsafeTypeAssertion<XmlNode | undefined>(pPr?.spcBef)),
-    spaceAfter: parseSpacing(unsafeTypeAssertion<XmlNode | undefined>(pPr?.spcAft)),
+    spaceBefore: parseSpacing(unsafeXmlBoundaryAssertion<XmlNode | undefined>(pPr?.spcBef)),
+    spaceAfter: parseSpacing(unsafeXmlBoundaryAssertion<XmlNode | undefined>(pPr?.spcAft)),
     level,
     bullet: bullet ?? lstLevelProps?.bullet ?? null,
     bulletFont: bulletFont ?? lstLevelProps?.bulletFont ?? null,
@@ -1521,7 +1536,7 @@ function parseParagraph(
   };
 
   // defRPr のマージ: pPr.defRPr > lstStyle.lvl.defRPr
-  const pPrDefRPr = parseDefaultRunProperties(unsafeTypeAssertion<XmlNode>(pPr?.defRPr));
+  const pPrDefRPr = parseDefaultRunProperties(unsafeXmlBoundaryAssertion<XmlNode>(pPr?.defRPr));
   const lstDefRPr = lstLevelProps?.defaultRunProperties;
   const mergedDefaults = mergeDefaultRunProperties(pPrDefRPr, lstDefRPr);
 
@@ -1530,9 +1545,9 @@ function parseParagraph(
   if (orderedPChildren) {
     // ordered children があれば、ドキュメント順で r/fld/br を処理
     const tagCounters: Record<string, number> = {};
-    const rList = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
-    const fldList = unsafeTypeAssertion<XmlNode[] | undefined>(p.fld) ?? [];
-    const brList = unsafeTypeAssertion<XmlNode[] | undefined>(p.br) ?? [];
+    const rList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.r) ?? [];
+    const fldList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.fld) ?? [];
+    const brList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.br) ?? [];
 
     for (const child of orderedPChildren) {
       const tag = Object.keys(child).find((k) => k !== ":@");
@@ -1545,7 +1560,7 @@ function parseParagraph(
         const r = rList[idx];
         if (r) {
           const textContent = extractTextContent(r);
-          const rPr = unsafeTypeAssertion<XmlNode | undefined>(r.rPr);
+          const rPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(r.rPr);
           const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
           runs.push({ text: textContent, properties: runProps });
         }
@@ -1553,18 +1568,18 @@ function parseParagraph(
         const fld = fldList[idx];
         if (fld) {
           const textContent = extractTextContent(fld);
-          const rPr = unsafeTypeAssertion<XmlNode | undefined>(fld.rPr);
+          const rPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(fld.rPr);
           const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
           runs.push({ text: textContent, properties: runProps });
         }
       } else if (tag === "br") {
         const br = brList[idx];
-        const rPr = unsafeTypeAssertion<XmlNode | undefined>(br?.rPr);
+        const rPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(br?.rPr);
         const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
         runs.push({ text: "\n", properties: runProps });
       } else if (tag === "m") {
         // 数式テキスト抽出 (a14:m → NS prefix removed → m)
-        const mNode = unsafeTypeAssertion<XmlNode | XmlNode[] | undefined>(p.m);
+        const mNode = unsafeXmlBoundaryAssertion<XmlNode | XmlNode[] | undefined>(p.m);
         if (mNode) {
           const mData = Array.isArray(mNode) ? mNode[idx] : idx === 0 ? mNode : undefined;
           if (mData) {
@@ -1585,33 +1600,33 @@ function parseParagraph(
     }
   } else {
     // フォールバック: ordered data がない場合は r のみ処理し、fld/br を追加
-    const rList = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
+    const rList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.r) ?? [];
     for (const r of rList) {
       const textContent = extractTextContent(r);
-      const rPr = unsafeTypeAssertion<XmlNode | undefined>(r.rPr);
+      const rPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(r.rPr);
       const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
       runs.push({ text: textContent, properties: runProps });
     }
 
     // fld をフォールバック処理（ordered data なしでも最低限表示）
-    const fldList = unsafeTypeAssertion<XmlNode[] | undefined>(p.fld) ?? [];
+    const fldList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.fld) ?? [];
     for (const fld of fldList) {
       const textContent = extractTextContent(fld);
-      const rPr = unsafeTypeAssertion<XmlNode | undefined>(fld.rPr);
+      const rPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(fld.rPr);
       const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
       runs.push({ text: textContent, properties: runProps });
     }
 
     // br をフォールバック処理
-    const brList = unsafeTypeAssertion<XmlNode[] | undefined>(p.br) ?? [];
+    const brList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.br) ?? [];
     for (const _br of brList) {
-      const rPr = unsafeTypeAssertion<XmlNode | undefined>(_br?.rPr);
+      const rPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(_br?.rPr);
       const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
       runs.push({ text: "\n", properties: runProps });
     }
 
     // 数式テキスト抽出
-    const mNode = unsafeTypeAssertion<XmlNode | XmlNode[] | undefined>(p.m);
+    const mNode = unsafeXmlBoundaryAssertion<XmlNode | XmlNode[] | undefined>(p.m);
     if (mNode) {
       const mArr = Array.isArray(mNode) ? mNode : [mNode];
       for (const m of mArr) {
@@ -1631,7 +1646,7 @@ function parseParagraph(
   }
 
   // endParaRPr をパース（空段落の高さ計算に使用）
-  const endParaRPrNode = unsafeTypeAssertion<XmlNode | undefined>(p.endParaRPr);
+  const endParaRPrNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(p.endParaRPr);
   const endParaRunProperties = endParaRPrNode
     ? parseRunProperties(endParaRPrNode, colorResolver, rels, fontScheme, mergedDefaults)
     : undefined;
@@ -1690,23 +1705,29 @@ function parseRunProperties(
     warn("rPr.highlight", "text highlighting not implemented");
   }
 
-  const latin = unsafeTypeAssertion<XmlNode | undefined>(rPr.latin);
-  const ea = unsafeTypeAssertion<XmlNode | undefined>(rPr.ea);
-  const cs = unsafeTypeAssertion<XmlNode | undefined>(rPr.cs);
+  const latin = unsafeXmlBoundaryAssertion<XmlNode | undefined>(rPr.latin);
+  const ea = unsafeXmlBoundaryAssertion<XmlNode | undefined>(rPr.ea);
+  const cs = unsafeXmlBoundaryAssertion<XmlNode | undefined>(rPr.cs);
 
   const fontSize = rPr["@_sz"]
     ? hundredthPointToPoint(asHundredthPt(Number(rPr["@_sz"])))
     : (defaults?.fontSize ?? null);
   const fontFamily = resolveThemeFont(
-    unsafeTypeAssertion<string | undefined>(latin?.["@_typeface"]) ?? defaults?.fontFamily ?? null,
+    unsafeXmlBoundaryAssertion<string | undefined>(latin?.["@_typeface"]) ??
+      defaults?.fontFamily ??
+      null,
     fontScheme,
   );
   const fontFamilyEa = resolveThemeFont(
-    unsafeTypeAssertion<string | undefined>(ea?.["@_typeface"]) ?? defaults?.fontFamilyEa ?? null,
+    unsafeXmlBoundaryAssertion<string | undefined>(ea?.["@_typeface"]) ??
+      defaults?.fontFamilyEa ??
+      null,
     fontScheme,
   );
   const fontFamilyCs = resolveThemeFont(
-    unsafeTypeAssertion<string | undefined>(cs?.["@_typeface"]) ?? defaults?.fontFamilyCs ?? null,
+    unsafeXmlBoundaryAssertion<string | undefined>(cs?.["@_typeface"]) ??
+      defaults?.fontFamilyCs ??
+      null,
     fontScheme,
   );
   const bold =
@@ -1725,13 +1746,16 @@ function parseRunProperties(
       : (defaults?.strikethrough ?? false);
   const baseline = rPr["@_baseline"] ? Number(rPr["@_baseline"]) / 1000 : 0;
 
-  const solidFill = unsafeTypeAssertion<XmlNode | undefined>(rPr.solidFill);
+  const solidFill = unsafeXmlBoundaryAssertion<XmlNode | undefined>(rPr.solidFill);
   let color = colorResolver.resolve(solidFill ?? rPr);
   if (!solidFill && !rPr.srgbClr && !rPr.schemeClr && !rPr.sysClr) {
     color = null;
   }
 
-  const hyperlink = parseHyperlink(unsafeTypeAssertion<XmlNode | undefined>(rPr.hlinkClick), rels);
+  const hyperlink = parseHyperlink(
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(rPr.hlinkClick),
+    rels,
+  );
 
   // Default hyperlink style: theme hlink color + underline
   if (hyperlink) {
@@ -1743,11 +1767,11 @@ function parseRunProperties(
     }
   }
 
-  const ln = unsafeTypeAssertion<XmlNode | undefined>(rPr.ln);
+  const ln = unsafeXmlBoundaryAssertion<XmlNode | undefined>(rPr.ln);
   let outline: TextOutline | null = null;
   if (ln) {
     const lnWidth = asEmu(Number(ln["@_w"] ?? 12700));
-    const lnFill = unsafeTypeAssertion<XmlNode | undefined>(ln.solidFill);
+    const lnFill = unsafeXmlBoundaryAssertion<XmlNode | undefined>(ln.solidFill);
     const lnColor = lnFill ? colorResolver.resolve(lnFill) : null;
     if (lnColor) {
       outline = { width: lnWidth, color: lnColor };
@@ -1777,13 +1801,13 @@ function parseHyperlink(
   if (!hlinkClick) return null;
 
   const rId =
-    unsafeTypeAssertion<string | undefined>(hlinkClick["@_r:id"]) ??
-    unsafeTypeAssertion<string | undefined>(hlinkClick["@_id"]);
+    unsafeXmlBoundaryAssertion<string | undefined>(hlinkClick["@_r:id"]) ??
+    unsafeXmlBoundaryAssertion<string | undefined>(hlinkClick["@_id"]);
   if (!rId || !rels) return null;
 
   const rel = rels.get(rId);
   if (!rel) return null;
 
-  const tooltip = unsafeTypeAssertion<string | undefined>(hlinkClick["@_tooltip"]);
+  const tooltip = unsafeXmlBoundaryAssertion<string | undefined>(hlinkClick["@_tooltip"]);
   return { url: rel.target, ...(tooltip && { tooltip }) };
 }

--- a/packages/core/src/parser/slide-parser.ts
+++ b/packages/core/src/parser/slide-parser.ts
@@ -33,6 +33,7 @@ import { asEmu, asHundredthPt } from "@pptx-glimpse/renderer";
 import { debug, warn } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseBlipEffects } from "./blip-effect-parser.js";
 import { parseChart } from "./chart-parser.js";
 import { parseCustomGeometry } from "./custom-geometry-parser.js";
@@ -72,7 +73,7 @@ export function navigateOrdered(
   for (const key of path) {
     const entry = current.find((item: XmlOrderedNode) => key in item);
     if (!entry) return null;
-    current = entry[key] as XmlOrderedNode[];
+    current = unsafeTypeAssertion<XmlOrderedNode[]>(entry[key]);
     if (!Array.isArray(current)) return null;
   }
   return current;
@@ -89,7 +90,7 @@ export function parseSlide(
   placeholderStyles?: PlaceholderStyleInfo[],
 ): Slide {
   const parsed = parseXml(slideXml);
-  const sld = parsed.sld as XmlNode | undefined;
+  const sld = unsafeTypeAssertion<XmlNode | undefined>(parsed.sld);
   if (!sld) {
     debug("slide.missing", `missing root element "sld" in XML`, `Slide ${slideNumber}`);
   }
@@ -99,15 +100,19 @@ export function parseSlide(
   const rels = relsXml ? parseRelationships(relsXml) : new Map<string, Relationship>();
 
   const fillContext: FillParseContext = { rels, archive, basePath: slidePath };
-  const cSld = (sld?.cSld as XmlNode | undefined) ?? undefined;
-  const background = parseBackground(cSld?.bg as XmlNode | undefined, colorResolver, fillContext);
+  const cSld = unsafeTypeAssertion<XmlNode | undefined>(sld?.cSld) ?? undefined;
+  const background = parseBackground(
+    unsafeTypeAssertion<XmlNode | undefined>(cSld?.bg),
+    colorResolver,
+    fillContext,
+  );
 
   // ordered パーサーで子要素の出現順序を取得（Z-order 保持のため）
   const orderedParsed = parseXmlOrdered(slideXml);
   const orderedSpTree = navigateOrdered(orderedParsed, ["sld", "cSld", "spTree"]);
 
   const elements = parseShapeTree(
-    cSld?.spTree as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(cSld?.spTree),
     rels,
     slidePath,
     archive,
@@ -133,7 +138,7 @@ function parseBackground(
 ): Background | null {
   if (!bgNode) return null;
 
-  const bgPr = bgNode.bgPr as XmlNode | undefined;
+  const bgPr = unsafeTypeAssertion<XmlNode | undefined>(bgNode.bgPr);
   if (!bgPr) return null;
 
   const fill = parseFillFromNode(bgPr, colorResolver, context);
@@ -150,7 +155,7 @@ function mergeChildElements(spTree: XmlNode, source: XmlNode): void {
     }
     const arr = Array.isArray(items) ? items : [items];
     for (const item of arr) {
-      (spTree[tag] as unknown[]).push(item);
+      unsafeTypeAssertion<unknown[]>(spTree[tag]).push(item);
     }
   }
 }
@@ -189,18 +194,19 @@ export function parseShapeTree(
 
   // フォールバック: タイプ別イテレーション（後方互換）
   // mc:AlternateContent の処理: Choice 内の要素を spTree にマージ
-  const alternateContents = (spTree.AlternateContent as XmlNode[] | undefined) ?? [];
+  const alternateContents =
+    unsafeTypeAssertion<XmlNode[] | undefined>(spTree.AlternateContent) ?? [];
   for (const ac of alternateContents) {
     const choices = Array.isArray(ac.Choice) ? ac.Choice : ac.Choice ? [ac.Choice] : [];
     for (const choice of choices) {
-      mergeChildElements(spTree, choice as XmlNode);
+      mergeChildElements(spTree, unsafeTypeAssertion<XmlNode>(choice));
     }
   }
 
   const ctx = context ?? slidePath;
   const elements: SlideElement[] = [];
 
-  const shapes = (spTree.sp as XmlNode[] | undefined) ?? [];
+  const shapes = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.sp) ?? [];
   for (const sp of shapes) {
     const shape = parseShape(
       sp,
@@ -219,7 +225,7 @@ export function parseShapeTree(
     }
   }
 
-  const pics = (spTree.pic as XmlNode[] | undefined) ?? [];
+  const pics = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.pic) ?? [];
   for (const pic of pics) {
     const img = parseImage(pic, rels, slidePath, archive, colorResolver);
     if (img) {
@@ -229,7 +235,7 @@ export function parseShapeTree(
     }
   }
 
-  const cxnSps = (spTree.cxnSp as XmlNode[] | undefined) ?? [];
+  const cxnSps = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.cxnSp) ?? [];
   for (const cxn of cxnSps) {
     const connector = parseConnector(cxn, colorResolver, fmtScheme);
     if (connector) {
@@ -239,7 +245,7 @@ export function parseShapeTree(
     }
   }
 
-  const grpSps = (spTree.grpSp as XmlNode[] | undefined) ?? [];
+  const grpSps = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.grpSp) ?? [];
   for (const grp of grpSps) {
     const group = parseGroup(
       grp,
@@ -259,7 +265,7 @@ export function parseShapeTree(
     }
   }
 
-  const graphicFrames = (spTree.graphicFrame as XmlNode[] | undefined) ?? [];
+  const graphicFrames = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.graphicFrame) ?? [];
   for (const gf of graphicFrames) {
     const chart = parseGraphicFrame(gf, rels, slidePath, archive, colorResolver, fontScheme);
     if (chart) {
@@ -299,7 +305,7 @@ function parseShapeTreeOrdered(
       const acIndex = tagCounters["AlternateContent"] ?? 0;
       tagCounters["AlternateContent"] = acIndex + 1;
 
-      const acList = (spTree.AlternateContent as XmlNode[] | undefined) ?? [];
+      const acList = unsafeTypeAssertion<XmlNode[] | undefined>(spTree.AlternateContent) ?? [];
       const acData = acList[acIndex] as XmlNode | undefined;
       if (!acData) continue;
 
@@ -308,16 +314,20 @@ function parseShapeTreeOrdered(
         : acData.Choice
           ? [acData.Choice]
           : [];
-      const firstChoice = choices[0] as XmlNode | undefined;
+      const firstChoice = unsafeTypeAssertion<XmlNode | undefined>(choices[0]);
       if (!firstChoice) continue;
 
       // ordered 結果から Choice の子要素を取得
-      const acOrderedChildren = child.AlternateContent as XmlOrderedNode[] | undefined;
+      const acOrderedChildren = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(
+        child.AlternateContent,
+      );
 
       const choiceOrdered = Array.isArray(acOrderedChildren)
         ? acOrderedChildren.find((c: XmlOrderedNode) => "Choice" in c)
         : null;
-      const choiceChildren = choiceOrdered?.Choice as XmlOrderedNode[] | undefined;
+      const choiceChildren = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(
+        choiceOrdered?.Choice,
+      );
 
       if (Array.isArray(choiceChildren)) {
         // Choice 内の子要素をドキュメント順で処理
@@ -331,7 +341,7 @@ function parseShapeTreeOrdered(
 
           const items = firstChoice[choiceTag];
           const arr = Array.isArray(items) ? items : items ? [items] : [];
-          const element = arr[choiceIdx] as XmlNode | undefined;
+          const element = unsafeTypeAssertion<XmlNode | undefined>(arr[choiceIdx]);
           if (!element) continue;
 
           parseAndPushElement(
@@ -359,7 +369,7 @@ function parseShapeTreeOrdered(
     const index = tagCounters[tag] ?? 0;
     tagCounters[tag] = index + 1;
 
-    const tagArray = spTree[tag] as XmlNode[] | undefined;
+    const tagArray = unsafeTypeAssertion<XmlNode[] | undefined>(spTree[tag]);
     const element = tagArray?.[index];
     if (!element) continue;
 
@@ -438,7 +448,8 @@ function parseAndPushElement(
     }
     case "grpSp": {
       // ordered 結果からグループの子要素順序を取得
-      const grpOrderedChildren = (orderedNode[tag] as XmlOrderedNode[] | undefined) ?? null;
+      const grpOrderedChildren =
+        unsafeTypeAssertion<XmlOrderedNode[] | undefined>(orderedNode[tag]) ?? null;
       const group = parseGroup(
         element,
         rels,
@@ -486,14 +497,16 @@ function parseShape(
   fmtScheme?: FormatScheme,
   placeholderStyles?: PlaceholderStyleInfo[],
 ): ShapeElement | null {
-  const spPr = sp.spPr as XmlNode | undefined;
+  const spPr = unsafeTypeAssertion<XmlNode | undefined>(sp.spPr);
   const spPrIsObject = spPr != null && typeof spPr === "object";
 
   // プレースホルダー情報を先に抽出（transform フォールバックに必要）
-  const nvSpPr = sp.nvSpPr as XmlNode | undefined;
-  const nvPr = nvSpPr?.nvPr as XmlNode | undefined;
-  const ph = nvPr?.ph as XmlNode | undefined;
-  const placeholderType = ph ? ((ph["@_type"] as string | undefined) ?? "body") : undefined;
+  const nvSpPr = unsafeTypeAssertion<XmlNode | undefined>(sp.nvSpPr);
+  const nvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.nvPr);
+  const ph = unsafeTypeAssertion<XmlNode | undefined>(nvPr?.ph);
+  const placeholderType = ph
+    ? (unsafeTypeAssertion<string | undefined>(ph["@_type"]) ?? "body")
+    : undefined;
   const placeholderIdx = ph?.["@_idx"] !== undefined ? Number(ph["@_idx"]) : undefined;
 
   // spPr が空/未定義の場合、プレースホルダーならコンテキストからフォールバック
@@ -501,7 +514,7 @@ function parseShape(
   let geometry: Geometry;
 
   if (spPrIsObject) {
-    transform = parseTransform(spPr.xfrm as XmlNode | undefined);
+    transform = parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm));
     geometry = parseGeometry(spPr);
   } else {
     geometry = { type: "preset", preset: "rect", adjustValues: {} };
@@ -529,26 +542,32 @@ function parseShape(
   }
 
   // Resolve style references (sp.style) as fallback for direct attributes
-  const styleRef = resolveShapeStyle(sp.style as XmlNode | undefined, fmtScheme, colorResolver);
+  const styleRef = resolveShapeStyle(
+    unsafeTypeAssertion<XmlNode | undefined>(sp.style),
+    fmtScheme,
+    colorResolver,
+  );
 
   const directFill = spPrIsObject ? parseFillFromNode(spPr, colorResolver, fillContext) : null;
   const fill = directFill ?? styleRef?.fill ?? null;
 
-  const directOutline = spPrIsObject ? parseOutline(spPr.ln as XmlNode, colorResolver) : null;
+  const directOutline = spPrIsObject
+    ? parseOutline(unsafeTypeAssertion<XmlNode>(spPr.ln), colorResolver)
+    : null;
   const outline = directOutline ?? styleRef?.outline ?? null;
 
   // ordered ノードから txBody の ordered children を抽出
   let orderedTxBody: XmlOrderedNode[] | undefined;
   if (orderedNode) {
-    const spChildren = orderedNode.sp as XmlOrderedNode[] | undefined;
+    const spChildren = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(orderedNode.sp);
     if (Array.isArray(spChildren)) {
       const txBodyEntry = spChildren.find((c: XmlOrderedNode) => "txBody" in c);
-      orderedTxBody = txBodyEntry?.txBody as XmlOrderedNode[] | undefined;
+      orderedTxBody = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(txBodyEntry?.txBody);
     }
   }
 
   const textBody = parseTextBody(
-    sp.txBody as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(sp.txBody),
     colorResolver,
     rels,
     fontScheme,
@@ -557,13 +576,16 @@ function parseShape(
   );
 
   const directEffects = spPrIsObject
-    ? parseEffectList(spPr.effectLst as XmlNode, colorResolver)
+    ? parseEffectList(unsafeTypeAssertion<XmlNode>(spPr.effectLst), colorResolver)
     : null;
   const effects = directEffects ?? styleRef?.effects ?? null;
 
-  const cNvPr = nvSpPr?.cNvPr as XmlNode | undefined;
-  const altText = cNvPr?.["@_descr"] as string | undefined;
-  const hyperlink = parseHyperlink(cNvPr?.hlinkClick as XmlNode | undefined, rels);
+  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvSpPr?.cNvPr);
+  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
+  const hyperlink = parseHyperlink(
+    unsafeTypeAssertion<XmlNode | undefined>(cNvPr?.hlinkClick),
+    rels,
+  );
 
   return {
     type: "shape",
@@ -587,16 +609,17 @@ function parseImage(
   archive: PptxArchive,
   colorResolver: ColorResolver,
 ): ImageElement | null {
-  const spPr = pic.spPr as XmlNode | undefined;
+  const spPr = unsafeTypeAssertion<XmlNode | undefined>(pic.spPr);
   if (!spPr) return null;
 
-  const transform = parseTransform(spPr.xfrm as XmlNode | undefined);
+  const transform = parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm));
   if (!transform) return null;
 
-  const blipFill = pic.blipFill as XmlNode | undefined;
-  const blip = blipFill?.blip as XmlNode | undefined;
+  const blipFill = unsafeTypeAssertion<XmlNode | undefined>(pic.blipFill);
+  const blip = unsafeTypeAssertion<XmlNode | undefined>(blipFill?.blip);
   const rId =
-    (blip?.["@_r:embed"] as string | undefined) ?? (blip?.["@_embed"] as string | undefined);
+    unsafeTypeAssertion<string | undefined>(blip?.["@_r:embed"]) ??
+    unsafeTypeAssertion<string | undefined>(blip?.["@_embed"]);
   if (!rId) return null;
 
   const rel = rels.get(rId);
@@ -621,15 +644,15 @@ function parseImage(
   };
   const mimeType = mimeMap[ext] ?? "image/png";
   const imageData = uint8ArrayToBase64(mediaData);
-  const effects = parseEffectList(spPr.effectLst as XmlNode, colorResolver);
-  const blipEffects = parseBlipEffects(blip as XmlNode, colorResolver);
-  const srcRect = parseSrcRect(blipFill?.srcRect as XmlNode | undefined);
-  const stretch = parseStretchFillRect(blipFill?.stretch as XmlNode | undefined);
-  const tile = parseTileInfo(blipFill?.tile as XmlNode | undefined);
+  const effects = parseEffectList(unsafeTypeAssertion<XmlNode>(spPr.effectLst), colorResolver);
+  const blipEffects = parseBlipEffects(unsafeTypeAssertion<XmlNode>(blip), colorResolver);
+  const srcRect = parseSrcRect(unsafeTypeAssertion<XmlNode | undefined>(blipFill?.srcRect));
+  const stretch = parseStretchFillRect(unsafeTypeAssertion<XmlNode | undefined>(blipFill?.stretch));
+  const tile = parseTileInfo(unsafeTypeAssertion<XmlNode | undefined>(blipFill?.tile));
 
-  const nvPicPr = pic.nvPicPr as XmlNode | undefined;
-  const cNvPr = nvPicPr?.cNvPr as XmlNode | undefined;
-  const altText = cNvPr?.["@_descr"] as string | undefined;
+  const nvPicPr = unsafeTypeAssertion<XmlNode | undefined>(pic.nvPicPr);
+  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvPicPr?.cNvPr);
+  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
 
   return {
     type: "image",
@@ -657,7 +680,7 @@ function parseSrcRect(node: XmlNode | undefined): SrcRect | null {
 
 function parseStretchFillRect(stretchNode: XmlNode | undefined): StretchFillRect | null {
   if (!stretchNode) return null;
-  const fillRect = stretchNode.fillRect as XmlNode | undefined;
+  const fillRect = unsafeTypeAssertion<XmlNode | undefined>(stretchNode.fillRect);
   if (!fillRect) return null;
   const l = Number(fillRect["@_l"] ?? 0) / 100000;
   const t = Number(fillRect["@_t"] ?? 0) / 100000;
@@ -674,8 +697,8 @@ function parseTileInfo(node: XmlNode | undefined): TileInfo | null {
     ty: asEmu(Number(node["@_ty"] ?? 0)),
     sx: Number(node["@_sx"] ?? 100000) / 100000,
     sy: Number(node["@_sy"] ?? 100000) / 100000,
-    flip: ((node["@_flip"] as string) ?? "none") as TileInfo["flip"],
-    align: (node["@_algn"] as string) ?? "tl",
+    flip: unsafeTypeAssertion<TileInfo["flip"]>(node["@_flip"] ?? "none"),
+    align: unsafeTypeAssertion<string>(node["@_algn"]) ?? "tl",
   };
 }
 
@@ -684,23 +707,30 @@ function parseConnector(
   colorResolver: ColorResolver,
   fmtScheme?: FormatScheme,
 ): ConnectorElement | null {
-  const spPr = cxn.spPr as XmlNode | undefined;
+  const spPr = unsafeTypeAssertion<XmlNode | undefined>(cxn.spPr);
   if (!spPr) return null;
 
-  const transform = parseTransform(spPr.xfrm as XmlNode | undefined);
+  const transform = parseTransform(unsafeTypeAssertion<XmlNode | undefined>(spPr.xfrm));
   if (!transform) return null;
 
   const geometry = parseGeometry(spPr);
 
-  const styleRef = resolveShapeStyle(cxn.style as XmlNode | undefined, fmtScheme, colorResolver);
-  const directOutline = parseOutline(spPr.ln as XmlNode, colorResolver);
+  const styleRef = resolveShapeStyle(
+    unsafeTypeAssertion<XmlNode | undefined>(cxn.style),
+    fmtScheme,
+    colorResolver,
+  );
+  const directOutline = parseOutline(unsafeTypeAssertion<XmlNode>(spPr.ln), colorResolver);
   const outline = directOutline ?? styleRef?.outline ?? null;
-  const directEffects = parseEffectList(spPr.effectLst as XmlNode, colorResolver);
+  const directEffects = parseEffectList(
+    unsafeTypeAssertion<XmlNode>(spPr.effectLst),
+    colorResolver,
+  );
   const effects = directEffects ?? styleRef?.effects ?? null;
 
-  const nvCxnSpPr = cxn.nvCxnSpPr as XmlNode | undefined;
-  const cNvPr = nvCxnSpPr?.cNvPr as XmlNode | undefined;
-  const altText = cNvPr?.["@_descr"] as string | undefined;
+  const nvCxnSpPr = unsafeTypeAssertion<XmlNode | undefined>(cxn.nvCxnSpPr);
+  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvCxnSpPr?.cNvPr);
+  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
 
   return { type: "connector", transform, geometry, outline, effects, ...(altText && { altText }) };
 }
@@ -716,15 +746,15 @@ function parseGroup(
   orderedChildren?: XmlOrderedNode[] | null,
   fmtScheme?: FormatScheme,
 ): GroupElement | null {
-  const grpSpPr = grp.grpSpPr as XmlNode | undefined;
+  const grpSpPr = unsafeTypeAssertion<XmlNode | undefined>(grp.grpSpPr);
   if (!grpSpPr) return null;
 
-  const xfrm = grpSpPr.xfrm as XmlNode | undefined;
+  const xfrm = unsafeTypeAssertion<XmlNode | undefined>(grpSpPr.xfrm);
   const transform = parseTransform(xfrm);
   if (!transform) return null;
 
-  const childOff = xfrm?.chOff as XmlNode | undefined;
-  const childExt = xfrm?.chExt as XmlNode | undefined;
+  const childOff = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chOff);
+  const childExt = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chExt);
   const childTransform: Transform = {
     offsetX: asEmu(Number(childOff?.["@_x"] ?? 0)),
     offsetY: asEmu(Number(childOff?.["@_y"] ?? 0)),
@@ -755,11 +785,11 @@ function parseGroup(
     orderedChildren,
     fmtScheme,
   );
-  const effects = parseEffectList(grpSpPr.effectLst as XmlNode, colorResolver);
+  const effects = parseEffectList(unsafeTypeAssertion<XmlNode>(grpSpPr.effectLst), colorResolver);
 
-  const nvGrpSpPr = grp.nvGrpSpPr as XmlNode | undefined;
-  const cNvPr = nvGrpSpPr?.cNvPr as XmlNode | undefined;
-  const altText = cNvPr?.["@_descr"] as string | undefined;
+  const nvGrpSpPr = unsafeTypeAssertion<XmlNode | undefined>(grp.nvGrpSpPr);
+  const cNvPr = unsafeTypeAssertion<XmlNode | undefined>(nvGrpSpPr?.cNvPr);
+  const altText = unsafeTypeAssertion<string | undefined>(cNvPr?.["@_descr"]);
 
   return {
     type: "group",
@@ -779,19 +809,20 @@ function parseGraphicFrame(
   colorResolver: ColorResolver,
   fontScheme?: FontScheme | null,
 ): ChartElement | TableElement | GroupElement | null {
-  const xfrm = gf.xfrm as XmlNode | undefined;
+  const xfrm = unsafeTypeAssertion<XmlNode | undefined>(gf.xfrm);
   const transform = parseTransform(xfrm);
   if (!transform) return null;
 
-  const graphic = gf.graphic as XmlNode | undefined;
-  const graphicData = graphic?.graphicData as XmlNode | undefined;
+  const graphic = unsafeTypeAssertion<XmlNode | undefined>(gf.graphic);
+  const graphicData = unsafeTypeAssertion<XmlNode | undefined>(graphic?.graphicData);
   if (!graphicData) return null;
 
   // Chart
-  const chartRef = graphicData.chart as XmlNode | undefined;
+  const chartRef = unsafeTypeAssertion<XmlNode | undefined>(graphicData.chart);
   if (chartRef) {
     const rId =
-      (chartRef["@_r:id"] as string | undefined) ?? (chartRef["@_id"] as string | undefined);
+      unsafeTypeAssertion<string | undefined>(chartRef["@_r:id"]) ??
+      unsafeTypeAssertion<string | undefined>(chartRef["@_id"]);
     if (!rId) return null;
 
     const rel = rels.get(rId);
@@ -808,7 +839,7 @@ function parseGraphicFrame(
   }
 
   // Table
-  const tblNode = graphicData.tbl as XmlNode | undefined;
+  const tblNode = unsafeTypeAssertion<XmlNode | undefined>(graphicData.tbl);
   if (tblNode) {
     const tableData = parseTable(tblNode, colorResolver, fontScheme);
     if (!tableData) return null;
@@ -817,7 +848,7 @@ function parseGraphicFrame(
   }
 
   // SmartArt (Diagram) — Transitional and Strict URIs
-  if (SMARTART_DIAGRAM_URIS.has(graphicData["@_uri"] as string)) {
+  if (SMARTART_DIAGRAM_URIS.has(unsafeTypeAssertion<string>(graphicData["@_uri"]))) {
     return parseSmartArt(
       graphicData,
       transform,
@@ -829,7 +860,7 @@ function parseGraphicFrame(
     );
   }
 
-  const uri = (graphicData["@_uri"] as string | undefined) ?? "unknown";
+  const uri = unsafeTypeAssertion<string | undefined>(graphicData["@_uri"]) ?? "unknown";
   warn("graphicFrame.unsupported", `unsupported graphicFrame content (uri: ${uri})`);
 
   return null;
@@ -845,11 +876,13 @@ function parseSmartArt(
   fontScheme?: FontScheme | null,
 ): GroupElement | null {
   // dgm:relIds → removeNSPrefix → relIds
-  const relIds = graphicData.relIds as XmlNode | undefined;
+  const relIds = unsafeTypeAssertion<XmlNode | undefined>(graphicData.relIds);
   if (!relIds) return null;
 
   // r:dm 属性 (data model relationship ID)
-  const dmRId = (relIds["@_r:dm"] as string | undefined) ?? (relIds["@_dm"] as string | undefined);
+  const dmRId =
+    unsafeTypeAssertion<string | undefined>(relIds["@_r:dm"]) ??
+    unsafeTypeAssertion<string | undefined>(relIds["@_dm"]);
   if (!dmRId) return null;
 
   const dmRel = rels.get(dmRId);
@@ -895,8 +928,8 @@ function parseSmartArt(
   }
 
   const parsed = parseXml(drawingXml);
-  const drawing = parsed.drawing as XmlNode | undefined;
-  const spTree = drawing?.spTree as XmlNode | undefined;
+  const drawing = unsafeTypeAssertion<XmlNode | undefined>(parsed.drawing);
+  const spTree = unsafeTypeAssertion<XmlNode | undefined>(drawing?.spTree);
   if (!spTree) return null;
 
   // drawing XML 用のリレーションシップを取得
@@ -907,10 +940,10 @@ function parseSmartArt(
     : new Map<string, Relationship>();
 
   // grpSpPr から childTransform を取得
-  const grpSpPr = spTree.grpSpPr as XmlNode | undefined;
-  const grpXfrm = grpSpPr?.xfrm as XmlNode | undefined;
-  const childOff = grpXfrm?.chOff as XmlNode | undefined;
-  const childExt = grpXfrm?.chExt as XmlNode | undefined;
+  const grpSpPr = unsafeTypeAssertion<XmlNode | undefined>(spTree.grpSpPr);
+  const grpXfrm = unsafeTypeAssertion<XmlNode | undefined>(grpSpPr?.xfrm);
+  const childOff = unsafeTypeAssertion<XmlNode | undefined>(grpXfrm?.chOff);
+  const childExt = unsafeTypeAssertion<XmlNode | undefined>(grpXfrm?.chExt);
   const childTransform: Transform = {
     offsetX: asEmu(Number(childOff?.["@_x"] ?? 0)),
     offsetY: asEmu(Number(childOff?.["@_y"] ?? 0)),
@@ -957,8 +990,8 @@ function parseSmartArt(
 export function parseTransform(xfrm: XmlNode | undefined): Transform | null {
   if (!xfrm) return null;
 
-  const off = xfrm.off as XmlNode | undefined;
-  const ext = xfrm.ext as XmlNode | undefined;
+  const off = unsafeTypeAssertion<XmlNode | undefined>(xfrm.off);
+  const ext = unsafeTypeAssertion<XmlNode | undefined>(xfrm.ext);
   if (!off || !ext) return null;
 
   let offsetX = asEmu(Number(off["@_x"] ?? 0));
@@ -1001,17 +1034,17 @@ export function parseTransform(xfrm: XmlNode | undefined): Transform | null {
 
 export function parseGeometry(spPr: XmlNode): Geometry {
   if (spPr.prstGeom) {
-    const prstGeom = spPr.prstGeom as XmlNode;
-    const preset = (prstGeom["@_prst"] as string | undefined) ?? "rect";
-    const avLst = prstGeom.avLst as XmlNode | undefined;
+    const prstGeom = unsafeTypeAssertion<XmlNode>(spPr.prstGeom);
+    const preset = unsafeTypeAssertion<string | undefined>(prstGeom["@_prst"]) ?? "rect";
+    const avLst = unsafeTypeAssertion<XmlNode | undefined>(prstGeom.avLst);
     const adjustValues: Record<string, number> = {};
 
     if (avLst?.gd) {
       const guides = Array.isArray(avLst.gd) ? avLst.gd : [avLst.gd];
       for (const gd of guides) {
-        const gdNode = gd as XmlNode;
-        const name = gdNode["@_name"] as string;
-        const fmla = gdNode["@_fmla"] as string;
+        const gdNode = unsafeTypeAssertion<XmlNode>(gd);
+        const name = unsafeTypeAssertion<string>(gdNode["@_name"]);
+        const fmla = unsafeTypeAssertion<string>(gdNode["@_fmla"]);
         const match = fmla?.match(/val\s+(\d+)/);
         if (name && match) {
           adjustValues[name] = Number(match[1]);
@@ -1023,7 +1056,7 @@ export function parseGeometry(spPr: XmlNode): Geometry {
   }
 
   if (spPr.custGeom) {
-    const paths = parseCustomGeometry(spPr.custGeom as XmlNode);
+    const paths = parseCustomGeometry(unsafeTypeAssertion<XmlNode>(spPr.custGeom));
     if (paths) {
       return { type: "custom", paths };
     }
@@ -1080,9 +1113,9 @@ function findMatchingPlaceholder(
 function hasMultipleBulletPPr(p: XmlNode, orderedChildren: XmlOrderedNode[]): boolean {
   const rawPPr = p.pPr;
   const pPrList: XmlNode[] = Array.isArray(rawPPr)
-    ? (rawPPr as XmlNode[])
+    ? unsafeTypeAssertion<XmlNode[]>(rawPPr)
     : rawPPr
-      ? [rawPPr as XmlNode]
+      ? [unsafeTypeAssertion<XmlNode>(rawPPr)]
       : [];
 
   let bulletPPrCount = 0;
@@ -1122,14 +1155,14 @@ function splitInterleavedParagraph(
 ): Paragraph[] {
   const rawPPr = p.pPr;
   const pPrList: XmlNode[] = Array.isArray(rawPPr)
-    ? (rawPPr as XmlNode[])
+    ? unsafeTypeAssertion<XmlNode[]>(rawPPr)
     : rawPPr
-      ? [rawPPr as XmlNode]
+      ? [unsafeTypeAssertion<XmlNode>(rawPPr)]
       : [];
 
-  const rList: XmlNode[] = (p.r as XmlNode[] | undefined) ?? [];
-  const fldList: XmlNode[] = (p.fld as XmlNode[] | undefined) ?? [];
-  const brList: XmlNode[] = (p.br as XmlNode[] | undefined) ?? [];
+  const rList: XmlNode[] = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
+  const fldList: XmlNode[] = unsafeTypeAssertion<XmlNode[] | undefined>(p.fld) ?? [];
+  const brList: XmlNode[] = unsafeTypeAssertion<XmlNode[] | undefined>(p.br) ?? [];
 
   interface Group {
     pPrIdx: number;
@@ -1252,9 +1285,10 @@ export function parseTextBody(
 ): TextBody | null {
   if (!txBody) return null;
 
-  const bodyPr = txBody.bodyPr as XmlNode | undefined;
+  const bodyPr = unsafeTypeAssertion<XmlNode | undefined>(txBody.bodyPr);
 
-  const vert = (bodyPr?.["@_vert"] as BodyProperties["vert"] | undefined) ?? "horz";
+  const vert =
+    unsafeTypeAssertion<BodyProperties["vert"] | undefined>(bodyPr?.["@_vert"]) ?? "horz";
 
   const numCol = bodyPr?.["@_numCol"] ? Math.max(1, Number(bodyPr["@_numCol"])) : 1;
 
@@ -1265,7 +1299,7 @@ export function parseTextBody(
     autoFit = "normAutofit";
     const normAutofit = bodyPr.normAutofit;
     if (typeof normAutofit === "object" && normAutofit !== null) {
-      const normNode = normAutofit as XmlNode;
+      const normNode = unsafeTypeAssertion<XmlNode>(normAutofit);
       fontScale = normNode["@_fontScale"] ? Number(normNode["@_fontScale"]) / 100000 : 1;
       lnSpcReduction = normNode["@_lnSpcReduction"]
         ? Number(normNode["@_lnSpcReduction"]) / 100000
@@ -1276,12 +1310,12 @@ export function parseTextBody(
   }
 
   const bodyProperties: BodyProperties = {
-    anchor: (bodyPr?.["@_anchor"] as "t" | "ctr" | "b") ?? "t",
+    anchor: unsafeTypeAssertion<"t" | "ctr" | "b">(bodyPr?.["@_anchor"]) ?? "t",
     marginLeft: asEmu(Number(bodyPr?.["@_lIns"] ?? 91440)),
     marginRight: asEmu(Number(bodyPr?.["@_rIns"] ?? 91440)),
     marginTop: asEmu(Number(bodyPr?.["@_tIns"] ?? 45720)),
     marginBottom: asEmu(Number(bodyPr?.["@_bIns"] ?? 45720)),
-    wrap: (bodyPr?.["@_wrap"] as "square" | "none") ?? "square",
+    wrap: unsafeTypeAssertion<"square" | "none">(bodyPr?.["@_wrap"]) ?? "square",
     autoFit,
     fontScale,
     lnSpcReduction,
@@ -1289,20 +1323,21 @@ export function parseTextBody(
     vert,
   };
 
-  const lstStyle = lstStyleOverride ?? parseListStyle(txBody.lstStyle as XmlNode);
+  const lstStyle =
+    lstStyleOverride ?? parseListStyle(unsafeTypeAssertion<XmlNode>(txBody.lstStyle));
 
   // ordered data から各段落の ordered children を抽出
   const orderedParagraphs: (XmlOrderedNode[] | undefined)[] = [];
   if (orderedTxBody) {
     for (const child of orderedTxBody) {
       if ("p" in child) {
-        orderedParagraphs.push(child.p as XmlOrderedNode[]);
+        orderedParagraphs.push(unsafeTypeAssertion<XmlOrderedNode[]>(child.p));
       }
     }
   }
 
   const paragraphs: Paragraph[] = [];
-  const pList = (txBody.p as XmlNode[] | undefined) ?? [];
+  const pList = unsafeTypeAssertion<XmlNode[] | undefined>(txBody.p) ?? [];
   for (let i = 0; i < pList.length; i++) {
     const orderedChildren = orderedParagraphs[i];
     // 単一 <a:p> 内に bullet pPr が複数回交互配置されている非標準XMLを検出して分割
@@ -1345,30 +1380,35 @@ const VALID_AUTO_NUM_SCHEMES = new Set([
 function parseBullet(pPr: XmlNode | undefined, colorResolver: ColorResolver) {
   let bullet: BulletType | null = null;
   let bulletFont: string | null = null;
-  const buClr = pPr?.buClr as XmlNode | undefined;
-  let bulletColor = colorResolver.resolve(buClr as XmlNode);
+  const buClr = unsafeTypeAssertion<XmlNode | undefined>(pPr?.buClr);
+  let bulletColor = colorResolver.resolve(unsafeTypeAssertion<XmlNode>(buClr));
   if (!buClr) bulletColor = null;
-  const buSzPct = pPr?.buSzPct as XmlNode | undefined;
+  const buSzPct = unsafeTypeAssertion<XmlNode | undefined>(pPr?.buSzPct);
   const bulletSizePct: number | null = buSzPct ? Number(buSzPct["@_val"]) : null;
 
   if (pPr?.buNone !== undefined) {
     bullet = { type: "none" };
   } else if (pPr?.buChar) {
-    const buChar = pPr.buChar as XmlNode;
-    bullet = { type: "char", char: (buChar["@_char"] as string | undefined) ?? "\u2022" };
+    const buChar = unsafeTypeAssertion<XmlNode>(pPr.buChar);
+    bullet = {
+      type: "char",
+      char: unsafeTypeAssertion<string | undefined>(buChar["@_char"]) ?? "\u2022",
+    };
   } else if (pPr?.buAutoNum) {
-    const buAutoNum = pPr.buAutoNum as XmlNode;
-    const scheme = (buAutoNum["@_type"] as string | undefined) ?? "arabicPeriod";
+    const buAutoNum = unsafeTypeAssertion<XmlNode>(pPr.buAutoNum);
+    const scheme = unsafeTypeAssertion<string | undefined>(buAutoNum["@_type"]) ?? "arabicPeriod";
     bullet = {
       type: "autoNum",
-      scheme: VALID_AUTO_NUM_SCHEMES.has(scheme) ? (scheme as AutoNumScheme) : "arabicPeriod",
+      scheme: VALID_AUTO_NUM_SCHEMES.has(scheme)
+        ? unsafeTypeAssertion<AutoNumScheme>(scheme)
+        : "arabicPeriod",
       startAt: Number(buAutoNum["@_startAt"] ?? 1),
     };
   }
 
   if (pPr?.buFont) {
-    const buFont = pPr.buFont as XmlNode;
-    bulletFont = (buFont["@_typeface"] as string | undefined) ?? null;
+    const buFont = unsafeTypeAssertion<XmlNode>(pPr.buFont);
+    bulletFont = unsafeTypeAssertion<string | undefined>(buFont["@_typeface"]) ?? null;
   }
 
   return { bullet, bulletFont, bulletColor, bulletSizePct };
@@ -1376,27 +1416,29 @@ function parseBullet(pPr: XmlNode | undefined, colorResolver: ColorResolver) {
 
 function parseSpacing(spc: XmlNode | undefined): SpacingValue {
   if (spc?.spcPts) {
-    const spcPts = spc.spcPts as XmlNode;
+    const spcPts = unsafeTypeAssertion<XmlNode>(spc.spcPts);
     return { type: "pts", value: asHundredthPt(Number(spcPts["@_val"])) };
   }
   if (spc?.spcPct) {
-    const spcPct = spc.spcPct as XmlNode;
+    const spcPct = unsafeTypeAssertion<XmlNode>(spc.spcPct);
     return { type: "pct", value: Number(spcPct["@_val"]) };
   }
   return { type: "pts", value: asHundredthPt(0) };
 }
 
 function parseTabStops(pPr: XmlNode | undefined): TabStop[] {
-  const tabLst = pPr?.tabLst as XmlNode | undefined;
+  const tabLst = unsafeTypeAssertion<XmlNode | undefined>(pPr?.tabLst);
   if (!tabLst) return [];
 
   const tabs = tabLst.tab;
   if (!tabs) return [];
 
-  const tabArr = Array.isArray(tabs) ? (tabs as XmlNode[]) : [tabs as XmlNode];
+  const tabArr = Array.isArray(tabs)
+    ? unsafeTypeAssertion<XmlNode[]>(tabs)
+    : [unsafeTypeAssertion<XmlNode>(tabs)];
   return tabArr.map((tab) => ({
     position: asEmu(Number(tab["@_pos"] ?? 0)),
-    alignment: (tab["@_algn"] as TabStop["alignment"]) ?? "l",
+    alignment: unsafeTypeAssertion<TabStop["alignment"]>(tab["@_algn"]) ?? "l",
   }));
 }
 
@@ -1407,7 +1449,7 @@ function extractMathText(node: XmlNode): string {
     if (key.startsWith("@_")) continue;
     if (key === "t") {
       if (typeof value === "object" && value !== null) {
-        text += ((value as XmlNode)["#text"] as string) ?? "";
+        text += unsafeTypeAssertion<string>(unsafeTypeAssertion<XmlNode>(value)["#text"]) ?? "";
       } else if (
         typeof value === "string" ||
         typeof value === "number" ||
@@ -1419,7 +1461,7 @@ function extractMathText(node: XmlNode): string {
       const items = Array.isArray(value) ? value : [value];
       for (const item of items) {
         if (typeof item === "object" && item !== null) {
-          text += extractMathText(item as XmlNode);
+          text += extractMathText(unsafeTypeAssertion<XmlNode>(item));
         }
       }
     }
@@ -1430,7 +1472,7 @@ function extractMathText(node: XmlNode): string {
 function extractTextContent(node: XmlNode): string {
   const text = node.t;
   if (typeof text === "object") {
-    return ((text as XmlNode)["#text"] as string) ?? "";
+    return unsafeTypeAssertion<string>(unsafeTypeAssertion<XmlNode>(text)["#text"]) ?? "";
   }
   return typeof text === "string" || typeof text === "number" || typeof text === "boolean"
     ? String(text)
@@ -1445,20 +1487,23 @@ function parseParagraph(
   lstStyle?: DefaultTextStyle,
   orderedPChildren?: XmlOrderedNode[],
 ): Paragraph {
-  const pPr = p.pPr as XmlNode | undefined;
+  const pPr = unsafeTypeAssertion<XmlNode | undefined>(p.pPr);
   const level = Number(pPr?.["@_lvl"] ?? 0);
 
   // lstStyle からレベル対応のデフォルト段落プロパティを取得
   const lstLevelProps = lstStyle?.levels[level];
 
   const { bullet, bulletFont, bulletColor, bulletSizePct } = parseBullet(pPr, colorResolver);
-  const lnSpc = pPr?.lnSpc as XmlNode | undefined;
+  const lnSpc = unsafeTypeAssertion<XmlNode | undefined>(pPr?.lnSpc);
   const tabStops = parseTabStops(pPr);
   const properties = {
-    alignment: (pPr?.["@_algn"] as "l" | "ctr" | "r" | "just") ?? lstLevelProps?.alignment ?? null,
+    alignment:
+      unsafeTypeAssertion<"l" | "ctr" | "r" | "just">(pPr?.["@_algn"]) ??
+      lstLevelProps?.alignment ??
+      null,
     lineSpacing: lnSpc?.spcPts || lnSpc?.spcPct ? parseSpacing(lnSpc) : null,
-    spaceBefore: parseSpacing(pPr?.spcBef as XmlNode | undefined),
-    spaceAfter: parseSpacing(pPr?.spcAft as XmlNode | undefined),
+    spaceBefore: parseSpacing(unsafeTypeAssertion<XmlNode | undefined>(pPr?.spcBef)),
+    spaceAfter: parseSpacing(unsafeTypeAssertion<XmlNode | undefined>(pPr?.spcAft)),
     level,
     bullet: bullet ?? lstLevelProps?.bullet ?? null,
     bulletFont: bulletFont ?? lstLevelProps?.bulletFont ?? null,
@@ -1476,7 +1521,7 @@ function parseParagraph(
   };
 
   // defRPr のマージ: pPr.defRPr > lstStyle.lvl.defRPr
-  const pPrDefRPr = parseDefaultRunProperties(pPr?.defRPr as XmlNode);
+  const pPrDefRPr = parseDefaultRunProperties(unsafeTypeAssertion<XmlNode>(pPr?.defRPr));
   const lstDefRPr = lstLevelProps?.defaultRunProperties;
   const mergedDefaults = mergeDefaultRunProperties(pPrDefRPr, lstDefRPr);
 
@@ -1485,9 +1530,9 @@ function parseParagraph(
   if (orderedPChildren) {
     // ordered children があれば、ドキュメント順で r/fld/br を処理
     const tagCounters: Record<string, number> = {};
-    const rList = (p.r as XmlNode[] | undefined) ?? [];
-    const fldList = (p.fld as XmlNode[] | undefined) ?? [];
-    const brList = (p.br as XmlNode[] | undefined) ?? [];
+    const rList = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
+    const fldList = unsafeTypeAssertion<XmlNode[] | undefined>(p.fld) ?? [];
+    const brList = unsafeTypeAssertion<XmlNode[] | undefined>(p.br) ?? [];
 
     for (const child of orderedPChildren) {
       const tag = Object.keys(child).find((k) => k !== ":@");
@@ -1500,7 +1545,7 @@ function parseParagraph(
         const r = rList[idx];
         if (r) {
           const textContent = extractTextContent(r);
-          const rPr = r.rPr as XmlNode | undefined;
+          const rPr = unsafeTypeAssertion<XmlNode | undefined>(r.rPr);
           const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
           runs.push({ text: textContent, properties: runProps });
         }
@@ -1508,18 +1553,18 @@ function parseParagraph(
         const fld = fldList[idx];
         if (fld) {
           const textContent = extractTextContent(fld);
-          const rPr = fld.rPr as XmlNode | undefined;
+          const rPr = unsafeTypeAssertion<XmlNode | undefined>(fld.rPr);
           const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
           runs.push({ text: textContent, properties: runProps });
         }
       } else if (tag === "br") {
         const br = brList[idx];
-        const rPr = br?.rPr as XmlNode | undefined;
+        const rPr = unsafeTypeAssertion<XmlNode | undefined>(br?.rPr);
         const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
         runs.push({ text: "\n", properties: runProps });
       } else if (tag === "m") {
         // 数式テキスト抽出 (a14:m → NS prefix removed → m)
-        const mNode = p.m as XmlNode | XmlNode[] | undefined;
+        const mNode = unsafeTypeAssertion<XmlNode | XmlNode[] | undefined>(p.m);
         if (mNode) {
           const mData = Array.isArray(mNode) ? mNode[idx] : idx === 0 ? mNode : undefined;
           if (mData) {
@@ -1540,33 +1585,33 @@ function parseParagraph(
     }
   } else {
     // フォールバック: ordered data がない場合は r のみ処理し、fld/br を追加
-    const rList = (p.r as XmlNode[] | undefined) ?? [];
+    const rList = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
     for (const r of rList) {
       const textContent = extractTextContent(r);
-      const rPr = r.rPr as XmlNode | undefined;
+      const rPr = unsafeTypeAssertion<XmlNode | undefined>(r.rPr);
       const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
       runs.push({ text: textContent, properties: runProps });
     }
 
     // fld をフォールバック処理（ordered data なしでも最低限表示）
-    const fldList = (p.fld as XmlNode[] | undefined) ?? [];
+    const fldList = unsafeTypeAssertion<XmlNode[] | undefined>(p.fld) ?? [];
     for (const fld of fldList) {
       const textContent = extractTextContent(fld);
-      const rPr = fld.rPr as XmlNode | undefined;
+      const rPr = unsafeTypeAssertion<XmlNode | undefined>(fld.rPr);
       const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
       runs.push({ text: textContent, properties: runProps });
     }
 
     // br をフォールバック処理
-    const brList = (p.br as XmlNode[] | undefined) ?? [];
+    const brList = unsafeTypeAssertion<XmlNode[] | undefined>(p.br) ?? [];
     for (const _br of brList) {
-      const rPr = _br?.rPr as XmlNode | undefined;
+      const rPr = unsafeTypeAssertion<XmlNode | undefined>(_br?.rPr);
       const runProps = parseRunProperties(rPr, colorResolver, rels, fontScheme, mergedDefaults);
       runs.push({ text: "\n", properties: runProps });
     }
 
     // 数式テキスト抽出
-    const mNode = p.m as XmlNode | XmlNode[] | undefined;
+    const mNode = unsafeTypeAssertion<XmlNode | XmlNode[] | undefined>(p.m);
     if (mNode) {
       const mArr = Array.isArray(mNode) ? mNode : [mNode];
       for (const m of mArr) {
@@ -1586,7 +1631,7 @@ function parseParagraph(
   }
 
   // endParaRPr をパース（空段落の高さ計算に使用）
-  const endParaRPrNode = p.endParaRPr as XmlNode | undefined;
+  const endParaRPrNode = unsafeTypeAssertion<XmlNode | undefined>(p.endParaRPr);
   const endParaRunProperties = endParaRPrNode
     ? parseRunProperties(endParaRPrNode, colorResolver, rels, fontScheme, mergedDefaults)
     : undefined;
@@ -1645,23 +1690,23 @@ function parseRunProperties(
     warn("rPr.highlight", "text highlighting not implemented");
   }
 
-  const latin = rPr.latin as XmlNode | undefined;
-  const ea = rPr.ea as XmlNode | undefined;
-  const cs = rPr.cs as XmlNode | undefined;
+  const latin = unsafeTypeAssertion<XmlNode | undefined>(rPr.latin);
+  const ea = unsafeTypeAssertion<XmlNode | undefined>(rPr.ea);
+  const cs = unsafeTypeAssertion<XmlNode | undefined>(rPr.cs);
 
   const fontSize = rPr["@_sz"]
     ? hundredthPointToPoint(asHundredthPt(Number(rPr["@_sz"])))
     : (defaults?.fontSize ?? null);
   const fontFamily = resolveThemeFont(
-    (latin?.["@_typeface"] as string | undefined) ?? defaults?.fontFamily ?? null,
+    unsafeTypeAssertion<string | undefined>(latin?.["@_typeface"]) ?? defaults?.fontFamily ?? null,
     fontScheme,
   );
   const fontFamilyEa = resolveThemeFont(
-    (ea?.["@_typeface"] as string | undefined) ?? defaults?.fontFamilyEa ?? null,
+    unsafeTypeAssertion<string | undefined>(ea?.["@_typeface"]) ?? defaults?.fontFamilyEa ?? null,
     fontScheme,
   );
   const fontFamilyCs = resolveThemeFont(
-    (cs?.["@_typeface"] as string | undefined) ?? defaults?.fontFamilyCs ?? null,
+    unsafeTypeAssertion<string | undefined>(cs?.["@_typeface"]) ?? defaults?.fontFamilyCs ?? null,
     fontScheme,
   );
   const bold =
@@ -1680,13 +1725,13 @@ function parseRunProperties(
       : (defaults?.strikethrough ?? false);
   const baseline = rPr["@_baseline"] ? Number(rPr["@_baseline"]) / 1000 : 0;
 
-  const solidFill = rPr.solidFill as XmlNode | undefined;
+  const solidFill = unsafeTypeAssertion<XmlNode | undefined>(rPr.solidFill);
   let color = colorResolver.resolve(solidFill ?? rPr);
   if (!solidFill && !rPr.srgbClr && !rPr.schemeClr && !rPr.sysClr) {
     color = null;
   }
 
-  const hyperlink = parseHyperlink(rPr.hlinkClick as XmlNode | undefined, rels);
+  const hyperlink = parseHyperlink(unsafeTypeAssertion<XmlNode | undefined>(rPr.hlinkClick), rels);
 
   // Default hyperlink style: theme hlink color + underline
   if (hyperlink) {
@@ -1698,11 +1743,11 @@ function parseRunProperties(
     }
   }
 
-  const ln = rPr.ln as XmlNode | undefined;
+  const ln = unsafeTypeAssertion<XmlNode | undefined>(rPr.ln);
   let outline: TextOutline | null = null;
   if (ln) {
     const lnWidth = asEmu(Number(ln["@_w"] ?? 12700));
-    const lnFill = ln.solidFill as XmlNode | undefined;
+    const lnFill = unsafeTypeAssertion<XmlNode | undefined>(ln.solidFill);
     const lnColor = lnFill ? colorResolver.resolve(lnFill) : null;
     if (lnColor) {
       outline = { width: lnWidth, color: lnColor };
@@ -1732,12 +1777,13 @@ function parseHyperlink(
   if (!hlinkClick) return null;
 
   const rId =
-    (hlinkClick["@_r:id"] as string | undefined) ?? (hlinkClick["@_id"] as string | undefined);
+    unsafeTypeAssertion<string | undefined>(hlinkClick["@_r:id"]) ??
+    unsafeTypeAssertion<string | undefined>(hlinkClick["@_id"]);
   if (!rId || !rels) return null;
 
   const rel = rels.get(rId);
   if (!rel) return null;
 
-  const tooltip = hlinkClick["@_tooltip"] as string | undefined;
+  const tooltip = unsafeTypeAssertion<string | undefined>(hlinkClick["@_tooltip"]);
   return { url: rel.target, ...(tooltip && { tooltip }) };
 }

--- a/packages/core/src/parser/style-reference-resolver.ts
+++ b/packages/core/src/parser/style-reference-resolver.ts
@@ -5,7 +5,7 @@ import type { Outline } from "@pptx-glimpse/renderer";
 import type { FormatScheme } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 interface ResolvedStyleReference {
@@ -22,10 +22,10 @@ export function resolveShapeStyle(
 ): ResolvedStyleReference | null {
   if (!styleNode || !fmtScheme) return null;
 
-  const fillRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.fillRef);
-  const lnRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.lnRef);
-  const effectRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.effectRef);
-  const fontRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.fontRef);
+  const fillRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(styleNode.fillRef);
+  const lnRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(styleNode.lnRef);
+  const effectRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(styleNode.effectRef);
+  const fontRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(styleNode.fontRef);
 
   const fill = resolveFillRef(fillRef, fmtScheme, colorResolver);
   const outline = resolveLineRef(lnRef, fmtScheme, colorResolver);
@@ -33,7 +33,7 @@ export function resolveShapeStyle(
 
   let fontRefResult: { idx: string; color: ResolvedColor | null } | undefined;
   if (fontRef) {
-    const idx = unsafeTypeAssertion<string | undefined>(fontRef["@_idx"]) ?? "minor";
+    const idx = unsafeXmlBoundaryAssertion<string | undefined>(fontRef["@_idx"]) ?? "minor";
     const color = colorResolver.resolve(fontRef);
     fontRefResult = { idx, color };
   }

--- a/packages/core/src/parser/style-reference-resolver.ts
+++ b/packages/core/src/parser/style-reference-resolver.ts
@@ -5,6 +5,7 @@ import type { Outline } from "@pptx-glimpse/renderer";
 import type { FormatScheme } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 interface ResolvedStyleReference {
@@ -21,10 +22,10 @@ export function resolveShapeStyle(
 ): ResolvedStyleReference | null {
   if (!styleNode || !fmtScheme) return null;
 
-  const fillRef = styleNode.fillRef as XmlNode | undefined;
-  const lnRef = styleNode.lnRef as XmlNode | undefined;
-  const effectRef = styleNode.effectRef as XmlNode | undefined;
-  const fontRef = styleNode.fontRef as XmlNode | undefined;
+  const fillRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.fillRef);
+  const lnRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.lnRef);
+  const effectRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.effectRef);
+  const fontRef = unsafeTypeAssertion<XmlNode | undefined>(styleNode.fontRef);
 
   const fill = resolveFillRef(fillRef, fmtScheme, colorResolver);
   const outline = resolveLineRef(lnRef, fmtScheme, colorResolver);
@@ -32,7 +33,7 @@ export function resolveShapeStyle(
 
   let fontRefResult: { idx: string; color: ResolvedColor | null } | undefined;
   if (fontRef) {
-    const idx = (fontRef["@_idx"] as string | undefined) ?? "minor";
+    const idx = unsafeTypeAssertion<string | undefined>(fontRef["@_idx"]) ?? "minor";
     const color = colorResolver.resolve(fontRef);
     fontRefResult = { idx, color };
   }

--- a/packages/core/src/parser/table-parser.ts
+++ b/packages/core/src/parser/table-parser.ts
@@ -10,7 +10,7 @@ import type { FontScheme } from "@pptx-glimpse/renderer";
 import { asEmu } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseFillFromNode, parseOutline } from "./fill-parser.js";
 import { parseTextBody } from "./slide-parser.js";
 import type { XmlNode } from "./xml-parser.js";
@@ -22,15 +22,15 @@ export function parseTable(
 ): TableData | null {
   if (!tblNode) return null;
 
-  const columns = parseColumns(unsafeTypeAssertion<XmlNode>(tblNode.tblGrid));
+  const columns = parseColumns(unsafeXmlBoundaryAssertion<XmlNode>(tblNode.tblGrid));
   if (columns.length === 0) return null;
 
-  const tblPr = unsafeTypeAssertion<XmlNode | undefined>(tblNode.tblPr);
+  const tblPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(tblNode.tblPr);
   const hasTableStyle = tblPr?.tableStyleId !== undefined;
   const defaultBorders = hasTableStyle ? createDefaultBorders() : null;
 
   const rows = parseRows(
-    unsafeTypeAssertion<XmlNode>(tblNode.tr),
+    unsafeXmlBoundaryAssertion<XmlNode>(tblNode.tr),
     colorResolver,
     fontScheme,
     defaultBorders,
@@ -42,7 +42,7 @@ export function parseTable(
 function parseColumns(tblGrid: XmlNode): TableColumn[] {
   if (!tblGrid) return [];
 
-  const gridCols = unsafeTypeAssertion<XmlNode[] | undefined>(tblGrid.gridCol) ?? [];
+  const gridCols = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(tblGrid.gridCol) ?? [];
   return gridCols.map((col) => ({
     width: asEmu(Number(col["@_w"] ?? 0)),
   }));
@@ -61,7 +61,7 @@ function parseRows(
   for (const tr of trArr) {
     const height = asEmu(Number(tr["@_h"] ?? 0));
     const cells = parseCells(
-      unsafeTypeAssertion<XmlNode>(tr.tc),
+      unsafeXmlBoundaryAssertion<XmlNode>(tr.tc),
       colorResolver,
       fontScheme,
       defaultBorders,
@@ -83,23 +83,23 @@ function parseCells(
   const cells: TableCell[] = [];
   for (const tc of tcArr) {
     const textBody = parseTextBody(
-      unsafeTypeAssertion<XmlNode>(tc.txBody),
+      unsafeXmlBoundaryAssertion<XmlNode>(tc.txBody),
       colorResolver,
       undefined,
       fontScheme,
     );
-    const tcPr = unsafeTypeAssertion<XmlNode | undefined>(tc.tcPr);
+    const tcPr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(tc.tcPr);
     const fill = tcPr ? parseFillFromNode(tcPr, colorResolver) : null;
     const inlineBorders = tcPr ? parseCellBorders(tcPr, colorResolver) : null;
     const borders = inlineBorders ?? defaultBorders ?? null;
     const gridSpan = Number(tc["@_gridSpan"] ?? 1);
     const rowSpan = Number(tc["@_rowSpan"] ?? 1);
     const hMerge =
-      unsafeTypeAssertion<string | undefined>(tcPr?.["@_hMerge"]) === "1" ||
-      unsafeTypeAssertion<string | undefined>(tcPr?.["@_hMerge"]) === "true";
+      unsafeXmlBoundaryAssertion<string | undefined>(tcPr?.["@_hMerge"]) === "1" ||
+      unsafeXmlBoundaryAssertion<string | undefined>(tcPr?.["@_hMerge"]) === "true";
     const vMerge =
-      unsafeTypeAssertion<string | undefined>(tcPr?.["@_vMerge"]) === "1" ||
-      unsafeTypeAssertion<string | undefined>(tcPr?.["@_vMerge"]) === "true";
+      unsafeXmlBoundaryAssertion<string | undefined>(tcPr?.["@_vMerge"]) === "1" ||
+      unsafeXmlBoundaryAssertion<string | undefined>(tcPr?.["@_vMerge"]) === "true";
 
     cells.push({ textBody, fill, borders, gridSpan, rowSpan, hMerge, vMerge });
   }
@@ -107,10 +107,10 @@ function parseCells(
 }
 
 function parseCellBorders(tcPr: XmlNode, colorResolver: ColorResolver): CellBorders | null {
-  const top = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnT), colorResolver);
-  const bottom = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnB), colorResolver);
-  const left = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnL), colorResolver);
-  const right = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnR), colorResolver);
+  const top = parseOutline(unsafeXmlBoundaryAssertion<XmlNode>(tcPr.lnT), colorResolver);
+  const bottom = parseOutline(unsafeXmlBoundaryAssertion<XmlNode>(tcPr.lnB), colorResolver);
+  const left = parseOutline(unsafeXmlBoundaryAssertion<XmlNode>(tcPr.lnL), colorResolver);
+  const right = parseOutline(unsafeXmlBoundaryAssertion<XmlNode>(tcPr.lnR), colorResolver);
 
   for (const border of [top, bottom, left, right]) {
     if (border && !border.fill) {

--- a/packages/core/src/parser/table-parser.ts
+++ b/packages/core/src/parser/table-parser.ts
@@ -10,6 +10,7 @@ import type { FontScheme } from "@pptx-glimpse/renderer";
 import { asEmu } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseFillFromNode, parseOutline } from "./fill-parser.js";
 import { parseTextBody } from "./slide-parser.js";
 import type { XmlNode } from "./xml-parser.js";
@@ -21,14 +22,19 @@ export function parseTable(
 ): TableData | null {
   if (!tblNode) return null;
 
-  const columns = parseColumns(tblNode.tblGrid as XmlNode);
+  const columns = parseColumns(unsafeTypeAssertion<XmlNode>(tblNode.tblGrid));
   if (columns.length === 0) return null;
 
-  const tblPr = tblNode.tblPr as XmlNode | undefined;
+  const tblPr = unsafeTypeAssertion<XmlNode | undefined>(tblNode.tblPr);
   const hasTableStyle = tblPr?.tableStyleId !== undefined;
   const defaultBorders = hasTableStyle ? createDefaultBorders() : null;
 
-  const rows = parseRows(tblNode.tr as XmlNode, colorResolver, fontScheme, defaultBorders);
+  const rows = parseRows(
+    unsafeTypeAssertion<XmlNode>(tblNode.tr),
+    colorResolver,
+    fontScheme,
+    defaultBorders,
+  );
 
   return { rows, columns };
 }
@@ -36,7 +42,7 @@ export function parseTable(
 function parseColumns(tblGrid: XmlNode): TableColumn[] {
   if (!tblGrid) return [];
 
-  const gridCols = (tblGrid.gridCol as XmlNode[] | undefined) ?? [];
+  const gridCols = unsafeTypeAssertion<XmlNode[] | undefined>(tblGrid.gridCol) ?? [];
   return gridCols.map((col) => ({
     width: asEmu(Number(col["@_w"] ?? 0)),
   }));
@@ -54,7 +60,12 @@ function parseRows(
   const rows: TableRow[] = [];
   for (const tr of trArr) {
     const height = asEmu(Number(tr["@_h"] ?? 0));
-    const cells = parseCells(tr.tc as XmlNode, colorResolver, fontScheme, defaultBorders);
+    const cells = parseCells(
+      unsafeTypeAssertion<XmlNode>(tr.tc),
+      colorResolver,
+      fontScheme,
+      defaultBorders,
+    );
     rows.push({ height, cells });
   }
   return rows;
@@ -71,19 +82,24 @@ function parseCells(
   const tcArr = Array.isArray(tcList) ? (tcList as XmlNode[]) : [tcList];
   const cells: TableCell[] = [];
   for (const tc of tcArr) {
-    const textBody = parseTextBody(tc.txBody as XmlNode, colorResolver, undefined, fontScheme);
-    const tcPr = tc.tcPr as XmlNode | undefined;
+    const textBody = parseTextBody(
+      unsafeTypeAssertion<XmlNode>(tc.txBody),
+      colorResolver,
+      undefined,
+      fontScheme,
+    );
+    const tcPr = unsafeTypeAssertion<XmlNode | undefined>(tc.tcPr);
     const fill = tcPr ? parseFillFromNode(tcPr, colorResolver) : null;
     const inlineBorders = tcPr ? parseCellBorders(tcPr, colorResolver) : null;
     const borders = inlineBorders ?? defaultBorders ?? null;
     const gridSpan = Number(tc["@_gridSpan"] ?? 1);
     const rowSpan = Number(tc["@_rowSpan"] ?? 1);
     const hMerge =
-      (tcPr?.["@_hMerge"] as string | undefined) === "1" ||
-      (tcPr?.["@_hMerge"] as string | undefined) === "true";
+      unsafeTypeAssertion<string | undefined>(tcPr?.["@_hMerge"]) === "1" ||
+      unsafeTypeAssertion<string | undefined>(tcPr?.["@_hMerge"]) === "true";
     const vMerge =
-      (tcPr?.["@_vMerge"] as string | undefined) === "1" ||
-      (tcPr?.["@_vMerge"] as string | undefined) === "true";
+      unsafeTypeAssertion<string | undefined>(tcPr?.["@_vMerge"]) === "1" ||
+      unsafeTypeAssertion<string | undefined>(tcPr?.["@_vMerge"]) === "true";
 
     cells.push({ textBody, fill, borders, gridSpan, rowSpan, hMerge, vMerge });
   }
@@ -91,10 +107,10 @@ function parseCells(
 }
 
 function parseCellBorders(tcPr: XmlNode, colorResolver: ColorResolver): CellBorders | null {
-  const top = parseOutline(tcPr.lnT as XmlNode, colorResolver);
-  const bottom = parseOutline(tcPr.lnB as XmlNode, colorResolver);
-  const left = parseOutline(tcPr.lnL as XmlNode, colorResolver);
-  const right = parseOutline(tcPr.lnR as XmlNode, colorResolver);
+  const top = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnT), colorResolver);
+  const bottom = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnB), colorResolver);
+  const left = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnL), colorResolver);
+  const right = parseOutline(unsafeTypeAssertion<XmlNode>(tcPr.lnR), colorResolver);
 
   for (const border of [top, bottom, left, right]) {
     if (border && !border.fill) {

--- a/packages/core/src/parser/text-style-parser.ts
+++ b/packages/core/src/parser/text-style-parser.ts
@@ -9,7 +9,7 @@ import { hundredthPointToPoint } from "@pptx-glimpse/renderer";
 import { asEmu, asHundredthPt } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 export function parseDefaultRunProperties(
@@ -23,17 +23,17 @@ export function parseDefaultRunProperties(
   if (defRPr["@_sz"] !== undefined) {
     result.fontSize = hundredthPointToPoint(asHundredthPt(Number(defRPr["@_sz"])));
   }
-  const latin = unsafeTypeAssertion<XmlNode | undefined>(defRPr.latin);
+  const latin = unsafeXmlBoundaryAssertion<XmlNode | undefined>(defRPr.latin);
   if (latin?.["@_typeface"] !== undefined) {
-    result.fontFamily = unsafeTypeAssertion<string>(latin["@_typeface"]);
+    result.fontFamily = unsafeXmlBoundaryAssertion<string>(latin["@_typeface"]);
   }
-  const ea = unsafeTypeAssertion<XmlNode | undefined>(defRPr.ea);
+  const ea = unsafeXmlBoundaryAssertion<XmlNode | undefined>(defRPr.ea);
   if (ea?.["@_typeface"] !== undefined) {
-    result.fontFamilyEa = unsafeTypeAssertion<string>(ea["@_typeface"]);
+    result.fontFamilyEa = unsafeXmlBoundaryAssertion<string>(ea["@_typeface"]);
   }
-  const cs = unsafeTypeAssertion<XmlNode | undefined>(defRPr.cs);
+  const cs = unsafeXmlBoundaryAssertion<XmlNode | undefined>(defRPr.cs);
   if (cs?.["@_typeface"] !== undefined) {
-    result.fontFamilyCs = unsafeTypeAssertion<string>(cs["@_typeface"]);
+    result.fontFamilyCs = unsafeXmlBoundaryAssertion<string>(cs["@_typeface"]);
   }
   if (defRPr["@_b"] !== undefined) {
     result.bold = defRPr["@_b"] === "1" || defRPr["@_b"] === "true";
@@ -49,7 +49,7 @@ export function parseDefaultRunProperties(
   }
 
   if (colorResolver) {
-    const solidFill = unsafeTypeAssertion<XmlNode | undefined>(defRPr.solidFill);
+    const solidFill = unsafeXmlBoundaryAssertion<XmlNode | undefined>(defRPr.solidFill);
     if (solidFill) {
       const color = colorResolver.resolve(solidFill);
       if (color) {
@@ -82,7 +82,7 @@ export function parseParagraphLevelProperties(
   const result: DefaultParagraphLevelProperties = {};
 
   if (node["@_algn"] !== undefined) {
-    result.alignment = unsafeTypeAssertion<"l" | "ctr" | "r" | "just">(node["@_algn"]);
+    result.alignment = unsafeXmlBoundaryAssertion<"l" | "ctr" | "r" | "just">(node["@_algn"]);
   }
   if (node["@_marL"] !== undefined) {
     result.marginLeft = asEmu(Number(node["@_marL"]));
@@ -95,41 +95,42 @@ export function parseParagraphLevelProperties(
   if (node.buNone !== undefined) {
     result.bullet = { type: "none" };
   } else if (node.buChar) {
-    const buChar = unsafeTypeAssertion<XmlNode>(node.buChar);
+    const buChar = unsafeXmlBoundaryAssertion<XmlNode>(node.buChar);
     result.bullet = {
       type: "char",
-      char: unsafeTypeAssertion<string | undefined>(buChar["@_char"]) ?? "\u2022",
+      char: unsafeXmlBoundaryAssertion<string | undefined>(buChar["@_char"]) ?? "\u2022",
     };
   } else if (node.buAutoNum) {
-    const buAutoNum = unsafeTypeAssertion<XmlNode>(node.buAutoNum);
-    const scheme = unsafeTypeAssertion<string | undefined>(buAutoNum["@_type"]) ?? "arabicPeriod";
+    const buAutoNum = unsafeXmlBoundaryAssertion<XmlNode>(node.buAutoNum);
+    const scheme =
+      unsafeXmlBoundaryAssertion<string | undefined>(buAutoNum["@_type"]) ?? "arabicPeriod";
     result.bullet = {
       type: "autoNum",
       scheme: VALID_AUTO_NUM_SCHEMES.has(scheme)
-        ? unsafeTypeAssertion<AutoNumScheme>(scheme)
+        ? unsafeXmlBoundaryAssertion<AutoNumScheme>(scheme)
         : "arabicPeriod",
       startAt: Number(buAutoNum["@_startAt"] ?? 1),
     };
   }
   if (node.buFont) {
-    const buFont = unsafeTypeAssertion<XmlNode>(node.buFont);
-    const typeface = unsafeTypeAssertion<string | undefined>(buFont["@_typeface"]) ?? null;
+    const buFont = unsafeXmlBoundaryAssertion<XmlNode>(node.buFont);
+    const typeface = unsafeXmlBoundaryAssertion<string | undefined>(buFont["@_typeface"]) ?? null;
     if (typeface) result.bulletFont = typeface;
   }
   if (colorResolver) {
-    const buClr = unsafeTypeAssertion<XmlNode | undefined>(node.buClr);
+    const buClr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.buClr);
     if (buClr) {
       const color = colorResolver.resolve(buClr);
       if (color) result.bulletColor = color;
     }
   }
-  const buSzPct = unsafeTypeAssertion<XmlNode | undefined>(node.buSzPct);
+  const buSzPct = unsafeXmlBoundaryAssertion<XmlNode | undefined>(node.buSzPct);
   if (buSzPct) {
     result.bulletSizePct = Number(buSzPct["@_val"]);
   }
 
   const defRPr = parseDefaultRunProperties(
-    unsafeTypeAssertion<XmlNode>(node.defRPr),
+    unsafeXmlBoundaryAssertion<XmlNode>(node.defRPr),
     colorResolver,
   );
   if (defRPr) {
@@ -150,7 +151,7 @@ export function parseListStyle(
   if (!node) return undefined;
 
   const defaultParagraph = parseParagraphLevelProperties(
-    unsafeTypeAssertion<XmlNode>(node.defPPr),
+    unsafeXmlBoundaryAssertion<XmlNode>(node.defPPr),
     colorResolver,
   );
 
@@ -158,7 +159,7 @@ export function parseListStyle(
   for (let i = 1; i <= 9; i++) {
     levels.push(
       parseParagraphLevelProperties(
-        unsafeTypeAssertion<XmlNode>(node[`lvl${i}pPr`]),
+        unsafeXmlBoundaryAssertion<XmlNode>(node[`lvl${i}pPr`]),
         colorResolver,
       ),
     );

--- a/packages/core/src/parser/text-style-parser.ts
+++ b/packages/core/src/parser/text-style-parser.ts
@@ -9,6 +9,7 @@ import { hundredthPointToPoint } from "@pptx-glimpse/renderer";
 import { asEmu, asHundredthPt } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { XmlNode } from "./xml-parser.js";
 
 export function parseDefaultRunProperties(
@@ -22,17 +23,17 @@ export function parseDefaultRunProperties(
   if (defRPr["@_sz"] !== undefined) {
     result.fontSize = hundredthPointToPoint(asHundredthPt(Number(defRPr["@_sz"])));
   }
-  const latin = defRPr.latin as XmlNode | undefined;
+  const latin = unsafeTypeAssertion<XmlNode | undefined>(defRPr.latin);
   if (latin?.["@_typeface"] !== undefined) {
-    result.fontFamily = latin["@_typeface"] as string;
+    result.fontFamily = unsafeTypeAssertion<string>(latin["@_typeface"]);
   }
-  const ea = defRPr.ea as XmlNode | undefined;
+  const ea = unsafeTypeAssertion<XmlNode | undefined>(defRPr.ea);
   if (ea?.["@_typeface"] !== undefined) {
-    result.fontFamilyEa = ea["@_typeface"] as string;
+    result.fontFamilyEa = unsafeTypeAssertion<string>(ea["@_typeface"]);
   }
-  const cs = defRPr.cs as XmlNode | undefined;
+  const cs = unsafeTypeAssertion<XmlNode | undefined>(defRPr.cs);
   if (cs?.["@_typeface"] !== undefined) {
-    result.fontFamilyCs = cs["@_typeface"] as string;
+    result.fontFamilyCs = unsafeTypeAssertion<string>(cs["@_typeface"]);
   }
   if (defRPr["@_b"] !== undefined) {
     result.bold = defRPr["@_b"] === "1" || defRPr["@_b"] === "true";
@@ -48,7 +49,7 @@ export function parseDefaultRunProperties(
   }
 
   if (colorResolver) {
-    const solidFill = defRPr.solidFill as XmlNode | undefined;
+    const solidFill = unsafeTypeAssertion<XmlNode | undefined>(defRPr.solidFill);
     if (solidFill) {
       const color = colorResolver.resolve(solidFill);
       if (color) {
@@ -81,7 +82,7 @@ export function parseParagraphLevelProperties(
   const result: DefaultParagraphLevelProperties = {};
 
   if (node["@_algn"] !== undefined) {
-    result.alignment = node["@_algn"] as "l" | "ctr" | "r" | "just";
+    result.alignment = unsafeTypeAssertion<"l" | "ctr" | "r" | "just">(node["@_algn"]);
   }
   if (node["@_marL"] !== undefined) {
     result.marginLeft = asEmu(Number(node["@_marL"]));
@@ -94,35 +95,43 @@ export function parseParagraphLevelProperties(
   if (node.buNone !== undefined) {
     result.bullet = { type: "none" };
   } else if (node.buChar) {
-    const buChar = node.buChar as XmlNode;
-    result.bullet = { type: "char", char: (buChar["@_char"] as string | undefined) ?? "\u2022" };
+    const buChar = unsafeTypeAssertion<XmlNode>(node.buChar);
+    result.bullet = {
+      type: "char",
+      char: unsafeTypeAssertion<string | undefined>(buChar["@_char"]) ?? "\u2022",
+    };
   } else if (node.buAutoNum) {
-    const buAutoNum = node.buAutoNum as XmlNode;
-    const scheme = (buAutoNum["@_type"] as string | undefined) ?? "arabicPeriod";
+    const buAutoNum = unsafeTypeAssertion<XmlNode>(node.buAutoNum);
+    const scheme = unsafeTypeAssertion<string | undefined>(buAutoNum["@_type"]) ?? "arabicPeriod";
     result.bullet = {
       type: "autoNum",
-      scheme: VALID_AUTO_NUM_SCHEMES.has(scheme) ? (scheme as AutoNumScheme) : "arabicPeriod",
+      scheme: VALID_AUTO_NUM_SCHEMES.has(scheme)
+        ? unsafeTypeAssertion<AutoNumScheme>(scheme)
+        : "arabicPeriod",
       startAt: Number(buAutoNum["@_startAt"] ?? 1),
     };
   }
   if (node.buFont) {
-    const buFont = node.buFont as XmlNode;
-    const typeface = (buFont["@_typeface"] as string | undefined) ?? null;
+    const buFont = unsafeTypeAssertion<XmlNode>(node.buFont);
+    const typeface = unsafeTypeAssertion<string | undefined>(buFont["@_typeface"]) ?? null;
     if (typeface) result.bulletFont = typeface;
   }
   if (colorResolver) {
-    const buClr = node.buClr as XmlNode | undefined;
+    const buClr = unsafeTypeAssertion<XmlNode | undefined>(node.buClr);
     if (buClr) {
       const color = colorResolver.resolve(buClr);
       if (color) result.bulletColor = color;
     }
   }
-  const buSzPct = node.buSzPct as XmlNode | undefined;
+  const buSzPct = unsafeTypeAssertion<XmlNode | undefined>(node.buSzPct);
   if (buSzPct) {
     result.bulletSizePct = Number(buSzPct["@_val"]);
   }
 
-  const defRPr = parseDefaultRunProperties(node.defRPr as XmlNode, colorResolver);
+  const defRPr = parseDefaultRunProperties(
+    unsafeTypeAssertion<XmlNode>(node.defRPr),
+    colorResolver,
+  );
   if (defRPr) {
     result.defaultRunProperties = defRPr;
   }
@@ -140,11 +149,19 @@ export function parseListStyle(
 ): DefaultTextStyle | undefined {
   if (!node) return undefined;
 
-  const defaultParagraph = parseParagraphLevelProperties(node.defPPr as XmlNode, colorResolver);
+  const defaultParagraph = parseParagraphLevelProperties(
+    unsafeTypeAssertion<XmlNode>(node.defPPr),
+    colorResolver,
+  );
 
   const levels: (DefaultParagraphLevelProperties | undefined)[] = [];
   for (let i = 1; i <= 9; i++) {
-    levels.push(parseParagraphLevelProperties(node[`lvl${i}pPr`] as XmlNode, colorResolver));
+    levels.push(
+      parseParagraphLevelProperties(
+        unsafeTypeAssertion<XmlNode>(node[`lvl${i}pPr`]),
+        colorResolver,
+      ),
+    );
   }
 
   // すべてのレベルが undefined で defaultParagraph もなければ undefined を返す

--- a/packages/core/src/parser/theme-parser.ts
+++ b/packages/core/src/parser/theme-parser.ts
@@ -5,7 +5,7 @@ import type { ColorScheme, FontScheme, FormatScheme, Theme } from "@pptx-glimpse
 import { debug } from "@pptx-glimpse/renderer";
 
 import { ColorResolver } from "../color/color-resolver.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseEffectList } from "./effect-parser.js";
 import { parseFillFromNode, parseOutline } from "./fill-parser.js";
 import { parseXml, parseXmlOrdered, type XmlNode, type XmlOrderedNode } from "./xml-parser.js";
@@ -30,8 +30,8 @@ export function parseTheme(xml: string): Theme {
     };
   }
 
-  const themeElements = unsafeTypeAssertion<XmlNode | undefined>(
-    unsafeTypeAssertion<XmlNode>(parsed.theme).themeElements,
+  const themeElements = unsafeXmlBoundaryAssertion<XmlNode | undefined>(
+    unsafeXmlBoundaryAssertion<XmlNode>(parsed.theme).themeElements,
   );
   if (!themeElements) {
     debug("theme.themeElements", "themeElements not found, using defaults");
@@ -57,11 +57,13 @@ export function parseTheme(xml: string): Theme {
     debug("theme.fontScheme", "fontScheme not found, using defaults");
   }
 
-  const colorScheme = parseColorScheme(unsafeTypeAssertion<XmlNode>(themeElements.clrScheme));
-  const fontScheme = parseFontScheme(unsafeTypeAssertion<XmlNode>(themeElements.fontScheme));
+  const colorScheme = parseColorScheme(
+    unsafeXmlBoundaryAssertion<XmlNode>(themeElements.clrScheme),
+  );
+  const fontScheme = parseFontScheme(unsafeXmlBoundaryAssertion<XmlNode>(themeElements.fontScheme));
 
   const fmtScheme = parseFmtScheme(
-    unsafeTypeAssertion<XmlNode | undefined>(themeElements.fmtScheme),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(themeElements.fmtScheme),
     colorScheme,
     xml,
   );
@@ -73,31 +75,31 @@ function parseColorScheme(clrScheme: XmlNode): ColorScheme {
   if (!clrScheme) return defaultColorScheme();
 
   return {
-    dk1: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.dk1)),
-    lt1: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.lt1)),
-    dk2: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.dk2)),
-    lt2: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.lt2)),
-    accent1: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent1)),
-    accent2: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent2)),
-    accent3: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent3)),
-    accent4: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent4)),
-    accent5: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent5)),
-    accent6: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent6)),
-    hlink: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.hlink)),
-    folHlink: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.folHlink)),
+    dk1: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.dk1)),
+    lt1: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.lt1)),
+    dk2: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.dk2)),
+    lt2: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.lt2)),
+    accent1: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.accent1)),
+    accent2: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.accent2)),
+    accent3: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.accent3)),
+    accent4: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.accent4)),
+    accent5: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.accent5)),
+    accent6: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.accent6)),
+    hlink: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.hlink)),
+    folHlink: extractColor(unsafeXmlBoundaryAssertion<XmlNode>(clrScheme.folHlink)),
   };
 }
 
 function extractColor(colorNode: XmlNode): string {
   if (!colorNode) return "#000000";
 
-  const srgbClr = unsafeTypeAssertion<XmlNode | undefined>(colorNode.srgbClr);
+  const srgbClr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(colorNode.srgbClr);
   if (srgbClr) {
-    return `#${unsafeTypeAssertion<string>(srgbClr["@_val"])}`;
+    return `#${unsafeXmlBoundaryAssertion<string>(srgbClr["@_val"])}`;
   }
-  const sysClr = unsafeTypeAssertion<XmlNode | undefined>(colorNode.sysClr);
+  const sysClr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(colorNode.sysClr);
   if (sysClr) {
-    return `#${unsafeTypeAssertion<string | undefined>(sysClr["@_lastClr"]) ?? "000000"}`;
+    return `#${unsafeXmlBoundaryAssertion<string | undefined>(sysClr["@_lastClr"]) ?? "000000"}`;
   }
   return "#000000";
 }
@@ -115,25 +117,25 @@ function parseFontScheme(fontScheme: XmlNode): FontScheme {
       minorFontJpan: null,
     };
 
-  const majorFontNode = unsafeTypeAssertion<XmlNode | undefined>(fontScheme.majorFont);
-  const minorFontNode = unsafeTypeAssertion<XmlNode | undefined>(fontScheme.minorFont);
+  const majorFontNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(fontScheme.majorFont);
+  const minorFontNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(fontScheme.minorFont);
   const majorFont =
-    unsafeTypeAssertion<string | undefined>(
-      unsafeTypeAssertion<XmlNode | undefined>(majorFontNode?.latin)?.["@_typeface"],
+    unsafeXmlBoundaryAssertion<string | undefined>(
+      unsafeXmlBoundaryAssertion<XmlNode | undefined>(majorFontNode?.latin)?.["@_typeface"],
     ) ?? "Calibri";
   const minorFont =
-    unsafeTypeAssertion<string | undefined>(
-      unsafeTypeAssertion<XmlNode | undefined>(minorFontNode?.latin)?.["@_typeface"],
+    unsafeXmlBoundaryAssertion<string | undefined>(
+      unsafeXmlBoundaryAssertion<XmlNode | undefined>(minorFontNode?.latin)?.["@_typeface"],
     ) ?? "Calibri";
   const majorFontEa = resolveEaFont(majorFontNode);
   const minorFontEa = resolveEaFont(minorFontNode);
   const majorFontCs =
-    unsafeTypeAssertion<string | undefined>(
-      unsafeTypeAssertion<XmlNode | undefined>(majorFontNode?.cs)?.["@_typeface"],
+    unsafeXmlBoundaryAssertion<string | undefined>(
+      unsafeXmlBoundaryAssertion<XmlNode | undefined>(majorFontNode?.cs)?.["@_typeface"],
     ) ?? null;
   const minorFontCs =
-    unsafeTypeAssertion<string | undefined>(
-      unsafeTypeAssertion<XmlNode | undefined>(minorFontNode?.cs)?.["@_typeface"],
+    unsafeXmlBoundaryAssertion<string | undefined>(
+      unsafeXmlBoundaryAssertion<XmlNode | undefined>(minorFontNode?.cs)?.["@_typeface"],
     ) ?? null;
   const majorFontJpan = findScriptFont(majorFontNode, "Jpan");
   const minorFontJpan = findScriptFont(minorFontNode, "Jpan");
@@ -154,8 +156,8 @@ function parseFontScheme(fontScheme: XmlNode): FontScheme {
  * ea タグの typeface を取得し、空文字の場合は script="Jpan" のフォントにフォールバックする。
  */
 function resolveEaFont(fontNode: XmlNode | undefined): string | null {
-  const eaTypeface = unsafeTypeAssertion<string | undefined>(
-    unsafeTypeAssertion<XmlNode | undefined>(fontNode?.ea)?.["@_typeface"],
+  const eaTypeface = unsafeXmlBoundaryAssertion<string | undefined>(
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(fontNode?.ea)?.["@_typeface"],
   );
   if (eaTypeface) return eaTypeface;
 
@@ -166,11 +168,11 @@ function resolveEaFont(fontNode: XmlNode | undefined): string | null {
  * <a:font script="..." typeface="..."> からスクリプトベースのフォント名を取得する。
  */
 function findScriptFont(fontNode: XmlNode | undefined, script: string): string | null {
-  const fontItems = unsafeTypeAssertion<XmlNode[] | undefined>(fontNode?.font);
+  const fontItems = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(fontNode?.font);
   if (!fontItems) return null;
   for (const f of fontItems) {
     if (f["@_script"] === script && f["@_typeface"]) {
-      return unsafeTypeAssertion<string>(f["@_typeface"]);
+      return unsafeXmlBoundaryAssertion<string>(f["@_typeface"]);
     }
   }
   return null;
@@ -227,21 +229,21 @@ function parseFmtScheme(
   const fillStyles = parseFillStyleListOrdered(
     fmtSchemeOrdered,
     "fillStyleLst",
-    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.fillStyleLst),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(fmtSchemeNode.fillStyleLst),
     colorResolver,
   );
   const bgFillStyles = parseFillStyleListOrdered(
     fmtSchemeOrdered,
     "bgFillStyleLst",
-    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.bgFillStyleLst),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(fmtSchemeNode.bgFillStyleLst),
     colorResolver,
   );
   const lnStyles = parseLineStyleList(
-    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.lnStyleLst),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(fmtSchemeNode.lnStyleLst),
     colorResolver,
   );
   const effectStyles = parseEffectStyleList(
-    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.effectStyleLst),
+    unsafeXmlBoundaryAssertion<XmlNode | undefined>(fmtSchemeNode.effectStyleLst),
     colorResolver,
   );
 
@@ -262,7 +264,7 @@ function navigateThemeOrdered(ordered: XmlOrderedNode[], path: string[]): XmlOrd
   for (const key of path) {
     const entry = current.find((item: XmlOrderedNode) => key in item);
     if (!entry) return null;
-    current = unsafeTypeAssertion<XmlOrderedNode[]>(entry[key]);
+    current = unsafeXmlBoundaryAssertion<XmlOrderedNode[]>(entry[key]);
     if (!Array.isArray(current)) return null;
   }
   return current;
@@ -278,7 +280,7 @@ function parseFillStyleListOrdered(
 
   const listOrdered = fmtSchemeOrdered.find((c: XmlOrderedNode) => listTag in c);
   if (!listOrdered) return [];
-  const children = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(listOrdered[listTag]);
+  const children = unsafeXmlBoundaryAssertion<XmlOrderedNode[] | undefined>(listOrdered[listTag]);
   if (!Array.isArray(children)) return [];
 
   const fills: Fill[] = [];
@@ -294,7 +296,7 @@ function parseFillStyleListOrdered(
     // Wrap the fill in a container node for parseFillFromNode
     const rawItems = listNode[tag];
     const items = Array.isArray(rawItems) ? rawItems : rawItems ? [rawItems] : [];
-    const fillData = unsafeTypeAssertion<XmlNode | undefined>(items[idx]);
+    const fillData = unsafeXmlBoundaryAssertion<XmlNode | undefined>(items[idx]);
     if (!fillData) continue;
 
     const wrapper: XmlNode = { [tag]: fillData };
@@ -314,7 +316,7 @@ function parseLineStyleList(
   const lnArr = Array.isArray(lnItems) ? lnItems : lnItems ? [lnItems] : [];
   const outlines: Outline[] = [];
   for (const ln of lnArr) {
-    const outline = parseOutline(unsafeTypeAssertion<XmlNode>(ln), colorResolver);
+    const outline = parseOutline(unsafeXmlBoundaryAssertion<XmlNode>(ln), colorResolver);
     if (outline) outlines.push(outline);
   }
   return outlines;
@@ -325,8 +327,9 @@ function parseEffectStyleList(
   colorResolver: ColorResolver,
 ): (EffectList | null)[] {
   if (!effectStyleLstNode) return [];
-  const items = unsafeTypeAssertion<XmlNode[] | undefined>(effectStyleLstNode.effectStyle) ?? [];
+  const items =
+    unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(effectStyleLstNode.effectStyle) ?? [];
   return items.map((es) =>
-    parseEffectList(unsafeTypeAssertion<XmlNode>(es.effectLst), colorResolver),
+    parseEffectList(unsafeXmlBoundaryAssertion<XmlNode>(es.effectLst), colorResolver),
   );
 }

--- a/packages/core/src/parser/theme-parser.ts
+++ b/packages/core/src/parser/theme-parser.ts
@@ -5,6 +5,7 @@ import type { ColorScheme, FontScheme, FormatScheme, Theme } from "@pptx-glimpse
 import { debug } from "@pptx-glimpse/renderer";
 
 import { ColorResolver } from "../color/color-resolver.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseEffectList } from "./effect-parser.js";
 import { parseFillFromNode, parseOutline } from "./fill-parser.js";
 import { parseXml, parseXmlOrdered, type XmlNode, type XmlOrderedNode } from "./xml-parser.js";
@@ -29,7 +30,9 @@ export function parseTheme(xml: string): Theme {
     };
   }
 
-  const themeElements = (parsed.theme as XmlNode).themeElements as XmlNode | undefined;
+  const themeElements = unsafeTypeAssertion<XmlNode | undefined>(
+    unsafeTypeAssertion<XmlNode>(parsed.theme).themeElements,
+  );
   if (!themeElements) {
     debug("theme.themeElements", "themeElements not found, using defaults");
     return {
@@ -54,11 +57,11 @@ export function parseTheme(xml: string): Theme {
     debug("theme.fontScheme", "fontScheme not found, using defaults");
   }
 
-  const colorScheme = parseColorScheme(themeElements.clrScheme as XmlNode);
-  const fontScheme = parseFontScheme(themeElements.fontScheme as XmlNode);
+  const colorScheme = parseColorScheme(unsafeTypeAssertion<XmlNode>(themeElements.clrScheme));
+  const fontScheme = parseFontScheme(unsafeTypeAssertion<XmlNode>(themeElements.fontScheme));
 
   const fmtScheme = parseFmtScheme(
-    themeElements.fmtScheme as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(themeElements.fmtScheme),
     colorScheme,
     xml,
   );
@@ -70,31 +73,31 @@ function parseColorScheme(clrScheme: XmlNode): ColorScheme {
   if (!clrScheme) return defaultColorScheme();
 
   return {
-    dk1: extractColor(clrScheme.dk1 as XmlNode),
-    lt1: extractColor(clrScheme.lt1 as XmlNode),
-    dk2: extractColor(clrScheme.dk2 as XmlNode),
-    lt2: extractColor(clrScheme.lt2 as XmlNode),
-    accent1: extractColor(clrScheme.accent1 as XmlNode),
-    accent2: extractColor(clrScheme.accent2 as XmlNode),
-    accent3: extractColor(clrScheme.accent3 as XmlNode),
-    accent4: extractColor(clrScheme.accent4 as XmlNode),
-    accent5: extractColor(clrScheme.accent5 as XmlNode),
-    accent6: extractColor(clrScheme.accent6 as XmlNode),
-    hlink: extractColor(clrScheme.hlink as XmlNode),
-    folHlink: extractColor(clrScheme.folHlink as XmlNode),
+    dk1: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.dk1)),
+    lt1: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.lt1)),
+    dk2: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.dk2)),
+    lt2: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.lt2)),
+    accent1: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent1)),
+    accent2: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent2)),
+    accent3: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent3)),
+    accent4: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent4)),
+    accent5: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent5)),
+    accent6: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.accent6)),
+    hlink: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.hlink)),
+    folHlink: extractColor(unsafeTypeAssertion<XmlNode>(clrScheme.folHlink)),
   };
 }
 
 function extractColor(colorNode: XmlNode): string {
   if (!colorNode) return "#000000";
 
-  const srgbClr = colorNode.srgbClr as XmlNode | undefined;
+  const srgbClr = unsafeTypeAssertion<XmlNode | undefined>(colorNode.srgbClr);
   if (srgbClr) {
-    return `#${srgbClr["@_val"] as string}`;
+    return `#${unsafeTypeAssertion<string>(srgbClr["@_val"])}`;
   }
-  const sysClr = colorNode.sysClr as XmlNode | undefined;
+  const sysClr = unsafeTypeAssertion<XmlNode | undefined>(colorNode.sysClr);
   if (sysClr) {
-    return `#${(sysClr["@_lastClr"] as string | undefined) ?? "000000"}`;
+    return `#${unsafeTypeAssertion<string | undefined>(sysClr["@_lastClr"]) ?? "000000"}`;
   }
   return "#000000";
 }
@@ -112,20 +115,26 @@ function parseFontScheme(fontScheme: XmlNode): FontScheme {
       minorFontJpan: null,
     };
 
-  const majorFontNode = fontScheme.majorFont as XmlNode | undefined;
-  const minorFontNode = fontScheme.minorFont as XmlNode | undefined;
+  const majorFontNode = unsafeTypeAssertion<XmlNode | undefined>(fontScheme.majorFont);
+  const minorFontNode = unsafeTypeAssertion<XmlNode | undefined>(fontScheme.minorFont);
   const majorFont =
-    ((majorFontNode?.latin as XmlNode | undefined)?.["@_typeface"] as string | undefined) ??
-    "Calibri";
+    unsafeTypeAssertion<string | undefined>(
+      unsafeTypeAssertion<XmlNode | undefined>(majorFontNode?.latin)?.["@_typeface"],
+    ) ?? "Calibri";
   const minorFont =
-    ((minorFontNode?.latin as XmlNode | undefined)?.["@_typeface"] as string | undefined) ??
-    "Calibri";
+    unsafeTypeAssertion<string | undefined>(
+      unsafeTypeAssertion<XmlNode | undefined>(minorFontNode?.latin)?.["@_typeface"],
+    ) ?? "Calibri";
   const majorFontEa = resolveEaFont(majorFontNode);
   const minorFontEa = resolveEaFont(minorFontNode);
   const majorFontCs =
-    ((majorFontNode?.cs as XmlNode | undefined)?.["@_typeface"] as string | undefined) ?? null;
+    unsafeTypeAssertion<string | undefined>(
+      unsafeTypeAssertion<XmlNode | undefined>(majorFontNode?.cs)?.["@_typeface"],
+    ) ?? null;
   const minorFontCs =
-    ((minorFontNode?.cs as XmlNode | undefined)?.["@_typeface"] as string | undefined) ?? null;
+    unsafeTypeAssertion<string | undefined>(
+      unsafeTypeAssertion<XmlNode | undefined>(minorFontNode?.cs)?.["@_typeface"],
+    ) ?? null;
   const majorFontJpan = findScriptFont(majorFontNode, "Jpan");
   const minorFontJpan = findScriptFont(minorFontNode, "Jpan");
 
@@ -145,7 +154,9 @@ function parseFontScheme(fontScheme: XmlNode): FontScheme {
  * ea タグの typeface を取得し、空文字の場合は script="Jpan" のフォントにフォールバックする。
  */
 function resolveEaFont(fontNode: XmlNode | undefined): string | null {
-  const eaTypeface = (fontNode?.ea as XmlNode | undefined)?.["@_typeface"] as string | undefined;
+  const eaTypeface = unsafeTypeAssertion<string | undefined>(
+    unsafeTypeAssertion<XmlNode | undefined>(fontNode?.ea)?.["@_typeface"],
+  );
   if (eaTypeface) return eaTypeface;
 
   return findScriptFont(fontNode, "Jpan");
@@ -155,11 +166,11 @@ function resolveEaFont(fontNode: XmlNode | undefined): string | null {
  * <a:font script="..." typeface="..."> からスクリプトベースのフォント名を取得する。
  */
 function findScriptFont(fontNode: XmlNode | undefined, script: string): string | null {
-  const fontItems = fontNode?.font as XmlNode[] | undefined;
+  const fontItems = unsafeTypeAssertion<XmlNode[] | undefined>(fontNode?.font);
   if (!fontItems) return null;
   for (const f of fontItems) {
     if (f["@_script"] === script && f["@_typeface"]) {
-      return f["@_typeface"] as string;
+      return unsafeTypeAssertion<string>(f["@_typeface"]);
     }
   }
   return null;
@@ -216,21 +227,21 @@ function parseFmtScheme(
   const fillStyles = parseFillStyleListOrdered(
     fmtSchemeOrdered,
     "fillStyleLst",
-    fmtSchemeNode.fillStyleLst as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.fillStyleLst),
     colorResolver,
   );
   const bgFillStyles = parseFillStyleListOrdered(
     fmtSchemeOrdered,
     "bgFillStyleLst",
-    fmtSchemeNode.bgFillStyleLst as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.bgFillStyleLst),
     colorResolver,
   );
   const lnStyles = parseLineStyleList(
-    fmtSchemeNode.lnStyleLst as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.lnStyleLst),
     colorResolver,
   );
   const effectStyles = parseEffectStyleList(
-    fmtSchemeNode.effectStyleLst as XmlNode | undefined,
+    unsafeTypeAssertion<XmlNode | undefined>(fmtSchemeNode.effectStyleLst),
     colorResolver,
   );
 
@@ -251,7 +262,7 @@ function navigateThemeOrdered(ordered: XmlOrderedNode[], path: string[]): XmlOrd
   for (const key of path) {
     const entry = current.find((item: XmlOrderedNode) => key in item);
     if (!entry) return null;
-    current = entry[key] as XmlOrderedNode[];
+    current = unsafeTypeAssertion<XmlOrderedNode[]>(entry[key]);
     if (!Array.isArray(current)) return null;
   }
   return current;
@@ -267,7 +278,7 @@ function parseFillStyleListOrdered(
 
   const listOrdered = fmtSchemeOrdered.find((c: XmlOrderedNode) => listTag in c);
   if (!listOrdered) return [];
-  const children = listOrdered[listTag] as XmlOrderedNode[] | undefined;
+  const children = unsafeTypeAssertion<XmlOrderedNode[] | undefined>(listOrdered[listTag]);
   if (!Array.isArray(children)) return [];
 
   const fills: Fill[] = [];
@@ -283,7 +294,7 @@ function parseFillStyleListOrdered(
     // Wrap the fill in a container node for parseFillFromNode
     const rawItems = listNode[tag];
     const items = Array.isArray(rawItems) ? rawItems : rawItems ? [rawItems] : [];
-    const fillData = items[idx] as XmlNode | undefined;
+    const fillData = unsafeTypeAssertion<XmlNode | undefined>(items[idx]);
     if (!fillData) continue;
 
     const wrapper: XmlNode = { [tag]: fillData };
@@ -303,7 +314,7 @@ function parseLineStyleList(
   const lnArr = Array.isArray(lnItems) ? lnItems : lnItems ? [lnItems] : [];
   const outlines: Outline[] = [];
   for (const ln of lnArr) {
-    const outline = parseOutline(ln as XmlNode, colorResolver);
+    const outline = parseOutline(unsafeTypeAssertion<XmlNode>(ln), colorResolver);
     if (outline) outlines.push(outline);
   }
   return outlines;
@@ -314,6 +325,8 @@ function parseEffectStyleList(
   colorResolver: ColorResolver,
 ): (EffectList | null)[] {
   if (!effectStyleLstNode) return [];
-  const items = (effectStyleLstNode.effectStyle as XmlNode[] | undefined) ?? [];
-  return items.map((es) => parseEffectList(es.effectLst as XmlNode, colorResolver));
+  const items = unsafeTypeAssertion<XmlNode[] | undefined>(effectStyleLstNode.effectStyle) ?? [];
+  return items.map((es) =>
+    parseEffectList(unsafeTypeAssertion<XmlNode>(es.effectLst), colorResolver),
+  );
 }

--- a/packages/core/src/parser/xml-parser.test.ts
+++ b/packages/core/src/parser/xml-parser.test.ts
@@ -1,16 +1,17 @@
 import { describe, expect, it } from "vitest";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseXml } from "./xml-parser.js";
 
 describe("parseXml", () => {
   it("parses simple XML", () => {
     const result = parseXml("<root><child>value</child></root>");
-    expect((result.root as Record<string, unknown>).child).toBe("value");
+    expect(unsafeTypeAssertion<Record<string, unknown>>(result.root).child).toBe("value");
   });
 
   it("preserves attributes with @_ prefix", () => {
     const result = parseXml('<shape type="rect" id="1"/>');
-    const shape = result.shape as Record<string, unknown>;
+    const shape = unsafeTypeAssertion<Record<string, unknown>>(result.shape);
     expect(shape["@_type"]).toBe("rect");
     expect(shape["@_id"]).toBe("1");
   });
@@ -18,7 +19,7 @@ describe("parseXml", () => {
   it("removes namespace prefix", () => {
     const result = parseXml('<p:sp xmlns:p="http://example.com"><p:nvSpPr/></p:sp>');
     expect(result).toHaveProperty("sp");
-    const sp = (result.sp as Record<string, unknown>[])[0];
+    const sp = unsafeTypeAssertion<Record<string, unknown>[]>(result.sp)[0];
     expect(sp).toHaveProperty("nvSpPr");
   });
 });
@@ -48,7 +49,7 @@ describe("ARRAY_TAGS", () => {
   it.each(arrayTags)("returns <%s> as array when single element", (tag) => {
     const xml = `<root><${tag}>content</${tag}></root>`;
     const result = parseXml(xml);
-    const root = result.root as Record<string, unknown>;
+    const root = unsafeTypeAssertion<Record<string, unknown>>(result.root);
     expect(Array.isArray(root[tag])).toBe(true);
     expect(root[tag]).toHaveLength(1);
   });
@@ -56,7 +57,7 @@ describe("ARRAY_TAGS", () => {
   it("returns sp as array when multiple elements", () => {
     const xml = "<spTree><sp><nvSpPr/></sp><sp><nvSpPr/></sp></spTree>";
     const result = parseXml(xml);
-    const spTree = result.spTree as Record<string, unknown>;
+    const spTree = unsafeTypeAssertion<Record<string, unknown>>(result.spTree);
     expect(Array.isArray(spTree.sp)).toBe(true);
     expect(spTree.sp).toHaveLength(2);
   });
@@ -64,7 +65,7 @@ describe("ARRAY_TAGS", () => {
   it("does not return non-array tag as array", () => {
     const xml = "<root><single>value</single></root>";
     const result = parseXml(xml);
-    const root = result.root as Record<string, unknown>;
+    const root = unsafeTypeAssertion<Record<string, unknown>>(result.root);
     expect(Array.isArray(root.single)).toBe(false);
     expect(root.single).toBe("value");
   });

--- a/packages/core/src/parser/xml-parser.test.ts
+++ b/packages/core/src/parser/xml-parser.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import { parseXml } from "./xml-parser.js";
 
 describe("parseXml", () => {
   it("parses simple XML", () => {
     const result = parseXml("<root><child>value</child></root>");
-    expect(unsafeTypeAssertion<Record<string, unknown>>(result.root).child).toBe("value");
+    expect(unsafeFixtureAssertion<Record<string, unknown>>(result.root).child).toBe("value");
   });
 
   it("preserves attributes with @_ prefix", () => {
     const result = parseXml('<shape type="rect" id="1"/>');
-    const shape = unsafeTypeAssertion<Record<string, unknown>>(result.shape);
+    const shape = unsafeFixtureAssertion<Record<string, unknown>>(result.shape);
     expect(shape["@_type"]).toBe("rect");
     expect(shape["@_id"]).toBe("1");
   });
@@ -19,7 +19,7 @@ describe("parseXml", () => {
   it("removes namespace prefix", () => {
     const result = parseXml('<p:sp xmlns:p="http://example.com"><p:nvSpPr/></p:sp>');
     expect(result).toHaveProperty("sp");
-    const sp = unsafeTypeAssertion<Record<string, unknown>[]>(result.sp)[0];
+    const sp = unsafeFixtureAssertion<Record<string, unknown>[]>(result.sp)[0];
     expect(sp).toHaveProperty("nvSpPr");
   });
 });
@@ -49,7 +49,7 @@ describe("ARRAY_TAGS", () => {
   it.each(arrayTags)("returns <%s> as array when single element", (tag) => {
     const xml = `<root><${tag}>content</${tag}></root>`;
     const result = parseXml(xml);
-    const root = unsafeTypeAssertion<Record<string, unknown>>(result.root);
+    const root = unsafeFixtureAssertion<Record<string, unknown>>(result.root);
     expect(Array.isArray(root[tag])).toBe(true);
     expect(root[tag]).toHaveLength(1);
   });
@@ -57,7 +57,7 @@ describe("ARRAY_TAGS", () => {
   it("returns sp as array when multiple elements", () => {
     const xml = "<spTree><sp><nvSpPr/></sp><sp><nvSpPr/></sp></spTree>";
     const result = parseXml(xml);
-    const spTree = unsafeTypeAssertion<Record<string, unknown>>(result.spTree);
+    const spTree = unsafeFixtureAssertion<Record<string, unknown>>(result.spTree);
     expect(Array.isArray(spTree.sp)).toBe(true);
     expect(spTree.sp).toHaveLength(2);
   });
@@ -65,7 +65,7 @@ describe("ARRAY_TAGS", () => {
   it("does not return non-array tag as array", () => {
     const xml = "<root><single>value</single></root>";
     const result = parseXml(xml);
-    const root = unsafeTypeAssertion<Record<string, unknown>>(result.root);
+    const root = unsafeFixtureAssertion<Record<string, unknown>>(result.root);
     expect(Array.isArray(root.single)).toBe(false);
     expect(root.single).toBe("value");
   });

--- a/packages/core/src/parser/xml-parser.ts
+++ b/packages/core/src/parser/xml-parser.ts
@@ -1,6 +1,6 @@
 import { XMLParser } from "fast-xml-parser";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 
 /** fast-xml-parser が返す XML ノードの型エイリアス */
 export type XmlNode = Record<string, unknown>;
@@ -80,7 +80,7 @@ export function parseXml(xml: string): Record<string, unknown> {
     const cached = xmlCache.get(xml);
     if (cached) return cached;
   }
-  const result = unsafeTypeAssertion<Record<string, unknown>>(standardParser.parse(xml));
+  const result = unsafeXmlBoundaryAssertion<Record<string, unknown>>(standardParser.parse(xml));
   xmlCache?.set(xml, result);
   return result;
 }
@@ -93,7 +93,7 @@ export function parseXmlOrdered(xml: string): XmlOrderedNode[] {
     const cached = xmlOrderedCache.get(xml);
     if (cached) return cached;
   }
-  const result = unsafeTypeAssertion<XmlOrderedNode[]>(orderedParser.parse(xml));
+  const result = unsafeXmlBoundaryAssertion<XmlOrderedNode[]>(orderedParser.parse(xml));
   xmlOrderedCache?.set(xml, result);
   return result;
 }

--- a/packages/core/src/parser/xml-parser.ts
+++ b/packages/core/src/parser/xml-parser.ts
@@ -1,5 +1,7 @@
 import { XMLParser } from "fast-xml-parser";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+
 /** fast-xml-parser が返す XML ノードの型エイリアス */
 export type XmlNode = Record<string, unknown>;
 
@@ -78,7 +80,7 @@ export function parseXml(xml: string): Record<string, unknown> {
     const cached = xmlCache.get(xml);
     if (cached) return cached;
   }
-  const result = standardParser.parse(xml) as Record<string, unknown>;
+  const result = unsafeTypeAssertion<Record<string, unknown>>(standardParser.parse(xml));
   xmlCache?.set(xml, result);
   return result;
 }
@@ -91,7 +93,7 @@ export function parseXmlOrdered(xml: string): XmlOrderedNode[] {
     const cached = xmlOrderedCache.get(xml);
     if (cached) return cached;
   }
-  const result = orderedParser.parse(xml) as XmlOrderedNode[];
+  const result = unsafeTypeAssertion<XmlOrderedNode[]>(orderedParser.parse(xml));
   xmlOrderedCache?.set(xml, result);
   return result;
 }

--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -55,6 +55,7 @@ import type { Relationship } from "./parser/relationship-parser.js";
 import { navigateOrdered, parseShapeTree } from "./parser/slide-parser.js";
 import { parseXml, parseXmlOrdered, type XmlNode } from "./parser/xml-parser.js";
 import { convertChartXmlToRendererChartData } from "./renderer-chart-data-converter.js";
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
 
 interface RendererAdapterResult {
   readonly slideSize?: SlideSize;
@@ -312,8 +313,8 @@ function adaptSmartArt(
   }
 
   const parsed = parseXml(smartArt.drawingXml);
-  const drawing = parsed.drawing as XmlNode | undefined;
-  const spTree = drawing?.spTree as XmlNode | undefined;
+  const drawing = unsafeTypeAssertion<XmlNode | undefined>(parsed.drawing);
+  const spTree = unsafeTypeAssertion<XmlNode | undefined>(drawing?.spTree);
   if (spTree === undefined) {
     pushAdapterWarning(
       diagnostics,
@@ -379,9 +380,11 @@ function adaptSmartArt(
 }
 
 function adaptSmartArtChildTransform(spTree: XmlNode, groupTransform: Transform): Transform {
-  const xfrm = (spTree.grpSpPr as XmlNode | undefined)?.xfrm as XmlNode | undefined;
-  const chOff = xfrm?.chOff as XmlNode | undefined;
-  const chExt = xfrm?.chExt as XmlNode | undefined;
+  const xfrm = unsafeTypeAssertion<XmlNode | undefined>(
+    unsafeTypeAssertion<XmlNode | undefined>(spTree.grpSpPr)?.xfrm,
+  );
+  const chOff = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chOff);
+  const chExt = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chExt);
 
   return {
     offsetX: asEmu(Number(chOff?.["@_x"] ?? 0)),
@@ -844,7 +847,7 @@ function toRendererEmu(value: number): ReturnType<typeof asEmu> {
 }
 
 function toRendererPt(value: number): NonNullable<RunProperties["fontSize"]> {
-  return Number(value) as NonNullable<RunProperties["fontSize"]>;
+  return unsafeTypeAssertion<NonNullable<RunProperties["fontSize"]>>(Number(value));
 }
 
 function normalizeImageMimeType(contentType: string): string {

--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -55,7 +55,7 @@ import type { Relationship } from "./parser/relationship-parser.js";
 import { navigateOrdered, parseShapeTree } from "./parser/slide-parser.js";
 import { parseXml, parseXmlOrdered, type XmlNode } from "./parser/xml-parser.js";
 import { convertChartXmlToRendererChartData } from "./renderer-chart-data-converter.js";
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeAdapterBoundaryAssertion } from "./unsafe-type-assertion.js";
 
 interface RendererAdapterResult {
   readonly slideSize?: SlideSize;
@@ -313,8 +313,8 @@ function adaptSmartArt(
   }
 
   const parsed = parseXml(smartArt.drawingXml);
-  const drawing = unsafeTypeAssertion<XmlNode | undefined>(parsed.drawing);
-  const spTree = unsafeTypeAssertion<XmlNode | undefined>(drawing?.spTree);
+  const drawing = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(parsed.drawing);
+  const spTree = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(drawing?.spTree);
   if (spTree === undefined) {
     pushAdapterWarning(
       diagnostics,
@@ -380,11 +380,11 @@ function adaptSmartArt(
 }
 
 function adaptSmartArtChildTransform(spTree: XmlNode, groupTransform: Transform): Transform {
-  const xfrm = unsafeTypeAssertion<XmlNode | undefined>(
-    unsafeTypeAssertion<XmlNode | undefined>(spTree.grpSpPr)?.xfrm,
+  const xfrm = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(
+    unsafeAdapterBoundaryAssertion<XmlNode | undefined>(spTree.grpSpPr)?.xfrm,
   );
-  const chOff = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chOff);
-  const chExt = unsafeTypeAssertion<XmlNode | undefined>(xfrm?.chExt);
+  const chOff = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(xfrm?.chOff);
+  const chExt = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(xfrm?.chExt);
 
   return {
     offsetX: asEmu(Number(chOff?.["@_x"] ?? 0)),
@@ -847,7 +847,7 @@ function toRendererEmu(value: number): ReturnType<typeof asEmu> {
 }
 
 function toRendererPt(value: number): NonNullable<RunProperties["fontSize"]> {
-  return unsafeTypeAssertion<NonNullable<RunProperties["fontSize"]>>(Number(value));
+  return unsafeAdapterBoundaryAssertion<NonNullable<RunProperties["fontSize"]>>(Number(value));
 }
 
 function normalizeImageMimeType(contentType: string): string {

--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -55,7 +55,7 @@ import type { Relationship } from "./parser/relationship-parser.js";
 import { navigateOrdered, parseShapeTree } from "./parser/slide-parser.js";
 import { parseXml, parseXmlOrdered, type XmlNode } from "./parser/xml-parser.js";
 import { convertChartXmlToRendererChartData } from "./renderer-chart-data-converter.js";
-import { unsafeAdapterBoundaryAssertion } from "./unsafe-type-assertion.js";
+import { unsafeAdapterBoundaryAssertion, unsafeBrandAssertion } from "./unsafe-type-assertion.js";
 
 interface RendererAdapterResult {
   readonly slideSize?: SlideSize;
@@ -847,7 +847,7 @@ function toRendererEmu(value: number): ReturnType<typeof asEmu> {
 }
 
 function toRendererPt(value: number): NonNullable<RunProperties["fontSize"]> {
-  return unsafeAdapterBoundaryAssertion<NonNullable<RunProperties["fontSize"]>>(Number(value));
+  return unsafeBrandAssertion<NonNullable<RunProperties["fontSize"]>>(Number(value));
 }
 
 function normalizeImageMimeType(contentType: string): string {

--- a/packages/core/src/pptx-data-parser.ts
+++ b/packages/core/src/pptx-data-parser.ts
@@ -34,7 +34,7 @@ import { parseSlide } from "./parser/slide-parser.js";
 import { parseTheme } from "./parser/theme-parser.js";
 import { parseXml, type XmlNode } from "./parser/xml-parser.js";
 import { applyTextStyleInheritance } from "./text-style-resolver.js";
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "./unsafe-type-assertion.js";
 
 interface MasterData {
   colorMap: ColorMap;
@@ -444,17 +444,17 @@ function parseClrMapOverride(xml: string): Partial<ColorMap> | null {
   const parsed = parseXml(xml);
 
   // Navigate to root element (sld or sldLayout)
-  const root = unsafeTypeAssertion<XmlNode | undefined>(parsed.sld ?? parsed.sldLayout);
+  const root = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.sld ?? parsed.sldLayout);
   if (!root) return null;
 
-  const clrMapOvr = unsafeTypeAssertion<XmlNode | undefined>(root.clrMapOvr);
+  const clrMapOvr = unsafeXmlBoundaryAssertion<XmlNode | undefined>(root.clrMapOvr);
   if (!clrMapOvr) return null;
 
   // masterClrMapping = use master as-is (no override)
   if (clrMapOvr.masterClrMapping !== undefined) return null;
 
   // overrideClrMapping = individual attribute overrides
-  const override = unsafeTypeAssertion<XmlNode | undefined>(clrMapOvr.overrideClrMapping);
+  const override = unsafeXmlBoundaryAssertion<XmlNode | undefined>(clrMapOvr.overrideClrMapping);
   if (!override) return null;
 
   const result: Partial<ColorMap> = {};
@@ -473,7 +473,7 @@ function parseClrMapOverride(xml: string): Partial<ColorMap> | null {
     "folHlink",
   ];
   for (const key of keys) {
-    const val = unsafeTypeAssertion<string | undefined>(override[`@_${key}`]);
+    const val = unsafeXmlBoundaryAssertion<string | undefined>(override[`@_${key}`]);
     if (val) {
       (result as Record<string, string>)[key] = val;
     }

--- a/packages/core/src/pptx-data-parser.ts
+++ b/packages/core/src/pptx-data-parser.ts
@@ -34,6 +34,7 @@ import { parseSlide } from "./parser/slide-parser.js";
 import { parseTheme } from "./parser/theme-parser.js";
 import { parseXml, type XmlNode } from "./parser/xml-parser.js";
 import { applyTextStyleInheritance } from "./text-style-resolver.js";
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
 
 interface MasterData {
   colorMap: ColorMap;
@@ -443,17 +444,17 @@ function parseClrMapOverride(xml: string): Partial<ColorMap> | null {
   const parsed = parseXml(xml);
 
   // Navigate to root element (sld or sldLayout)
-  const root = (parsed.sld ?? parsed.sldLayout) as XmlNode | undefined;
+  const root = unsafeTypeAssertion<XmlNode | undefined>(parsed.sld ?? parsed.sldLayout);
   if (!root) return null;
 
-  const clrMapOvr = root.clrMapOvr as XmlNode | undefined;
+  const clrMapOvr = unsafeTypeAssertion<XmlNode | undefined>(root.clrMapOvr);
   if (!clrMapOvr) return null;
 
   // masterClrMapping = use master as-is (no override)
   if (clrMapOvr.masterClrMapping !== undefined) return null;
 
   // overrideClrMapping = individual attribute overrides
-  const override = clrMapOvr.overrideClrMapping as XmlNode | undefined;
+  const override = unsafeTypeAssertion<XmlNode | undefined>(clrMapOvr.overrideClrMapping);
   if (!override) return null;
 
   const result: Partial<ColorMap> = {};
@@ -472,7 +473,7 @@ function parseClrMapOverride(xml: string): Partial<ColorMap> | null {
     "folHlink",
   ];
   for (const key of keys) {
-    const val = override[`@_${key}`] as string | undefined;
+    const val = unsafeTypeAssertion<string | undefined>(override[`@_${key}`]);
     if (val) {
       (result as Record<string, string>)[key] = val;
     }

--- a/packages/core/src/renderer-chart-data-converter.ts
+++ b/packages/core/src/renderer-chart-data-converter.ts
@@ -3,6 +3,7 @@ import type { ResolvedColor } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "./color/color-resolver.js";
 import { parseXml, type XmlNode } from "./parser/xml-parser.js";
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
 
 const ACCENT_KEYS = ["accent1", "accent2", "accent3", "accent4", "accent5", "accent6"] as const;
 
@@ -42,16 +43,16 @@ export function convertChartXmlToRendererChartData(
   colorResolver: ColorResolver,
 ): ChartData | null {
   const parsed = parseXml(chartXml);
-  const chartSpace = parsed.chartSpace as XmlNode | undefined;
+  const chartSpace = unsafeTypeAssertion<XmlNode | undefined>(parsed.chartSpace);
   if (!chartSpace) return null;
 
-  const chart = chartSpace.chart as XmlNode | undefined;
+  const chart = unsafeTypeAssertion<XmlNode | undefined>(chartSpace.chart);
   if (!chart) return null;
 
-  const plotArea = chart.plotArea as XmlNode | undefined;
+  const plotArea = unsafeTypeAssertion<XmlNode | undefined>(chart.plotArea);
   if (!plotArea) return null;
 
-  const title = parseChartTitle(chart.title as XmlNode);
+  const title = parseChartTitle(unsafeTypeAssertion<XmlNode>(chart.title));
   const {
     chartType,
     series,
@@ -65,7 +66,7 @@ export function convertChartXmlToRendererChartData(
   } = parseChartTypeAndData(plotArea, colorResolver);
   if (!chartType) return null;
 
-  const legend = parseLegend(chart.legend as XmlNode);
+  const legend = parseLegend(unsafeTypeAssertion<XmlNode>(chart.legend));
 
   return {
     chartType,
@@ -97,43 +98,46 @@ function parseChartTypeAndData(
   splitPos?: number;
 } {
   for (const [xmlTag, chartType] of CHART_TYPE_MAP) {
-    const chartNode = plotArea[xmlTag] as XmlNode | undefined;
+    const chartNode = unsafeTypeAssertion<XmlNode | undefined>(plotArea[xmlTag]);
     if (!chartNode) continue;
 
-    const serList = (chartNode.ser as XmlNode[] | undefined) ?? [];
+    const serList = unsafeTypeAssertion<XmlNode[] | undefined>(chartNode.ser) ?? [];
     const series = serList.map((ser: XmlNode, index: number) =>
       parseSeries(ser, chartType, index, colorResolver),
     );
     const categories = extractCategories(serList);
-    const barDirNode = chartNode.barDir as XmlNode | undefined;
+    const barDirNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.barDir);
     const barDirection =
       chartType === "bar"
-        ? (((barDirNode?.["@_val"] as string | undefined) ?? "col") as "col" | "bar")
+        ? unsafeTypeAssertion<"col" | "bar">(
+            unsafeTypeAssertion<string | undefined>(barDirNode?.["@_val"]) ?? "col",
+          )
         : undefined;
 
-    const holeSizeNode = chartNode.holeSize as XmlNode | undefined;
+    const holeSizeNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.holeSize);
     const holeSize = chartType === "doughnut" ? Number(holeSizeNode?.["@_val"] ?? 50) : undefined;
 
-    const radarStyleNode = chartNode.radarStyle as XmlNode | undefined;
+    const radarStyleNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.radarStyle);
     const radarStyle =
       chartType === "radar"
-        ? (((radarStyleNode?.["@_val"] as string | undefined) ?? "standard") as
-            | "standard"
-            | "marker"
-            | "filled")
+        ? unsafeTypeAssertion<"standard" | "marker" | "filled">(
+            unsafeTypeAssertion<string | undefined>(radarStyleNode?.["@_val"]) ?? "standard",
+          )
         : undefined;
 
-    const ofPieTypeNode = chartNode.ofPieType as XmlNode | undefined;
+    const ofPieTypeNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.ofPieType);
     const ofPieType =
       chartType === "ofPie"
-        ? (((ofPieTypeNode?.["@_val"] as string | undefined) ?? "pie") as "pie" | "bar")
+        ? unsafeTypeAssertion<"pie" | "bar">(
+            unsafeTypeAssertion<string | undefined>(ofPieTypeNode?.["@_val"]) ?? "pie",
+          )
         : undefined;
 
-    const secondPieSizeNode = chartNode.secondPieSize as XmlNode | undefined;
+    const secondPieSizeNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.secondPieSize);
     const secondPieSize =
       chartType === "ofPie" ? Number(secondPieSizeNode?.["@_val"] ?? 75) : undefined;
 
-    const splitPosNode = chartNode.splitPos as XmlNode | undefined;
+    const splitPosNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.splitPos);
     const splitPos = chartType === "ofPie" ? Number(splitPosNode?.["@_val"] ?? 2) : undefined;
 
     return {
@@ -158,13 +162,21 @@ function parseSeries(
   seriesIndex: number,
   colorResolver: ColorResolver,
 ): ChartSeries {
-  const name = parseSeriesName(ser.tx as XmlNode);
+  const name = parseSeriesName(unsafeTypeAssertion<XmlNode>(ser.tx));
   const usesXY = chartType === "scatter" || chartType === "bubble";
-  const values = parseNumericData(usesXY ? (ser.yVal as XmlNode) : (ser.val as XmlNode));
-  const xValues = usesXY ? parseNumericData(ser.xVal as XmlNode) : undefined;
+  const values = parseNumericData(
+    usesXY ? unsafeTypeAssertion<XmlNode>(ser.yVal) : unsafeTypeAssertion<XmlNode>(ser.val),
+  );
+  const xValues = usesXY ? parseNumericData(unsafeTypeAssertion<XmlNode>(ser.xVal)) : undefined;
   const bubbleSizes =
-    chartType === "bubble" ? parseNumericData(ser.bubbleSize as XmlNode) : undefined;
-  const color = resolveSeriesColor(ser.spPr as XmlNode, seriesIndex, colorResolver);
+    chartType === "bubble"
+      ? parseNumericData(unsafeTypeAssertion<XmlNode>(ser.bubbleSize))
+      : undefined;
+  const color = resolveSeriesColor(
+    unsafeTypeAssertion<XmlNode>(ser.spPr),
+    seriesIndex,
+    colorResolver,
+  );
 
   return {
     name,
@@ -177,11 +189,11 @@ function parseSeries(
 
 function parseSeriesName(tx: XmlNode): string | null {
   if (!tx) return null;
-  const strRef = tx.strRef as XmlNode | undefined;
-  const strCache = strRef?.strCache as XmlNode | undefined;
+  const strRef = unsafeTypeAssertion<XmlNode | undefined>(tx.strRef);
+  const strCache = unsafeTypeAssertion<XmlNode | undefined>(strRef?.strCache);
   if (strCache?.pt) {
-    const pts = strCache.pt as XmlNode[];
-    return (pts[0]?.v as string | undefined) ?? null;
+    const pts = unsafeTypeAssertion<XmlNode[]>(strCache.pt);
+    return unsafeTypeAssertion<string | undefined>(pts[0]?.v) ?? null;
   }
   if (typeof tx.v === "string") return tx.v;
   return null;
@@ -189,10 +201,10 @@ function parseSeriesName(tx: XmlNode): string | null {
 
 function parseNumericData(valNode: XmlNode): number[] {
   if (!valNode) return [];
-  const numRef = valNode.numRef as XmlNode | undefined;
-  const numCache = numRef?.numCache as XmlNode | undefined;
+  const numRef = unsafeTypeAssertion<XmlNode | undefined>(valNode.numRef);
+  const numCache = unsafeTypeAssertion<XmlNode | undefined>(numRef?.numCache);
   if (!numCache?.pt) return [];
-  const pts = numCache.pt as XmlNode[];
+  const pts = unsafeTypeAssertion<XmlNode[]>(numCache.pt);
 
   return pts
     .slice()
@@ -202,31 +214,34 @@ function parseNumericData(valNode: XmlNode): number[] {
 
 function extractCategories(serList: XmlNode[]): string[] {
   for (const ser of serList) {
-    const cat = ser.cat as XmlNode | undefined;
+    const cat = unsafeTypeAssertion<XmlNode | undefined>(ser.cat);
     if (!cat) continue;
-    const strRef = cat.strRef as XmlNode | undefined;
-    const numRef = cat.numRef as XmlNode | undefined;
-    const multiLvlStrRef = cat.multiLvlStrRef as XmlNode | undefined;
+    const strRef = unsafeTypeAssertion<XmlNode | undefined>(cat.strRef);
+    const numRef = unsafeTypeAssertion<XmlNode | undefined>(cat.numRef);
+    const multiLvlStrRef = unsafeTypeAssertion<XmlNode | undefined>(cat.multiLvlStrRef);
     const strCache =
-      (strRef?.strCache as XmlNode | undefined) ?? (numRef?.numCache as XmlNode | undefined);
+      unsafeTypeAssertion<XmlNode | undefined>(strRef?.strCache) ??
+      unsafeTypeAssertion<XmlNode | undefined>(numRef?.numCache);
     if (strCache?.pt) {
-      return (strCache.pt as XmlNode[])
+      return unsafeTypeAssertion<XmlNode[]>(strCache.pt)
         .slice()
         .sort((a: XmlNode, b: XmlNode) => Number(a["@_idx"]) - Number(b["@_idx"]))
-        .map((pt: XmlNode) => String((pt.v as string | number | undefined) ?? ""));
+        .map((pt: XmlNode) => String(unsafeTypeAssertion<string | number | undefined>(pt.v) ?? ""));
     }
     // multiLvlStrRef: categories stored in lvl > pt structure (uses first level only)
-    const multiCache = multiLvlStrRef?.multiLvlStrCache as XmlNode | undefined;
+    const multiCache = unsafeTypeAssertion<XmlNode | undefined>(multiLvlStrRef?.multiLvlStrCache);
     if (multiCache?.lvl) {
       const lvls = Array.isArray(multiCache.lvl)
-        ? (multiCache.lvl as XmlNode[])
-        : [multiCache.lvl as XmlNode];
+        ? unsafeTypeAssertion<XmlNode[]>(multiCache.lvl)
+        : [unsafeTypeAssertion<XmlNode>(multiCache.lvl)];
       const firstLvl = lvls[0];
       if (firstLvl?.pt) {
-        return (firstLvl.pt as XmlNode[])
+        return unsafeTypeAssertion<XmlNode[]>(firstLvl.pt)
           .slice()
           .sort((a: XmlNode, b: XmlNode) => Number(a["@_idx"]) - Number(b["@_idx"]))
-          .map((pt: XmlNode) => String((pt.v as string | number | undefined) ?? ""));
+          .map((pt: XmlNode) =>
+            String(unsafeTypeAssertion<string | number | undefined>(pt.v) ?? ""),
+          );
       }
     }
   }
@@ -239,7 +254,9 @@ function resolveSeriesColor(
   colorResolver: ColorResolver,
 ): ResolvedColor {
   if (spPr) {
-    const resolved = colorResolver.resolve((spPr.solidFill as XmlNode | undefined) ?? spPr);
+    const resolved = colorResolver.resolve(
+      unsafeTypeAssertion<XmlNode | undefined>(spPr.solidFill) ?? spPr,
+    );
     if (resolved) return resolved;
   }
   // Default: use theme accent colors
@@ -250,17 +267,20 @@ function resolveSeriesColor(
 
 function parseChartTitle(titleNode: XmlNode): string | null {
   if (!titleNode) return null;
-  const tx = titleNode.tx as XmlNode | undefined;
-  const rich = tx?.rich as XmlNode | undefined;
+  const tx = unsafeTypeAssertion<XmlNode | undefined>(titleNode.tx);
+  const rich = unsafeTypeAssertion<XmlNode | undefined>(tx?.rich);
   if (!rich?.p) return null;
-  const pList = Array.isArray(rich.p) ? (rich.p as XmlNode[]) : [rich.p as XmlNode];
+  const pList = Array.isArray(rich.p)
+    ? unsafeTypeAssertion<XmlNode[]>(rich.p)
+    : [unsafeTypeAssertion<XmlNode>(rich.p)];
   const texts: string[] = [];
   for (const p of pList) {
-    const rList = (p.r as XmlNode[] | undefined) ?? [];
+    const rList = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
     for (const r of rList) {
       const t = r.t;
       if (typeof t === "string") texts.push(t);
-      else if (t && (t as XmlNode)["#text"]) texts.push(String((t as XmlNode)["#text"]));
+      else if (t && unsafeTypeAssertion<XmlNode>(t)["#text"])
+        texts.push(String(unsafeTypeAssertion<XmlNode>(t)["#text"]));
     }
   }
   return texts.length > 0 ? texts.join("") : null;
@@ -268,7 +288,9 @@ function parseChartTitle(titleNode: XmlNode): string | null {
 
 function parseLegend(legendNode: XmlNode): ChartLegend | null {
   if (!legendNode) return null;
-  const legendPos = legendNode.legendPos as XmlNode | undefined;
-  const pos = ((legendPos?.["@_val"] as string | undefined) ?? "r") as ChartLegend["position"];
+  const legendPos = unsafeTypeAssertion<XmlNode | undefined>(legendNode.legendPos);
+  const pos = unsafeTypeAssertion<ChartLegend["position"]>(
+    unsafeTypeAssertion<string | undefined>(legendPos?.["@_val"]) ?? "r",
+  );
   return { position: pos };
 }

--- a/packages/core/src/renderer-chart-data-converter.ts
+++ b/packages/core/src/renderer-chart-data-converter.ts
@@ -3,7 +3,7 @@ import type { ResolvedColor } from "@pptx-glimpse/renderer";
 
 import type { ColorResolver } from "./color/color-resolver.js";
 import { parseXml, type XmlNode } from "./parser/xml-parser.js";
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeXmlBoundaryAssertion } from "./unsafe-type-assertion.js";
 
 const ACCENT_KEYS = ["accent1", "accent2", "accent3", "accent4", "accent5", "accent6"] as const;
 
@@ -43,16 +43,16 @@ export function convertChartXmlToRendererChartData(
   colorResolver: ColorResolver,
 ): ChartData | null {
   const parsed = parseXml(chartXml);
-  const chartSpace = unsafeTypeAssertion<XmlNode | undefined>(parsed.chartSpace);
+  const chartSpace = unsafeXmlBoundaryAssertion<XmlNode | undefined>(parsed.chartSpace);
   if (!chartSpace) return null;
 
-  const chart = unsafeTypeAssertion<XmlNode | undefined>(chartSpace.chart);
+  const chart = unsafeXmlBoundaryAssertion<XmlNode | undefined>(chartSpace.chart);
   if (!chart) return null;
 
-  const plotArea = unsafeTypeAssertion<XmlNode | undefined>(chart.plotArea);
+  const plotArea = unsafeXmlBoundaryAssertion<XmlNode | undefined>(chart.plotArea);
   if (!plotArea) return null;
 
-  const title = parseChartTitle(unsafeTypeAssertion<XmlNode>(chart.title));
+  const title = parseChartTitle(unsafeXmlBoundaryAssertion<XmlNode>(chart.title));
   const {
     chartType,
     series,
@@ -66,7 +66,7 @@ export function convertChartXmlToRendererChartData(
   } = parseChartTypeAndData(plotArea, colorResolver);
   if (!chartType) return null;
 
-  const legend = parseLegend(unsafeTypeAssertion<XmlNode>(chart.legend));
+  const legend = parseLegend(unsafeXmlBoundaryAssertion<XmlNode>(chart.legend));
 
   return {
     chartType,
@@ -98,46 +98,48 @@ function parseChartTypeAndData(
   splitPos?: number;
 } {
   for (const [xmlTag, chartType] of CHART_TYPE_MAP) {
-    const chartNode = unsafeTypeAssertion<XmlNode | undefined>(plotArea[xmlTag]);
+    const chartNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(plotArea[xmlTag]);
     if (!chartNode) continue;
 
-    const serList = unsafeTypeAssertion<XmlNode[] | undefined>(chartNode.ser) ?? [];
+    const serList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(chartNode.ser) ?? [];
     const series = serList.map((ser: XmlNode, index: number) =>
       parseSeries(ser, chartType, index, colorResolver),
     );
     const categories = extractCategories(serList);
-    const barDirNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.barDir);
+    const barDirNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(chartNode.barDir);
     const barDirection =
       chartType === "bar"
-        ? unsafeTypeAssertion<"col" | "bar">(
-            unsafeTypeAssertion<string | undefined>(barDirNode?.["@_val"]) ?? "col",
+        ? unsafeXmlBoundaryAssertion<"col" | "bar">(
+            unsafeXmlBoundaryAssertion<string | undefined>(barDirNode?.["@_val"]) ?? "col",
           )
         : undefined;
 
-    const holeSizeNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.holeSize);
+    const holeSizeNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(chartNode.holeSize);
     const holeSize = chartType === "doughnut" ? Number(holeSizeNode?.["@_val"] ?? 50) : undefined;
 
-    const radarStyleNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.radarStyle);
+    const radarStyleNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(chartNode.radarStyle);
     const radarStyle =
       chartType === "radar"
-        ? unsafeTypeAssertion<"standard" | "marker" | "filled">(
-            unsafeTypeAssertion<string | undefined>(radarStyleNode?.["@_val"]) ?? "standard",
+        ? unsafeXmlBoundaryAssertion<"standard" | "marker" | "filled">(
+            unsafeXmlBoundaryAssertion<string | undefined>(radarStyleNode?.["@_val"]) ?? "standard",
           )
         : undefined;
 
-    const ofPieTypeNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.ofPieType);
+    const ofPieTypeNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(chartNode.ofPieType);
     const ofPieType =
       chartType === "ofPie"
-        ? unsafeTypeAssertion<"pie" | "bar">(
-            unsafeTypeAssertion<string | undefined>(ofPieTypeNode?.["@_val"]) ?? "pie",
+        ? unsafeXmlBoundaryAssertion<"pie" | "bar">(
+            unsafeXmlBoundaryAssertion<string | undefined>(ofPieTypeNode?.["@_val"]) ?? "pie",
           )
         : undefined;
 
-    const secondPieSizeNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.secondPieSize);
+    const secondPieSizeNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(
+      chartNode.secondPieSize,
+    );
     const secondPieSize =
       chartType === "ofPie" ? Number(secondPieSizeNode?.["@_val"] ?? 75) : undefined;
 
-    const splitPosNode = unsafeTypeAssertion<XmlNode | undefined>(chartNode.splitPos);
+    const splitPosNode = unsafeXmlBoundaryAssertion<XmlNode | undefined>(chartNode.splitPos);
     const splitPos = chartType === "ofPie" ? Number(splitPosNode?.["@_val"] ?? 2) : undefined;
 
     return {
@@ -162,18 +164,22 @@ function parseSeries(
   seriesIndex: number,
   colorResolver: ColorResolver,
 ): ChartSeries {
-  const name = parseSeriesName(unsafeTypeAssertion<XmlNode>(ser.tx));
+  const name = parseSeriesName(unsafeXmlBoundaryAssertion<XmlNode>(ser.tx));
   const usesXY = chartType === "scatter" || chartType === "bubble";
   const values = parseNumericData(
-    usesXY ? unsafeTypeAssertion<XmlNode>(ser.yVal) : unsafeTypeAssertion<XmlNode>(ser.val),
+    usesXY
+      ? unsafeXmlBoundaryAssertion<XmlNode>(ser.yVal)
+      : unsafeXmlBoundaryAssertion<XmlNode>(ser.val),
   );
-  const xValues = usesXY ? parseNumericData(unsafeTypeAssertion<XmlNode>(ser.xVal)) : undefined;
+  const xValues = usesXY
+    ? parseNumericData(unsafeXmlBoundaryAssertion<XmlNode>(ser.xVal))
+    : undefined;
   const bubbleSizes =
     chartType === "bubble"
-      ? parseNumericData(unsafeTypeAssertion<XmlNode>(ser.bubbleSize))
+      ? parseNumericData(unsafeXmlBoundaryAssertion<XmlNode>(ser.bubbleSize))
       : undefined;
   const color = resolveSeriesColor(
-    unsafeTypeAssertion<XmlNode>(ser.spPr),
+    unsafeXmlBoundaryAssertion<XmlNode>(ser.spPr),
     seriesIndex,
     colorResolver,
   );
@@ -189,11 +195,11 @@ function parseSeries(
 
 function parseSeriesName(tx: XmlNode): string | null {
   if (!tx) return null;
-  const strRef = unsafeTypeAssertion<XmlNode | undefined>(tx.strRef);
-  const strCache = unsafeTypeAssertion<XmlNode | undefined>(strRef?.strCache);
+  const strRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(tx.strRef);
+  const strCache = unsafeXmlBoundaryAssertion<XmlNode | undefined>(strRef?.strCache);
   if (strCache?.pt) {
-    const pts = unsafeTypeAssertion<XmlNode[]>(strCache.pt);
-    return unsafeTypeAssertion<string | undefined>(pts[0]?.v) ?? null;
+    const pts = unsafeXmlBoundaryAssertion<XmlNode[]>(strCache.pt);
+    return unsafeXmlBoundaryAssertion<string | undefined>(pts[0]?.v) ?? null;
   }
   if (typeof tx.v === "string") return tx.v;
   return null;
@@ -201,10 +207,10 @@ function parseSeriesName(tx: XmlNode): string | null {
 
 function parseNumericData(valNode: XmlNode): number[] {
   if (!valNode) return [];
-  const numRef = unsafeTypeAssertion<XmlNode | undefined>(valNode.numRef);
-  const numCache = unsafeTypeAssertion<XmlNode | undefined>(numRef?.numCache);
+  const numRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(valNode.numRef);
+  const numCache = unsafeXmlBoundaryAssertion<XmlNode | undefined>(numRef?.numCache);
   if (!numCache?.pt) return [];
-  const pts = unsafeTypeAssertion<XmlNode[]>(numCache.pt);
+  const pts = unsafeXmlBoundaryAssertion<XmlNode[]>(numCache.pt);
 
   return pts
     .slice()
@@ -214,33 +220,37 @@ function parseNumericData(valNode: XmlNode): number[] {
 
 function extractCategories(serList: XmlNode[]): string[] {
   for (const ser of serList) {
-    const cat = unsafeTypeAssertion<XmlNode | undefined>(ser.cat);
+    const cat = unsafeXmlBoundaryAssertion<XmlNode | undefined>(ser.cat);
     if (!cat) continue;
-    const strRef = unsafeTypeAssertion<XmlNode | undefined>(cat.strRef);
-    const numRef = unsafeTypeAssertion<XmlNode | undefined>(cat.numRef);
-    const multiLvlStrRef = unsafeTypeAssertion<XmlNode | undefined>(cat.multiLvlStrRef);
+    const strRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cat.strRef);
+    const numRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cat.numRef);
+    const multiLvlStrRef = unsafeXmlBoundaryAssertion<XmlNode | undefined>(cat.multiLvlStrRef);
     const strCache =
-      unsafeTypeAssertion<XmlNode | undefined>(strRef?.strCache) ??
-      unsafeTypeAssertion<XmlNode | undefined>(numRef?.numCache);
+      unsafeXmlBoundaryAssertion<XmlNode | undefined>(strRef?.strCache) ??
+      unsafeXmlBoundaryAssertion<XmlNode | undefined>(numRef?.numCache);
     if (strCache?.pt) {
-      return unsafeTypeAssertion<XmlNode[]>(strCache.pt)
+      return unsafeXmlBoundaryAssertion<XmlNode[]>(strCache.pt)
         .slice()
         .sort((a: XmlNode, b: XmlNode) => Number(a["@_idx"]) - Number(b["@_idx"]))
-        .map((pt: XmlNode) => String(unsafeTypeAssertion<string | number | undefined>(pt.v) ?? ""));
+        .map((pt: XmlNode) =>
+          String(unsafeXmlBoundaryAssertion<string | number | undefined>(pt.v) ?? ""),
+        );
     }
     // multiLvlStrRef: categories stored in lvl > pt structure (uses first level only)
-    const multiCache = unsafeTypeAssertion<XmlNode | undefined>(multiLvlStrRef?.multiLvlStrCache);
+    const multiCache = unsafeXmlBoundaryAssertion<XmlNode | undefined>(
+      multiLvlStrRef?.multiLvlStrCache,
+    );
     if (multiCache?.lvl) {
       const lvls = Array.isArray(multiCache.lvl)
-        ? unsafeTypeAssertion<XmlNode[]>(multiCache.lvl)
-        : [unsafeTypeAssertion<XmlNode>(multiCache.lvl)];
+        ? unsafeXmlBoundaryAssertion<XmlNode[]>(multiCache.lvl)
+        : [unsafeXmlBoundaryAssertion<XmlNode>(multiCache.lvl)];
       const firstLvl = lvls[0];
       if (firstLvl?.pt) {
-        return unsafeTypeAssertion<XmlNode[]>(firstLvl.pt)
+        return unsafeXmlBoundaryAssertion<XmlNode[]>(firstLvl.pt)
           .slice()
           .sort((a: XmlNode, b: XmlNode) => Number(a["@_idx"]) - Number(b["@_idx"]))
           .map((pt: XmlNode) =>
-            String(unsafeTypeAssertion<string | number | undefined>(pt.v) ?? ""),
+            String(unsafeXmlBoundaryAssertion<string | number | undefined>(pt.v) ?? ""),
           );
       }
     }
@@ -255,7 +265,7 @@ function resolveSeriesColor(
 ): ResolvedColor {
   if (spPr) {
     const resolved = colorResolver.resolve(
-      unsafeTypeAssertion<XmlNode | undefined>(spPr.solidFill) ?? spPr,
+      unsafeXmlBoundaryAssertion<XmlNode | undefined>(spPr.solidFill) ?? spPr,
     );
     if (resolved) return resolved;
   }
@@ -267,20 +277,20 @@ function resolveSeriesColor(
 
 function parseChartTitle(titleNode: XmlNode): string | null {
   if (!titleNode) return null;
-  const tx = unsafeTypeAssertion<XmlNode | undefined>(titleNode.tx);
-  const rich = unsafeTypeAssertion<XmlNode | undefined>(tx?.rich);
+  const tx = unsafeXmlBoundaryAssertion<XmlNode | undefined>(titleNode.tx);
+  const rich = unsafeXmlBoundaryAssertion<XmlNode | undefined>(tx?.rich);
   if (!rich?.p) return null;
   const pList = Array.isArray(rich.p)
-    ? unsafeTypeAssertion<XmlNode[]>(rich.p)
-    : [unsafeTypeAssertion<XmlNode>(rich.p)];
+    ? unsafeXmlBoundaryAssertion<XmlNode[]>(rich.p)
+    : [unsafeXmlBoundaryAssertion<XmlNode>(rich.p)];
   const texts: string[] = [];
   for (const p of pList) {
-    const rList = unsafeTypeAssertion<XmlNode[] | undefined>(p.r) ?? [];
+    const rList = unsafeXmlBoundaryAssertion<XmlNode[] | undefined>(p.r) ?? [];
     for (const r of rList) {
       const t = r.t;
       if (typeof t === "string") texts.push(t);
-      else if (t && unsafeTypeAssertion<XmlNode>(t)["#text"])
-        texts.push(String(unsafeTypeAssertion<XmlNode>(t)["#text"]));
+      else if (t && unsafeXmlBoundaryAssertion<XmlNode>(t)["#text"])
+        texts.push(String(unsafeXmlBoundaryAssertion<XmlNode>(t)["#text"]));
     }
   }
   return texts.length > 0 ? texts.join("") : null;
@@ -288,9 +298,9 @@ function parseChartTitle(titleNode: XmlNode): string | null {
 
 function parseLegend(legendNode: XmlNode): ChartLegend | null {
   if (!legendNode) return null;
-  const legendPos = unsafeTypeAssertion<XmlNode | undefined>(legendNode.legendPos);
-  const pos = unsafeTypeAssertion<ChartLegend["position"]>(
-    unsafeTypeAssertion<string | undefined>(legendPos?.["@_val"]) ?? "r",
+  const legendPos = unsafeXmlBoundaryAssertion<XmlNode | undefined>(legendNode.legendPos);
+  const pos = unsafeXmlBoundaryAssertion<ChartLegend["position"]>(
+    unsafeXmlBoundaryAssertion<string | undefined>(legendPos?.["@_val"]) ?? "r",
   );
   return { position: pos };
 }

--- a/packages/core/src/text-style-resolver.test.ts
+++ b/packages/core/src/text-style-resolver.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import type { TextStyleContext } from "./text-style-resolver.js";
 import { applyTextStyleInheritance } from "./text-style-resolver.js";
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "./unsafe-type-assertion.js";
 
 function makeRunProperties(overrides: Partial<RunProperties> = {}): RunProperties {
   return {
@@ -515,7 +515,7 @@ describe("applyTextStyleInheritance", () => {
   describe("レベル対応", () => {
     it("段落レベルに応じた正しいスタイルが適用される", () => {
       const shape = makeShape({ placeholderType: "body" });
-      const levels = unsafeTypeAssertion<
+      const levels = unsafeFixtureAssertion<
         (undefined | { defaultRunProperties: { fontSize: number } })[]
       >(Array(9).fill(undefined));
       levels[0] = { defaultRunProperties: { fontSize: 32 } };

--- a/packages/core/src/text-style-resolver.test.ts
+++ b/packages/core/src/text-style-resolver.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import type { TextStyleContext } from "./text-style-resolver.js";
 import { applyTextStyleInheritance } from "./text-style-resolver.js";
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
 
 function makeRunProperties(overrides: Partial<RunProperties> = {}): RunProperties {
   return {
@@ -514,10 +515,9 @@ describe("applyTextStyleInheritance", () => {
   describe("レベル対応", () => {
     it("段落レベルに応じた正しいスタイルが適用される", () => {
       const shape = makeShape({ placeholderType: "body" });
-      const levels = Array(9).fill(undefined) as (
-        | undefined
-        | { defaultRunProperties: { fontSize: number } }
-      )[];
+      const levels = unsafeTypeAssertion<
+        (undefined | { defaultRunProperties: { fontSize: number } })[]
+      >(Array(9).fill(undefined));
       levels[0] = { defaultRunProperties: { fontSize: 32 } };
       levels[1] = { defaultRunProperties: { fontSize: 28 } };
       levels[2] = { defaultRunProperties: { fontSize: 24 } };

--- a/packages/core/src/unsafe-type-assertion.ts
+++ b/packages/core/src/unsafe-type-assertion.ts
@@ -1,4 +1,16 @@
-export function unsafeTypeAssertion<T>(value: unknown): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- XML parser and fixture boundaries intentionally centralize unchecked narrowing here.
+export function unsafeXmlBoundaryAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+export function unsafeFixtureAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+export function unsafeAdapterBoundaryAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+function assertUnsafeBoundary<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core XML, fixture, and adapter helpers intentionally centralize unchecked narrowing here.
   return value as T;
 }

--- a/packages/core/src/unsafe-type-assertion.ts
+++ b/packages/core/src/unsafe-type-assertion.ts
@@ -1,0 +1,4 @@
+export function unsafeTypeAssertion<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- XML parser and fixture boundaries intentionally centralize unchecked narrowing here.
+  return value as T;
+}

--- a/packages/core/src/unsafe-type-assertion.ts
+++ b/packages/core/src/unsafe-type-assertion.ts
@@ -1,16 +1,19 @@
 export function unsafeXmlBoundaryAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core XML parser boundaries narrow fast-xml-parser output behind this named helper.
+  return value as T;
 }
 
 export function unsafeFixtureAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core tests narrow fixture values behind this test-only helper.
+  return value as T;
 }
 
 export function unsafeAdapterBoundaryAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core adapter boundaries narrow computed/document interop values behind this named helper.
+  return value as T;
 }
 
-function assertUnsafeBoundary<T>(value: unknown): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core XML, fixture, and adapter helpers intentionally centralize unchecked narrowing here.
+export function unsafeBrandAssertion<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core branded value constructors narrow primitive values behind this named helper.
   return value as T;
 }

--- a/packages/document/src/package-boundary.test.ts
+++ b/packages/document/src/package-boundary.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { documentExperimentalApi } from "./experimental.js";
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
 
 interface PackageJson {
   readonly dependencies?: Record<string, string>;
@@ -79,7 +80,7 @@ async function listTypeScriptFiles(dir: string): Promise<string[]> {
 function parsePackageJson(text: string): PackageJson {
   const parsed: unknown = JSON.parse(text);
 
-  return parsed as PackageJson;
+  return unsafeTypeAssertion<PackageJson>(parsed);
 }
 
 describe("@pptx-glimpse/document package boundary", () => {

--- a/packages/document/src/package-boundary.test.ts
+++ b/packages/document/src/package-boundary.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { documentExperimentalApi } from "./experimental.js";
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "./unsafe-type-assertion.js";
 
 interface PackageJson {
   readonly dependencies?: Record<string, string>;
@@ -80,7 +80,7 @@ async function listTypeScriptFiles(dir: string): Promise<string[]> {
 function parsePackageJson(text: string): PackageJson {
   const parsed: unknown = JSON.parse(text);
 
-  return unsafeTypeAssertion<PackageJson>(parsed);
+  return unsafeFixtureAssertion<PackageJson>(parsed);
 }
 
 describe("@pptx-glimpse/document package boundary", () => {

--- a/packages/document/src/reader/drawing.ts
+++ b/packages/document/src/reader/drawing.ts
@@ -31,7 +31,7 @@ import type {
   SourceTransform,
 } from "../source/index.js";
 import { asEmu, asOoxmlAngle, asOoxmlPercent, asRelationshipId } from "../source/index.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseEnumValue, parseEnumValueWithDefault } from "./ooxml-values.js";
 import { makeSidecar } from "./raw-node.js";
 import {
@@ -458,7 +458,7 @@ function withTransforms(base: SourceColor, colorNode: XmlNode): SourceColor {
     const value = colorNode[key];
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
-      const raw = getAttr(unsafeTypeAssertion<XmlNode>(item), "val");
+      const raw = getAttr(unsafeOoxmlBoundaryAssertion<XmlNode>(item), "val");
       if (raw === undefined) continue;
       const numeric = Number(raw);
       if (!Number.isFinite(numeric)) continue;

--- a/packages/document/src/reader/drawing.ts
+++ b/packages/document/src/reader/drawing.ts
@@ -31,6 +31,7 @@ import type {
   SourceTransform,
 } from "../source/index.js";
 import { asEmu, asOoxmlAngle, asOoxmlPercent, asRelationshipId } from "../source/index.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseEnumValue, parseEnumValueWithDefault } from "./ooxml-values.js";
 import { makeSidecar } from "./raw-node.js";
 import {
@@ -457,7 +458,7 @@ function withTransforms(base: SourceColor, colorNode: XmlNode): SourceColor {
     const value = colorNode[key];
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
-      const raw = getAttr(item as XmlNode, "val");
+      const raw = getAttr(unsafeTypeAssertion<XmlNode>(item), "val");
       if (raw === undefined) continue;
       const numeric = Number(raw);
       if (!Number.isFinite(numeric)) continue;

--- a/packages/document/src/reader/ooxml-values.ts
+++ b/packages/document/src/reader/ooxml-values.ts
@@ -1,11 +1,11 @@
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 
 export function parseEnumValue<const T extends string>(
   value: string | undefined,
   allowed: ReadonlySet<T>,
 ): T | undefined {
-  return value !== undefined && allowed.has(unsafeTypeAssertion<T>(value))
-    ? unsafeTypeAssertion<T>(value)
+  return value !== undefined && allowed.has(unsafeOoxmlBoundaryAssertion<T>(value))
+    ? unsafeOoxmlBoundaryAssertion<T>(value)
     : undefined;
 }
 

--- a/packages/document/src/reader/ooxml-values.ts
+++ b/packages/document/src/reader/ooxml-values.ts
@@ -1,8 +1,12 @@
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+
 export function parseEnumValue<const T extends string>(
   value: string | undefined,
   allowed: ReadonlySet<T>,
 ): T | undefined {
-  return value !== undefined && allowed.has(value as T) ? (value as T) : undefined;
+  return value !== undefined && allowed.has(unsafeTypeAssertion<T>(value))
+    ? unsafeTypeAssertion<T>(value)
+    : undefined;
 }
 
 export function parseEnumValueWithDefault<const T extends string>(

--- a/packages/document/src/reader/raw-node.ts
+++ b/packages/document/src/reader/raw-node.ts
@@ -9,6 +9,7 @@
 
 import type { RawOoxmlNode, RawSidecar, RawSidecarId } from "../source/index.js";
 import { asRawSidecarId } from "../source/index.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { localName, type XmlNode } from "./xml.js";
 
 const ATTR_PREFIX = "@_";
@@ -31,7 +32,7 @@ function xmlValueToRawNode(name: string, value: unknown): RawOoxmlNode {
     return text !== undefined && text !== "" ? { name, text } : { name };
   }
 
-  const obj = value as Record<string, unknown>;
+  const obj = unsafeTypeAssertion<Record<string, unknown>>(value);
   const attributes: Record<string, string> = {};
   const children: RawOoxmlNode[] = [];
   let text: string | undefined;

--- a/packages/document/src/reader/raw-node.ts
+++ b/packages/document/src/reader/raw-node.ts
@@ -9,7 +9,7 @@
 
 import type { RawOoxmlNode, RawSidecar, RawSidecarId } from "../source/index.js";
 import { asRawSidecarId } from "../source/index.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { localName, type XmlNode } from "./xml.js";
 
 const ATTR_PREFIX = "@_";
@@ -32,7 +32,7 @@ function xmlValueToRawNode(name: string, value: unknown): RawOoxmlNode {
     return text !== undefined && text !== "" ? { name, text } : { name };
   }
 
-  const obj = unsafeTypeAssertion<Record<string, unknown>>(value);
+  const obj = unsafeOoxmlBoundaryAssertion<Record<string, unknown>>(value);
   const attributes: Record<string, string> = {};
   const children: RawOoxmlNode[] = [];
   let text: string | undefined;

--- a/packages/document/src/reader/shape-tree.ts
+++ b/packages/document/src/reader/shape-tree.ts
@@ -40,6 +40,7 @@ import type {
   SourceTransform,
 } from "../source/index.js";
 import { asEmu, asOoxmlPercent, asRelationshipId, asSourceNodeId } from "../source/index.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseCustomGeometry } from "./custom-geometry.js";
 import {
   isTrue,
@@ -168,7 +169,7 @@ export function parseShapeTree(
     const value = spTree[key];
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
-      const node = item as XmlNode;
+      const node = unsafeTypeAssertion<XmlNode>(item);
       if (local === "sp") {
         nodes.push(parseShape(node, partPath, nextId, orderingSlot));
       } else if (local === "pic") {
@@ -245,7 +246,9 @@ function parseShapeTreeNode(
     return parseConnector(node, partPath, nextId, orderingSlot, orderedNode);
   }
   if (local === "grpSp") {
-    const orderedGroupChildren = orderedNode?.[local] as readonly XmlOrderedNode[] | undefined;
+    const orderedGroupChildren = unsafeTypeAssertion<readonly XmlOrderedNode[] | undefined>(
+      orderedNode?.[local],
+    );
     return parseGroup(node, partPath, nextId, orderingSlot, orderedGroupChildren);
   }
   if (local === "graphicFrame") {
@@ -590,7 +593,7 @@ function parseAlternateContentBranch(
     const value = branch[key];
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
-      const node = item as XmlNode;
+      const node = unsafeTypeAssertion<XmlNode>(item);
       if (local === "sp") nodes.push(parseShape(node, partPath, nextId, orderingSlot));
       else if (local === "pic") nodes.push(parseImage(node, partPath, nextId, orderingSlot));
       else if (local === "cxnSp") {

--- a/packages/document/src/reader/shape-tree.ts
+++ b/packages/document/src/reader/shape-tree.ts
@@ -40,7 +40,7 @@ import type {
   SourceTransform,
 } from "../source/index.js";
 import { asEmu, asOoxmlPercent, asRelationshipId, asSourceNodeId } from "../source/index.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseCustomGeometry } from "./custom-geometry.js";
 import {
   isTrue,
@@ -169,7 +169,7 @@ export function parseShapeTree(
     const value = spTree[key];
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
-      const node = unsafeTypeAssertion<XmlNode>(item);
+      const node = unsafeOoxmlBoundaryAssertion<XmlNode>(item);
       if (local === "sp") {
         nodes.push(parseShape(node, partPath, nextId, orderingSlot));
       } else if (local === "pic") {
@@ -246,9 +246,9 @@ function parseShapeTreeNode(
     return parseConnector(node, partPath, nextId, orderingSlot, orderedNode);
   }
   if (local === "grpSp") {
-    const orderedGroupChildren = unsafeTypeAssertion<readonly XmlOrderedNode[] | undefined>(
-      orderedNode?.[local],
-    );
+    const orderedGroupChildren = unsafeOoxmlBoundaryAssertion<
+      readonly XmlOrderedNode[] | undefined
+    >(orderedNode?.[local]);
     return parseGroup(node, partPath, nextId, orderingSlot, orderedGroupChildren);
   }
   if (local === "graphicFrame") {
@@ -593,7 +593,7 @@ function parseAlternateContentBranch(
     const value = branch[key];
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
-      const node = unsafeTypeAssertion<XmlNode>(item);
+      const node = unsafeOoxmlBoundaryAssertion<XmlNode>(item);
       if (local === "sp") nodes.push(parseShape(node, partPath, nextId, orderingSlot));
       else if (local === "pic") nodes.push(parseImage(node, partPath, nextId, orderingSlot));
       else if (local === "cxnSp") {

--- a/packages/document/src/reader/slide-reader.test.ts
+++ b/packages/document/src/reader/slide-reader.test.ts
@@ -15,7 +15,7 @@ import type {
 } from "../experimental.js";
 // 実際の公開面 (`@pptx-glimpse/document/experimental`) 経由で import する。
 import { readPptx } from "../experimental.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 
 const encoder = new TextEncoder();
 
@@ -221,7 +221,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</p:spPr></p:sp>`,
       ),
     );
-    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.transform).toEqual({
       offsetX: 100,
       offsetY: 200,
@@ -261,7 +261,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.textBody?.properties).toMatchObject({
       wrap: "none",
       vert: "eaVert",
@@ -296,7 +296,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
     const paragraphs = shape.textBody!.paragraphs;
     expect(paragraphs.map((paragraph) => paragraph.runs.map((run) => run.text))).toEqual([
       ["first", "\n", "after break"],
@@ -316,7 +316,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.textBody?.properties).toMatchObject({ autoFit: "spAutofit" });
   });
 
@@ -330,7 +330,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.textBody?.properties).toMatchObject({
       autoFit: "noAutofit",
       fontScale: 1,
@@ -348,7 +348,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</p:spPr></p:sp>`,
       ),
     );
-    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.fill).toMatchObject({
       kind: "gradient",
       gradientType: "linear",
@@ -372,7 +372,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</a:effectLst></p:spPr></p:sp>`,
       ),
     );
-    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.effects).toMatchObject({
       outerShadow: {
         blurRadius: 40000,
@@ -416,7 +416,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</p:pic>`,
       ),
     );
-    const image = unsafeTypeAssertion<SourceImage>(source.slides[0].shapes[0]);
+    const image = unsafeFixtureAssertion<SourceImage>(source.slides[0].shapes[0]);
     expect(image.effects?.softEdge).toEqual({ radius: 1000 });
     expect(image.blipEffects).toMatchObject({
       grayscale: true,
@@ -466,7 +466,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const table = unsafeTypeAssertion<SourceTable>(source.slides[0].shapes[0]);
+    const table = unsafeFixtureAssertion<SourceTable>(source.slides[0].shapes[0]);
     expect(table.kind).toBe("table");
     expect(table.nodeId).toBe("20");
     expect(table.name).toBe("Sales table");
@@ -533,7 +533,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const [chart, smartArt, connector] = unsafeTypeAssertion<
+    const [chart, smartArt, connector] = unsafeFixtureAssertion<
       [SourceChart, SourceSmartArt, SourceConnector]
     >(source.slides[0].shapes);
     expect(chart).toMatchObject({
@@ -621,7 +621,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       "shape",
       "shape",
     ]);
-    const [connector, group, custom, orderedCustom] = unsafeTypeAssertion<
+    const [connector, group, custom, orderedCustom] = unsafeFixtureAssertion<
       [SourceConnector, SourceGroup, SourceShape, SourceShape]
     >(source.slides[0].shapes);
     expect(connector).toMatchObject({

--- a/packages/document/src/reader/slide-reader.test.ts
+++ b/packages/document/src/reader/slide-reader.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "../experimental.js";
 // 実際の公開面 (`@pptx-glimpse/document/experimental`) 経由で import する。
 import { readPptx } from "../experimental.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 
 const encoder = new TextEncoder();
 
@@ -220,7 +221,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</p:spPr></p:sp>`,
       ),
     );
-    const shape = source.slides[0].shapes[0] as SourceShape;
+    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.transform).toEqual({
       offsetX: 100,
       offsetY: 200,
@@ -260,7 +261,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = source.slides[0].shapes[0] as SourceShape;
+    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.textBody?.properties).toMatchObject({
       wrap: "none",
       vert: "eaVert",
@@ -295,7 +296,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = source.slides[0].shapes[0] as SourceShape;
+    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
     const paragraphs = shape.textBody!.paragraphs;
     expect(paragraphs.map((paragraph) => paragraph.runs.map((run) => run.text))).toEqual([
       ["first", "\n", "after break"],
@@ -315,7 +316,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = source.slides[0].shapes[0] as SourceShape;
+    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.textBody?.properties).toMatchObject({ autoFit: "spAutofit" });
   });
 
@@ -329,7 +330,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const shape = source.slides[0].shapes[0] as SourceShape;
+    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.textBody?.properties).toMatchObject({
       autoFit: "noAutofit",
       fontScale: 1,
@@ -347,7 +348,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</p:spPr></p:sp>`,
       ),
     );
-    const shape = source.slides[0].shapes[0] as SourceShape;
+    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.fill).toMatchObject({
       kind: "gradient",
       gradientType: "linear",
@@ -371,7 +372,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</a:effectLst></p:spPr></p:sp>`,
       ),
     );
-    const shape = source.slides[0].shapes[0] as SourceShape;
+    const shape = unsafeTypeAssertion<SourceShape>(source.slides[0].shapes[0]);
     expect(shape.effects).toMatchObject({
       outerShadow: {
         blurRadius: 40000,
@@ -415,7 +416,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
           `</p:pic>`,
       ),
     );
-    const image = source.slides[0].shapes[0] as SourceImage;
+    const image = unsafeTypeAssertion<SourceImage>(source.slides[0].shapes[0]);
     expect(image.effects?.softEdge).toEqual({ radius: 1000 });
     expect(image.blipEffects).toMatchObject({
       grayscale: true,
@@ -465,7 +466,7 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const table = source.slides[0].shapes[0] as SourceTable;
+    const table = unsafeTypeAssertion<SourceTable>(source.slides[0].shapes[0]);
     expect(table.kind).toBe("table");
     expect(table.nodeId).toBe("20");
     expect(table.name).toBe("Sales table");
@@ -532,11 +533,9 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       ),
     );
 
-    const [chart, smartArt, connector] = source.slides[0].shapes as [
-      SourceChart,
-      SourceSmartArt,
-      SourceConnector,
-    ];
+    const [chart, smartArt, connector] = unsafeTypeAssertion<
+      [SourceChart, SourceSmartArt, SourceConnector]
+    >(source.slides[0].shapes);
     expect(chart).toMatchObject({
       kind: "chart",
       nodeId: "30",
@@ -622,12 +621,9 @@ describe("readPptx — typed shape detail (synthetic)", () => {
       "shape",
       "shape",
     ]);
-    const [connector, group, custom, orderedCustom] = source.slides[0].shapes as [
-      SourceConnector,
-      SourceGroup,
-      SourceShape,
-      SourceShape,
-    ];
+    const [connector, group, custom, orderedCustom] = unsafeTypeAssertion<
+      [SourceConnector, SourceGroup, SourceShape, SourceShape]
+    >(source.slides[0].shapes);
     expect(connector).toMatchObject({
       name: "Connector first",
       geometry: { preset: "bentConnector3", adjustValues: { adj1: 50000 } },

--- a/packages/document/src/reader/text.ts
+++ b/packages/document/src/reader/text.ts
@@ -26,6 +26,7 @@ import type {
   SourceVerticalAnchor,
 } from "../source/index.js";
 import { asEmu, asHundredthPt, asPt, asSourceNodeId } from "../source/index.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { parseColorElement } from "./drawing.js";
 import { isTrue, numericAttr } from "./drawing.js";
 import { parseEnumValue, parseEnumValueWithDefault } from "./ooxml-values.js";
@@ -523,7 +524,8 @@ function parseTabStops(
 ): NonNullable<SourceParagraphProperties["tabStops"]> {
   return getChildArray(getChild(pPr, "tabLst"), "tab").map((tab) => ({
     position: emu(numericAttr(tab, "pos") ?? 0),
-    alignment: (getAttr(tab, "algn") as "l" | "ctr" | "r" | "dec" | undefined) ?? "l",
+    alignment:
+      unsafeTypeAssertion<"l" | "ctr" | "r" | "dec" | undefined>(getAttr(tab, "algn")) ?? "l",
   }));
 }
 

--- a/packages/document/src/reader/text.ts
+++ b/packages/document/src/reader/text.ts
@@ -26,7 +26,7 @@ import type {
   SourceVerticalAnchor,
 } from "../source/index.js";
 import { asEmu, asHundredthPt, asPt, asSourceNodeId } from "../source/index.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 import { parseColorElement } from "./drawing.js";
 import { isTrue, numericAttr } from "./drawing.js";
 import { parseEnumValue, parseEnumValueWithDefault } from "./ooxml-values.js";
@@ -525,7 +525,8 @@ function parseTabStops(
   return getChildArray(getChild(pPr, "tabLst"), "tab").map((tab) => ({
     position: emu(numericAttr(tab, "pos") ?? 0),
     alignment:
-      unsafeTypeAssertion<"l" | "ctr" | "r" | "dec" | undefined>(getAttr(tab, "algn")) ?? "l",
+      unsafeOoxmlBoundaryAssertion<"l" | "ctr" | "r" | "dec" | undefined>(getAttr(tab, "algn")) ??
+      "l",
   }));
 }
 

--- a/packages/document/src/reader/xml.ts
+++ b/packages/document/src/reader/xml.ts
@@ -12,6 +12,8 @@
 
 import { XMLParser } from "fast-xml-parser";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+
 export type XmlNode = Record<string, unknown>;
 export type XmlOrderedNode = Record<string, unknown>;
 
@@ -36,11 +38,11 @@ const orderedParser = new XMLParser({
 
 /** XML 文字列をパースして root オブジェクトを返す。 */
 export function parseXml(xml: string): XmlNode {
-  return parser.parse(xml) as XmlNode;
+  return unsafeTypeAssertion<XmlNode>(parser.parse(xml));
 }
 
 export function parseXmlOrdered(xml: string): XmlOrderedNode[] {
-  return orderedParser.parse(xml) as XmlOrderedNode[];
+  return unsafeTypeAssertion<XmlOrderedNode[]>(orderedParser.parse(xml));
 }
 
 export function navigateOrdered(
@@ -52,7 +54,7 @@ export function navigateOrdered(
     const entry = current.find((item) => key in item);
     const value = entry?.[key];
     if (!Array.isArray(value)) return undefined;
-    current = value as XmlOrderedNode[];
+    current = unsafeTypeAssertion<XmlOrderedNode[]>(value);
   }
   return [...current];
 }
@@ -74,8 +76,8 @@ export function getChild(node: XmlNode | undefined, name: string): XmlNode | und
     if (localName(key) === name) {
       const value = node[key];
       return Array.isArray(value)
-        ? (value[0] as XmlNode | undefined)
-        : (value as XmlNode | undefined);
+        ? unsafeTypeAssertion<XmlNode | undefined>(value[0])
+        : unsafeTypeAssertion<XmlNode | undefined>(value);
     }
   }
   return undefined;
@@ -103,7 +105,7 @@ export function getChildArray(node: XmlNode | undefined, name: string): XmlNode[
     if (localName(key) === name) {
       const value = node[key];
       if (value === undefined || value === null) return [];
-      return (Array.isArray(value) ? value : [value]) as XmlNode[];
+      return unsafeTypeAssertion<XmlNode[]>(Array.isArray(value) ? value : [value]);
     }
   }
   return [];
@@ -151,7 +153,7 @@ export function getChildText(node: XmlNode | undefined, name: string): string | 
     if (typeof item === "string") return item;
     if (typeof item === "number" || typeof item === "boolean") return String(item);
     if (item && typeof item === "object") {
-      return scalarToString((item as XmlNode)["#text"]);
+      return scalarToString(unsafeTypeAssertion<XmlNode>(item)["#text"]);
     }
     return undefined;
   }

--- a/packages/document/src/reader/xml.ts
+++ b/packages/document/src/reader/xml.ts
@@ -12,7 +12,7 @@
 
 import { XMLParser } from "fast-xml-parser";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 
 export type XmlNode = Record<string, unknown>;
 export type XmlOrderedNode = Record<string, unknown>;
@@ -38,11 +38,11 @@ const orderedParser = new XMLParser({
 
 /** XML 文字列をパースして root オブジェクトを返す。 */
 export function parseXml(xml: string): XmlNode {
-  return unsafeTypeAssertion<XmlNode>(parser.parse(xml));
+  return unsafeOoxmlBoundaryAssertion<XmlNode>(parser.parse(xml));
 }
 
 export function parseXmlOrdered(xml: string): XmlOrderedNode[] {
-  return unsafeTypeAssertion<XmlOrderedNode[]>(orderedParser.parse(xml));
+  return unsafeOoxmlBoundaryAssertion<XmlOrderedNode[]>(orderedParser.parse(xml));
 }
 
 export function navigateOrdered(
@@ -54,7 +54,7 @@ export function navigateOrdered(
     const entry = current.find((item) => key in item);
     const value = entry?.[key];
     if (!Array.isArray(value)) return undefined;
-    current = unsafeTypeAssertion<XmlOrderedNode[]>(value);
+    current = unsafeOoxmlBoundaryAssertion<XmlOrderedNode[]>(value);
   }
   return [...current];
 }
@@ -76,8 +76,8 @@ export function getChild(node: XmlNode | undefined, name: string): XmlNode | und
     if (localName(key) === name) {
       const value = node[key];
       return Array.isArray(value)
-        ? unsafeTypeAssertion<XmlNode | undefined>(value[0])
-        : unsafeTypeAssertion<XmlNode | undefined>(value);
+        ? unsafeOoxmlBoundaryAssertion<XmlNode | undefined>(value[0])
+        : unsafeOoxmlBoundaryAssertion<XmlNode | undefined>(value);
     }
   }
   return undefined;
@@ -105,7 +105,7 @@ export function getChildArray(node: XmlNode | undefined, name: string): XmlNode[
     if (localName(key) === name) {
       const value = node[key];
       if (value === undefined || value === null) return [];
-      return unsafeTypeAssertion<XmlNode[]>(Array.isArray(value) ? value : [value]);
+      return unsafeOoxmlBoundaryAssertion<XmlNode[]>(Array.isArray(value) ? value : [value]);
     }
   }
   return [];
@@ -153,7 +153,7 @@ export function getChildText(node: XmlNode | undefined, name: string): string | 
     if (typeof item === "string") return item;
     if (typeof item === "number" || typeof item === "boolean") return String(item);
     if (item && typeof item === "object") {
-      return scalarToString(unsafeTypeAssertion<XmlNode>(item)["#text"]);
+      return scalarToString(unsafeOoxmlBoundaryAssertion<XmlNode>(item)["#text"]);
     }
     return undefined;
   }

--- a/packages/document/src/source/handles.ts
+++ b/packages/document/src/source/handles.ts
@@ -1,3 +1,5 @@
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+
 /**
  * Source handle 関連の型。
  *
@@ -28,19 +30,19 @@ export type SourceNodeId = string & { readonly [SourceNodeIdBrand]: typeof Sourc
 export type RawSidecarId = string & { readonly [RawSidecarIdBrand]: typeof RawSidecarIdBrand };
 
 export function asPartPath(value: string): PartPath {
-  return value as PartPath;
+  return unsafeTypeAssertion<PartPath>(value);
 }
 
 export function asRelationshipId(value: string): RelationshipId {
-  return value as RelationshipId;
+  return unsafeTypeAssertion<RelationshipId>(value);
 }
 
 export function asSourceNodeId(value: string): SourceNodeId {
-  return value as SourceNodeId;
+  return unsafeTypeAssertion<SourceNodeId>(value);
 }
 
 export function asRawSidecarId(value: string): RawSidecarId {
-  return value as RawSidecarId;
+  return unsafeTypeAssertion<RawSidecarId>(value);
 }
 
 /**

--- a/packages/document/src/source/handles.ts
+++ b/packages/document/src/source/handles.ts
@@ -1,4 +1,4 @@
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeBrandAssertion } from "../unsafe-type-assertion.js";
 
 /**
  * Source handle 関連の型。
@@ -30,19 +30,19 @@ export type SourceNodeId = string & { readonly [SourceNodeIdBrand]: typeof Sourc
 export type RawSidecarId = string & { readonly [RawSidecarIdBrand]: typeof RawSidecarIdBrand };
 
 export function asPartPath(value: string): PartPath {
-  return unsafeTypeAssertion<PartPath>(value);
+  return unsafeBrandAssertion<PartPath>(value);
 }
 
 export function asRelationshipId(value: string): RelationshipId {
-  return unsafeTypeAssertion<RelationshipId>(value);
+  return unsafeBrandAssertion<RelationshipId>(value);
 }
 
 export function asSourceNodeId(value: string): SourceNodeId {
-  return unsafeTypeAssertion<SourceNodeId>(value);
+  return unsafeBrandAssertion<SourceNodeId>(value);
 }
 
 export function asRawSidecarId(value: string): RawSidecarId {
-  return unsafeTypeAssertion<RawSidecarId>(value);
+  return unsafeBrandAssertion<RawSidecarId>(value);
 }
 
 /**

--- a/packages/document/src/source/units.ts
+++ b/packages/document/src/source/units.ts
@@ -1,4 +1,4 @@
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeBrandAssertion } from "../unsafe-type-assertion.js";
 
 /**
  * PptxSourceModel source model が使う PPTX-native な typed units。
@@ -37,21 +37,21 @@ export type OoxmlPercent = number & { readonly [OoxmlPercentBrand]: typeof Ooxml
 export type OoxmlAngle = number & { readonly [OoxmlAngleBrand]: typeof OoxmlAngleBrand };
 
 export function asEmu(value: number): Emu {
-  return unsafeTypeAssertion<Emu>(value);
+  return unsafeBrandAssertion<Emu>(value);
 }
 
 export function asPt(value: number): Pt {
-  return unsafeTypeAssertion<Pt>(value);
+  return unsafeBrandAssertion<Pt>(value);
 }
 
 export function asHundredthPt(value: number): HundredthPt {
-  return unsafeTypeAssertion<HundredthPt>(value);
+  return unsafeBrandAssertion<HundredthPt>(value);
 }
 
 export function asOoxmlPercent(value: number): OoxmlPercent {
-  return unsafeTypeAssertion<OoxmlPercent>(value);
+  return unsafeBrandAssertion<OoxmlPercent>(value);
 }
 
 export function asOoxmlAngle(value: number): OoxmlAngle {
-  return unsafeTypeAssertion<OoxmlAngle>(value);
+  return unsafeBrandAssertion<OoxmlAngle>(value);
 }

--- a/packages/document/src/source/units.ts
+++ b/packages/document/src/source/units.ts
@@ -1,3 +1,5 @@
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+
 /**
  * PptxSourceModel source model が使う PPTX-native な typed units。
  *
@@ -35,21 +37,21 @@ export type OoxmlPercent = number & { readonly [OoxmlPercentBrand]: typeof Ooxml
 export type OoxmlAngle = number & { readonly [OoxmlAngleBrand]: typeof OoxmlAngleBrand };
 
 export function asEmu(value: number): Emu {
-  return value as Emu;
+  return unsafeTypeAssertion<Emu>(value);
 }
 
 export function asPt(value: number): Pt {
-  return value as Pt;
+  return unsafeTypeAssertion<Pt>(value);
 }
 
 export function asHundredthPt(value: number): HundredthPt {
-  return value as HundredthPt;
+  return unsafeTypeAssertion<HundredthPt>(value);
 }
 
 export function asOoxmlPercent(value: number): OoxmlPercent {
-  return value as OoxmlPercent;
+  return unsafeTypeAssertion<OoxmlPercent>(value);
 }
 
 export function asOoxmlAngle(value: number): OoxmlAngle {
-  return value as OoxmlAngle;
+  return unsafeTypeAssertion<OoxmlAngle>(value);
 }

--- a/packages/document/src/unsafe-type-assertion.ts
+++ b/packages/document/src/unsafe-type-assertion.ts
@@ -1,0 +1,4 @@
+export function unsafeTypeAssertion<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- OOXML reader and source-model boundaries intentionally centralize unchecked narrowing here.
+  return value as T;
+}

--- a/packages/document/src/unsafe-type-assertion.ts
+++ b/packages/document/src/unsafe-type-assertion.ts
@@ -1,16 +1,14 @@
 export function unsafeOoxmlBoundaryAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Document OOXML reader boundaries narrow parsed XML output behind this named helper.
+  return value as T;
 }
 
 export function unsafeBrandAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Document branded value constructors narrow primitive values behind this named helper.
+  return value as T;
 }
 
 export function unsafeFixtureAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
-}
-
-function assertUnsafeBoundary<T>(value: unknown): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Document OOXML, brand, and fixture helpers intentionally centralize unchecked narrowing here.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Document tests narrow fixture values behind this test-only helper.
   return value as T;
 }

--- a/packages/document/src/unsafe-type-assertion.ts
+++ b/packages/document/src/unsafe-type-assertion.ts
@@ -1,4 +1,16 @@
-export function unsafeTypeAssertion<T>(value: unknown): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- OOXML reader and source-model boundaries intentionally centralize unchecked narrowing here.
+export function unsafeOoxmlBoundaryAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+export function unsafeBrandAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+export function unsafeFixtureAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+function assertUnsafeBoundary<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Document OOXML, brand, and fixture helpers intentionally centralize unchecked narrowing here.
   return value as T;
 }

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -29,7 +29,7 @@ import type {
   RawPackagePart,
 } from "../source/index.js";
 import { isRelationshipPart, relationshipsPartPath } from "../source/package-paths.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
 
 /** `writePptx` の出力。 */
 export type WritePptxOutput = Uint8Array;
@@ -203,7 +203,7 @@ function getShapeByOrderingSlot(
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
       if (currentSlot === orderingSlot) {
-        return local === "sp" ? unsafeTypeAssertion<XmlNode>(item) : undefined;
+        return local === "sp" ? unsafeOoxmlBoundaryAssertion<XmlNode>(item) : undefined;
       }
       currentSlot++;
     }
@@ -230,7 +230,7 @@ function setChildText(node: XmlNode, name: string, text: string): void {
 
 function textElementValue(existing: unknown, text: string): unknown {
   if (typeof existing === "object" && existing !== null && !Array.isArray(existing)) {
-    const next: XmlNode = { ...unsafeTypeAssertion<XmlNode>(existing), "#text": text };
+    const next: XmlNode = { ...unsafeOoxmlBoundaryAssertion<XmlNode>(existing), "#text": text };
     if (textRequiresPreserve(text)) next["@_xml:space"] = "preserve";
     else delete next["@_xml:space"];
     return next;

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -29,6 +29,7 @@ import type {
   RawPackagePart,
 } from "../source/index.js";
 import { isRelationshipPart, relationshipsPartPath } from "../source/package-paths.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 
 /** `writePptx` の出力。 */
 export type WritePptxOutput = Uint8Array;
@@ -202,7 +203,7 @@ function getShapeByOrderingSlot(
     const items = Array.isArray(value) ? value : [value];
     for (const item of items) {
       if (currentSlot === orderingSlot) {
-        return local === "sp" ? (item as XmlNode) : undefined;
+        return local === "sp" ? unsafeTypeAssertion<XmlNode>(item) : undefined;
       }
       currentSlot++;
     }
@@ -229,7 +230,7 @@ function setChildText(node: XmlNode, name: string, text: string): void {
 
 function textElementValue(existing: unknown, text: string): unknown {
   if (typeof existing === "object" && existing !== null && !Array.isArray(existing)) {
-    const next: XmlNode = { ...(existing as XmlNode), "#text": text };
+    const next: XmlNode = { ...unsafeTypeAssertion<XmlNode>(existing), "#text": text };
     if (textRequiresPreserve(text)) next["@_xml:space"] = "preserve";
     else delete next["@_xml:space"];
     return next;

--- a/packages/renderer/src/font/font-subsetter.test.ts
+++ b/packages/renderer/src/font/font-subsetter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { subsetFont } from "./font-subsetter.js";
 import type { OpentypeFullFont } from "./text-path-context.js";
 
@@ -77,13 +78,15 @@ async function createParsedTestFont(): Promise<OpentypeFullFont> {
     glyphs: [notdefGlyph, spaceGlyph, glyphA, glyphB],
   });
 
-  return opentype.parse(font.toArrayBuffer()) as unknown as OpentypeFullFont;
+  return unsafeTypeAssertion<OpentypeFullFont>(opentype.parse(font.toArrayBuffer()));
 }
 
 async function parseSubsetBuffer(buffer: Uint8Array): Promise<ParsedFontForTest> {
   const opentype = await loadOpentype();
   return opentype.parse(
-    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer,
+    unsafeTypeAssertion<ArrayBuffer>(
+      buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    ),
   );
 }
 
@@ -131,7 +134,7 @@ describe("subsetFont", () => {
   });
 
   it("charToGlyph を持たないオブジェクトで null を返す", async () => {
-    const fakeFont = { unitsPerEm: 1000 } as unknown as OpentypeFullFont;
+    const fakeFont = unsafeTypeAssertion<OpentypeFullFont>({ unitsPerEm: 1000 });
     const buffer = await subsetFont(fakeFont, new Set(["A"]), "Fake");
 
     expect(buffer).toBeNull();

--- a/packages/renderer/src/font/font-subsetter.test.ts
+++ b/packages/renderer/src/font/font-subsetter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import { subsetFont } from "./font-subsetter.js";
 import type { OpentypeFullFont } from "./text-path-context.js";
 
@@ -78,13 +78,13 @@ async function createParsedTestFont(): Promise<OpentypeFullFont> {
     glyphs: [notdefGlyph, spaceGlyph, glyphA, glyphB],
   });
 
-  return unsafeTypeAssertion<OpentypeFullFont>(opentype.parse(font.toArrayBuffer()));
+  return unsafeFixtureAssertion<OpentypeFullFont>(opentype.parse(font.toArrayBuffer()));
 }
 
 async function parseSubsetBuffer(buffer: Uint8Array): Promise<ParsedFontForTest> {
   const opentype = await loadOpentype();
   return opentype.parse(
-    unsafeTypeAssertion<ArrayBuffer>(
+    unsafeFixtureAssertion<ArrayBuffer>(
       buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
     ),
   );
@@ -134,7 +134,7 @@ describe("subsetFont", () => {
   });
 
   it("charToGlyph を持たないオブジェクトで null を返す", async () => {
-    const fakeFont = unsafeTypeAssertion<OpentypeFullFont>({ unitsPerEm: 1000 });
+    const fakeFont = unsafeFixtureAssertion<OpentypeFullFont>({ unitsPerEm: 1000 });
     const buffer = await subsetFont(fakeFont, new Set(["A"]), "Fake");
 
     expect(buffer).toBeNull();

--- a/packages/renderer/src/font/font-subsetter.ts
+++ b/packages/renderer/src/font/font-subsetter.ts
@@ -3,7 +3,7 @@
  * ネイティブ <text> 出力モードの @font-face 埋め込み用。
  */
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeExternalInteropAssertion } from "../unsafe-type-assertion.js";
 import { warn } from "../warning-logger.js";
 import type { OpentypeFullFont } from "./text-path-context.js";
 
@@ -65,7 +65,7 @@ export async function subsetFont(
   const opentype = await tryLoadOpentypeCtors();
   if (!opentype) return null;
 
-  const source = unsafeTypeAssertion<SubsettableFont>(font);
+  const source = unsafeExternalInteropAssertion<SubsettableFont>(font);
   if (typeof source.charToGlyph !== "function" || !source.glyphs) return null;
 
   // グリフインデックス → { グリフ, 担当ユニコード集合 }。

--- a/packages/renderer/src/font/font-subsetter.ts
+++ b/packages/renderer/src/font/font-subsetter.ts
@@ -3,6 +3,7 @@
  * ネイティブ <text> 出力モードの @font-face 埋め込み用。
  */
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { warn } from "../warning-logger.js";
 import type { OpentypeFullFont } from "./text-path-context.js";
 
@@ -64,7 +65,7 @@ export async function subsetFont(
   const opentype = await tryLoadOpentypeCtors();
   if (!opentype) return null;
 
-  const source = font as unknown as SubsettableFont;
+  const source = unsafeTypeAssertion<SubsettableFont>(font);
   if (typeof source.charToGlyph !== "function" || !source.glyphs) return null;
 
   // グリフインデックス → { グリフ, 担当ユニコード集合 }。

--- a/packages/renderer/src/font/opentype-helpers.ts
+++ b/packages/renderer/src/font/opentype-helpers.ts
@@ -3,6 +3,7 @@
  */
 import { readFile } from "node:fs/promises";
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import type { FontMapping } from "./font-mapping.js";
 import { createFontMapping } from "./font-mapping.js";
 import type { OpentypeFont } from "./opentype-text-measurer.js";
@@ -66,7 +67,9 @@ function buildReverseMapping(mapping: FontMapping): Map<string, string[]> {
  */
 function toArrayBuffer(data: ArrayBuffer | Uint8Array): ArrayBuffer {
   if (data instanceof ArrayBuffer) return data;
-  return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+  return unsafeTypeAssertion<ArrayBuffer>(
+    data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+  );
 }
 
 /**
@@ -142,7 +145,7 @@ export async function createOpentypeSetupFromBuffers(
 
       for (const font of fonts) {
         if (!firstMeasurerFont) firstMeasurerFont = font;
-        if (!firstResolverFont) firstResolverFont = font as unknown as OpentypeFullFont;
+        if (!firstResolverFont) firstResolverFont = unsafeTypeAssertion<OpentypeFullFont>(font);
 
         if (isTtc) {
           // TTC: names テーブルからフォント名を取得して登録
@@ -176,7 +179,7 @@ function registerFont(
   measurerFonts: Map<string, OpentypeFont>,
   resolverFonts: Map<string, OpentypeFullFont>,
 ): void {
-  const fullFont = font as unknown as OpentypeFullFont;
+  const fullFont = unsafeTypeAssertion<OpentypeFullFont>(font);
   if (!measurerFonts.has(name)) {
     measurerFonts.set(name, font);
     resolverFonts.set(name, fullFont);
@@ -285,7 +288,7 @@ export async function createOpentypeSetupFromSystem(
 
       for (const font of fonts) {
         if (!firstMeasurerFont) firstMeasurerFont = font;
-        if (!firstResolverFont) firstResolverFont = font as unknown as OpentypeFullFont;
+        if (!firstResolverFont) firstResolverFont = unsafeTypeAssertion<OpentypeFullFont>(font);
 
         // names テーブルからフォント名を取得して登録
         for (const name of collectFontNames(font)) {

--- a/packages/renderer/src/font/opentype-helpers.ts
+++ b/packages/renderer/src/font/opentype-helpers.ts
@@ -3,7 +3,7 @@
  */
 import { readFile } from "node:fs/promises";
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeExternalInteropAssertion } from "../unsafe-type-assertion.js";
 import type { FontMapping } from "./font-mapping.js";
 import { createFontMapping } from "./font-mapping.js";
 import type { OpentypeFont } from "./opentype-text-measurer.js";
@@ -67,7 +67,7 @@ function buildReverseMapping(mapping: FontMapping): Map<string, string[]> {
  */
 function toArrayBuffer(data: ArrayBuffer | Uint8Array): ArrayBuffer {
   if (data instanceof ArrayBuffer) return data;
-  return unsafeTypeAssertion<ArrayBuffer>(
+  return unsafeExternalInteropAssertion<ArrayBuffer>(
     data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
   );
 }
@@ -145,7 +145,8 @@ export async function createOpentypeSetupFromBuffers(
 
       for (const font of fonts) {
         if (!firstMeasurerFont) firstMeasurerFont = font;
-        if (!firstResolverFont) firstResolverFont = unsafeTypeAssertion<OpentypeFullFont>(font);
+        if (!firstResolverFont)
+          firstResolverFont = unsafeExternalInteropAssertion<OpentypeFullFont>(font);
 
         if (isTtc) {
           // TTC: names テーブルからフォント名を取得して登録
@@ -179,7 +180,7 @@ function registerFont(
   measurerFonts: Map<string, OpentypeFont>,
   resolverFonts: Map<string, OpentypeFullFont>,
 ): void {
-  const fullFont = unsafeTypeAssertion<OpentypeFullFont>(font);
+  const fullFont = unsafeExternalInteropAssertion<OpentypeFullFont>(font);
   if (!measurerFonts.has(name)) {
     measurerFonts.set(name, font);
     resolverFonts.set(name, fullFont);
@@ -288,7 +289,8 @@ export async function createOpentypeSetupFromSystem(
 
       for (const font of fonts) {
         if (!firstMeasurerFont) firstMeasurerFont = font;
-        if (!firstResolverFont) firstResolverFont = unsafeTypeAssertion<OpentypeFullFont>(font);
+        if (!firstResolverFont)
+          firstResolverFont = unsafeExternalInteropAssertion<OpentypeFullFont>(font);
 
         // names テーブルからフォント名を取得して登録
         for (const name of collectFontNames(font)) {

--- a/packages/renderer/src/png/png-converter.test.ts
+++ b/packages/renderer/src/png/png-converter.test.ts
@@ -23,6 +23,7 @@ vi.mock("fs/promises", () => ({
   readFile: vi.fn().mockResolvedValue(Buffer.alloc(0)),
 }));
 
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { svgToPng } from "./png-converter.js";
 
 const MINIMAL_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
@@ -31,14 +32,18 @@ describe("svgToPng", () => {
   it("fontBuffers 未指定のとき font オプションを Resvg に渡さない", async () => {
     mocks.MockResvg.mockClear();
     await svgToPng(MINIMAL_SVG);
-    const opts = mocks.MockResvg.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    const opts = unsafeTypeAssertion<Record<string, unknown> | undefined>(
+      mocks.MockResvg.mock.calls[0]?.[1],
+    );
     expect(opts?.font).toBeUndefined();
   });
 
   it("fontBuffers が空配列のとき font オプションを Resvg に渡さない", async () => {
     mocks.MockResvg.mockClear();
     await svgToPng(MINIMAL_SVG, { fontBuffers: [] });
-    const opts = mocks.MockResvg.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    const opts = unsafeTypeAssertion<Record<string, unknown> | undefined>(
+      mocks.MockResvg.mock.calls[0]?.[1],
+    );
     expect(opts?.font).toBeUndefined();
   });
 
@@ -46,7 +51,9 @@ describe("svgToPng", () => {
     const fontBuffers = [new Uint8Array([1, 2, 3])];
     mocks.MockResvg.mockClear();
     await svgToPng(MINIMAL_SVG, { fontBuffers });
-    const opts = mocks.MockResvg.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
+    const opts = unsafeTypeAssertion<Record<string, unknown> | undefined>(
+      mocks.MockResvg.mock.calls[0]?.[1],
+    );
     expect(opts?.font).toEqual({ fontBuffers });
   });
 });

--- a/packages/renderer/src/png/png-converter.test.ts
+++ b/packages/renderer/src/png/png-converter.test.ts
@@ -23,7 +23,7 @@ vi.mock("fs/promises", () => ({
   readFile: vi.fn().mockResolvedValue(Buffer.alloc(0)),
 }));
 
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import { svgToPng } from "./png-converter.js";
 
 const MINIMAL_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
@@ -32,7 +32,7 @@ describe("svgToPng", () => {
   it("fontBuffers 未指定のとき font オプションを Resvg に渡さない", async () => {
     mocks.MockResvg.mockClear();
     await svgToPng(MINIMAL_SVG);
-    const opts = unsafeTypeAssertion<Record<string, unknown> | undefined>(
+    const opts = unsafeFixtureAssertion<Record<string, unknown> | undefined>(
       mocks.MockResvg.mock.calls[0]?.[1],
     );
     expect(opts?.font).toBeUndefined();
@@ -41,7 +41,7 @@ describe("svgToPng", () => {
   it("fontBuffers が空配列のとき font オプションを Resvg に渡さない", async () => {
     mocks.MockResvg.mockClear();
     await svgToPng(MINIMAL_SVG, { fontBuffers: [] });
-    const opts = unsafeTypeAssertion<Record<string, unknown> | undefined>(
+    const opts = unsafeFixtureAssertion<Record<string, unknown> | undefined>(
       mocks.MockResvg.mock.calls[0]?.[1],
     );
     expect(opts?.font).toBeUndefined();
@@ -51,7 +51,7 @@ describe("svgToPng", () => {
     const fontBuffers = [new Uint8Array([1, 2, 3])];
     mocks.MockResvg.mockClear();
     await svgToPng(MINIMAL_SVG, { fontBuffers });
-    const opts = unsafeTypeAssertion<Record<string, unknown> | undefined>(
+    const opts = unsafeFixtureAssertion<Record<string, unknown> | undefined>(
       mocks.MockResvg.mock.calls[0]?.[1],
     );
     expect(opts?.font).toEqual({ fontBuffers });

--- a/packages/renderer/src/renderer/blip-effect-renderer.test.ts
+++ b/packages/renderer/src/renderer/blip-effect-renderer.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { BlipEffects } from "../model/effect.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import { renderBlipEffects } from "./blip-effect-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
+    return unsafeFixtureAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/renderer/blip-effect-renderer.test.ts
+++ b/packages/renderer/src/renderer/blip-effect-renderer.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { BlipEffects } from "../model/effect.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { renderBlipEffects } from "./blip-effect-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return `test-uuid-${counter++}` as ReturnType<typeof crypto.randomUUID>;
+    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/renderer/effect-renderer.test.ts
+++ b/packages/renderer/src/renderer/effect-renderer.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EffectList } from "../model/effect.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import { renderEffects } from "./effect-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
+    return unsafeFixtureAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/renderer/effect-renderer.test.ts
+++ b/packages/renderer/src/renderer/effect-renderer.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EffectList } from "../model/effect.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { renderEffects } from "./effect-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return `test-uuid-${counter++}` as ReturnType<typeof crypto.randomUUID>;
+    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/renderer/image-renderer.test.ts
+++ b/packages/renderer/src/renderer/image-renderer.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ImageElement } from "../model/image.js";
 import type { Transform } from "../model/shape.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { renderImage } from "./image-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return `test-uuid-${counter++}` as ReturnType<typeof crypto.randomUUID>;
+    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/renderer/image-renderer.test.ts
+++ b/packages/renderer/src/renderer/image-renderer.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ImageElement } from "../model/image.js";
 import type { Transform } from "../model/shape.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import { renderImage } from "./image-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
+    return unsafeFixtureAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/renderer/shape-renderer.test.ts
+++ b/packages/renderer/src/renderer/shape-renderer.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ConnectorElement, ShapeElement, Transform } from "../model/shape.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { renderConnector, renderShape } from "./shape-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return `test-uuid-${counter++}` as ReturnType<typeof crypto.randomUUID>;
+    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/renderer/shape-renderer.test.ts
+++ b/packages/renderer/src/renderer/shape-renderer.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ConnectorElement, ShapeElement, Transform } from "../model/shape.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
 import { renderConnector, renderShape } from "./shape-renderer.js";
 
 beforeEach(() => {
   let counter = 0;
   vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-    return unsafeTypeAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
+    return unsafeFixtureAssertion<ReturnType<typeof crypto.randomUUID>>(`test-uuid-${counter++}`);
   });
 });
 

--- a/packages/renderer/src/unsafe-type-assertion.ts
+++ b/packages/renderer/src/unsafe-type-assertion.ts
@@ -1,16 +1,14 @@
 export function unsafeExternalInteropAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Renderer external-library interop narrows untyped library values behind this named helper.
+  return value as T;
 }
 
 export function unsafeBrandAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Renderer branded value constructors narrow primitive values behind this named helper.
+  return value as T;
 }
 
 export function unsafeFixtureAssertion<T>(value: unknown): T {
-  return assertUnsafeBoundary<T>(value);
-}
-
-function assertUnsafeBoundary<T>(value: unknown): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Renderer external interop, brand, and fixture helpers intentionally centralize unchecked narrowing here.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Renderer tests narrow fixture values behind this test-only helper.
   return value as T;
 }

--- a/packages/renderer/src/unsafe-type-assertion.ts
+++ b/packages/renderer/src/unsafe-type-assertion.ts
@@ -1,0 +1,4 @@
+export function unsafeTypeAssertion<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Renderer adapter and external-library boundaries intentionally centralize unchecked narrowing here.
+  return value as T;
+}

--- a/packages/renderer/src/unsafe-type-assertion.ts
+++ b/packages/renderer/src/unsafe-type-assertion.ts
@@ -1,4 +1,16 @@
-export function unsafeTypeAssertion<T>(value: unknown): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Renderer adapter and external-library boundaries intentionally centralize unchecked narrowing here.
+export function unsafeExternalInteropAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+export function unsafeBrandAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+export function unsafeFixtureAssertion<T>(value: unknown): T {
+  return assertUnsafeBoundary<T>(value);
+}
+
+function assertUnsafeBoundary<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Renderer external interop, brand, and fixture helpers intentionally centralize unchecked narrowing here.
   return value as T;
 }

--- a/packages/renderer/src/utils/emu.ts
+++ b/packages/renderer/src/utils/emu.ts
@@ -1,4 +1,4 @@
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeBrandAssertion } from "../unsafe-type-assertion.js";
 import { DEFAULT_DPI, EMU_PER_INCH, EMU_PER_POINT, ROTATION_UNIT } from "./constants.js";
 import type { Emu, HundredthPt, Pt } from "./unit-types.js";
 
@@ -17,5 +17,5 @@ export function rotationToDegrees(rotation: number): number {
 
 /** 1/100ポイント → ポイント */
 export function hundredthPointToPoint(value: HundredthPt): Pt {
-  return unsafeTypeAssertion<Pt>(value / 100);
+  return unsafeBrandAssertion<Pt>(value / 100);
 }

--- a/packages/renderer/src/utils/emu.ts
+++ b/packages/renderer/src/utils/emu.ts
@@ -1,3 +1,4 @@
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 import { DEFAULT_DPI, EMU_PER_INCH, EMU_PER_POINT, ROTATION_UNIT } from "./constants.js";
 import type { Emu, HundredthPt, Pt } from "./unit-types.js";
 
@@ -16,5 +17,5 @@ export function rotationToDegrees(rotation: number): number {
 
 /** 1/100ポイント → ポイント */
 export function hundredthPointToPoint(value: HundredthPt): Pt {
-  return (value / 100) as Pt;
+  return unsafeTypeAssertion<Pt>(value / 100);
 }

--- a/packages/renderer/src/utils/unit-types.ts
+++ b/packages/renderer/src/utils/unit-types.ts
@@ -1,4 +1,4 @@
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeBrandAssertion } from "../unsafe-type-assertion.js";
 
 /**
  * ブランド型（Branded Types）による単位の型安全性
@@ -22,9 +22,9 @@ export type Pt = number & { readonly [PtBrand]: typeof PtBrand };
 export type HundredthPt = number & { readonly [HundredthPtBrand]: typeof HundredthPtBrand };
 
 export function asEmu(value: number): Emu {
-  return unsafeTypeAssertion<Emu>(value);
+  return unsafeBrandAssertion<Emu>(value);
 }
 
 export function asHundredthPt(value: number): HundredthPt {
-  return unsafeTypeAssertion<HundredthPt>(value);
+  return unsafeBrandAssertion<HundredthPt>(value);
 }

--- a/packages/renderer/src/utils/unit-types.ts
+++ b/packages/renderer/src/utils/unit-types.ts
@@ -1,3 +1,5 @@
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+
 /**
  * ブランド型（Branded Types）による単位の型安全性
  *
@@ -20,9 +22,9 @@ export type Pt = number & { readonly [PtBrand]: typeof PtBrand };
 export type HundredthPt = number & { readonly [HundredthPtBrand]: typeof HundredthPtBrand };
 
 export function asEmu(value: number): Emu {
-  return value as Emu;
+  return unsafeTypeAssertion<Emu>(value);
 }
 
 export function asHundredthPt(value: number): HundredthPt {
-  return value as HundredthPt;
+  return unsafeTypeAssertion<HundredthPt>(value);
 }

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -5,6 +5,8 @@ import { basename, resolve } from "path";
 import { promisify } from "util";
 import { type WebSocket, WebSocketServer } from "ws";
 
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+
 const DEFAULT_PORT = 3000;
 const DEBOUNCE_MS = 300;
 const WATCH_DIRS = [resolve("packages/core/src"), resolve("packages/renderer/src")];
@@ -26,7 +28,7 @@ async function renderSlides(pptxPath: string): Promise<SlideSvg[]> {
     maxBuffer: MAX_BUFFER,
     timeout: RENDER_TIMEOUT_MS,
   });
-  return JSON.parse(stdout) as SlideSvg[];
+  return unsafeTypeAssertion<SlideSvg[]>(JSON.parse(stdout));
 }
 
 // --- WebSocket ---

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -5,7 +5,7 @@ import { basename, resolve } from "path";
 import { promisify } from "util";
 import { type WebSocket, WebSocketServer } from "ws";
 
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeScriptInputAssertion } from "./unsafe-type-assertion.js";
 
 const DEFAULT_PORT = 3000;
 const DEBOUNCE_MS = 300;
@@ -28,7 +28,7 @@ async function renderSlides(pptxPath: string): Promise<SlideSvg[]> {
     maxBuffer: MAX_BUFFER,
     timeout: RENDER_TIMEOUT_MS,
   });
-  return unsafeTypeAssertion<SlideSvg[]>(JSON.parse(stdout));
+  return unsafeScriptInputAssertion<SlideSvg[]>(JSON.parse(stdout));
 }
 
 // --- WebSocket ---

--- a/scripts/extract-font-metrics.ts
+++ b/scripts/extract-font-metrics.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from "node:url";
 
 import opentype from "opentype.js";
 
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeScriptInputAssertion } from "./unsafe-type-assertion.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -104,7 +104,7 @@ for (const { key, file } of FONTS) {
     const charCount = Object.keys(metrics.widths).length;
     console.error(`✓ ${key}: ${charCount} chars extracted (unitsPerEm=${metrics.unitsPerEm})`);
   } catch (e) {
-    console.error(`✗ ${key}: ${unsafeTypeAssertion<Error>(e).message}`);
+    console.error(`✗ ${key}: ${unsafeScriptInputAssertion<Error>(e).message}`);
   }
 }
 

--- a/scripts/extract-font-metrics.ts
+++ b/scripts/extract-font-metrics.ts
@@ -11,6 +11,8 @@ import { fileURLToPath } from "node:url";
 
 import opentype from "opentype.js";
 
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface ExtractedMetrics {
@@ -102,7 +104,7 @@ for (const { key, file } of FONTS) {
     const charCount = Object.keys(metrics.widths).length;
     console.error(`✓ ${key}: ${charCount} chars extracted (unitsPerEm=${metrics.unitsPerEm})`);
   } catch (e) {
-    console.error(`✗ ${key}: ${(e as Error).message}`);
+    console.error(`✗ ${key}: ${unsafeTypeAssertion<Error>(e).message}`);
   }
 }
 

--- a/scripts/format-bench-comment.ts
+++ b/scripts/format-bench-comment.ts
@@ -9,7 +9,7 @@
  */
 import { readFileSync } from "node:fs";
 
-import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+import { unsafeScriptInputAssertion } from "./unsafe-type-assertion.js";
 
 interface VitestBenchmark {
   name: string;
@@ -46,7 +46,9 @@ function extractSuiteName(fullName: string): string {
 }
 
 function parseBenchOutput(path: string): FlatBenchmark[] {
-  const raw = unsafeTypeAssertion<VitestBenchOutput>(JSON.parse(readFileSync(path, "utf-8")));
+  const raw = unsafeScriptInputAssertion<VitestBenchOutput>(
+    JSON.parse(readFileSync(path, "utf-8")),
+  );
   const results: FlatBenchmark[] = [];
   for (const file of raw.files) {
     for (const group of file.groups) {

--- a/scripts/format-bench-comment.ts
+++ b/scripts/format-bench-comment.ts
@@ -9,6 +9,8 @@
  */
 import { readFileSync } from "node:fs";
 
+import { unsafeTypeAssertion } from "./unsafe-type-assertion.js";
+
 interface VitestBenchmark {
   name: string;
   hz: number;
@@ -44,7 +46,7 @@ function extractSuiteName(fullName: string): string {
 }
 
 function parseBenchOutput(path: string): FlatBenchmark[] {
-  const raw = JSON.parse(readFileSync(path, "utf-8")) as VitestBenchOutput;
+  const raw = unsafeTypeAssertion<VitestBenchOutput>(JSON.parse(readFileSync(path, "utf-8")));
   const results: FlatBenchmark[] = [];
   for (const file of raw.files) {
     for (const group of file.groups) {

--- a/scripts/unsafe-type-assertion.ts
+++ b/scripts/unsafe-type-assertion.ts
@@ -1,4 +1,4 @@
-export function unsafeTypeAssertion<T>(value: unknown): T {
+export function unsafeScriptInputAssertion<T>(value: unknown): T {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Script input and runtime boundaries intentionally centralize unchecked narrowing here.
   return value as T;
 }

--- a/scripts/unsafe-type-assertion.ts
+++ b/scripts/unsafe-type-assertion.ts
@@ -1,0 +1,4 @@
+export function unsafeTypeAssertion<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Script input and runtime boundaries intentionally centralize unchecked narrowing here.
+  return value as T;
+}

--- a/vrt/snapshot/render-options.ts
+++ b/vrt/snapshot/render-options.ts
@@ -11,7 +11,7 @@ import type { ConvertOptions } from "../../packages/core/src/converter.js";
 import { createFontMapping, getMappedFont } from "../../packages/renderer/src/font/font-mapping.js";
 import { subsetFont } from "../../packages/renderer/src/font/font-subsetter.js";
 import type { OpentypeFullFont } from "../../packages/renderer/src/font/text-path-context.js";
-import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
+import { unsafeVrtInteropAssertion } from "../unsafe-type-assertion.js";
 
 type VrtRenderOptions = Pick<ConvertOptions, "fontDirs" | "skipSystemFonts">;
 
@@ -291,7 +291,7 @@ async function readBufferIfExists(path: string): Promise<Buffer | null> {
 }
 
 function toArrayBuffer(buffer: Uint8Array): ArrayBuffer {
-  return unsafeTypeAssertion<ArrayBuffer>(
+  return unsafeVrtInteropAssertion<ArrayBuffer>(
     buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
   );
 }

--- a/vrt/snapshot/render-options.ts
+++ b/vrt/snapshot/render-options.ts
@@ -11,6 +11,7 @@ import type { ConvertOptions } from "../../packages/core/src/converter.js";
 import { createFontMapping, getMappedFont } from "../../packages/renderer/src/font/font-mapping.js";
 import { subsetFont } from "../../packages/renderer/src/font/font-subsetter.js";
 import type { OpentypeFullFont } from "../../packages/renderer/src/font/text-path-context.js";
+import { unsafeTypeAssertion } from "../unsafe-type-assertion.js";
 
 type VrtRenderOptions = Pick<ConvertOptions, "fontDirs" | "skipSystemFonts">;
 
@@ -290,10 +291,9 @@ async function readBufferIfExists(path: string): Promise<Buffer | null> {
 }
 
 function toArrayBuffer(buffer: Uint8Array): ArrayBuffer {
-  return buffer.buffer.slice(
-    buffer.byteOffset,
-    buffer.byteOffset + buffer.byteLength,
-  ) as ArrayBuffer;
+  return unsafeTypeAssertion<ArrayBuffer>(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+  );
 }
 
 function sha256(buffer: Uint8Array): string {

--- a/vrt/unsafe-type-assertion.ts
+++ b/vrt/unsafe-type-assertion.ts
@@ -1,4 +1,4 @@
-export function unsafeTypeAssertion<T>(value: unknown): T {
+export function unsafeVrtInteropAssertion<T>(value: unknown): T {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- VRT external-library boundaries intentionally centralize unchecked narrowing here.
   return value as T;
 }

--- a/vrt/unsafe-type-assertion.ts
+++ b/vrt/unsafe-type-assertion.ts
@@ -1,0 +1,4 @@
+export function unsafeTypeAssertion<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- VRT external-library boundaries intentionally centralize unchecked narrowing here.
+  return value as T;
+}


### PR DESCRIPTION
close #525

## 目的

`@typescript-eslint/no-unsafe-type-assertion` の既存 warning を解消し、ESLint 設定を `warn` から `error` に引き上げます。

## 変更内容

- `eslint.config.mjs` で `@typescript-eslint/no-unsafe-type-assertion` を `error` 化
- XML / OOXML / fixture / brand / external interop などの用途別 `unsafe*Assertion` helper を追加
- 既存の unsafe narrowing を用途別 helper へ移動
- `unsafeFixtureAssertion` が production package source から import されないよう `no-restricted-imports` を追加
- `docs/type-assertion-policy.md` の inventory と error 化後の方針を更新

## 影響パッケージ / パス

- `packages/core/src/**`
- `packages/document/src/**`
- `packages/renderer/src/**`
- `scripts/**`
- `vrt/**`
- `eslint.config.mjs`
- `docs/type-assertion-policy.md`

## ローカル検証

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run format:check`
- `npm run audit:type-assertions`
- `npm run build`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run bench`

補足: `npm run build` では既存の `import.meta` / CJS 警告が表示されますが、build は成功しています。`npm run bench` は通常 heap では OOM したため、8GB heap 指定で完走確認しました。
