### PR TITLE
renderer/document の string token を union type に絞る

### DIFF
--- a/.changeset/string-token-unions.md
+++ b/.changeset/string-token-unions.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+Narrow renderer/document image MIME and rectangle alignment token fields to explicit union types.

--- a/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.test.ts
@@ -13,6 +13,7 @@ import type { SlideElement } from "@pptx-glimpse/renderer";
 import { describe, expect, it } from "vitest";
 
 import { adaptComputedViewToRendererModel } from "./pptx-computed-view-renderer-adapter.js";
+import { unsafeFixtureAssertion } from "./unsafe-type-assertion.js";
 
 describe("adaptComputedViewToRendererModel", () => {
   it("slide size / background / effective element ordering を renderer model に変換する", () => {
@@ -518,6 +519,87 @@ describe("adaptComputedViewToRendererModel", () => {
       type: "shape",
       fill: { type: "image", mimeType: "image/emf" },
     });
+  });
+
+  it("unknown image MIME type を renderer contract の既定値へ正規化する", () => {
+    const source = buildSource();
+    const sourceWithUnknownMedia: PptxSourceModel = {
+      ...source,
+      packageGraph: {
+        ...source.packageGraph,
+        media: source.packageGraph.media.map((media) => ({
+          ...media,
+          contentType: "application/octet-stream",
+        })),
+      },
+    };
+
+    const result = adaptComputedViewToRendererModel(createComputedView(sourceWithUnknownMedia));
+
+    expect(findElementByAltText(result.slides[0].elements, "Hero image")).toMatchObject({
+      type: "image",
+      mimeType: "image/png",
+    });
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "pptx-computed-view-adapter.unsupported-image-mime-type",
+        sourcePartPath: "ppt/slides/slide1.xml",
+      }),
+    );
+  });
+
+  it("unknown rectangle alignment token を renderer contract の既定値へ正規化する", () => {
+    const result = adaptComputedViewToRendererModel(
+      createComputedView(
+        buildSource({
+          extraSlideShapes: [
+            shape("Unknown shadow alignment", {
+              transform: transform(110, 111, 112, 113),
+              effects: {
+                outerShadow: {
+                  blurRadius: asEmu(10),
+                  distance: asEmu(20),
+                  direction: asOoxmlAngle(30),
+                  color: { kind: "srgb", hex: "000000" },
+                  alignment: unsafeFixtureAssertion<"b">("unknown"),
+                  rotateWithShape: true,
+                },
+              },
+            }),
+            {
+              kind: "image",
+              name: "Unknown tile alignment",
+              transform: transform(120, 121, 122, 123),
+              blipRelationshipId: asRelationshipId("rIdImage"),
+              tile: {
+                tx: asEmu(1),
+                ty: asEmu(2),
+                sx: 0.5,
+                sy: 0.75,
+                flip: "none",
+                align: unsafeFixtureAssertion<"tl">("unknown"),
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    expect(
+      findElementByAltText(result.slides[0].elements, "Unknown shadow alignment"),
+    ).toMatchObject({
+      type: "shape",
+      effects: { outerShadow: { alignment: "b" } },
+    });
+    expect(findElementByAltText(result.slides[0].elements, "Unknown tile alignment")).toMatchObject(
+      {
+        type: "image",
+        tile: { align: "tl" },
+      },
+    );
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
+      expect.arrayContaining(["pptx-computed-view-adapter.unsupported-rectangle-alignment"]),
+    );
   });
 
   it("chart と SmartArt fallback を renderer model に変換する", () => {

--- a/packages/core/src/pptx-computed-view-renderer-adapter.ts
+++ b/packages/core/src/pptx-computed-view-renderer-adapter.ts
@@ -54,9 +54,11 @@ import type {
   Geometry,
   GroupElement,
   ImageElement,
+  ImageMimeType,
   Outline,
   Paragraph,
   ParagraphProperties,
+  RectangleAlignment,
   ResolvedColor,
   RunProperties,
   Slide,
@@ -88,6 +90,8 @@ export interface RendererAdapterDiagnostic {
     | "pptx-computed-view-adapter.raw-element-skipped"
     | "pptx-computed-view-adapter.raw-background-ignored"
     | "pptx-computed-view-adapter.raw-fill-ignored"
+    | "pptx-computed-view-adapter.unsupported-image-mime-type"
+    | "pptx-computed-view-adapter.unsupported-rectangle-alignment"
     | "pptx-computed-view-adapter.unresolved-chart-skipped"
     | "pptx-computed-view-adapter.unresolved-smartart-skipped"
     | "pptx-computed-view-adapter.unresolved-image-skipped";
@@ -243,7 +247,10 @@ function adaptConnector(
     geometry: adaptGeometry(connector.geometry),
     outline:
       connector.outline !== undefined ? adaptOutline(connector.outline, slide, diagnostics) : null,
-    effects: connector.effects !== undefined ? adaptEffects(connector.effects) : null,
+    effects:
+      connector.effects !== undefined
+        ? adaptEffects(connector.effects, slide, diagnostics, connector.sourcePartPath)
+        : null,
     ...(connector.sourceNode.name !== undefined ? { altText: connector.sourceNode.name } : {}),
   };
 }
@@ -270,7 +277,10 @@ function adaptGroup(
             flipV: false,
           },
     children: group.children.flatMap((child) => adaptElement(child, slide, diagnostics)),
-    effects: group.effects !== undefined ? adaptEffects(group.effects) : null,
+    effects:
+      group.effects !== undefined
+        ? adaptEffects(group.effects, slide, diagnostics, group.sourcePartPath)
+        : null,
     ...(group.sourceNode.name !== undefined ? { altText: group.sourceNode.name } : {}),
   };
 }
@@ -434,7 +444,10 @@ function adaptShape(
     fill: shape.fill !== undefined ? adaptFill(shape.fill, slide, diagnostics) : null,
     outline: shape.outline !== undefined ? adaptOutline(shape.outline, slide, diagnostics) : null,
     textBody: shape.textBody !== undefined ? adaptTextBody(shape.textBody) : null,
-    effects: shape.effects !== undefined ? adaptEffects(shape.effects) : null,
+    effects:
+      shape.effects !== undefined
+        ? adaptEffects(shape.effects, slide, diagnostics, shape.sourcePartPath)
+        : null,
     ...(shape.sourceNode.placeholder !== undefined
       ? { placeholderType: shape.sourceNode.placeholder.type ?? "body" }
       : {}),
@@ -445,7 +458,12 @@ function adaptShape(
   };
 }
 
-function adaptEffects(effects: ComputedEffectList): EffectList {
+function adaptEffects(
+  effects: ComputedEffectList,
+  slide: ComputedSlide,
+  diagnostics: DiagnosticSink,
+  sourcePartPath?: string,
+): EffectList {
   return {
     outerShadow:
       effects.outerShadow !== undefined
@@ -454,7 +472,13 @@ function adaptEffects(effects: ComputedEffectList): EffectList {
             distance: toRendererEmu(effects.outerShadow.distance),
             direction: effects.outerShadow.direction,
             color: adaptColor(effects.outerShadow.color),
-            alignment: effects.outerShadow.alignment,
+            alignment: adaptRectangleAlignment(
+              effects.outerShadow.alignment,
+              "b",
+              diagnostics,
+              slide,
+              sourcePartPath,
+            ),
             rotateWithShape: effects.outerShadow.rotateWithShape,
           }
         : null,
@@ -503,8 +527,16 @@ function adaptImage(
     type: "image",
     transform: adaptTransform(image.transform, slide, diagnostics, image.sourcePartPath),
     imageData: uint8ArrayToBase64(image.media.bytes),
-    mimeType: normalizeImageMimeType(image.media.contentType),
-    effects: image.effects !== undefined ? adaptEffects(image.effects) : null,
+    mimeType: normalizeImageMimeType(
+      image.media.contentType,
+      diagnostics,
+      slide,
+      image.sourcePartPath,
+    ),
+    effects:
+      image.effects !== undefined
+        ? adaptEffects(image.effects, slide, diagnostics, image.sourcePartPath)
+        : null,
     blipEffects: image.blipEffects !== undefined ? adaptBlipEffects(image.blipEffects) : null,
     srcRect: image.sourceNode.crop
       ? {
@@ -524,7 +556,13 @@ function adaptImage(
             sx: image.sourceNode.tile.sx,
             sy: image.sourceNode.tile.sy,
             flip: image.sourceNode.tile.flip,
-            align: image.sourceNode.tile.align,
+            align: adaptRectangleAlignment(
+              image.sourceNode.tile.align,
+              "tl",
+              diagnostics,
+              slide,
+              image.sourcePartPath,
+            ),
           }
         : null,
   };
@@ -636,7 +674,7 @@ function adaptFill(
         return {
           type: "image",
           imageData: uint8ArrayToBase64(fill.media.bytes),
-          mimeType: normalizeImageMimeType(fill.media.contentType),
+          mimeType: normalizeImageMimeType(fill.media.contentType, diagnostics, slide),
           tile:
             fill.tile !== undefined
               ? {
@@ -645,7 +683,7 @@ function adaptFill(
                   sx: fill.tile.sx,
                   sy: fill.tile.sy,
                   flip: fill.tile.flip,
-                  align: fill.tile.align,
+                  align: adaptRectangleAlignment(fill.tile.align, "tl", diagnostics, slide),
                 }
               : null,
         };
@@ -837,10 +875,77 @@ function toRendererPt(value: number): NonNullable<RunProperties["fontSize"]> {
   return unsafeBrandAssertion<NonNullable<RunProperties["fontSize"]>>(Number(value));
 }
 
-function normalizeImageMimeType(contentType: string): string {
-  if (contentType === "image/x-emf") return "image/emf";
-  if (contentType === "image/x-wmf") return "image/wmf";
-  return contentType;
+function normalizeImageMimeType(
+  contentType: string,
+  diagnostics: DiagnosticSink,
+  slide: ComputedSlide,
+  sourcePartPath?: string,
+): ImageMimeType {
+  switch (contentType) {
+    case "image/png":
+    case "image/jpeg":
+    case "image/gif":
+    case "image/bmp":
+    case "image/tiff":
+    case "image/svg+xml":
+    case "image/webp":
+    case "image/x-icon":
+      return contentType;
+    case "image/jpg":
+      return "image/jpeg";
+    case "image/x-emf":
+      return "image/emf";
+    case "image/x-wmf":
+      return "image/wmf";
+    default:
+      pushAdapterWarning(
+        diagnostics,
+        "pptx-computed-view-adapter.unsupported-image-mime-type",
+        `Unsupported image MIME type '${contentType}' was normalized to image/png.`,
+        slide,
+        sourcePartPath,
+      );
+      return "image/png";
+  }
+}
+
+function adaptRectangleAlignment(
+  alignment: string | undefined,
+  fallback: RectangleAlignment,
+  diagnostics: DiagnosticSink,
+  slide: ComputedSlide,
+  sourcePartPath?: string,
+): RectangleAlignment {
+  switch (alignment) {
+    case "tl":
+    case "t":
+    case "tr":
+    case "l":
+    case "ctr":
+    case "r":
+    case "bl":
+    case "b":
+    case "br":
+      return alignment;
+    case undefined:
+      pushAdapterWarning(
+        diagnostics,
+        "pptx-computed-view-adapter.unsupported-rectangle-alignment",
+        `Unsupported rectangle alignment '' was normalized to ${fallback}.`,
+        slide,
+        sourcePartPath,
+      );
+      return fallback;
+    default:
+      pushAdapterWarning(
+        diagnostics,
+        "pptx-computed-view-adapter.unsupported-rectangle-alignment",
+        `Unsupported rectangle alignment '${alignment ?? ""}' was normalized to ${fallback}.`,
+        slide,
+        sourcePartPath,
+      );
+      return fallback;
+  }
 }
 
 function pushAdapterWarning(

--- a/packages/document/src/computed/pptx-computed-view.ts
+++ b/packages/document/src/computed/pptx-computed-view.ts
@@ -40,6 +40,7 @@ import type {
   SourceOutline,
   SourceParagraphProperties,
   SourceRawShapeNode,
+  SourceRectangleAlignment,
   SourceRunProperties,
   SourceShape,
   SourceShapeNode,
@@ -309,7 +310,7 @@ export interface ComputedOuterShadow {
   readonly distance: Emu;
   readonly direction: number;
   readonly color: ComputedColor;
-  readonly alignment: string;
+  readonly alignment: SourceRectangleAlignment;
   readonly rotateWithShape: boolean;
 }
 

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -123,6 +123,7 @@ export type {
   SourcePresentation,
   SourcePresetGeometry,
   SourceRawShapeNode,
+  SourceRectangleAlignment,
   SourceRunProperties,
   SourceShape,
   SourceShapeNode,

--- a/packages/document/src/reader/drawing.ts
+++ b/packages/document/src/reader/drawing.ts
@@ -27,6 +27,7 @@ import type {
   SourceLineJoin,
   SourceLumEffect,
   SourceOutline,
+  SourceRectangleAlignment,
   SourceTransform,
 } from "../source/index.js";
 import { asEmu, asOoxmlAngle, asOoxmlPercent, asRelationshipId } from "../source/index.js";
@@ -42,6 +43,18 @@ import {
   localName,
   type XmlNode,
 } from "./xml.js";
+
+const RECTANGLE_ALIGNMENT_TOKENS: ReadonlySet<SourceRectangleAlignment> = new Set([
+  "tl",
+  "t",
+  "tr",
+  "l",
+  "ctr",
+  "r",
+  "bl",
+  "b",
+  "br",
+]);
 
 const COLOR_TRANSFORM_KINDS: ReadonlySet<SourceColorTransform["kind"]> = new Set([
   "lumMod",
@@ -156,7 +169,7 @@ function parseOuterShadow(node: XmlNode | undefined): SourceEffectList["outerSha
     distance: asEmu(numericAttr(node, "dist") ?? 0),
     direction: asOoxmlAngle(numericAttr(node, "dir") ?? 0),
     color,
-    alignment: getAttr(node, "algn") ?? "b",
+    alignment: parseRectangleAlignment(getAttr(node, "algn"), "b"),
     rotateWithShape: getAttr(node, "rotWithShape") !== "0",
   };
 }
@@ -362,8 +375,15 @@ export function parseImageFillTile(tile: XmlNode | undefined): SourceImageFillTi
     sx: (numericAttr(tile, "sx") ?? 100000) / 100000,
     sy: (numericAttr(tile, "sy") ?? 100000) / 100000,
     flip: flip === "x" || flip === "y" || flip === "xy" ? flip : "none",
-    align: getAttr(tile, "algn") ?? "tl",
+    align: parseRectangleAlignment(getAttr(tile, "algn"), "tl"),
   };
+}
+
+export function parseRectangleAlignment(
+  value: string | undefined,
+  fallback: SourceRectangleAlignment,
+): SourceRectangleAlignment {
+  return parseEnumValueWithDefault(value, RECTANGLE_ALIGNMENT_TOKENS, fallback);
 }
 
 function parsePatternFill(pattern: XmlNode): SourceFill | undefined {

--- a/packages/document/src/reader/slide-parts.ts
+++ b/packages/document/src/reader/slide-parts.ts
@@ -29,7 +29,14 @@ import {
   type SourceFill,
   type SourceMasterTextStyles,
 } from "../source/index.js";
-import { isTrue, numericAttr, parseColorElement, parseFill, parseLine } from "./drawing.js";
+import {
+  isTrue,
+  numericAttr,
+  parseColorElement,
+  parseFill,
+  parseLine,
+  parseRectangleAlignment,
+} from "./drawing.js";
 import { makeSidecar } from "./raw-node.js";
 import { parseShapeTree } from "./shape-tree.js";
 import { parseTextStyle } from "./text.js";
@@ -363,7 +370,7 @@ function parseOuterShadow(node: XmlNode | undefined): SourceEffectList["outerSha
     distance: asEmu(numericAttr(node, "dist") ?? 0),
     direction: asOoxmlAngle(numericAttr(node, "dir") ?? 0),
     color,
-    alignment: getAttr(node, "algn") ?? "b",
+    alignment: parseRectangleAlignment(getAttr(node, "algn"), "b"),
     rotateWithShape: getAttr(node, "rotWithShape") !== "0",
   };
 }

--- a/packages/document/src/reader/slide-reader.test.ts
+++ b/packages/document/src/reader/slide-reader.test.ts
@@ -401,6 +401,26 @@ describe("readPptx — typed shape detail (synthetic)", () => {
     expect(shape.rawSidecars?.map((sidecar) => sidecar.node.name) ?? []).toContain("a:reflection");
   });
 
+  it("unknown rectangle alignment token は source field ごとの既定値に fallback する", () => {
+    const source = readPptx(
+      buildSyntheticPptx(
+        `<p:sp><p:nvSpPr><p:cNvPr id="13" name="Shadow"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:effectLst>` +
+          `<a:outerShdw algn="invalid"><a:srgbClr val="000000"/></a:outerShdw>` +
+          `</a:effectLst></p:spPr></p:sp>` +
+          `<p:pic><p:nvPicPr><p:cNvPr id="14" name="Pic"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>` +
+          `<p:blipFill><a:blip r:embed="rIdImage"/><a:tile algn="invalid"/></p:blipFill>` +
+          `<p:spPr/></p:pic>`,
+      ),
+    );
+
+    const shape = unsafeFixtureAssertion<SourceShape>(source.slides[0].shapes[0]);
+    const image = unsafeFixtureAssertion<SourceImage>(source.slides[0].shapes[1]);
+
+    expect(shape.effects?.outerShadow?.alignment).toBe("b");
+    expect(image.tile?.align).toBe("tl");
+  });
+
   it("image shape effects と blip effects を typed source effects として読む", () => {
     const source = readPptx(
       buildSyntheticPptx(

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -84,6 +84,7 @@ export type {
   SourcePlaceholder,
   SourcePresetGeometry,
   SourceRawShapeNode,
+  SourceRectangleAlignment,
   SourceRunProperties,
   SourceShape,
   SourceShapeNode,

--- a/packages/document/src/source/shapes.ts
+++ b/packages/document/src/source/shapes.ts
@@ -107,13 +107,15 @@ export type SourceGradient =
       readonly centerY: number;
     };
 
+export type SourceRectangleAlignment = "tl" | "t" | "tr" | "l" | "ctr" | "r" | "bl" | "b" | "br";
+
 export interface SourceImageFillTile {
   readonly tx: Emu;
   readonly ty: Emu;
   readonly sx: number;
   readonly sy: number;
   readonly flip: "none" | "x" | "y" | "xy";
-  readonly align: string;
+  readonly align: SourceRectangleAlignment;
 }
 
 export interface SourceStyleReference {
@@ -139,7 +141,7 @@ export interface SourceOuterShadow {
   readonly distance: Emu;
   readonly direction: OoxmlAngle;
   readonly color: SourceColor;
-  readonly alignment: string;
+  readonly alignment: SourceRectangleAlignment;
   readonly rotateWithShape: boolean;
 }
 

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -23,6 +23,7 @@ export * from "./model/slide.js";
 export * from "./model/table.js";
 export * from "./model/text.js";
 export * from "./model/theme.js";
+export * from "./model/tokens.js";
 export * from "./png/png-converter.js";
 export * from "./renderer/blip-effect-renderer.js";
 export * from "./renderer/chart-renderer.js";

--- a/packages/renderer/src/model/effect.ts
+++ b/packages/renderer/src/model/effect.ts
@@ -1,5 +1,6 @@
 import type { Emu } from "../utils/unit-types.js";
 import type { ResolvedColor } from "./fill.js";
+import type { RectangleAlignment } from "./tokens.js";
 
 export interface EffectList {
   outerShadow: OuterShadow | null;
@@ -13,7 +14,7 @@ export interface OuterShadow {
   distance: Emu;
   direction: number;
   color: ResolvedColor;
-  alignment: string;
+  alignment: RectangleAlignment;
   rotateWithShape: boolean;
 }
 

--- a/packages/renderer/src/model/fill.ts
+++ b/packages/renderer/src/model/fill.ts
@@ -1,4 +1,5 @@
 import type { Emu } from "../utils/unit-types.js";
+import type { ImageMimeType, RectangleAlignment } from "./tokens.js";
 
 export type Fill = SolidFill | GradientFill | ImageFill | PatternFill | NoFill;
 
@@ -24,7 +25,7 @@ export interface GradientStop {
 export interface ImageFill {
   type: "image";
   imageData: string;
-  mimeType: string;
+  mimeType: ImageMimeType;
   tile: ImageFillTile | null;
 }
 
@@ -34,7 +35,7 @@ export interface ImageFillTile {
   sx: number;
   sy: number;
   flip: "none" | "x" | "y" | "xy";
-  align: string;
+  align: RectangleAlignment;
 }
 
 export interface PatternFill {

--- a/packages/renderer/src/model/image.ts
+++ b/packages/renderer/src/model/image.ts
@@ -1,6 +1,7 @@
 import type { Emu } from "../utils/unit-types.js";
 import type { BlipEffects, EffectList } from "./effect.js";
 import type { Transform } from "./shape.js";
+import type { ImageMimeType, RectangleAlignment } from "./tokens.js";
 
 export interface SrcRect {
   left: number;
@@ -22,14 +23,14 @@ export interface TileInfo {
   sx: number;
   sy: number;
   flip: "none" | "x" | "y" | "xy";
-  align: string;
+  align: RectangleAlignment;
 }
 
 export interface ImageElement {
   type: "image";
   transform: Transform;
   imageData: string;
-  mimeType: string;
+  mimeType: ImageMimeType;
   effects: EffectList | null;
   blipEffects: BlipEffects | null;
   srcRect: SrcRect | null;

--- a/packages/renderer/src/model/tokens.ts
+++ b/packages/renderer/src/model/tokens.ts
@@ -1,0 +1,13 @@
+export type ImageMimeType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif"
+  | "image/bmp"
+  | "image/tiff"
+  | "image/svg+xml"
+  | "image/webp"
+  | "image/x-icon"
+  | "image/emf"
+  | "image/wmf";
+
+export type RectangleAlignment = "tl" | "t" | "tr" | "l" | "ctr" | "r" | "bl" | "b" | "br";


### PR DESCRIPTION
close #553

## 目的

renderer model と document source/computed model に残っていた閉じた token field を union type に絞り、adapter / reader 境界で未知値の扱いを明示します。

## 変更内容

- renderer model に `ImageMimeType` / `RectangleAlignment` を追加し、image `mimeType`、shadow alignment、tile alignment に適用
- document source/computed model に `SourceRectangleAlignment` を追加し、reader で未知 `algn` token を field ごとの既定値へ fallback
- adapter で未知 MIME type / alignment token を diagnostic として扱い、renderer contract の既定値へ正規化
- package graph / raw part / media part の `contentType: string` や relationship / typeface / text / URL / raw XML などの自由文字列は維持
- patch changeset を追加

## 影響範囲

- `packages/renderer/src/model/*`
- `packages/document/src/source/*`, `packages/document/src/computed/*`, `packages/document/src/reader/*`
- `packages/core/src/pptx-computed-view-renderer-adapter.ts`

## 検証

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`（既存の `import.meta` CJS warning は出るが成功）
- acceptance-check: 受け入れ条件すべて達成
- cross-review: warning 1 件を追加 commit で対応済み
