### PR TITLE
switch 網羅性を ESLint で検査する

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,6 +80,14 @@ export default tseslint.config(
         "error",
         { argsIgnorePattern: "^_" },
       ],
+      "@typescript-eslint/switch-exhaustiveness-check": [
+        "error",
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          considerDefaultExhaustiveForUnions: false,
+          requireDefaultForNonUnion: false,
+        },
+      ],
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-assignment": "error",
       "@typescript-eslint/no-unsafe-call": "error",

--- a/packages/core/src/font/font-collector.ts
+++ b/packages/core/src/font/font-collector.ts
@@ -143,6 +143,12 @@ function collectFontsFromElements(
           }
         }
         break;
+      case "connector":
+      case "image":
+      case "chart":
+      case "smartArt":
+      case "raw":
+        break;
     }
   }
 }
@@ -175,6 +181,8 @@ function resolveThemeFontAlias(
   font: string | undefined,
   fontScheme: SourceThemeFontScheme,
 ): string | undefined {
+  if (font === undefined) return undefined;
+
   switch (font) {
     case "+mj-lt":
       return fontScheme.majorLatin;
@@ -189,6 +197,6 @@ function resolveThemeFontAlias(
     case "+mn-cs":
       return fontScheme.minorComplexScript;
     default:
-      return font?.startsWith("+mj-") || font?.startsWith("+mn-") ? undefined : font;
+      return font.startsWith("+mj-") || font.startsWith("+mn-") ? undefined : font;
   }
 }

--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -191,8 +191,6 @@ function adaptBackground(
         slide,
       );
       return null;
-    default:
-      return assertNever(background);
   }
 }
 
@@ -231,8 +229,6 @@ function adaptElement(
         element.sourcePartPath,
       );
       return [];
-    default:
-      return assertNever(element);
   }
 }
 
@@ -669,8 +665,6 @@ function adaptFill(
         slide,
       );
       return null;
-    default:
-      return assertNever(fill);
   }
 }
 
@@ -863,8 +857,4 @@ function pushAdapterWarning(
     slideNumber: slide.slideNumber,
     ...(sourcePartPath !== undefined ? { sourcePartPath } : {}),
   });
-}
-
-function assertNever(value: never): never {
-  throw new Error(`Unexpected computed view union member: ${JSON.stringify(value)}`);
 }

--- a/packages/document/src/computed/color.ts
+++ b/packages/document/src/computed/color.ts
@@ -4,7 +4,6 @@ import type {
   SourceColorTransform,
   SourceTheme,
 } from "../source/index.js";
-import { assertNever } from "../utils/assert-never.js";
 import type { ComputedColor } from "./pptx-computed-view.js";
 
 const DEFAULT_COLOR_MAP: Readonly<Record<string, string>> = {
@@ -95,8 +94,6 @@ function resolveBaseHex(
         ? resolveColor(context, schemeColor, new Set([...visited, mappedName]))?.hex
         : FALLBACK_SCHEME_COLORS[mappedName];
     }
-    default:
-      return assertNever(color);
   }
 }
 
@@ -131,8 +128,6 @@ function applyColorTransforms(
       case "alpha":
         alpha = Number(transform.value) / 100000;
         break;
-      default:
-        assertNever(transform.kind);
     }
   }
 

--- a/packages/document/src/computed/create-computed-view.ts
+++ b/packages/document/src/computed/create-computed-view.ts
@@ -36,7 +36,6 @@ import type {
   SourceTransform,
 } from "../source/index.js";
 import { asEmu } from "../source/index.js";
-import { assertNever } from "../utils/assert-never.js";
 import { buildComputedColorScheme, buildEffectiveColorMap, resolveColor } from "./color.js";
 import { findPlaceholderMatch } from "./placeholders.js";
 import type {
@@ -262,8 +261,6 @@ function computeBackground(
     }
     case "raw":
       return { background: { kind: "raw", source: background, sourceLayer } };
-    default:
-      return assertNever(background);
   }
 }
 
@@ -311,8 +308,6 @@ function computeElement(
       return computeSmartArtElement(context, element, layer, partPath);
     case "raw":
       return { kind: "raw", sourceLayer: layer, sourcePartPath: partPath, sourceNode: element };
-    default:
-      return assertNever(element);
   }
 }
 
@@ -732,8 +727,6 @@ function computeFill(context: ComputeContext, fill: SourceFill, partPath: PartPa
         source: fill,
         color: resolveColor(context, fill.color) ?? { hex: "#000000", alpha: 1 },
       };
-    default:
-      return assertNever(fill);
   }
 }
 

--- a/packages/document/src/utils/assert-never.ts
+++ b/packages/document/src/utils/assert-never.ts
@@ -1,6 +1,0 @@
-export function assertNever(
-  value: never,
-  message = "Unexpected discriminated union member",
-): never {
-  throw new Error(`${message}: ${JSON.stringify(value)}`);
-}

--- a/packages/renderer/src/font/cjk-font-fallback.ts
+++ b/packages/renderer/src/font/cjk-font-fallback.ts
@@ -31,15 +31,12 @@ function getFallbackMap(): CjkFallbackMap {
   if (cachedFallbacks) return cachedFallbacks;
 
   const os = platform();
-  switch (os) {
-    case "darwin":
-      cachedFallbacks = MACOS_FALLBACKS;
-      break;
-    case "win32":
-      cachedFallbacks = WINDOWS_FALLBACKS;
-      break;
-    default:
-      cachedFallbacks = {};
+  if (os === "darwin") {
+    cachedFallbacks = MACOS_FALLBACKS;
+  } else if (os === "win32") {
+    cachedFallbacks = WINDOWS_FALLBACKS;
+  } else {
+    cachedFallbacks = {};
   }
   return cachedFallbacks;
 }

--- a/packages/renderer/src/font/system-font-loader.ts
+++ b/packages/renderer/src/font/system-font-loader.ts
@@ -29,16 +29,12 @@ let cachedSkipSystemFonts: boolean | null = null;
 
 function getSystemFontDirs(): string[] {
   const os = platform();
-  switch (os) {
-    case "linux":
-      return ["/usr/share/fonts", "/usr/local/share/fonts"];
-    case "darwin":
-      return ["/System/Library/Fonts", "/Library/Fonts", join(homedir(), "Library/Fonts")];
-    case "win32":
-      return ["C:\\Windows\\Fonts"];
-    default:
-      return [];
+  if (os === "linux") return ["/usr/share/fonts", "/usr/local/share/fonts"];
+  if (os === "darwin") {
+    return ["/System/Library/Fonts", "/Library/Fonts", join(homedir(), "Library/Fonts")];
   }
+  if (os === "win32") return ["C:\\Windows\\Fonts"];
+  return [];
 }
 
 function isCjkTtc(name: string): boolean {

--- a/packages/renderer/src/renderer/fill-renderer.ts
+++ b/packages/renderer/src/renderer/fill-renderer.ts
@@ -343,7 +343,7 @@ function buildMarkerDef(
       path = `M 0 0 L ${mw} ${mh / 2} L 0 ${mh}`;
       fillAttr = `fill="none" stroke="${color}" stroke-width="1"`;
       break;
-    default:
+    case "none":
       return null;
   }
 

--- a/packages/renderer/src/renderer/svg-renderer.ts
+++ b/packages/renderer/src/renderer/svg-renderer.ts
@@ -76,8 +76,6 @@ function renderElement(element: SlideElement): RenderResult | null {
     case "table":
       result = renderTable(element);
       break;
-    default:
-      return null;
   }
 
   if (result && "altText" in element && element.altText) {

--- a/packages/renderer/src/renderer/text-renderer.ts
+++ b/packages/renderer/src/renderer/text-renderer.ts
@@ -393,8 +393,6 @@ export function formatAutoNum(scheme: AutoNumScheme, index: number): string {
       return `${toAlpha(index)})`;
     case "alphaLcParenR":
       return `${toAlpha(index).toLowerCase()})`;
-    default:
-      return `${index}.`;
   }
 }
 
@@ -487,14 +485,9 @@ function getAlignmentInfo(
   width: number,
   marginRightPx: number,
 ): { xPos: number; anchorValue: string } {
-  switch (alignment) {
-    case "ctr":
-      return { xPos: marginLeftPx + textWidth / 2, anchorValue: "middle" };
-    case "r":
-      return { xPos: width - marginRightPx, anchorValue: "end" };
-    default:
-      return { xPos: marginLeftPx, anchorValue: "start" };
-  }
+  if (alignment === "ctr") return { xPos: marginLeftPx + textWidth / 2, anchorValue: "middle" };
+  if (alignment === "r") return { xPos: width - marginRightPx, anchorValue: "end" };
+  return { xPos: marginLeftPx, anchorValue: "start" };
 }
 
 /**
@@ -934,14 +927,9 @@ function computePathLineX(
   marginRightPx: number,
   lineWidth: number,
 ): number {
-  switch (alignment) {
-    case "ctr":
-      return textStartX + (effectiveTextWidth - lineWidth) / 2;
-    case "r":
-      return width - marginRightPx - lineWidth;
-    default:
-      return textStartX;
-  }
+  if (alignment === "ctr") return textStartX + (effectiveTextWidth - lineWidth) / 2;
+  if (alignment === "r") return width - marginRightPx - lineWidth;
+  return textStartX;
 }
 
 /**


### PR DESCRIPTION
close #551

## 目的

`@typescript-eslint/switch-exhaustiveness-check` を有効化し、discriminated union / literal union の `switch` で case 追加漏れを ESLint error として検出できるようにします。

## 変更内容

- `eslint.config.mjs` に `@typescript-eslint/switch-exhaustiveness-check` を追加
- exhaustive な union switch から不要な `default: assertNever(...)` を削除
- 不要になった `packages/document/src/utils/assert-never.ts` と core adapter の local `assertNever` を削除
- rule 有効化で検出された既存 switch を、全 case 明示または fallback intent が明確な `if` 分岐へ整理

## 影響パッケージ / パス

- `eslint.config.mjs`
- `packages/document/src/computed/`
- `packages/core/src/`
- `packages/renderer/src/`

## ローカル検証

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## 補足

`npm run build` は既存の `import.meta` CJS warning を出しますが、build 自体は成功しています。
