### PR TITLE
public API に JSDoc を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Both `convertPptxToSvg` and `convertPptxToPng` accept an optional `ConvertOption
 const results = await convertPptxToPng(pptx, {
   slides: [1, 3], // Convert only slides 1 and 3
   width: 1920, // Output width in pixels (default: 960)
-  height: 1080, // Output height in pixels (width takes priority if both set)
+  height: 1080, // Currently ignored by public conversion; width controls PNG size
   logLevel: "warn", // Warning log level: "off" | "warn" | "debug"
   fontDirs: ["/custom/fonts"], // Additional font directories to search
   skipSystemFonts: true, // Skip OS system font directories; use fontDirs only

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -46,16 +46,18 @@ export interface ConvertOptions {
   /**
    * Output width in pixels.
    *
-   * SVG output uses this as the viewport width. PNG output rasterizes to this
-   * width while preserving the slide aspect ratio unless `height` is used alone.
-   * Defaults to 960.
+   * PNG output rasterizes to this width while preserving the slide aspect
+   * ratio. Defaults to 960. SVG output keeps the slide's native pixel size from
+   * the PPTX slide dimensions and does not use this option.
    */
   width?: number;
   /**
    * Output height in pixels.
    *
-   * When `width` is also specified, `width` takes precedence and this value is
-   * ignored by PNG rasterization.
+   * PNG rasterization currently always uses `width`, either the provided value
+   * or the default width, so this option is ignored by the public conversion
+   * APIs. SVG output keeps the slide's native pixel size and does not use this
+   * option.
    */
   height?: number;
   /**

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -32,44 +32,110 @@ import {
   type RendererAdapterDiagnostic,
 } from "./pptx-computed-view-renderer-adapter.js";
 
+/**
+ * Options shared by PPTX-to-SVG and PPTX-to-PNG conversion.
+ */
 export interface ConvertOptions {
-  /** Target slide numbers (1-based). When omitted, all slides are converted. */
+  /**
+   * Target slide numbers to convert, using PowerPoint-style 1-based numbering.
+   *
+   * When omitted, every slide in the presentation is converted. Missing or
+   * out-of-range slide numbers produce no output for those entries.
+   */
   slides?: number[];
-  /** Output image width in pixels. Defaults to 960. */
+  /**
+   * Output width in pixels.
+   *
+   * SVG output uses this as the viewport width. PNG output rasterizes to this
+   * width while preserving the slide aspect ratio unless `height` is used alone.
+   * Defaults to 960.
+   */
   width?: number;
-  /** Output image height in pixels. When width is also specified, width takes precedence. */
+  /**
+   * Output height in pixels.
+   *
+   * When `width` is also specified, `width` takes precedence and this value is
+   * ignored by PNG rasterization.
+   */
   height?: number;
-  /** Warning log level. Defaults to "off". */
+  /**
+   * Warning log level for unsupported or approximated PPTX features.
+   *
+   * Defaults to `"off"`. Use `"warn"` to collect and print summaries, or
+   * `"debug"` to print individual warning entries as they are recorded.
+   */
   logLevel?: LogLevel;
-  /** Additional font directory paths searched alongside system fonts. */
+  /**
+   * Additional directories that are scanned for font files.
+   *
+   * These directories are searched in addition to system font directories unless
+   * `skipSystemFonts` is true.
+   */
   fontDirs?: string[];
-  /** Custom PPTX font name -> OSS replacement font mapping merged into the default mapping. */
+  /**
+   * Custom PPTX font name to replacement font name mapping.
+   *
+   * Entries are merged with `DEFAULT_FONT_MAPPING`; user-provided entries take
+   * precedence. This is useful when a PPTX references proprietary or corporate
+   * fonts that should render with installed alternatives.
+   */
   fontMapping?: FontMapping;
-  /** When true, skips OS system font scanning and only uses fontDirs. */
+  /**
+   * Skip OS system font directories and only scan `fontDirs`.
+   *
+   * This is useful in containers or serverless environments where bundled fonts
+   * should be the only fonts used.
+   */
   skipSystemFonts?: boolean;
   /**
-   * Text output mode for SVG. Defaults to "path".
-   * - "path": outputs glyph outlines as <path> elements and does not depend on fonts
-   *   being available in the viewing environment.
-   * - "text": outputs native <text> elements plus subset-font @font-face data URIs.
-   *   This enables native browser text rendering and text selection for inline SVG, but
-   *   may not render as expected through <img src="...svg"> references or sanitized SVG
-   *   environments.
-   *   convertPptxToPng ignores this option and always uses "path" because resvg does not
-   *   interpret @font-face.
+   * Text output mode for SVG conversion.
+   *
+   * Defaults to `"path"`, which emits glyph outlines as `<path>` elements and
+   * does not require fonts in the SVG viewing environment. `"text"` emits native
+   * `<text>` elements with subset-font `@font-face` data URIs, enabling browser
+   * text selection and native text rendering for inline SVG.
+   *
+   * Embedded fonts and native text may not render as expected when the SVG is
+   * loaded through `<img src="...svg">` or sanitized. `convertPptxToPng` ignores
+   * this option and always renders with `"path"` output because resvg does not
+   * interpret the embedded `@font-face` rules used by SVG text output.
    */
   textOutput?: "path" | "text";
 }
 
+/**
+ * SVG conversion result for one slide.
+ */
 export interface SlideSvg {
+  /**
+   * Original slide number in the PPTX file, using 1-based numbering.
+   */
   slideNumber: number;
+  /**
+   * Complete SVG document string for the slide.
+   */
   svg: string;
 }
 
+/**
+ * PNG conversion result for one slide.
+ */
 export interface SlideImage {
+  /**
+   * Original slide number in the PPTX file, using 1-based numbering.
+   */
   slideNumber: number;
+  /**
+   * PNG image bytes for the rendered slide.
+   */
   png: Buffer;
+  /**
+   * Actual output image width in pixels after rasterization.
+   */
   width: number;
+  /**
+   * Actual output image height in pixels after rasterization.
+   */
   height: number;
 }
 
@@ -85,6 +151,19 @@ interface PngConversionResult {
   readonly diagnostics: readonly ConversionDiagnostic[];
 }
 
+/**
+ * Convert a PPTX file to SVG documents.
+ *
+ * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
+ * @param options Conversion options. `slides` uses 1-based slide numbers; when
+ * omitted, all slides are converted.
+ * @returns One SVG result per converted slide, preserving original slide numbers.
+ *
+ * Text is emitted as SVG paths by default for portable rendering. Set
+ * `textOutput: "text"` to emit native `<text>` elements with embedded subset
+ * fonts for inline browser SVG use. Font directories and font mapping options
+ * control how PPTX font names are resolved for text measurement and text output.
+ */
 export async function convertPptxToSvg(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
@@ -93,6 +172,21 @@ export async function convertPptxToSvg(
   return [...result.slides];
 }
 
+/**
+ * Convert a PPTX file to PNG images.
+ *
+ * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
+ * @param options Conversion options. `slides` uses 1-based slide numbers; when
+ * omitted, all slides are converted.
+ * @returns One PNG result per converted slide, preserving original slide numbers
+ * and reporting the actual rasterized image size.
+ *
+ * PNG conversion first renders each slide to SVG and then rasterizes it with
+ * resvg. The `textOutput` option is intentionally ignored: PNG rendering always
+ * uses path-based text output because resvg does not interpret the embedded
+ * `@font-face` rules used by SVG text mode. Font directories and font mapping
+ * options are still used to resolve glyph outlines and text metrics.
+ */
 export async function convertPptxToPng(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,

--- a/packages/core/src/font/font-collector.ts
+++ b/packages/core/src/font/font-collector.ts
@@ -1,6 +1,3 @@
-/**
- * API to collect the used font name from PPTX.
- */
 import {
   type ComputedElement,
   type ComputedTextBody,
@@ -10,18 +7,42 @@ import {
   type SourceThemeFontScheme,
 } from "@pptx-glimpse/document";
 
-/** Font collection results */
+/**
+ * Font names discovered in a PPTX file.
+ */
 export interface UsedFonts {
-  /** Fonts defined in the theme */
+  /**
+   * Theme font slots resolved from the presentation's default theme.
+   */
   theme: {
+    /**
+     * Major Latin theme font.
+     */
     majorFont: string;
+    /**
+     * Minor Latin theme font.
+     */
     minorFont: string;
+    /**
+     * Major East Asian theme font, when present.
+     */
     majorFontEa: string | null;
+    /**
+     * Minor East Asian theme font, when present.
+     */
     minorFontEa: string | null;
+    /**
+     * Major complex-script theme font, when present.
+     */
     majorFontCs: string | null;
+    /**
+     * Minor complex-script theme font, when present.
+     */
     minorFontCs: string | null;
   };
-  /** List of font names used in text runs and themes (no duplicates, sorted) */
+  /**
+   * Unique sorted font names used by text runs, bullets, and theme font slots.
+   */
   fonts: string[];
 }
 
@@ -34,8 +55,15 @@ const DEFAULT_THEME_FONTS: ResolvedThemeFontScheme = {
 };
 
 /**
- * Parse PPTX and collect the font name used.
- * Lightweight because no rendering is performed.
+ * Parse a PPTX file and collect the font names it references.
+ *
+ * This is a lightweight preflight helper: it reads the document model and text
+ * styles but does not render slides or load font files. Use it to decide which
+ * fonts should be installed, bundled, or mapped before calling the conversion
+ * APIs.
+ *
+ * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
+ * @returns Theme font slots and a unique sorted list of referenced font names.
  */
 export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
   const source = readPptx(input);

--- a/packages/renderer/src/font/font-mapping.ts
+++ b/packages/renderer/src/font/font-mapping.ts
@@ -1,12 +1,19 @@
 /**
- * PPTX font name -> OSS alternative font (Google Fonts) mapping.
- * Users can extend or override it.
+ * Mapping from PPTX font family names to replacement font family names.
+ *
+ * Keys are font names found in PPTX files. Values are font names that should be
+ * present in the rendering environment, commonly open-source alternatives to
+ * proprietary Microsoft Office fonts.
  */
-
-/** Font mapping table type */
 export type FontMapping = Record<string, string>;
 
-/** Default font mapping table */
+/**
+ * Default replacement mapping for common Microsoft Office fonts.
+ *
+ * The table maps fonts such as Calibri, Arial, Meiryo, and MS Gothic to
+ * open-source alternatives used during text measurement, SVG path generation,
+ * and font lookup.
+ */
 export const DEFAULT_FONT_MAPPING: Readonly<FontMapping> = {
   // Latin fonts
   Calibri: "Carlito",
@@ -39,8 +46,11 @@ export const DEFAULT_FONT_MAPPING: Readonly<FontMapping> = {
 };
 
 /**
- * Generate a table that merges default mapping and user mapping.
- * User-specified entries take precedence.
+ * Create a font mapping table by merging defaults with user overrides.
+ *
+ * @param userMapping Custom PPTX font name to replacement font name entries.
+ * User-specified entries take precedence over `DEFAULT_FONT_MAPPING`.
+ * @returns A new mutable mapping object.
  */
 export function createFontMapping(userMapping?: FontMapping): FontMapping {
   if (!userMapping) return { ...DEFAULT_FONT_MAPPING };
@@ -58,8 +68,14 @@ function normalizeFullWidth(s: string): string {
 }
 
 /**
- * Get the OSS alternative font name from the mapping table.
- * Looks up without case sensitivity.
+ * Look up the replacement font for a PPTX font family.
+ *
+ * Matching is case-insensitive and normalizes full-width alphanumeric
+ * characters used by some Japanese Office font names.
+ *
+ * @param fontFamily PPTX font family name to resolve.
+ * @param mapping Mapping table, usually from `createFontMapping`.
+ * @returns The replacement font name, or `null` when no mapping exists.
  */
 export function getMappedFont(
   fontFamily: string | null | undefined,

--- a/packages/renderer/src/font/opentype-helpers.ts
+++ b/packages/renderer/src/font/opentype-helpers.ts
@@ -13,9 +13,22 @@ import type { OpentypeFullFont, TextPathFontResolver } from "./text-path-context
 import { DefaultTextPathFontResolver } from "./text-path-context.js";
 import { extractTtcFonts, isTtcBuffer } from "./ttc-parser.js";
 
-/** Font buffer input format */
+/**
+ * Font file data supplied directly by the caller.
+ *
+ * Use this when system font scanning is unavailable or undesirable, such as in
+ * serverless environments. `name` is used to register TTF/OTF buffers under a
+ * specific family name; TTC buffers also read family names from their names
+ * table.
+ */
 export interface FontBuffer {
+  /**
+   * Optional font family name to register for this buffer.
+   */
   name?: string;
+  /**
+   * Raw TTF, OTF, or TTC font file bytes.
+   */
   data: ArrayBuffer | Uint8Array;
 }
 
@@ -97,10 +110,16 @@ function parseFontBuffer(
 }
 
 /**
- * Construct an OpentypeTextMeasurer from a font buffer array.
+ * Create a text measurer from caller-provided font buffers.
  *
- * Dynamically import opentype.js internally to parse the font.
- * Returns null if opentype.js is not available.
+ * This low-level helper is useful when rendering in an environment where fonts
+ * are bundled as bytes instead of discovered from the OS. It dynamically imports
+ * `opentype.js` and returns `null` if no fonts can be parsed or the optional
+ * dependency is unavailable.
+ *
+ * @param fontBuffers Font file bytes to parse.
+ * @param fontMapping Optional PPTX font name to replacement font mapping.
+ * @returns A text measurer, or `null` when setup is not possible.
  */
 export async function createOpentypeTextMeasurerFromBuffers(
   fontBuffers: FontBuffer[],
@@ -110,16 +129,31 @@ export async function createOpentypeTextMeasurerFromBuffers(
   return setup?.measurer ?? null;
 }
 
+/**
+ * Font services created from OpenType font data.
+ */
 export interface OpentypeSetup {
+  /**
+   * Measures text width for layout and wrapping.
+   */
   measurer: OpentypeTextMeasurer;
+  /**
+   * Resolves fonts for converting text to SVG path outlines.
+   */
   fontResolver: TextPathFontResolver;
 }
 
 /**
- * Construct OpentypeTextMeasurer and TextPathFontResolver simultaneously from the font buffer array.
+ * Create font measurement and SVG path resolution services from font buffers.
  *
- * The object returned by opentype.parse() satisfies both OpentypeFont and OpentypeFullFont, so
- * Pass the same Font object to both measurer and fontResolver.
+ * Use this for advanced integrations that need to provide fonts explicitly
+ * instead of relying on system font directories. Returned services can be wired
+ * into renderer internals; the public conversion APIs usually only need
+ * `fontDirs`, `skipSystemFonts`, and `fontMapping`.
+ *
+ * @param fontBuffers TTF, OTF, or TTC font file bytes.
+ * @param fontMapping Optional PPTX font name to replacement font mapping.
+ * @returns Font services, or `null` when no usable font setup can be created.
  */
 export async function createOpentypeSetupFromBuffers(
   fontBuffers: FontBuffer[],
@@ -239,9 +273,11 @@ let cachedSetup: OpentypeSetup | null = null;
 let cachedSetupKey: string | null = null;
 
 /**
- * Clear the font object cache.
- * Normally there is no need to call it, but after installing/uninstalling a font
- * Use this when you want to force reload.
+ * Clear the module-level cache of parsed system fonts.
+ *
+ * Conversion APIs cache parsed font objects for repeated calls with the same
+ * font options. Call this after installing, removing, or replacing fonts in a
+ * long-running process when subsequent conversions must reload font files.
  */
 export function clearFontCache(): void {
   cachedSetup = null;

--- a/packages/renderer/src/png/png-converter.ts
+++ b/packages/renderer/src/png/png-converter.ts
@@ -13,9 +13,11 @@ function resolveWasmPath(): string {
 }
 
 /**
- * Initializes the resvg-wasm WASM module.
- * Even when not called explicitly, it is initialized automatically on the first PNG conversion.
- * Use this when you want to initialize the application when it starts.
+ * Initialize the resvg-wasm module used for PNG conversion.
+ *
+ * Calling this is optional because `convertPptxToPng` initializes resvg-wasm on
+ * first use. Applications may call it during startup to pay the WASM loading
+ * cost before handling the first conversion request.
  */
 export async function initResvgWasm(): Promise<void> {
   if (!wasmInitPromise) {

--- a/packages/renderer/src/warning-logger.ts
+++ b/packages/renderer/src/warning-logger.ts
@@ -1,16 +1,40 @@
+/**
+ * Controls how unsupported-feature warnings are collected and printed.
+ *
+ * `"off"` disables collection, `"warn"` collects entries and prints summaries,
+ * and `"debug"` also prints each warning as it is recorded.
+ */
 export type LogLevel = "off" | "warn" | "debug";
 
+/**
+ * One unsupported or approximated feature encountered during conversion.
+ */
 export interface WarningEntry {
-  /** The feature key, e.g. "sp.style", "bodyPr@vert" */
+  /**
+   * Stable feature key, for example `"sp.style"` or `"bodyPr@vert"`.
+   */
   feature: string;
-  /** Human-readable description */
+  /**
+   * Human-readable warning message.
+   */
   message: string;
-  /** Location context, e.g. "Slide 1" */
+  /**
+   * Optional location context, for example `"Slide 1"`.
+   */
   context?: string;
 }
 
+/**
+ * Aggregated warnings from the most recent conversion cycle.
+ */
 export interface WarningSummary {
+  /**
+   * Total number of warning entries.
+   */
   totalCount: number;
+  /**
+   * Warning counts grouped by feature key.
+   */
   features: { feature: string; message: string; count: number }[];
 }
 
@@ -60,6 +84,15 @@ export function debug(feature: string, message: string, context?: string): void 
   console.warn(`${PREFIX} DEBUG: ${feature} - ${message}${ctx}`);
 }
 
+/**
+ * Return a grouped summary of currently collected warnings.
+ *
+ * This reads the active warning logger state. The public conversion APIs flush
+ * warnings at the end of a conversion so summaries can be printed; after that
+ * flush, this returns an empty summary until new warnings are recorded. It is
+ * mainly useful for lower-level renderer workflows, tests, and integrations
+ * that manage the warning cycle directly.
+ */
 export function getWarningSummary(): WarningSummary {
   const features: WarningSummary["features"] = [];
   for (const [feature, { message, count }] of featureCounts) {
@@ -84,6 +117,14 @@ export function flushWarnings(): WarningSummary {
   return summary;
 }
 
+/**
+ * Return individual warning entries collected in the current warning cycle.
+ *
+ * Entries include optional slide or element context when available. The public
+ * conversion APIs flush entries at the end of a conversion, so this is mainly
+ * useful for lower-level renderer workflows, tests, and integrations that
+ * manage the warning cycle directly.
+ */
 export function getWarningEntries(): readonly WarningEntry[] {
   return entries;
 }


### PR DESCRIPTION
close #554

## 目的

公開 package `pptx-glimpse` から export される主要 public API に英語 JSDoc を追加し、IDE hover と生成 `.d.ts` で入力・出力・option の意味や注意点を確認できるようにします。

## 影響パッケージ / パス

- `packages/core/src/converter.ts`
- `packages/core/src/font/font-collector.ts`
- `packages/renderer/src/font/font-mapping.ts`
- `packages/renderer/src/font/opentype-helpers.ts`
- `packages/renderer/src/png/png-converter.ts`
- `packages/renderer/src/warning-logger.ts`
- `README.md`

## 変更内容

- `ConvertOptions`、`SlideSvg`、`SlideImage`、変換 API に JSDoc を追加
- font utilities / warning utilities / WASM 初期化 helper の用途が分かる JSDoc を追加
- `npm run build` 後の `packages/core/dist/index.d.ts` に主要 JSDoc が残ることを確認
- cross-review 指摘に基づき、`width` / `height` の説明を現状挙動に合わせて補正

## ローカル検証

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

※ `npm run build` では既存の tsup `import.meta` CJS 警告が表示されますが、build は成功しています。