### PR TITLE
document XML helper の古い parser 記述を修正

### DIFF
--- a/packages/document/src/reader/xml.ts
+++ b/packages/document/src/reader/xml.ts
@@ -1,13 +1,20 @@
 /**
- * reader 内部で使う最小限の OOXML XML ヘルパー。
+ * Minimal OOXML XML helpers for document readers.
  *
- * `@pptx-glimpse/document` は下位基盤であり renderer 側の XML パーサーを参照
- * できないため、fast-xml-parser を直接利用する。namespace prefix は **保持**
- * する (`removeNSPrefix: false`)。これは `p:sldId` が namespace 無しの `id`
- * (スライド ID) と relationships namespace の `r:id` (relationship 参照) を
- * 同時に持ち、prefix を落とすと両者が衝突して relationship 参照を復元できなく
- * なるため。要素アクセスは local name (prefix を無視) で行い、属性は plain /
- * namespaced を区別して取得する。
+ * `@pptx-glimpse/document` owns the OOXML reader boundary as a lower-level
+ * package, so it parses OOXML parts directly instead of depending on parsing
+ * helpers from `@pptx-glimpse/core` or `@pptx-glimpse/renderer`.
+ *
+ * The object parser keeps namespace prefixes (`removeNSPrefix: false`) because
+ * elements such as `p:sldId` can carry both a plain `id` attribute (slide ID)
+ * and a relationships `r:id` attribute (relationship reference). Dropping the
+ * prefix would collapse those attributes into the same key and lose the
+ * relationship reference. Element lookup therefore uses local names while
+ * attribute lookup distinguishes plain and namespaced attributes.
+ *
+ * The ordered parser is used only when reader logic needs element order. It
+ * intentionally normalizes prefixes and ignores attributes, so it must not be
+ * used for relationship IDs or other attribute-sensitive OOXML data.
  */
 
 import { XMLParser } from "fast-xml-parser";


### PR DESCRIPTION
close #555

## 目的

`packages/document/src/reader/xml.ts` の module comment に残っていた古い renderer parser 前提の説明を、現在の package 構成に合わせて修正します。

## 変更内容

- `@pptx-glimpse/document` が OOXML reader boundary を所有し、core / renderer 側の parsing helper に依存しないことを現在形で説明
- namespace prefix を保持する理由を維持
- ordered parser の用途と制約を明記

## 影響パッケージ / パス

- `packages/document/src/reader/xml.ts`

## 検証

- `npm run format:check`
- acceptance-check: 受け入れ条件 6 件すべて ✓
- cross-review: critical / warning / info いずれも 0 件

## 備考

コメントのみの変更で、runtime behavior は変更していません。
