### PR TITLE
SmartArt fallback を document diagram contract 経由に置き換える

### DIFF
--- a/.changeset/smartart-diagram-contract.md
+++ b/.changeset/smartart-diagram-contract.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+Replace the SmartArt fallback's legacy parser shape-tree dependency with the document computed diagram drawing contract.

--- a/docs/legacy-parser-semantics-audit.md
+++ b/docs/legacy-parser-semantics-audit.md
@@ -23,9 +23,9 @@ the old `cleandoc-renderer-adapter.ts` reference is now
 The SmartArt fallback contract requested by
 [#528](https://github.com/hirokisakabe/pptx-glimpse/issues/528) is recorded in
 [smartart-fallback-contract.md](./smartart-fallback-contract.md). That note
-lists the current `parseShapeTree` helper dependencies, the raw resolved input
-contract from `PptxComputedView`, the renderer `GroupElement` output contract,
-and the conditions for removing the old parser dependency.
+records the current computed diagram drawing contract, the renderer
+`GroupElement` output contract, and the removal status for the old
+`parseShapeTree` SmartArt fallback dependency.
 
 This is the current-state companion to the historical migration plan. The
 default switch tracked by [#481](https://github.com/hirokisakabe/pptx-glimpse/issues/481)
@@ -82,7 +82,7 @@ These remain in core or renderer by design:
 | Warning setup, font setup, SVG text-output mode, PNG sizing                  | `packages/core/src/experimental-document-renderer.ts`          | Renderer environment setup and runtime conversion options are core concerns                                                                                               |
 | PptxSourceModel computed view to renderer model mapping                      | `packages/core/src/pptx-computed-view-renderer-adapter.ts`     | The renderer model is a display-oriented compatibility target, not the PptxSourceModel source model                                                                       |
 | Chart XML to renderer chart model mapping                                    | `packages/core/src/renderer-chart-data-converter.ts`           | Chart rendering model is still renderer-specific; move only after a chart source/computed contract exists                                                                 |
-| SmartArt drawing XML fallback to renderer shape tree                         | Adapter calling parser `parseShapeTree`                        | This is a rendering fallback for resolved diagram drawing XML, not canonical document semantics yet; see [smartart-fallback-contract.md](./smartart-fallback-contract.md) |
+| SmartArt computed diagram drawing fallback                                   | Document computed view + core adapter                          | The diagram drawing package contract is document-owned, while renderer `GroupElement` mapping remains a core adapter concern; see [smartart-fallback-contract.md](./smartart-fallback-contract.md) |
 | Font discovery, font mapping, text measurement, text-to-path, SVG/PNG output | `@pptx-glimpse/renderer`                                       | Renderer-specific behavior per `document-boundaries.md`                                                                                                                   |
 
 ## Remaining legacy parser call-site inventory
@@ -102,8 +102,8 @@ conversion orchestration.
 | `packages/core/src/dual-reader-structural-comparison.test.ts`              | Imports `parsePptxData`, `parseSlideWithLayout`, and `buildEffectiveSlideElements`                                                                                                                                                          | `structural comparison`      | Compares a focused supported subset of the old parser render model against the PptxSourceModel document path and core adapter output.              | Retire after VRT and public regressions fully cover the parser oracle's value.     |
 | `bench/conversion.bench.ts`                                                | Imports and calls `parsePptxData` / `parseSlideWithLayout` from `packages/core/src/pptx-data-parser.ts`                                                                                                                                     | `parser oracle`              | Benchmarks the old parser pipeline as an explicit baseline beside the public document-path conversion APIs.                                        | Remove or retarget with `pptx-data-parser.ts` retirement.                          |
 | `packages/core/src/pptx-computed-view-renderer-adapter.ts` `adaptChart`    | Calls `convertChartXmlToRendererChartData` from `packages/core/src/renderer-chart-data-converter.ts`                                                                                                                                        | `renderer-specific fallback` | Maps resolved chart XML from PptxSourceModel into the current renderer chart model until a document-owned chart source/computed contract exists.   | Replace after chart source/computed contracts are designed.                        |
-| `packages/core/src/pptx-computed-view-renderer-adapter.ts` `adaptSmartArt` | Imports `navigateOrdered` / `parseShapeTree` from `packages/core/src/parser/slide-parser.ts` and XML helpers from `packages/core/src/parser/`; the detailed contract is in [smartart-fallback-contract.md](./smartart-fallback-contract.md) | `renderer-specific fallback` | Turns resolved SmartArt diagram drawing XML into the current renderer group/shape model as a visual fallback, not as canonical document semantics. | Replace after a document-owned diagram drawing source/computed contract exists.    |
-| `packages/core/src/parse-render.integration.test.ts`                       | Imports `parseShapeTree` and parser XML/archive relationship types                                                                                                                                                                          | `renderer-specific fallback` | Keeps direct coverage for old parser shape-tree output that the renderer and SmartArt fallback still consume.                                      | Remove or move when adapter fallback use of `parseShapeTree` is replaced.          |
+| `packages/core/src/pptx-computed-view-renderer-adapter.ts` `adaptSmartArt` | No old parser import; consumes `ComputedSmartArtElement.diagramDrawing` from `@pptx-glimpse/document`                                                                                                                                       | `renderer-specific fallback` | Turns document computed diagram drawing children into the current renderer `GroupElement` model.                                                   | Keep as core adapter mapping until renderer/model ownership changes.               |
+| `packages/core/src/parse-render.integration.test.ts`                       | Imports `parseShapeTree` and parser XML/archive relationship types                                                                                                                                                                          | `parser oracle`              | Keeps direct coverage for old parser shape-tree output while parser oracle consumers remain.                                                       | Remove or move with the parser oracle, not with SmartArt fallback.                 |
 | `packages/core/src/parser-path-oracle.test.ts`                             | Imports `buildEffectiveSlideElements` and `ParsedSlide` from `packages/core/src/pptx-data-parser.ts`                                                                                                                                        | `parser oracle`              | Protects oracle-only effective element merging semantics after that logic moved out of `converter.ts`.                                             | Remove with `parser-path-oracle.ts`.                                               |
 | `packages/core/src/text-style-resolver.ts`                                 | Imports `resolveThemeFont` from `packages/core/src/parser/text-style-parser.ts`                                                                                                                                                             | `parser oracle`              | Supports old parser text-style inheritance used by `packages/core/src/pptx-data-parser.ts`; public font collection no longer depends on it.        | Remove or narrow with `pptx-data-parser.ts` retirement.                            |
 | `packages/core/src/text-style-resolver.test.ts`                            | Imports `applyTextStyleInheritance` and `TextStyleContext` from `packages/core/src/text-style-resolver.ts`                                                                                                                                  | `parser oracle`              | Protects the old parser text-style inheritance helper while `pptx-data-parser.ts` still consumes it.                                               | Remove or narrow with `text-style-resolver.ts` retirement.                         |
@@ -131,7 +131,7 @@ deleted:
 | `packages/core/src/parser-path-oracle.test.ts`                | Unit-tests `buildEffectiveSlideElements`.                                                                              | Protects oracle-only master/layout/slide ordering and placeholder filtering while VRT still depends on the oracle.     | Delete with `parser-path-oracle.ts` once no remaining test/VRT imports that helper.                                               |
 | `bench/conversion.bench.ts`                                   | Benchmarks `parsePptxData` / `parseSlideWithLayout` as the old-parser baseline.                                        | Keeps performance comparisons with the historical parser path explicit.                                                | Remove the parser benchmark lane or retarget it to a document-path-only baseline when parser performance is no longer tracked.    |
 | `packages/core/src/text-style-resolver.ts` and its unit test  | Supports text inheritance consumed by `pptx-data-parser.ts`.                                                           | Remains needed only because the parser oracle still assembles old-parser render models.                                | Remove or narrow after `pptx-data-parser.ts` no longer exists or no longer consumes this helper.                                  |
-| Parser subsystem unit tests under `packages/core/src/parser/` | Protect parser helpers still reached by `pptx-data-parser.ts` and by the SmartArt adapter fallback's `parseShapeTree`. | Some parser helpers still serve the oracle; `parseShapeTree` also serves a separate renderer fallback.                 | Split by consumer: delete oracle-only tests with the oracle, keep or move `parseShapeTree` coverage until #535 replaces it.       |
+| Parser subsystem unit tests under `packages/core/src/parser/` | Protect parser helpers still reached by `pptx-data-parser.ts` and parser-oracle tests.                                   | Parser helpers still serve the explicit oracle, but not the public SmartArt fallback.                                  | Delete or narrow with the parser oracle once no remaining oracle consumer imports them.                                            |
 
 `parser-path-oracle.ts` itself can be removed only after no VRT, unit test,
 benchmark, or adapter fallback imports `convertPptxToPngViaParserPath`,
@@ -222,8 +222,8 @@ deleted when all of these are true:
    moved into `@pptx-glimpse/document` / adapter tests or are explicitly removed
    as obsolete behavior.
 4. Parser subsystem tests have been split by remaining consumer: oracle-only
-   render-model tests are deleted, while parser helpers still needed by the
-   SmartArt fallback stay covered until the #535 replacement lands.
+   render-model tests are deleted when the parser oracle is deleted, while
+   SmartArt fallback coverage lives in document/computed and adapter tests.
 5. Public conversion tests, package verification, and VRT prove that
    `convertPptxToSvg` / `convertPptxToPng` remain document-path-only after the
    deletion.
@@ -247,16 +247,17 @@ Some duplication intentionally remains:
 
 - `pptx-data-parser.ts` still assembles slide/layout/master render models. Keep
   it until the parser oracle is no longer needed for zero-diff gates.
-- Parser unit tests under `packages/core/src/parser/` still protect the
-  old oracle and adapter fallback helpers. Delete or narrow them only after the
-  corresponding oracle role is removed.
+- Parser unit tests under `packages/core/src/parser/` still protect the old
+  oracle helpers. Delete or narrow them only after the corresponding oracle role
+  is removed.
 - `pptx-computed-view-renderer-adapter.ts` still calls renderer-specific fallback
-  helpers for chart parsing and SmartArt fallback rendering. Chart XML conversion
-  is isolated in `renderer-chart-data-converter.ts`; keep the renderer `ChartData`
-  adapter outside `document` unless it is replaced by a renderer-owned contract.
-  Split follow-up issues should define document-owned chart/diagram source
-  contracts only after chart data, style/color parts, embedded workbook
-  references, and compatibility expectations are covered.
+  helpers for chart parsing. SmartArt now consumes the document computed diagram
+  drawing contract, while the final mapping to renderer `GroupElement` remains
+  in core. Chart XML conversion is isolated in `renderer-chart-data-converter.ts`;
+  keep the renderer `ChartData` adapter outside `document` unless it is replaced
+  by a renderer-owned contract. Split follow-up issues should define
+  document-owned chart source contracts only after chart data, style/color parts,
+  embedded workbook references, and compatibility expectations are covered.
 - Comments in `packages/document/src/computed/create-computed-view.ts`
   that mention current-parser compatibility are retained as parity signposts.
   They should be removed only when the document path intentionally owns a
@@ -264,14 +265,10 @@ Some duplication intentionally remains:
 
 Suggested follow-up slices:
 
-1. Replace adapter SmartArt fallback use of `parseShapeTree` after introducing
-   the document-owned diagram drawing source/computed contract described in
-   [smartart-fallback-contract.md](./smartart-fallback-contract.md); this is
-   tracked by [#535](https://github.com/hirokisakabe/pptx-glimpse/issues/535).
-2. Introduce a chart source/computed contract in `document`, then replace or
+1. Introduce a chart source/computed contract in `document`, then replace or
    narrow `renderer-chart-data-converter.ts` from the core/renderer side without
    moving renderer `ChartData` ownership into `document`.
-3. Retire `dual-reader-structural-comparison.test.ts` after VRT and public
+2. Retire `dual-reader-structural-comparison.test.ts` after VRT and public
    regression tests fully cover the parser oracle's remaining value.
 4. Remove `pptx-data-parser.ts` and parser render-model tests after the explicit
    parser-path oracle is no longer used by VRT/CI.

--- a/docs/pptx-computed-renderer-model-boundaries.md
+++ b/docs/pptx-computed-renderer-model-boundaries.md
@@ -38,7 +38,7 @@ import renderer types.
 | `SourceTable`, `SourceTableCell`, table source styles                                                                                | `ComputedTableData`, `ComputedTableCell`, computed cell borders/fills/text                                                                                                                          | `TableElement`, `TableData`, `TableCell`, `CellBorders`                                            | Mixed. Table structure and merge state duplicate by design today; future table style/source contracts can reduce adapter-only shape conversions without moving renderer table rendering into `document`.          |
 | `SourceEffectList`, source blip effects                                                                                              | `ComputedEffectList`, `ComputedBlipEffects`                                                                                                                                                         | `EffectList`, `BlipEffects`                                                                        | Intentional boundary. Computed resolves colors in effects; renderer uses `null` defaults and render-ready effect objects.                                                                                         |
 | `SourceChart` plus chart relationship/package data                                                                                   | `ComputedChartElement` with resolved chart XML                                                                                                                                                      | `ChartElement`, `ChartData`                                                                        | Intentional renderer-specific fallback. Chart XML to renderer `ChartData` conversion stays outside `document` until a document-owned chart source/computed contract exists.                                       |
-| `SourceSmartArt` plus diagram data/drawing package data                                                                              | `ComputedSmartArtElement` with resolved raw drawing XML and media                                                                                                                                   | Renderer `GroupElement` produced through adapter fallback                                          | Temporary bridge. The current parser-backed fallback is intentionally scoped and tracked by [#535](https://github.com/hirokisakabe/pptx-glimpse/issues/535).                                                      |
+| `SourceSmartArt` plus diagram data/drawing package data                                                                              | `ComputedSmartArtElement` with `ComputedDiagramDrawing` ordered children, drawing relationships, media, raw handles, and diagnostics                                                                 | Renderer `GroupElement` produced through adapter fallback                                          | Intentional bridge. The old parser-backed fallback was replaced by the document computed diagram drawing contract in [#535](https://github.com/hirokisakabe/pptx-glimpse/issues/535).                              |
 | `SourceRawShapeNode`, raw sidecars, raw backgrounds/fills                                                                            | `ComputedRawElement`, raw computed background/fill variants                                                                                                                                         | No direct renderer equivalent; adapter warning and skip/ignore behavior                            | Intentional boundary. Raw material is for preservation and diagnostics, not direct SVG/PNG output.                                                                                                                |
 
 ## `ComputedSlide` vs renderer `Slide`
@@ -170,12 +170,13 @@ Renderer `ChartData` should not be moved into `document`.
 
 ### SmartArt and raw elements
 
-SmartArt is currently a raw-resolved fallback. `ComputedSmartArtElement`
-provides the resolved diagram drawing XML, drawing relationships, and media.
-The adapter combines that element data with the surrounding `ComputedSlide`
-color context and maps it into a renderer `GroupElement` using the temporary
-`parseShapeTree` bridge documented in
-[smartart-fallback-contract.md](./smartart-fallback-contract.md).
+SmartArt is currently a computed diagram drawing fallback.
+`ComputedSmartArtElement` provides the resolved diagram drawing XML for
+compatibility/provenance, plus `diagramDrawing` with ordered computed children,
+drawing relationships, media references, raw handles, root child transform, and
+diagnostics. The adapter maps that computed view into a renderer `GroupElement`
+without importing the legacy parser subsystem. The detailed contract is recorded
+in [smartart-fallback-contract.md](./smartart-fallback-contract.md).
 
 Raw elements, raw backgrounds, and raw fills have no renderer model equivalent.
 The adapter warns and skips or ignores them because raw OOXML preservation is a

--- a/docs/smartart-fallback-contract.md
+++ b/docs/smartart-fallback-contract.md
@@ -1,21 +1,19 @@
-# SmartArt fallback contract before `parseShapeTree` replacement
+# SmartArt fallback diagram drawing contract
 
 - Status: implementation note for [#528](https://github.com/hirokisakabe/pptx-glimpse/issues/528)
+  and [#535](https://github.com/hirokisakabe/pptx-glimpse/issues/535)
 - Date: 2026-06-27
-- Follow-up replacement issue:
-  [#535](https://github.com/hirokisakabe/pptx-glimpse/issues/535)
+- Updated: 2026-06-28
 
-This note records the current SmartArt fallback boundary after public SVG/PNG
-conversion moved to the PptxSourceModel document path. It complements
-[legacy-parser-semantics-audit.md](./legacy-parser-semantics-audit.md) and the
-package/source/computed boundaries in
+This note records the SmartArt fallback boundary after public SVG/PNG conversion
+moved to the PptxSourceModel document path and after the adapter stopped calling
+the old parser `parseShapeTree` helper for resolved diagram drawing XML. It
+complements [legacy-parser-semantics-audit.md](./legacy-parser-semantics-audit.md)
+and the package/source/computed boundaries in
 [document-boundaries.md](./document-boundaries.md) and
 [pptx-source-model-computed-view.md](./pptx-source-model-computed-view.md).
 
-This note does not replace the fallback implementation. It defines the contract
-needed to decide where that replacement should live.
-
-## Current call chain
+## Current Call Chain
 
 The public conversion path reaches SmartArt fallback through this sequence:
 
@@ -23,51 +21,30 @@ The public conversion path reaches SmartArt fallback through this sequence:
 convertPptxToSvg / convertPptxToPng
   -> readPptx
   -> createComputedView
+  -> ComputedSmartArtElement.diagramDrawing
   -> adaptComputedViewToRendererModel
   -> adaptSmartArt
-  -> parseShapeTree
   -> renderer GroupElement
 ```
 
-The fallback is limited to the already-resolved diagram drawing part. It is not
-the old slide parser path and it does not rebuild the slide, layout, or master
-cascade.
+The fallback remains limited to the already-resolved diagram drawing part. It is
+not the old slide parser path and it does not rebuild the slide, layout, or
+master cascade.
 
-## Current old parser dependencies
+## Parser Dependency Status
 
-`packages/core/src/pptx-computed-view-renderer-adapter.ts` currently depends on
-these old parser helpers for SmartArt fallback:
+`packages/core/src/pptx-computed-view-renderer-adapter.ts` no longer imports
+`packages/core/src/parser/*` for SmartArt fallback. The old adapter dependency
+on parser XML helpers, parser relationship maps, `navigateOrdered`, and
+`parseShapeTree` was replaced by a document-owned computed diagram drawing
+contract.
 
-| Dependency                                                            | Current use                                                                               |
-| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `parseXml` from `packages/core/src/parser/xml-parser.ts`              | Parse the resolved diagram drawing XML and find `drawing.spTree`.                         |
-| `parseXmlOrdered` from `packages/core/src/parser/xml-parser.ts`       | Parse the same drawing XML with preserve-order semantics.                                 |
-| `navigateOrdered` from `packages/core/src/parser/slide-parser.ts`     | Locate ordered `drawing.spTree` children so z-order follows XML order.                    |
-| `parseShapeTree` from `packages/core/src/parser/slide-parser.ts`      | Convert the diagram drawing `spTree` into renderer `SlideElement[]`.                      |
-| `Relationship` from `packages/core/src/parser/relationship-parser.ts` | Adapt computed relationships into the map shape expected by `parseShapeTree`.             |
-| `ColorResolver` from `packages/core/src/color/color-resolver.ts`      | Recreate a parser-compatible resolver from the computed slide color scheme and color map. |
+The old parser still exists for the explicit parser oracle and parser tests, but
+SmartArt fallback no longer depends on that subsystem.
 
-Calling `parseShapeTree` also pulls in its parser-side implementation fan-out:
+## Input Contract
 
-| Parser behavior reached through `parseShapeTree`                                               | Why SmartArt fallback currently gets it                                                                                                                                                                |
-| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Ordered shape tree traversal and `mc:AlternateContent` first-choice traversal                  | Diagram drawings must preserve child z-order and compatibility-branch content where the old parser already knows how.                                                                                  |
-| `p:sp` parsing                                                                                 | SmartArt drawing shapes need transform, preset/custom geometry, fill, outline, effects, text body, hyperlinks, and alt text mapped to renderer shapes.                                                 |
-| `p:pic` parsing                                                                                | Diagram drawings can contain generated raster/vector picture elements with drawing-part relationships to media.                                                                                        |
-| `p:cxnSp` parsing                                                                              | Diagram drawings can contain connectors between generated nodes.                                                                                                                                       |
-| `p:grpSp` recursion                                                                            | Diagram drawings can contain nested groups with child transforms and inherited group fills.                                                                                                            |
-| `p:graphicFrame` parsing                                                                       | The parser may encounter table/chart/diagram graphic frames while walking the shape tree, though the adapter's synthetic archive only makes already-resolved drawing XML and media reliably available. |
-| Fill, outline, shape style, effects, blip effects, text style, table, chart, and image helpers | These are not imported directly by the adapter, but they are part of the renderer model conversion provided by `parseShapeTree`.                                                                       |
-
-The adapter passes `undefined` for parser `fontScheme`, `fmtScheme`, and
-`placeholderStyles`. Therefore SmartArt fallback currently relies on the
-diagram drawing's local formatting plus the computed slide color scheme/map; it
-does not inherit placeholder geometry or theme font/style scheme data through
-this old parser call.
-
-## Input contract
-
-`@pptx-glimpse/document` currently provides the source/computed input boundary:
+`@pptx-glimpse/document` provides the source/computed input boundary:
 
 | Field                                                  | Owner                  | Contract                                                                                                                        |
 | ------------------------------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -75,133 +52,96 @@ this old parser call.
 | `ComputedSmartArtElement.dataRelationship`             | document computed view | Resolves the slide relationship to the diagram data part.                                                                       |
 | `ComputedSmartArtElement.drawingRelationship`          | document computed view | Resolves the diagram data part relationship to the diagram drawing part.                                                        |
 | `ComputedSmartArtElement.drawingPartPath`              | document computed view | Gives the canonical package part path for the resolved drawing XML.                                                             |
-| `ComputedSmartArtElement.drawingXml`                   | document computed view | Exposes the raw drawing XML text for the resolved drawing part.                                                                 |
+| `ComputedSmartArtElement.drawingXml`                   | document computed view | Exposes the raw drawing XML text for compatibility and diagnostics.                                                             |
 | `ComputedSmartArtElement.drawingRelationships`         | document computed view | Resolves relationships owned by the drawing part, including media references.                                                   |
 | `ComputedSmartArtElement.media`                        | document computed view | Exposes package media bytes so drawing-part image relationships can be rendered.                                                |
-| `ComputedSlide.colorScheme` / `ComputedSlide.colorMap` | document computed view | Provide document-level theme color context for a parser-compatible color resolver.                                              |
+| `ComputedSmartArtElement.diagramDrawing`               | document computed view | Exposes the parsed computed diagram drawing view used by the adapter.                                                           |
+| `ComputedSlide.colorScheme` / `ComputedSlide.colorMap` | document computed view | Provide document-level theme color context for computed child fills/outlines/text.                                              |
 
-This is intentionally a raw-resolved fallback contract. `document` resolves the
-package graph and provides the source material, but it does not yet expose a
-typed diagram drawing source model or a computed diagram render view.
+`ComputedDiagramDrawing` contains:
 
-## Output contract
+- `sourcePartPath`: the resolved diagram drawing part path.
+- `rawXml`, `rawPart`, and `rawHandle`: raw preservation/provenance handles for
+  the source part.
+- `relationships`: relationships owned by the drawing part.
+- `media`: package media references available to computed image children.
+- `childTransform`: the root `spTree.grpSpPr.xfrm` child coordinate system.
+- `children`: ordered computed child elements parsed from the drawing shape tree.
+- `diagnostics`: document-level diagnostics with source part provenance, such as
+  missing `spTree`.
 
-`packages/core/src/pptx-computed-view-renderer-adapter.ts` owns the current
+The child elements reuse the existing document shape tree reader and computed
+element pipeline. Drawing-part relationships are used while computing diagram
+children, so `p:pic` and image fills inside the drawing resolve against the
+diagram drawing part instead of the outer slide part.
+
+## Output Contract
+
+`packages/core/src/pptx-computed-view-renderer-adapter.ts` owns the renderer
 output contract:
 
-1. If `drawingXml` or `drawingPartPath` is missing, emit
+1. If `diagramDrawing` is missing, emit
    `pptx-computed-view-adapter.unresolved-smartart-skipped` and skip the element.
-2. Parse `drawingXml` and require `drawing.spTree`; if absent, emit the same
-   warning code and skip the element.
-3. Convert `drawingRelationships` into the legacy parser relationship map.
-4. Build a minimal archive facade:
-   - `files.get(path)` returns `drawingXml` only for `drawingPartPath`.
-   - `files.has(path)` is true only for `drawingPartPath`.
-   - `media.get(path)` resolves bytes from `ComputedSmartArtElement.media`.
-5. Build a `ColorResolver` from the computed slide color scheme and color map.
-6. Call `parseShapeTree` with the diagram `spTree`, drawing relationships,
-   drawing part path, archive facade, color resolver, fill context, and ordered
-   children.
-7. If no children are produced, skip the element.
-8. Return a renderer `GroupElement`:
-   - `transform` is the SmartArt source transform adapted at the outer
-     `graphicFrame` boundary.
-   - `childTransform` is read from `drawing.spTree.grpSpPr.xfrm` and falls back
-     to the outer group extent.
-   - `children` are the renderer `SlideElement[]` produced by `parseShapeTree`.
+2. If `diagramDrawing.diagnostics` contains a warning, emit
+   `pptx-computed-view-adapter.unresolved-smartart-skipped` with the diagram
+   drawing source part path and skip the element.
+3. Convert `diagramDrawing.children` through the normal computed-element adapter
+   path.
+4. If no renderer-supported children are produced, emit
+   `pptx-computed-view-adapter.unresolved-smartart-skipped` and skip the element.
+5. Return a renderer `GroupElement`:
+   - `transform` comes from the outer SmartArt `graphicFrame`.
+   - `childTransform` comes from `diagramDrawing.childTransform`, falling back to
+     the outer group extent.
+   - `children` are the adapted renderer `SlideElement[]`.
    - `effects` is `null`.
    - `altText` comes from the `SourceSmartArt` name when present.
 
 The renderer receives an ordinary `GroupElement`. It has no SmartArt-specific
-knowledge and should not need to parse OOXML, resolve package relationships, or
-know PptxSourceModel types.
+knowledge and does not parse OOXML, resolve package relationships, or know
+PptxSourceModel types.
 
-## Owner options
+## Historical Parser Bridge
 
-### `document` source/computed contract
+Before #535, the adapter parsed `drawingXml` locally and called
+`packages/core/src/parser/slide-parser.ts` `parseShapeTree`. That bridge gave
+SmartArt fallback old-parser behavior for z-order, shapes, pictures, connectors,
+groups, text, fills, outlines, effects, image relationships, compatibility
+branches, and group fill inheritance.
 
-This is the right long-term owner for package-level diagram drawing source
-material. Diagram drawing XML, its relationships, media references, raw
-preservation, and stable source handles are document-package semantics. A future
-document-owned contract should expose a typed diagram drawing source tree, plus a
-computed view with effective values that are document semantics.
-
-It should not emit renderer `GroupElement` directly. Renderer model shape,
-warnings, pixel output choices, font fallback, and SVG/PNG behavior remain
-outside `document`.
-
-### core adapter-local parser
-
-This is the acceptable interim owner if the old parser must be retired before a
-typed document diagram drawing model exists. The adapter could own a narrow
-diagram drawing shape-tree parser that maps the raw resolved drawing XML into
-the current renderer model.
-
-The tradeoff is duplication: such a parser would need to copy or reimplement
-shape, image, connector, group, fill, text, effect, and ordering behavior that
-the old parser already provides. It would remove the cross-boundary import from
-`parser/slide-parser.ts`, but it would not create reusable document semantics.
-
-### renderer fallback
-
-This is not the right owner. The renderer should consume render-oriented model
-objects, not OOXML package parts. Moving SmartArt fallback into renderer would
-make renderer depend on XML parsing, PPTX relationship resolution, package part
-paths, media lookup, and theme color maps. That conflicts with the boundary that
-renderer owns SVG/PNG output and display-oriented rendering, while core/document
-own PPTX package interpretation.
-
-## Decision
-
-Keep the current SmartArt fallback in the core adapter until there is a typed
-diagram drawing source/computed contract in `@pptx-glimpse/document`.
-
-The replacement target should be:
+The replacement keeps those responsibilities split by owner:
 
 ```text
-diagram drawing part in @pptx-glimpse/document source model
-  -> computed diagram drawing view with resolved relationships/media/colors
+diagram drawing part in @pptx-glimpse/document computed view
+  -> computed diagram drawing view with ordered children, relationships, media,
+     raw handles, group fill inheritance, and diagnostics provenance
   -> core adapter mapping into renderer GroupElement/children
   -> renderer
 ```
 
-Do not move the fallback into renderer. Use a core adapter-local parser only as
-a temporary bridge if parser retirement is blocked before the document-owned
-diagram contract is ready.
+Do not move the fallback into renderer. Renderer owns SVG/PNG output and a
+display-oriented model; document/core own PPTX package interpretation and
+adapter mapping.
 
-## Why `parseShapeTree` remains for now
+## Removal Status
 
-The old helper remains temporarily because it is currently the only local code
-that converts a DrawingML shape tree into the existing renderer model with
-z-order, groups, shapes, pictures, connectors, text, fills, outlines, effects,
-image relationships, and compatibility branches.
+The old `parseShapeTree` SmartArt adapter dependency is removed when all of
+these remain true:
 
-Keeping it avoids an output-changing rewrite in this design issue and keeps
-SmartArt fallback behavior tied to the same tested shape-tree semantics as the
-parser oracle. The dependency is acceptable only while it is explicitly
-classified as a renderer-specific fallback and not as reusable document
-semantics.
-
-## Conditions for removal
-
-Stop using old `parseShapeTree` for SmartArt fallback when all of these are
-true:
-
-1. `@pptx-glimpse/document` exposes diagram drawing source nodes for the
+1. `@pptx-glimpse/document` exposes diagram drawing computed data for the
    resolved drawing part, including ordered child nodes, source part paths,
-   relationships, media references, raw preservation handles, and stable
-   diagnostics provenance.
-2. The computed view exposes the effective diagram drawing data needed by the
+   relationships, media references, raw preservation handles, and diagnostics
+   provenance.
+2. The computed view exposes effective diagram drawing data needed by the
    adapter without depending on renderer types.
 3. The core adapter maps the computed diagram drawing view to renderer
    `GroupElement` children without importing `packages/core/src/parser/*`.
 4. Focused tests cover SmartArt fallback ordering, group child transforms,
-   shape fills/outlines/text, media relationships, and skip diagnostics.
-5. Visual output for existing SmartArt fixtures is intentionally unchanged, or
-   any intentional change is covered by VRT updates in a separate rendering PR.
-6. `parse-render.integration.test.ts` and parser shape-tree tests are no longer
-   needed for SmartArt fallback coverage, or their role is narrowed to the
-   parser oracle only.
+   shape fills/outlines/text, media relationships, group fill inheritance, and
+   skip diagnostics.
+5. Visual output for existing SmartArt fixtures remains intentionally unchanged,
+   or any intentional change is covered by VRT updates in a separate rendering
+   PR.
 
-Replacement implementation is intentionally out of scope for #528 and is split
-into [#535](https://github.com/hirokisakabe/pptx-glimpse/issues/535).
+Parser shape-tree tests may still exist for the parser oracle. Their role is no
+longer SmartArt fallback coverage for the public document path.

--- a/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
@@ -563,8 +563,70 @@ describe("adaptComputedViewToRendererModel", () => {
         extentHeight: 430,
       },
     });
-    expect(smartArt?.children.map((element) => element.type)).toEqual(["shape"]);
+    expect(smartArt?.children.map((element) => element.type)).toEqual(["image", "group", "shape"]);
+    expect(smartArt?.children[0]).toMatchObject({
+      type: "image",
+      transform: {
+        offsetX: 11,
+        offsetY: 12,
+        extentWidth: 13,
+        extentHeight: 14,
+      },
+      mimeType: "image/png",
+    });
+    expect(smartArt?.children[1]).toMatchObject({
+      type: "group",
+      childTransform: {
+        offsetX: 210,
+        offsetY: 220,
+        extentWidth: 230,
+        extentHeight: 240,
+      },
+      children: [
+        expect.objectContaining({
+          type: "shape",
+          fill: { type: "solid", color: { hex: "#00ff00", alpha: 1 } },
+        }),
+      ],
+    });
+    expect(smartArt?.children[2]).toMatchObject({
+      type: "shape",
+      fill: { type: "solid", color: { hex: "#336699", alpha: 1 } },
+      outline: {
+        fill: { type: "solid", color: { hex: "#123456", alpha: 1 } },
+        width: 12700,
+      },
+      textBody: {
+        paragraphs: [
+          expect.objectContaining({
+            runs: [expect.objectContaining({ text: "Step" })],
+          }),
+        ],
+      },
+    });
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("SmartArt fallback の diagram drawing skip diagnostic を返す", () => {
+    const result = adaptComputedViewToRendererModel(
+      createComputedView(
+        buildSourceWithChartAndSmartArt({
+          smartArtDrawingXml: `<dsp:drawing xmlns:dsp="http://schemas.microsoft.com/office/drawing/2008/diagram"/>`,
+        }),
+      ),
+    );
+
+    expect(
+      result.slides[0].elements.some(
+        (element) => element.type === "group" && element.altText === "Process",
+      ),
+    ).toBe(false);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "pptx-computed-view-adapter.unresolved-smartart-skipped",
+        sourcePartPath: "ppt/diagrams/drawing1.xml",
+      }),
+    );
   });
 
   it("unsupported raw elements を diagnostic として扱い renderer model に漏らさない", () => {
@@ -808,7 +870,9 @@ function buildSource(options: BuildSourceOptions = {}): PptxSourceModel {
   };
 }
 
-function buildSourceWithChartAndSmartArt(): PptxSourceModel {
+function buildSourceWithChartAndSmartArt(
+  options: { readonly smartArtDrawingXml?: string } = {},
+): PptxSourceModel {
   const source = buildSource({
     extraSlideShapes: [
       {
@@ -863,11 +927,21 @@ function buildSourceWithChartAndSmartArt(): PptxSourceModel {
             },
           ],
         },
+        {
+          sourcePartPath: asPartPath("ppt/diagrams/drawing1.xml"),
+          relationships: [
+            {
+              id: asRelationshipId("rIdDiagramImage"),
+              type: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+              target: "../media/image1.png",
+            },
+          ],
+        },
       ],
       rawParts: [
         rawXmlPart("ppt/charts/chart1.xml", chartXml()),
         rawXmlPart("ppt/diagrams/data1.xml", `<dgm:dataModel/>`),
-        rawXmlPart("ppt/diagrams/drawing1.xml", smartArtDrawingXml()),
+        rawXmlPart("ppt/diagrams/drawing1.xml", options.smartArtDrawingXml ?? smartArtDrawingXml()),
       ],
     },
   };
@@ -888,12 +962,26 @@ function chartXml(): string {
 function smartArtDrawingXml(): string {
   return `<dsp:drawing xmlns:dsp="http://schemas.microsoft.com/office/drawing/2008/diagram"
     xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
-    xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+    xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+    xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <dsp:spTree>
     <dsp:grpSpPr><a:xfrm><a:off x="700" y="710"/><a:ext cx="720" cy="730"/><a:chOff x="100" y="110"/><a:chExt cx="420" cy="430"/></a:xfrm></dsp:grpSpPr>
+    <p:pic>
+      <p:nvPicPr><p:cNvPr id="3" name="Diagram image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>
+      <p:blipFill><a:blip r:embed="rIdDiagramImage"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>
+      <p:spPr><a:xfrm><a:off x="11" y="12"/><a:ext cx="13" cy="14"/></a:xfrm></p:spPr>
+    </p:pic>
+    <p:grpSp>
+      <p:nvGrpSpPr><p:cNvPr id="4" name="Diagram group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="200" y="201"/><a:ext cx="202" cy="203"/><a:chOff x="210" y="220"/><a:chExt cx="230" cy="240"/></a:xfrm></p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr><p:cNvPr id="5" name="Grouped shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
+        <p:spPr><a:xfrm><a:off x="21" y="22"/><a:ext cx="23" cy="24"/></a:xfrm><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></p:spPr>
+      </p:sp>
+    </p:grpSp>
     <p:sp>
       <p:nvSpPr><p:cNvPr id="1" name="Step"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
-      <p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="30" cy="40"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr>
+      <p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="30" cy="40"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:solidFill><a:schemeClr val="accent1"/></a:solidFill><a:ln w="12700"><a:solidFill><a:srgbClr val="123456"/></a:solidFill></a:ln></p:spPr>
       <p:txBody><a:bodyPr/><a:p><a:r><a:t>Step</a:t></a:r></a:p></p:txBody>
     </p:sp>
   </dsp:spTree>

--- a/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
@@ -973,10 +973,10 @@ function smartArtDrawingXml(): string {
     </p:pic>
     <p:grpSp>
       <p:nvGrpSpPr><p:cNvPr id="4" name="Diagram group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>
-      <p:grpSpPr><a:xfrm><a:off x="200" y="201"/><a:ext cx="202" cy="203"/><a:chOff x="210" y="220"/><a:chExt cx="230" cy="240"/></a:xfrm></p:grpSpPr>
+      <p:grpSpPr><a:xfrm><a:off x="200" y="201"/><a:ext cx="202" cy="203"/><a:chOff x="210" y="220"/><a:chExt cx="230" cy="240"/></a:xfrm><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></p:grpSpPr>
       <p:sp>
         <p:nvSpPr><p:cNvPr id="5" name="Grouped shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>
-        <p:spPr><a:xfrm><a:off x="21" y="22"/><a:ext cx="23" cy="24"/></a:xfrm><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></p:spPr>
+        <p:spPr><a:xfrm><a:off x="21" y="22"/><a:ext cx="23" cy="24"/></a:xfrm><a:grpFill/></p:spPr>
       </p:sp>
     </p:grpSp>
     <p:sp>

--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -51,11 +51,8 @@ import type {
 import { asEmu, asHundredthPt, uint8ArrayToBase64 } from "@pptx-glimpse/renderer";
 
 import { ColorResolver } from "./color/color-resolver.js";
-import type { Relationship } from "./parser/relationship-parser.js";
-import { navigateOrdered, parseShapeTree } from "./parser/slide-parser.js";
-import { parseXml, parseXmlOrdered, type XmlNode } from "./parser/xml-parser.js";
 import { convertChartXmlToRendererChartData } from "./renderer-chart-data-converter.js";
-import { unsafeAdapterBoundaryAssertion, unsafeBrandAssertion } from "./unsafe-type-assertion.js";
+import { unsafeBrandAssertion } from "./unsafe-type-assertion.js";
 
 interface RendererAdapterResult {
   readonly slideSize?: SlideSize;
@@ -301,65 +298,42 @@ function adaptSmartArt(
   slide: ComputedSlide,
   diagnostics: DiagnosticSink,
 ): GroupElement | undefined {
-  if (smartArt.drawingXml === undefined || smartArt.drawingPartPath === undefined) {
+  if (smartArt.diagramDrawing === undefined) {
     pushAdapterWarning(
       diagnostics,
       "pptx-computed-view-adapter.unresolved-smartart-skipped",
-      "PptxSourceModel SmartArt element has no resolved diagram drawing XML.",
+      "PptxSourceModel SmartArt element has no computed diagram drawing view.",
       slide,
       smartArt.sourcePartPath,
     );
     return undefined;
   }
 
-  const parsed = parseXml(smartArt.drawingXml);
-  const drawing = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(parsed.drawing);
-  const spTree = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(drawing?.spTree);
-  if (spTree === undefined) {
+  if (smartArt.diagramDrawing.diagnostics.length > 0) {
     pushAdapterWarning(
       diagnostics,
       "pptx-computed-view-adapter.unresolved-smartart-skipped",
-      "PptxSourceModel SmartArt diagram drawing XML has no shape tree.",
+      smartArt.diagramDrawing.diagnostics[0]?.message ??
+        "PptxSourceModel SmartArt diagram drawing could not be computed.",
       slide,
-      smartArt.sourcePartPath,
+      smartArt.diagramDrawing.sourcePartPath,
     );
     return undefined;
   }
 
-  const rels = new Map<string, Relationship>(
-    smartArt.drawingRelationships.map((rel) => [
-      rel.id,
-      {
-        id: rel.id,
-        type: rel.type,
-        target: rel.source.target,
-        ...(rel.targetMode !== undefined ? { targetMode: rel.targetMode } : {}),
-      },
-    ]),
+  const children = smartArt.diagramDrawing.children.flatMap((child) =>
+    adaptElement(child, slide, diagnostics),
   );
-  const archive = {
-    files: {
-      get: (path: string) => (path === smartArt.drawingPartPath ? smartArt.drawingXml : undefined),
-      has: (path: string) => path === smartArt.drawingPartPath,
-    },
-    media: {
-      get: (path: string) => smartArt.media.find((media) => media.partPath === path)?.bytes,
-    },
-  };
-  const orderedParsed = parseXmlOrdered(smartArt.drawingXml);
-  const orderedSpTree = navigateOrdered(orderedParsed, ["drawing", "spTree"]);
-  const children = parseShapeTree(
-    spTree,
-    rels,
-    smartArt.drawingPartPath,
-    archive,
-    createColorResolver(slide),
-    undefined,
-    { rels, archive, basePath: smartArt.drawingPartPath },
-    undefined,
-    orderedSpTree,
-  );
-  if (children.length === 0) return undefined;
+  if (children.length === 0) {
+    pushAdapterWarning(
+      diagnostics,
+      "pptx-computed-view-adapter.unresolved-smartart-skipped",
+      "PptxSourceModel SmartArt computed diagram drawing has no renderer-supported children.",
+      slide,
+      smartArt.diagramDrawing.sourcePartPath,
+    );
+    return undefined;
+  }
 
   const groupTransform = adaptTransform(
     smartArt.transform,
@@ -367,7 +341,23 @@ function adaptSmartArt(
     diagnostics,
     smartArt.sourcePartPath,
   );
-  const childTransform = adaptSmartArtChildTransform(spTree, groupTransform);
+  const childTransform =
+    smartArt.diagramDrawing.childTransform !== undefined
+      ? adaptTransform(
+          smartArt.diagramDrawing.childTransform,
+          slide,
+          diagnostics,
+          smartArt.diagramDrawing.sourcePartPath,
+        )
+      : {
+          offsetX: asEmu(0),
+          offsetY: asEmu(0),
+          extentWidth: groupTransform.extentWidth,
+          extentHeight: groupTransform.extentHeight,
+          rotation: 0,
+          flipH: false,
+          flipV: false,
+        };
 
   return {
     type: "group",
@@ -376,24 +366,6 @@ function adaptSmartArt(
     children,
     effects: null,
     ...(smartArt.sourceNode.name !== undefined ? { altText: smartArt.sourceNode.name } : {}),
-  };
-}
-
-function adaptSmartArtChildTransform(spTree: XmlNode, groupTransform: Transform): Transform {
-  const xfrm = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(
-    unsafeAdapterBoundaryAssertion<XmlNode | undefined>(spTree.grpSpPr)?.xfrm,
-  );
-  const chOff = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(xfrm?.chOff);
-  const chExt = unsafeAdapterBoundaryAssertion<XmlNode | undefined>(xfrm?.chExt);
-
-  return {
-    offsetX: asEmu(Number(chOff?.["@_x"] ?? 0)),
-    offsetY: asEmu(Number(chOff?.["@_y"] ?? 0)),
-    extentWidth: asEmu(Number(chExt?.["@_cx"] ?? groupTransform.extentWidth)),
-    extentHeight: asEmu(Number(chExt?.["@_cy"] ?? groupTransform.extentHeight)),
-    rotation: 0,
-    flipH: false,
-    flipV: false,
   };
 }
 

--- a/packages/core/src/unsafe-type-assertion.ts
+++ b/packages/core/src/unsafe-type-assertion.ts
@@ -8,11 +8,6 @@ export function unsafeFixtureAssertion<T>(value: unknown): T {
   return value as T;
 }
 
-export function unsafeAdapterBoundaryAssertion<T>(value: unknown): T {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core adapter boundaries narrow computed/document interop values behind this named helper.
-  return value as T;
-}
-
 export function unsafeBrandAssertion<T>(value: unknown): T {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Core branded value constructors narrow primitive values behind this named helper.
   return value as T;

--- a/packages/document/src/computed/create-computed-view.test.ts
+++ b/packages/document/src/computed/create-computed-view.test.ts
@@ -71,6 +71,51 @@ describe("createComputedView", () => {
     expect(smartArt.drawingPartPath).toBe("ppt/diagrams/drawing1.xml");
     expect(smartArt.drawingXml).toContain("<dsp:drawing");
     expect(smartArt.drawingRelationships).toHaveLength(0);
+    expect(smartArt.diagramDrawing).toMatchObject({
+      sourcePartPath: "ppt/diagrams/drawing1.xml",
+      rawHandle: { partPath: "ppt/diagrams/drawing1.xml" },
+      relationships: [],
+      media: source.packageGraph.media,
+      childTransform: {
+        offsetX: 100,
+        offsetY: 110,
+        width: 420,
+        height: 430,
+      },
+      diagnostics: [],
+    });
+    expect(smartArt.diagramDrawing?.children.map((child) => child.kind)).toEqual(["shape"]);
+    expect(smartArt.diagramDrawing?.children[0]).toMatchObject({
+      kind: "shape",
+      sourcePartPath: "ppt/diagrams/drawing1.xml",
+      sourceNode: {
+        name: "Diagram step",
+        handle: {
+          partPath: "ppt/diagrams/drawing1.xml",
+          orderingSlot: 0,
+        },
+      },
+    });
+  });
+
+  it("SmartArt diagram drawing の shape tree が無い場合は computed diagnostic に provenance を残す", () => {
+    const source = buildSourceWithChartAndSmartArt({
+      smartArtDrawingXml: `<dsp:drawing xmlns:dsp="http://schemas.microsoft.com/office/drawing/2008/diagram"/>`,
+    });
+    const slide = getSlide(createComputedView(source).slides, 0);
+    const smartArt = slide.elements.find((element) => element.kind === "smartArt");
+
+    expect(smartArt?.kind).toBe("smartArt");
+    if (smartArt?.kind !== "smartArt") throw new Error("SmartArt element not found");
+    expect(smartArt.diagramDrawing?.children).toEqual([]);
+    expect(smartArt.diagramDrawing?.diagnostics).toEqual([
+      {
+        severity: "warning",
+        code: "diagram-drawing-shape-tree-missing",
+        message: "diagram drawing part 'ppt/diagrams/drawing1.xml' has no shape tree",
+        sourcePartPath: "ppt/diagrams/drawing1.xml",
+      },
+    ]);
   });
 
   it("Strict OOXML の chart relationship type でも chart XML part を解決する", () => {
@@ -936,6 +981,7 @@ function buildSource(): PptxSourceModel {
 function buildSourceWithChartAndSmartArt(
   options: {
     readonly chartRelationshipType?: string;
+    readonly smartArtDrawingXml?: string;
   } = {},
 ): PptxSourceModel {
   const source = buildSource();
@@ -986,7 +1032,11 @@ function buildSourceWithChartAndSmartArt(
           `<c:chartSpace><c:chart><c:plotArea><c:barChart/></c:plotArea></c:chart></c:chartSpace>`,
         ),
         rawXmlPart("ppt/diagrams/data1.xml", `<dgm:dataModel/>`),
-        rawXmlPart("ppt/diagrams/drawing1.xml", `<dsp:drawing><dsp:spTree/></dsp:drawing>`),
+        rawXmlPart(
+          "ppt/diagrams/drawing1.xml",
+          options.smartArtDrawingXml ??
+            `<dsp:drawing xmlns:dsp="http://schemas.microsoft.com/office/drawing/2008/diagram" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><dsp:spTree><dsp:grpSpPr><a:xfrm><a:off x="700" y="710"/><a:ext cx="720" cy="730"/><a:chOff x="100" y="110"/><a:chExt cx="420" cy="430"/></a:xfrm></dsp:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="1" name="Diagram step"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="30" cy="40"/></a:xfrm></p:spPr></p:sp></dsp:spTree></dsp:drawing>`,
+        ),
       ],
     },
     slides: source.slides.map((slide) =>

--- a/packages/document/src/computed/create-computed-view.ts
+++ b/packages/document/src/computed/create-computed-view.ts
@@ -1,3 +1,13 @@
+import { parseTransform } from "../reader/drawing.js";
+import { createSidecarIdFactory } from "../reader/raw-node.js";
+import { parseShapeTree } from "../reader/shape-tree.js";
+import {
+  getChild,
+  navigateOrdered,
+  parseXml,
+  parseXmlOrdered,
+  type XmlNode,
+} from "../reader/xml.js";
 import type {
   PartPath,
   PptxSourceModel,
@@ -22,6 +32,7 @@ import type {
   SourceTextBody,
   SourceTextStyle,
   SourceTheme,
+  SourceTransform,
 } from "../source/index.js";
 import { asEmu } from "../source/index.js";
 import { assertNever } from "../utils/assert-never.js";
@@ -33,6 +44,8 @@ import type {
   ComputedCellBorders,
   ComputedChartElement,
   ComputedConnectorElement,
+  ComputedDiagramDrawing,
+  ComputedDiagramDrawingDiagnostic,
   ComputedEffectList,
   ComputedElement,
   ComputedElementLayer,
@@ -502,6 +515,14 @@ function computeSmartArtElement(
   const drawingPartPath = drawingRelationship?.targetPartPath;
   const drawingXml =
     drawingPartPath !== undefined ? readRawPackageText(context.source, drawingPartPath) : undefined;
+  const drawingRelationships =
+    drawingPartPath !== undefined
+      ? resolveComputedRelationships(context.source, drawingPartPath)
+      : [];
+  const diagramDrawing =
+    drawingPartPath !== undefined && drawingXml !== undefined
+      ? computeDiagramDrawing(context, drawingPartPath, drawingXml, drawingRelationships, layer)
+      : undefined;
 
   return {
     kind: "smartArt",
@@ -513,11 +534,85 @@ function computeSmartArtElement(
     ...(drawingRelationship !== undefined ? { drawingRelationship } : {}),
     ...(drawingPartPath !== undefined ? { drawingPartPath } : {}),
     ...(drawingXml !== undefined ? { drawingXml } : {}),
-    drawingRelationships:
-      drawingPartPath !== undefined
-        ? resolveComputedRelationships(context.source, drawingPartPath)
-        : [],
+    drawingRelationships,
     media: context.source.packageGraph.media,
+    ...(diagramDrawing !== undefined ? { diagramDrawing } : {}),
+  };
+}
+
+function computeDiagramDrawing(
+  context: ComputeContext,
+  drawingPartPath: PartPath,
+  drawingXml: string,
+  drawingRelationships: readonly ComputedRelationship[],
+  layer: ComputedElementLayer,
+): ComputedDiagramDrawing {
+  const rawPart = context.source.packageGraph.rawParts?.find(
+    (part) => part.partPath === drawingPartPath,
+  );
+  const parsed = parseXml(drawingXml);
+  const drawing = getChild(parsed, "drawing");
+  const spTree = getChild(drawing, "spTree");
+  const diagnostics: ComputedDiagramDrawingDiagnostic[] = [];
+
+  if (spTree === undefined) {
+    diagnostics.push({
+      severity: "warning",
+      code: "diagram-drawing-shape-tree-missing",
+      message: `diagram drawing part '${drawingPartPath}' has no shape tree`,
+      sourcePartPath: drawingPartPath,
+    });
+  }
+
+  const orderedSpTree =
+    spTree !== undefined
+      ? navigateOrdered(parseXmlOrdered(drawingXml), ["drawing", "spTree"])
+      : undefined;
+  const sourceChildren =
+    spTree !== undefined
+      ? parseShapeTree(
+          spTree,
+          drawingPartPath,
+          createSidecarIdFactory(drawingPartPath),
+          orderedSpTree,
+        )
+      : [];
+  const diagramContext: ComputeContext = {
+    ...context,
+    relationships: drawingRelationships,
+  };
+
+  return {
+    sourcePartPath: drawingPartPath,
+    rawXml: drawingXml,
+    ...(rawPart !== undefined ? { rawPart } : {}),
+    rawHandle: { partPath: drawingPartPath },
+    relationships: drawingRelationships,
+    media: context.source.packageGraph.media,
+    ...(spTree !== undefined ? { childTransform: parseDiagramChildTransform(spTree) } : {}),
+    children: sourceChildren.map((child) =>
+      computeElement(diagramContext, child, layer, drawingPartPath),
+    ),
+    diagnostics,
+  };
+}
+
+function parseDiagramChildTransform(spTree: XmlNode): SourceTransform | undefined {
+  const groupProperties = getChild(spTree, "grpSpPr");
+  const fallback = parseTransform(groupProperties);
+  const xfrm = getChild(groupProperties, "xfrm");
+  const childOff = getChild(xfrm, "chOff");
+  const childExt = getChild(xfrm, "chExt");
+  const offsetX = numericAttr(childOff, "x") ?? 0;
+  const offsetY = numericAttr(childOff, "y") ?? 0;
+  const width = numericAttr(childExt, "cx") ?? fallback?.width;
+  const height = numericAttr(childExt, "cy") ?? fallback?.height;
+  if (width === undefined || height === undefined) return undefined;
+  return {
+    offsetX: asEmu(offsetX),
+    offsetY: asEmu(offsetY),
+    width: asEmu(width),
+    height: asEmu(height),
   };
 }
 
@@ -1091,6 +1186,14 @@ function readRawPackageText(source: PptxSourceModel, partPath: PartPath): string
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
   if (rawPart?.kind === "binary") return textDecoder.decode(rawPart.bytes);
   return undefined;
+}
+
+function numericAttr(node: XmlNode | undefined, attrName: string): number | undefined {
+  if (node === undefined) return undefined;
+  const value = node[`@_${attrName}`];
+  if (value === undefined || value === null) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function omitColor(properties: SourceRunProperties): Omit<SourceRunProperties, "color"> {

--- a/packages/document/src/computed/create-computed-view.ts
+++ b/packages/document/src/computed/create-computed-view.ts
@@ -3,6 +3,7 @@ import { createSidecarIdFactory } from "../reader/raw-node.js";
 import { parseShapeTree } from "../reader/shape-tree.js";
 import {
   getChild,
+  localName,
   navigateOrdered,
   parseXml,
   parseXmlOrdered,
@@ -196,6 +197,7 @@ interface ComputeContext {
   readonly theme?: SourceTheme;
   readonly colorMap: Readonly<Record<string, string>>;
   readonly relationships: readonly ComputedRelationship[];
+  readonly groupFill?: ComputedFill;
 }
 
 interface TextStyleChainEntry {
@@ -349,8 +351,10 @@ function computeGroupElement(
   layer: ComputedElementLayer,
   partPath: PartPath,
 ): ComputedGroupElement {
+  const fill = group.fill !== undefined ? computeFill(context, group.fill, partPath) : undefined;
   const effects =
     group.effects !== undefined ? computeEffectList(context, group.effects) : undefined;
+  const childContext = fill !== undefined ? { ...context, groupFill: fill } : context;
   return {
     kind: "group",
     sourceLayer: layer,
@@ -358,8 +362,9 @@ function computeGroupElement(
     sourceNode: group,
     ...(group.transform !== undefined ? { transform: group.transform } : {}),
     ...(group.childTransform !== undefined ? { childTransform: group.childTransform } : {}),
+    ...(fill !== undefined ? { fill } : {}),
     ...(effects !== undefined ? { effects } : {}),
-    children: group.children.map((child) => computeElement(context, child, layer, partPath)),
+    children: group.children.map((child) => computeElement(childContext, child, layer, partPath)),
   };
 }
 
@@ -680,6 +685,9 @@ function computeFill(context: ComputeContext, fill: SourceFill, partPath: PartPa
     case "none":
       return { kind: "none", source: fill };
     case "raw":
+      if (localName(fill.raw.node.name) === "grpFill" && context.groupFill !== undefined) {
+        return context.groupFill;
+      }
       return { kind: "raw", source: fill };
     case "gradient":
       return {

--- a/packages/document/src/computed/index.ts
+++ b/packages/document/src/computed/index.ts
@@ -7,6 +7,8 @@ export type {
   ComputedColor,
   ComputedColorChangeEffect,
   ComputedConnectorElement,
+  ComputedDiagramDrawing,
+  ComputedDiagramDrawingDiagnostic,
   ComputedDuotoneEffect,
   ComputedEffectList,
   ComputedElement,

--- a/packages/document/src/computed/pptx-computed-view.ts
+++ b/packages/document/src/computed/pptx-computed-view.ts
@@ -10,6 +10,7 @@ import type {
   Emu,
   MediaPart,
   PartPath,
+  RawPackagePart,
   Relationship,
   RelationshipId,
   SourceBackground,
@@ -162,6 +163,26 @@ export interface ComputedSmartArtElement extends ComputedElementBase {
   readonly drawingXml?: string;
   readonly drawingRelationships: readonly ComputedRelationship[];
   readonly media: readonly MediaPart[];
+  readonly diagramDrawing?: ComputedDiagramDrawing;
+}
+
+export interface ComputedDiagramDrawing {
+  readonly sourcePartPath: PartPath;
+  readonly rawXml: string;
+  readonly rawPart?: RawPackagePart;
+  readonly rawHandle: { readonly partPath: PartPath };
+  readonly relationships: readonly ComputedRelationship[];
+  readonly media: readonly MediaPart[];
+  readonly childTransform?: SourceTransform;
+  readonly children: readonly ComputedElement[];
+  readonly diagnostics: readonly ComputedDiagramDrawingDiagnostic[];
+}
+
+export interface ComputedDiagramDrawingDiagnostic {
+  readonly severity: "warning";
+  readonly code: "diagram-drawing-shape-tree-missing";
+  readonly message: string;
+  readonly sourcePartPath: PartPath;
 }
 
 export interface ComputedTableData {

--- a/packages/document/src/computed/pptx-computed-view.ts
+++ b/packages/document/src/computed/pptx-computed-view.ts
@@ -134,6 +134,7 @@ export interface ComputedGroupElement extends ComputedElementBase {
   readonly sourceNode: SourceGroup;
   readonly transform?: SourceTransform;
   readonly childTransform?: SourceTransform;
+  readonly fill?: ComputedFill;
   readonly effects?: ComputedEffectList;
   readonly children: readonly ComputedElement[];
 }

--- a/packages/document/src/reader/drawing.ts
+++ b/packages/document/src/reader/drawing.ts
@@ -298,8 +298,9 @@ export function parseFill(
   }
 
   for (const name of RAW_FILL_LOCAL_NAMES) {
-    const node = getChild(parent, name);
-    if (node) return { kind: "raw", raw: makeSidecar(`a:${name}`, node, nextId) };
+    if (hasChild(parent, name)) {
+      return { kind: "raw", raw: makeSidecar(`a:${name}`, getChild(parent, name) ?? {}, nextId) };
+    }
   }
 
   return undefined;

--- a/packages/document/src/reader/shape-tree.ts
+++ b/packages/document/src/reader/shape-tree.ts
@@ -383,6 +383,7 @@ function parseGroup(
   const grpSpPr = getChild(grpSp, "grpSpPr");
   const transform = parseTransform(grpSpPr);
   const childTransform = parseChildTransform(grpSpPr, transform);
+  const fill = parseFill(grpSpPr, nextId);
   const effects = parseEffectList(getChild(grpSpPr, "effectLst"));
   const rawSidecars = [
     ...collectUnknownSidecars(grpSp, KNOWN_GROUP_CHILDREN, nextId),
@@ -396,6 +397,7 @@ function parseGroup(
     ...(name !== undefined ? { name } : {}),
     ...(transform !== undefined ? { transform } : {}),
     ...(childTransform !== undefined ? { childTransform } : {}),
+    ...(fill !== undefined ? { fill } : {}),
     ...(effects !== undefined ? { effects } : {}),
     children: parseShapeTree(grpSp, partPath, nextId, orderedChildren),
     handle: { partPath, ...(nodeId !== undefined ? { nodeId } : {}), orderingSlot },

--- a/packages/document/src/source/shapes.ts
+++ b/packages/document/src/source/shapes.ts
@@ -389,6 +389,7 @@ export interface SourceGroup {
   readonly name?: string;
   readonly transform?: SourceTransform;
   readonly childTransform?: SourceTransform;
+  readonly fill?: SourceFill;
   readonly effects?: SourceEffectList;
   readonly children: readonly SourceShapeNode[];
   readonly handle?: SourceHandle;


### PR DESCRIPTION
close #535

## 目的

SmartArt fallback が core adapter から旧 parser の `parseShapeTree` を呼んでいた依存を外し、`@pptx-glimpse/document` の computed diagram drawing contract から renderer `GroupElement` children を生成する経路へ置き換えます。

## 変更内容

- `ComputedSmartArtElement.diagramDrawing` / `ComputedDiagramDrawing` を追加し、diagram drawing part の ordered children、drawing relationships、media、raw handle、diagnostics provenance、root child transform を computed view に表現
- core adapter の SmartArt fallback から `packages/core/src/parser/*` import を削除し、computed diagram children を通常の adapter 経路で renderer model へ変換
- group fill inheritance (`grpFill`) を document computed path でも維持
- SmartArt fallback の ordering / group child transform / shape fill-outline-text / media relationship / skip diagnostics / group fill inheritance の focused tests を追加
- 関連 docs と changeset を更新

## 影響パス

- `packages/document/src/computed/*`
- `packages/document/src/reader/*`
- `packages/document/src/source/shapes.ts`
- `packages/core/src/pptx-computed-view-renderer-adapter.ts`
- `docs/smartart-fallback-contract.md`
- `docs/legacy-parser-semantics-audit.md`
- `docs/pptx-computed-renderer-model-boundaries.md`

## ローカル検証

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npx vitest run --config vitest.vrt.config.ts vrt/snapshot/document-path-zero-diff-gate.test.ts`
- `npm run build`

## レビュー対応

cross-review で指摘された group fill inheritance と関連 docs の同期漏れを追加 commit で修正済みです。
