### PR TITLE
変換診断レポートを public conversion API に統合

### DIFF
--- a/.changeset/conversion-report-api.md
+++ b/.changeset/conversion-report-api.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": major
+---
+
+Change `convertPptxToSvg` and `convertPptxToPng` to return conversion report objects with `slides`, `diagnostics`, and `supportCoverage` instead of returning slide arrays directly.

--- a/README.md
+++ b/README.md
@@ -80,16 +80,6 @@ const { slides, diagnostics, supportCoverage } = await convertPptxToSvg(pptx);
 - `diagnostics` contains document reader, computed view, renderer adapter, and renderer warning diagnostics collected during conversion.
 - `supportCoverage` summarizes support/renderability counts such as input elements, output elements, skipped elements, unresolved elements, fallback elements, and warnings. It is not a PowerPoint visual-match or pixel-accuracy score.
 
-Migration from the old array return value:
-
-```typescript
-// before
-const slides = await convertPptxToSvg(pptx);
-
-// after
-const { slides } = await convertPptxToSvg(pptx);
-```
-
 ### Options
 
 Both `convertPptxToSvg` and `convertPptxToPng` accept an optional `ConvertOptions` object.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const { slides, diagnostics, supportCoverage } = await convertPptxToSvg(pptx);
 Both `convertPptxToSvg` and `convertPptxToPng` accept an optional `ConvertOptions` object.
 
 ```typescript
-const { slides: results } = await convertPptxToPng(pptx, {
+const { slides } = await convertPptxToPng(pptx, {
   slides: [1, 3], // Convert only slides 1 and 3
   width: 1920, // Output width in pixels (default: 960)
   height: 1080, // Currently ignored by public conversion; width controls PNG size
@@ -199,7 +199,7 @@ Default mapping:
 You can customize the mapping via the `fontMapping` option:
 
 ```typescript
-const { slides: results } = await convertPptxToSvg(pptx, {
+const { slides } = await convertPptxToSvg(pptx, {
   fontMapping: {
     "Custom Corp Font": "Noto Sans", // Add a new mapping
     Arial: "Inter", // Override the default

--- a/README.md
+++ b/README.md
@@ -60,14 +60,34 @@ import { convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
 const pptx = readFileSync("presentation.pptx");
 
 // Convert to SVG
-const svgResults = await convertPptxToSvg(pptx);
+const { slides: svgResults } = await convertPptxToSvg(pptx);
 // [{ slideNumber: 1, svg: "<svg>...</svg>" }, ...]
 
 // Convert to PNG
-const pngResults = await convertPptxToPng(pptx);
+const { slides: pngResults } = await convertPptxToPng(pptx);
 // [{ slideNumber: 1, png: Buffer, width: 960, height: 540 }, ...]
 
 writeFileSync("slide1.png", pngResults[0].png);
+```
+
+The conversion APIs return a report object:
+
+```typescript
+const { slides, diagnostics, supportCoverage } = await convertPptxToSvg(pptx);
+```
+
+- `slides` contains the converted SVG or PNG slide results.
+- `diagnostics` contains document reader, computed view, renderer adapter, and renderer warning diagnostics collected during conversion.
+- `supportCoverage` summarizes support/renderability counts such as input elements, output elements, skipped elements, unresolved elements, fallback elements, and warnings. It is not a PowerPoint visual-match or pixel-accuracy score.
+
+Migration from the old array return value:
+
+```typescript
+// before
+const slides = await convertPptxToSvg(pptx);
+
+// after
+const { slides } = await convertPptxToSvg(pptx);
 ```
 
 ### Options
@@ -75,7 +95,7 @@ writeFileSync("slide1.png", pngResults[0].png);
 Both `convertPptxToSvg` and `convertPptxToPng` accept an optional `ConvertOptions` object.
 
 ```typescript
-const results = await convertPptxToPng(pptx, {
+const { slides: results } = await convertPptxToPng(pptx, {
   slides: [1, 3], // Convert only slides 1 and 3
   width: 1920, // Output width in pixels (default: 960)
   height: 1080, // Currently ignored by public conversion; width controls PNG size
@@ -96,7 +116,7 @@ With `textOutput: "text"`, `convertPptxToSvg` emits native `<text>` elements alo
 
 ```typescript
 // SVG only — convertPptxToPng always uses path output
-const svgResults = await convertPptxToSvg(pptx, { textOutput: "text" });
+const { slides: svgResults } = await convertPptxToSvg(pptx, { textOutput: "text" });
 ```
 
 Note: embedded fonts and `<text>` may not render as expected when the SVG is referenced via `<img src="...svg">` or sanitized. `convertPptxToPng` always uses path output regardless of this option.
@@ -189,7 +209,7 @@ Default mapping:
 You can customize the mapping via the `fontMapping` option:
 
 ```typescript
-const results = await convertPptxToSvg(pptx, {
+const { slides: results } = await convertPptxToSvg(pptx, {
   fontMapping: {
     "Custom Corp Font": "Noto Sans", // Add a new mapping
     Arial: "Inter", // Override the default

--- a/demo/src/app/api/convert/route.ts
+++ b/demo/src/app/api/convert/route.ts
@@ -12,7 +12,7 @@ export async function POST(request: NextRequest) {
 
     const arrayBuffer = await file.arrayBuffer();
     const uint8Array = new Uint8Array(arrayBuffer);
-    const slides = await convertPptxToSvg(uint8Array);
+    const { slides } = await convertPptxToSvg(uint8Array);
 
     if (slides.length === 0) {
       return NextResponse.json({ error: "No slides found in the uploaded file" }, { status: 400 });

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -24,19 +24,19 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("real-basic-theme.pptx (Google Slides)", () => {
     it("convertPptxToSvg completes without error", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
-      expect(results).toHaveLength(2);
-      for (const result of results) {
-        expect(result.svg).toContain("<svg");
-        expect(result.svg).toContain("</svg>");
+      expect(slides).toHaveLength(2);
+      for (const slide of slides) {
+        expect(slide.svg).toContain("<svg");
+        expect(slide.svg).toContain("</svg>");
       }
     });
 
     it("slide 1 contains title text", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
-      const slide1 = results[0].svg;
+      const { slides } = await convertPptxToSvg(input);
+      const slide1 = slides[0].svg;
 
       // Title and subtitle text (<text> or <path> via opentype)
       expect(slide1).toMatch(/<text|<path/);
@@ -44,8 +44,8 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slide 2 contains text, table, and image", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
-      const slide2 = results[1].svg;
+      const { slides } = await convertPptxToSvg(input);
+      const slide2 = slides[1].svg;
 
       // Table (cells are drawn with <rect>)
       expect(slide2).toContain("<rect");
@@ -57,17 +57,17 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("convertPptxToPng produces valid PNG", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const { slides: results } = await convertPptxToPng(input);
+      const { slides } = await convertPptxToPng(input);
 
-      expect(results).toHaveLength(2);
-      for (const result of results) {
+      expect(slides).toHaveLength(2);
+      for (const slide of slides) {
         // PNG magic bytes
-        expect(result.png[0]).toBe(0x89);
-        expect(result.png[1]).toBe(0x50);
-        expect(result.png[2]).toBe(0x4e);
-        expect(result.png[3]).toBe(0x47);
-        expect(result.width).toBeGreaterThan(0);
-        expect(result.height).toBeGreaterThan(0);
+        expect(slide.png[0]).toBe(0x89);
+        expect(slide.png[1]).toBe(0x50);
+        expect(slide.png[2]).toBe(0x4e);
+        expect(slide.png[3]).toBe(0x47);
+        expect(slide.width).toBeGreaterThan(0);
+        expect(slide.height).toBeGreaterThan(0);
       }
     });
   });
@@ -75,17 +75,17 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("real-product-page.pptx (product landing page)", () => {
     it("convertPptxToSvg completes without error", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
-      expect(results).toHaveLength(1);
-      expect(results[0].svg).toContain("<svg");
-      expect(results[0].svg).toContain("</svg>");
+      expect(slides).toHaveLength(1);
+      expect(slides[0].svg).toContain("<svg");
+      expect(slides[0].svg).toContain("</svg>");
     });
 
     it("slide contains text elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
-      const slide = results[0].svg;
+      const { slides } = await convertPptxToSvg(input);
+      const slide = slides[0].svg;
 
       // Text such as titles and buttons (<text> or <path> via opentype)
       expect(slide).toMatch(/<text|<path/);
@@ -93,8 +93,8 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slide contains shapes (roundRect, ellipse)", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
-      const slide = results[0].svg;
+      const { slides } = await convertPptxToSvg(input);
+      const slide = slides[0].svg;
 
       // Rounded rectangles for cards and buttons, and ellipses for icons
       expect(slide).toContain("<rect");
@@ -103,63 +103,63 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("convertPptxToPng produces valid PNG", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const { slides: results } = await convertPptxToPng(input);
+      const { slides } = await convertPptxToPng(input);
 
-      expect(results).toHaveLength(1);
+      expect(slides).toHaveLength(1);
       // PNG magic bytes
-      expect(results[0].png[0]).toBe(0x89);
-      expect(results[0].png[1]).toBe(0x50);
-      expect(results[0].png[2]).toBe(0x4e);
-      expect(results[0].png[3]).toBe(0x47);
-      expect(results[0].width).toBeGreaterThan(0);
-      expect(results[0].height).toBeGreaterThan(0);
+      expect(slides[0].png[0]).toBe(0x89);
+      expect(slides[0].png[1]).toBe(0x50);
+      expect(slides[0].png[2]).toBe(0x4e);
+      expect(slides[0].png[3]).toBe(0x47);
+      expect(slides[0].width).toBeGreaterThan(0);
+      expect(slides[0].height).toBeGreaterThan(0);
     });
   });
 
   describe("real-financial-report.pptx (financial report with charts)", () => {
     it("convertPptxToSvg completes without error for all 4 slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
-      expect(results).toHaveLength(4);
-      for (const result of results) {
-        expect(result.svg).toContain("<svg");
-        expect(result.svg).toContain("</svg>");
+      expect(slides).toHaveLength(4);
+      for (const slide of slides) {
+        expect(slide.svg).toContain("<svg");
+        expect(slide.svg).toContain("</svg>");
       }
     });
 
     it("slides contain text elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
-      for (const result of results) {
-        expect(result.svg).toMatch(/<text|<path/);
+      for (const slide of slides) {
+        expect(slide.svg).toMatch(/<text|<path/);
       }
     });
 
     it("chart slides contain rendered chart elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
       // The chart is included in slide 2 and beyond (drawn with graphicFrame -> <rect> / <path>)
-      const chartSlides = results.slice(1);
-      for (const result of chartSlides) {
-        expect(result.svg).toMatch(/<rect|<path/);
+      const chartSlides = slides.slice(1);
+      for (const slide of chartSlides) {
+        expect(slide.svg).toMatch(/<rect|<path/);
       }
     });
 
     it("convertPptxToPng produces valid PNG for all slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const { slides: results } = await convertPptxToPng(input);
+      const { slides } = await convertPptxToPng(input);
 
-      expect(results).toHaveLength(4);
-      for (const result of results) {
-        expect(result.png[0]).toBe(0x89);
-        expect(result.png[1]).toBe(0x50);
-        expect(result.png[2]).toBe(0x4e);
-        expect(result.png[3]).toBe(0x47);
-        expect(result.width).toBeGreaterThan(0);
-        expect(result.height).toBeGreaterThan(0);
+      expect(slides).toHaveLength(4);
+      for (const slide of slides) {
+        expect(slide.png[0]).toBe(0x89);
+        expect(slide.png[1]).toBe(0x50);
+        expect(slide.png[2]).toBe(0x4e);
+        expect(slide.png[3]).toBe(0x47);
+        expect(slide.width).toBeGreaterThan(0);
+        expect(slide.height).toBeGreaterThan(0);
       }
     });
   });
@@ -167,36 +167,36 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("sample.pptx (md-pptx generated, Japanese text)", () => {
     it("convertPptxToSvg completes without error for all 6 slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
-      expect(results).toHaveLength(6);
-      for (const result of results) {
-        expect(result.svg).toContain("<svg");
-        expect(result.svg).toContain("</svg>");
+      expect(slides).toHaveLength(6);
+      for (const slide of slides) {
+        expect(slide.svg).toContain("<svg");
+        expect(slide.svg).toContain("</svg>");
       }
     });
 
     it("slides contain text elements including Japanese", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
-      for (const result of results) {
-        expect(result.svg).toMatch(/<text|<path/);
+      for (const slide of slides) {
+        expect(slide.svg).toMatch(/<text|<path/);
       }
     });
 
     it("convertPptxToPng produces valid PNG for all slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
-      const { slides: results } = await convertPptxToPng(input);
+      const { slides } = await convertPptxToPng(input);
 
-      expect(results).toHaveLength(6);
-      for (const result of results) {
-        expect(result.png[0]).toBe(0x89);
-        expect(result.png[1]).toBe(0x50);
-        expect(result.png[2]).toBe(0x4e);
-        expect(result.png[3]).toBe(0x47);
-        expect(result.width).toBeGreaterThan(0);
-        expect(result.height).toBeGreaterThan(0);
+      expect(slides).toHaveLength(6);
+      for (const slide of slides) {
+        expect(slide.png[0]).toBe(0x89);
+        expect(slide.png[1]).toBe(0x50);
+        expect(slide.png[2]).toBe(0x4e);
+        expect(slide.png[3]).toBe(0x47);
+        expect(slide.width).toBeGreaterThan(0);
+        expect(slide.height).toBeGreaterThan(0);
       }
     });
   });
@@ -204,32 +204,32 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("sample-issue-387.pptx (inline text formatting)", () => {
     it("convertPptxToSvg completes without error", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
+      const { slides } = await convertPptxToSvg(input);
 
-      expect(results).toHaveLength(1);
-      expect(results[0].svg).toContain("<svg");
-      expect(results[0].svg).toContain("</svg>");
+      expect(slides).toHaveLength(1);
+      expect(slides[0].svg).toContain("<svg");
+      expect(slides[0].svg).toContain("</svg>");
     });
 
     it("slide contains text elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
-      const { slides: results } = await convertPptxToSvg(input);
-      const slide = results[0].svg;
+      const { slides } = await convertPptxToSvg(input);
+      const slide = slides[0].svg;
 
       expect(slide).toMatch(/<text|<path/);
     });
 
     it("convertPptxToPng produces valid PNG", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
-      const { slides: results } = await convertPptxToPng(input);
+      const { slides } = await convertPptxToPng(input);
 
-      expect(results).toHaveLength(1);
-      expect(results[0].png[0]).toBe(0x89);
-      expect(results[0].png[1]).toBe(0x50);
-      expect(results[0].png[2]).toBe(0x4e);
-      expect(results[0].png[3]).toBe(0x47);
-      expect(results[0].width).toBeGreaterThan(0);
-      expect(results[0].height).toBeGreaterThan(0);
+      expect(slides).toHaveLength(1);
+      expect(slides[0].png[0]).toBe(0x89);
+      expect(slides[0].png[1]).toBe(0x50);
+      expect(slides[0].png[2]).toBe(0x4e);
+      expect(slides[0].png[3]).toBe(0x47);
+      expect(slides[0].width).toBeGreaterThan(0);
+      expect(slides[0].height).toBeGreaterThan(0);
     });
   });
 });

--- a/e2e/smoke.test.ts
+++ b/e2e/smoke.test.ts
@@ -24,7 +24,7 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("real-basic-theme.pptx (Google Slides)", () => {
     it("convertPptxToSvg completes without error", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       expect(results).toHaveLength(2);
       for (const result of results) {
@@ -35,7 +35,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slide 1 contains title text", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
       const slide1 = results[0].svg;
 
       // Title and subtitle text (<text> or <path> via opentype)
@@ -44,7 +44,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slide 2 contains text, table, and image", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
       const slide2 = results[1].svg;
 
       // Table (cells are drawn with <rect>)
@@ -57,7 +57,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("convertPptxToPng produces valid PNG", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-basic-theme.pptx"));
-      const results = await convertPptxToPng(input);
+      const { slides: results } = await convertPptxToPng(input);
 
       expect(results).toHaveLength(2);
       for (const result of results) {
@@ -75,7 +75,7 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("real-product-page.pptx (product landing page)", () => {
     it("convertPptxToSvg completes without error", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       expect(results).toHaveLength(1);
       expect(results[0].svg).toContain("<svg");
@@ -84,7 +84,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slide contains text elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
       const slide = results[0].svg;
 
       // Text such as titles and buttons (<text> or <path> via opentype)
@@ -93,7 +93,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slide contains shapes (roundRect, ellipse)", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
       const slide = results[0].svg;
 
       // Rounded rectangles for cards and buttons, and ellipses for icons
@@ -103,7 +103,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("convertPptxToPng produces valid PNG", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-product-page.pptx"));
-      const results = await convertPptxToPng(input);
+      const { slides: results } = await convertPptxToPng(input);
 
       expect(results).toHaveLength(1);
       // PNG magic bytes
@@ -119,7 +119,7 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("real-financial-report.pptx (financial report with charts)", () => {
     it("convertPptxToSvg completes without error for all 4 slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       expect(results).toHaveLength(4);
       for (const result of results) {
@@ -130,7 +130,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slides contain text elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       for (const result of results) {
         expect(result.svg).toMatch(/<text|<path/);
@@ -139,7 +139,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("chart slides contain rendered chart elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       // The chart is included in slide 2 and beyond (drawn with graphicFrame -> <rect> / <path>)
       const chartSlides = results.slice(1);
@@ -150,7 +150,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("convertPptxToPng produces valid PNG for all slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "real-financial-report.pptx"));
-      const results = await convertPptxToPng(input);
+      const { slides: results } = await convertPptxToPng(input);
 
       expect(results).toHaveLength(4);
       for (const result of results) {
@@ -167,7 +167,7 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("sample.pptx (md-pptx generated, Japanese text)", () => {
     it("convertPptxToSvg completes without error for all 6 slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       expect(results).toHaveLength(6);
       for (const result of results) {
@@ -178,7 +178,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slides contain text elements including Japanese", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       for (const result of results) {
         expect(result.svg).toMatch(/<text|<path/);
@@ -187,7 +187,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("convertPptxToPng produces valid PNG for all slides", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample.pptx"));
-      const results = await convertPptxToPng(input);
+      const { slides: results } = await convertPptxToPng(input);
 
       expect(results).toHaveLength(6);
       for (const result of results) {
@@ -204,7 +204,7 @@ describe("Real PPTX E2E smoke tests", () => {
   describe("sample-issue-387.pptx (inline text formatting)", () => {
     it("convertPptxToSvg completes without error", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
 
       expect(results).toHaveLength(1);
       expect(results[0].svg).toContain("<svg");
@@ -213,7 +213,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("slide contains text elements", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
-      const results = await convertPptxToSvg(input);
+      const { slides: results } = await convertPptxToSvg(input);
       const slide = results[0].svg;
 
       expect(slide).toMatch(/<text|<path/);
@@ -221,7 +221,7 @@ describe("Real PPTX E2E smoke tests", () => {
 
     it("convertPptxToPng produces valid PNG", async () => {
       const input = readFileSync(join(FIXTURE_DIR, "sample-issue-387.pptx"));
-      const results = await convertPptxToPng(input);
+      const { slides: results } = await convertPptxToPng(input);
 
       expect(results).toHaveLength(1);
       expect(results[0].png[0]).toBe(0x89);

--- a/packages/core/src/converter.test.ts
+++ b/packages/core/src/converter.test.ts
@@ -438,17 +438,17 @@ describe("convertPptxToSvg", () => {
   });
 
   it("converts a PPTX file to SVG", async () => {
-    const { slides: results } = await convertPptxToSvg(testPptx);
+    const { slides } = await convertPptxToSvg(testPptx);
 
-    expect(results).toHaveLength(1);
-    expect(results[0].slideNumber).toBe(1);
-    expect(results[0].svg).toContain("<svg");
-    expect(results[0].svg).toContain("</svg>");
+    expect(slides).toHaveLength(1);
+    expect(slides[0].slideNumber).toBe(1);
+    expect(slides[0].svg).toContain("<svg");
+    expect(slides[0].svg).toContain("</svg>");
   });
 
   it("renders basic shapes", async () => {
-    const { slides: results } = await convertPptxToSvg(testPptx);
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(testPptx);
+    const svg = slides[0].svg;
 
     // Should contain rect (blue rectangle)
     expect(svg).toContain("<rect");
@@ -459,16 +459,16 @@ describe("convertPptxToSvg", () => {
   });
 
   it("has correct viewBox dimensions for 16:9", async () => {
-    const { slides: results } = await convertPptxToSvg(testPptx);
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(testPptx);
+    const svg = slides[0].svg;
 
     // 9144000 EMU = 960px, 5143500 EMU ≈ 540px
     expect(svg).toContain('viewBox="0 0 960');
   });
 
   it("applies fill colors", async () => {
-    const { slides: results } = await convertPptxToSvg(testPptx);
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(testPptx);
+    const svg = slides[0].svg;
 
     // Blue rectangle fill
     expect(svg.toLowerCase()).toContain("#4472c4");
@@ -477,16 +477,16 @@ describe("convertPptxToSvg", () => {
   });
 
   it("supports slide number filtering", async () => {
-    const { slides: results } = await convertPptxToSvg(testPptx, { slides: [1] });
+    const { slides } = await convertPptxToSvg(testPptx, { slides: [1] });
 
-    expect(results).toHaveLength(1);
-    expect(results[0].slideNumber).toBe(1);
+    expect(slides).toHaveLength(1);
+    expect(slides[0].slideNumber).toBe(1);
   });
 
   it("returns empty for non-existent slide numbers", async () => {
-    const { slides: results } = await convertPptxToSvg(testPptx, { slides: [99] });
+    const { slides } = await convertPptxToSvg(testPptx, { slides: [99] });
 
-    expect(results).toHaveLength(0);
+    expect(slides).toHaveLength(0);
   });
 });
 
@@ -625,24 +625,24 @@ describe("convertPptxToPng", () => {
   });
 
   it("converts a PPTX file to PNG", async () => {
-    const { slides: results } = await convertPptxToPng(testPptx);
+    const { slides } = await convertPptxToPng(testPptx);
 
-    expect(results).toHaveLength(1);
-    expect(results[0].slideNumber).toBe(1);
-    expect(results[0].png).toBeInstanceOf(Uint8Array);
-    expect(results[0].png.length).toBeGreaterThan(0);
+    expect(slides).toHaveLength(1);
+    expect(slides[0].slideNumber).toBe(1);
+    expect(slides[0].png).toBeInstanceOf(Uint8Array);
+    expect(slides[0].png.length).toBeGreaterThan(0);
     // PNG magic bytes
-    expect(results[0].png[0]).toBe(0x89);
-    expect(results[0].png[1]).toBe(0x50); // P
-    expect(results[0].png[2]).toBe(0x4e); // N
-    expect(results[0].png[3]).toBe(0x47); // G
+    expect(slides[0].png[0]).toBe(0x89);
+    expect(slides[0].png[1]).toBe(0x50); // P
+    expect(slides[0].png[2]).toBe(0x4e); // N
+    expect(slides[0].png[3]).toBe(0x47); // G
   });
 
   it("respects width option", async () => {
-    const { slides: results } = await convertPptxToPng(testPptx, { width: 480 });
+    const { slides } = await convertPptxToPng(testPptx, { width: 480 });
 
-    expect(results[0].width).toBe(480);
-    expect(results[0].height).toBeGreaterThan(0);
+    expect(slides[0].width).toBe(480);
+    expect(slides[0].height).toBeGreaterThan(0);
   });
 });
 
@@ -801,8 +801,8 @@ describe("master placeholder text filtering", () => {
 
   it("does not render master placeholder shapes on actual slides", async () => {
     const pptx = await createPptxWithMasterPlaceholder();
-    const { slides: results } = await convertPptxToSvg(pptx);
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx);
+    const svg = slides[0].svg;
 
     // Master has 3 shapes: title placeholder (id=2), body placeholder (id=3), decorative (id=4)
     // Only decorative (non-placeholder) should be rendered (red fill #FF0000)
@@ -1016,8 +1016,8 @@ describe("layout placeholder text filtering", () => {
 
   it("does not render layout placeholder shapes on actual slides", async () => {
     const pptx = await createPptxWithLayoutPlaceholder();
-    const { slides: results } = await convertPptxToSvg(pptx);
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx);
+    const svg = slides[0].svg;
 
     // Layout has 5 shapes: ctrTitle, subTitle, dt, ftr (all placeholders), decorative (non-placeholder)
     // Only decorative (non-placeholder) should be rendered (blue fill #0000FF)
@@ -1126,8 +1126,8 @@ describe("slide placeholder text filtering", () => {
 
   it("does not render empty placeholder shapes on the slide itself", async () => {
     const pptx = await createPptxWithSlidePlaceholders(emptyPlaceholderSlide);
-    const { slides: results } = await convertPptxToSvg(pptx);
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx);
+    const svg = slides[0].svg;
 
     // Decorative (non-placeholder) shape with magenta fill should remain.
     expect(svg.toLowerCase()).toContain("#ff00ff");
@@ -1147,8 +1147,8 @@ describe("slide placeholder text filtering", () => {
     );
 
     const pptx = await createPptxWithSlidePlaceholders(filledSlide);
-    const { slides: results } = await convertPptxToSvg(pptx);
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx);
+    const svg = slides[0].svg;
 
     // Filled title placeholder is kept (green fill renders).
     expect(svg.toLowerCase()).toContain("#00ff00");

--- a/packages/core/src/converter.test.ts
+++ b/packages/core/src/converter.test.ts
@@ -306,7 +306,7 @@ describe("public conversion orchestration", () => {
   it.each(SELECTED_SHARED_FIXTURES)(
     "renders selected slides from %s to SVG through the public converter",
     async (fixtureName) => {
-      const result = await convertPptxToSvg(readSharedFixture(fixtureName), {
+      const { slides: result } = await convertPptxToSvg(readSharedFixture(fixtureName), {
         slides: [1],
         textOutput: "text",
       });
@@ -319,7 +319,7 @@ describe("public conversion orchestration", () => {
   );
 
   it("connects the public SVG conversion to PNG conversion", async () => {
-    const result = await convertPptxToPng(readSharedFixture("real-basic-theme.pptx"), {
+    const { slides: result } = await convertPptxToPng(readSharedFixture("real-basic-theme.pptx"), {
       slides: [1],
       width: 240,
     });
@@ -337,7 +337,7 @@ describe("public conversion orchestration", () => {
     const readPptxSpy = vi.spyOn(document, "readPptx");
     const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");
     const input = readSharedFixture("real-basic-theme.pptx");
-    const publicDefault = await convertPptxToSvg(input, {
+    const { slides: publicDefault } = await convertPptxToSvg(input, {
       slides: [1],
       textOutput: "text",
     });
@@ -352,7 +352,7 @@ describe("public conversion orchestration", () => {
     const readPptxSpy = vi.spyOn(document, "readPptx");
     const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");
     const input = readSharedFixture("real-basic-theme.pptx");
-    const publicDefault = await convertPptxToPng(input, {
+    const { slides: publicDefault } = await convertPptxToPng(input, {
       slides: [1],
       width: 240,
     });
@@ -365,8 +365,62 @@ describe("public conversion orchestration", () => {
 });
 
 describe("convertPptxToSvg", () => {
+  it("returns a conversion report with slides, diagnostics, and support coverage", async () => {
+    const report = await convertPptxToSvg(testPptx);
+
+    expect(Array.isArray(report)).toBe(false);
+    expect(report.slides).toHaveLength(1);
+    expect(report.diagnostics).toEqual(expect.any(Array));
+    expect(typeof report.supportCoverage.overall.inputElements).toBe("number");
+    expect(typeof report.supportCoverage.overall.outputElements).toBe("number");
+    expect(typeof report.supportCoverage.overall.skippedElements).toBe("number");
+    expect(typeof report.supportCoverage.overall.unresolvedElements).toBe("number");
+    expect(typeof report.supportCoverage.overall.fallbackElements).toBe("number");
+    expect(typeof report.supportCoverage.overall.warnings).toBe("number");
+    expect(report.supportCoverage.slides[0]).toMatchObject({
+      slideNumber: 1,
+      inputElements: 3,
+      outputElements: 3,
+    });
+  });
+
+  it("integrates document reader diagnostics into the conversion report", async () => {
+    const report = await convertPptxToSvg(await createPptxWithInvalidSlideRelationship());
+
+    expect(report.slides).toHaveLength(0);
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        source: "document",
+        severity: "warning",
+        code: "slide-relationship-invalid",
+        sourcePartPath: "ppt/presentation.xml",
+      }),
+    );
+  });
+
+  it("integrates renderer adapter diagnostics into diagnostics and support coverage", async () => {
+    const report = await convertPptxToSvg(await createPptxWithRawGraphicFrame());
+
+    expect(report.slides).toHaveLength(1);
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        source: "renderer-adapter",
+        severity: "warning",
+        code: "pptx-computed-view-adapter.raw-element-skipped",
+        slideNumber: 1,
+      }),
+    );
+    expect(report.supportCoverage.slides[0]).toMatchObject({
+      slideNumber: 1,
+      inputElements: 4,
+      outputElements: 3,
+      skippedElements: 1,
+      warnings: 1,
+    });
+  });
+
   it("converts a PPTX file to SVG", async () => {
-    const results = await convertPptxToSvg(testPptx);
+    const { slides: results } = await convertPptxToSvg(testPptx);
 
     expect(results).toHaveLength(1);
     expect(results[0].slideNumber).toBe(1);
@@ -375,7 +429,7 @@ describe("convertPptxToSvg", () => {
   });
 
   it("renders basic shapes", async () => {
-    const results = await convertPptxToSvg(testPptx);
+    const { slides: results } = await convertPptxToSvg(testPptx);
     const svg = results[0].svg;
 
     // Should contain rect (blue rectangle)
@@ -387,7 +441,7 @@ describe("convertPptxToSvg", () => {
   });
 
   it("has correct viewBox dimensions for 16:9", async () => {
-    const results = await convertPptxToSvg(testPptx);
+    const { slides: results } = await convertPptxToSvg(testPptx);
     const svg = results[0].svg;
 
     // 9144000 EMU = 960px, 5143500 EMU ≈ 540px
@@ -395,7 +449,7 @@ describe("convertPptxToSvg", () => {
   });
 
   it("applies fill colors", async () => {
-    const results = await convertPptxToSvg(testPptx);
+    const { slides: results } = await convertPptxToSvg(testPptx);
     const svg = results[0].svg;
 
     // Blue rectangle fill
@@ -405,14 +459,14 @@ describe("convertPptxToSvg", () => {
   });
 
   it("supports slide number filtering", async () => {
-    const results = await convertPptxToSvg(testPptx, { slides: [1] });
+    const { slides: results } = await convertPptxToSvg(testPptx, { slides: [1] });
 
     expect(results).toHaveLength(1);
     expect(results[0].slideNumber).toBe(1);
   });
 
   it("returns empty for non-existent slide numbers", async () => {
-    const results = await convertPptxToSvg(testPptx, { slides: [99] });
+    const { slides: results } = await convertPptxToSvg(testPptx, { slides: [99] });
 
     expect(results).toHaveLength(0);
   });
@@ -422,9 +476,84 @@ function readSharedFixture(name: (typeof SELECTED_SHARED_FIXTURES)[number]): Buf
   return readFileSync(fileURLToPath(new URL(`../../../shared-fixtures/${name}`, import.meta.url)));
 }
 
+async function createPptxWithInvalidSlideRelationship(): Promise<Buffer> {
+  const invalidPresentationXml = presentationXml.replace(
+    '<p:sldId id="256" r:id="rId2"/>',
+    '<p:sldId id="256" r:id="rIdBogus"/>',
+  );
+  const invalidPresentationRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>
+  <Relationship Id="rIdBogus" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster" Target="notesMasters/notesMaster1.xml"/>
+</Relationships>`;
+
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypes);
+  zip.file("_rels/.rels", rootRels);
+  zip.file("ppt/presentation.xml", invalidPresentationXml);
+  zip.file("ppt/_rels/presentation.xml.rels", invalidPresentationRels);
+  zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
+  zip.file("ppt/slideMasters/_rels/slideMaster1.xml.rels", slideMaster1Rels);
+  zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
+  zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
+  zip.file("ppt/theme/theme1.xml", theme1);
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+async function createPptxWithRawGraphicFrame(): Promise<Buffer> {
+  const rawGraphicFrame = `
+      <p:graphicFrame>
+        <p:nvGraphicFramePr>
+          <p:cNvPr id="5" name="Unsupported Graphic"/>
+          <p:cNvGraphicFramePr/>
+          <p:nvPr/>
+        </p:nvGraphicFramePr>
+        <p:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="914400" cy="914400"/>
+        </p:xfrm>
+        <a:graphic>
+          <a:graphicData uri="urn:pptx-glimpse:test:unsupported"/>
+        </a:graphic>
+      </p:graphicFrame>`;
+  const slideWithRawGraphicFrame = slide1Xml.replace(
+    "</p:spTree>",
+    `${rawGraphicFrame}
+    </p:spTree>`,
+  );
+
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypes);
+  zip.file("_rels/.rels", rootRels);
+  zip.file("ppt/presentation.xml", presentationXml);
+  zip.file("ppt/_rels/presentation.xml.rels", presentationRels);
+  zip.file("ppt/slides/slide1.xml", slideWithRawGraphicFrame);
+  zip.file("ppt/slides/_rels/slide1.xml.rels", slide1Rels);
+  zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
+  zip.file("ppt/slideMasters/_rels/slideMaster1.xml.rels", slideMaster1Rels);
+  zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
+  zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
+  zip.file("ppt/theme/theme1.xml", theme1);
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
 describe("convertPptxToPng", () => {
+  it("returns a conversion report with PNG slides and SVG-path diagnostics", async () => {
+    const report = await convertPptxToPng(testPptx);
+
+    expect(Array.isArray(report)).toBe(false);
+    expect(report.slides).toHaveLength(1);
+    expect(report.slides[0]).toMatchObject({ slideNumber: 1 });
+    expect(report.diagnostics).toEqual(expect.any(Array));
+    expect(report.supportCoverage.slides[0]).toMatchObject({
+      slideNumber: 1,
+      inputElements: 3,
+      outputElements: 3,
+    });
+  });
+
   it("converts a PPTX file to PNG", async () => {
-    const results = await convertPptxToPng(testPptx);
+    const { slides: results } = await convertPptxToPng(testPptx);
 
     expect(results).toHaveLength(1);
     expect(results[0].slideNumber).toBe(1);
@@ -438,7 +567,7 @@ describe("convertPptxToPng", () => {
   });
 
   it("respects width option", async () => {
-    const results = await convertPptxToPng(testPptx, { width: 480 });
+    const { slides: results } = await convertPptxToPng(testPptx, { width: 480 });
 
     expect(results[0].width).toBe(480);
     expect(results[0].height).toBeGreaterThan(0);
@@ -600,7 +729,7 @@ describe("master placeholder text filtering", () => {
 
   it("does not render master placeholder shapes on actual slides", async () => {
     const pptx = await createPptxWithMasterPlaceholder();
-    const results = await convertPptxToSvg(pptx);
+    const { slides: results } = await convertPptxToSvg(pptx);
     const svg = results[0].svg;
 
     // Master has 3 shapes: title placeholder (id=2), body placeholder (id=3), decorative (id=4)
@@ -815,7 +944,7 @@ describe("layout placeholder text filtering", () => {
 
   it("does not render layout placeholder shapes on actual slides", async () => {
     const pptx = await createPptxWithLayoutPlaceholder();
-    const results = await convertPptxToSvg(pptx);
+    const { slides: results } = await convertPptxToSvg(pptx);
     const svg = results[0].svg;
 
     // Layout has 5 shapes: ctrTitle, subTitle, dt, ftr (all placeholders), decorative (non-placeholder)
@@ -925,7 +1054,7 @@ describe("slide placeholder text filtering", () => {
 
   it("does not render empty placeholder shapes on the slide itself", async () => {
     const pptx = await createPptxWithSlidePlaceholders(emptyPlaceholderSlide);
-    const results = await convertPptxToSvg(pptx);
+    const { slides: results } = await convertPptxToSvg(pptx);
     const svg = results[0].svg;
 
     // Decorative (non-placeholder) shape with magenta fill should remain.
@@ -946,7 +1075,7 @@ describe("slide placeholder text filtering", () => {
     );
 
     const pptx = await createPptxWithSlidePlaceholders(filledSlide);
-    const results = await convertPptxToSvg(pptx);
+    const { slides: results } = await convertPptxToSvg(pptx);
     const svg = results[0].svg;
 
     // Filled title placeholder is kept (green fill renders).
@@ -1006,9 +1135,28 @@ describe("presentation.noSlides warning", () => {
 
   it("returns empty array for PPTX with no slides", async () => {
     const pptx = await createEmptyPptx();
-    const results = await convertPptxToSvg(pptx);
+    const report = await convertPptxToSvg(pptx);
 
-    expect(results).toHaveLength(0);
+    expect(report.slides).toHaveLength(0);
+    expect(report.supportCoverage.overall).toMatchObject({
+      inputElements: 0,
+      outputElements: 0,
+    });
+  });
+
+  it('collects renderer warnings in diagnostics even when logLevel is "off"', async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const pptx = await createEmptyPptx();
+    const report = await convertPptxToSvg(pptx, { logLevel: "off" });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        source: "renderer",
+        severity: "warning",
+        code: "renderer.presentation.noSlides",
+      }),
+    );
   });
 
   it("emits presentation.noSlides warning for empty PPTX", async () => {

--- a/packages/core/src/converter.test.ts
+++ b/packages/core/src/converter.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import * as document from "@pptx-glimpse/document";
-import { clearFontCache } from "@pptx-glimpse/renderer";
+import { clearFontCache, getWarningEntries, warn } from "@pptx-glimpse/renderer";
 import JSZip from "jszip";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -431,6 +431,10 @@ describe("convertPptxToSvg", () => {
         sourcePartPath: "ppt/diagrams/drawing1.xml",
       }),
     );
+    expect(report.supportCoverage.slides[0]).toMatchObject({
+      skippedElements: 0,
+      unresolvedElements: 1,
+    });
   });
 
   it("converts a PPTX file to SVG", async () => {
@@ -1225,6 +1229,16 @@ describe("presentation.noSlides warning", () => {
         code: "renderer.presentation.noSlides",
       }),
     );
+    expect(report.supportCoverage.overall.warnings).toBe(1);
+  });
+
+  it('restores the warning logger when logLevel is "off" and conversion throws', async () => {
+    await expect(convertPptxToSvg(Buffer.from("not a pptx"), { logLevel: "off" })).rejects.toThrow(
+      /zip|pptx|invalid/i,
+    );
+
+    warn("test.afterFailure", "should not be collected");
+    expect(getWarningEntries()).toHaveLength(0);
   });
 
   it("emits presentation.noSlides warning for empty PPTX", async () => {

--- a/packages/core/src/converter.test.ts
+++ b/packages/core/src/converter.test.ts
@@ -419,6 +419,20 @@ describe("convertPptxToSvg", () => {
     });
   });
 
+  it("integrates computed view diagnostics into the conversion report", async () => {
+    const report = await convertPptxToSvg(await createPptxWithSmartArtMissingShapeTree());
+
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        source: "computed-view",
+        severity: "warning",
+        code: "diagram-drawing-shape-tree-missing",
+        slideNumber: 1,
+        sourcePartPath: "ppt/diagrams/drawing1.xml",
+      }),
+    );
+  });
+
   it("converts a PPTX file to SVG", async () => {
     const { slides: results } = await convertPptxToSvg(testPptx);
 
@@ -534,6 +548,60 @@ async function createPptxWithRawGraphicFrame(): Promise<Buffer> {
   zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
   zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
   zip.file("ppt/theme/theme1.xml", theme1);
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+async function createPptxWithSmartArtMissingShapeTree(): Promise<Buffer> {
+  const smartArtFrame = `
+      <p:graphicFrame>
+        <p:nvGraphicFramePr>
+          <p:cNvPr id="5" name="SmartArt"/>
+          <p:cNvGraphicFramePr/>
+          <p:nvPr/>
+        </p:nvGraphicFramePr>
+        <p:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="914400" cy="914400"/>
+        </p:xfrm>
+        <a:graphic>
+          <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/diagram">
+            <dgm:relIds xmlns:dgm="http://schemas.openxmlformats.org/drawingml/2006/diagram" r:dm="rIdDiagramData"/>
+          </a:graphicData>
+        </a:graphic>
+      </p:graphicFrame>`;
+  const slideWithSmartArt = slide1Xml.replace(
+    "</p:spTree>",
+    `${smartArtFrame}
+    </p:spTree>`,
+  );
+  const slideRelsWithSmartArt = slide1Rels.replace(
+    "</Relationships>",
+    `  <Relationship Id="rIdDiagramData" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/diagramData" Target="../diagrams/data1.xml"/>
+</Relationships>`,
+  );
+  const diagramDataRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdDiagramDrawing" Type="http://schemas.microsoft.com/office/2007/relationships/diagramDrawing" Target="drawing1.xml"/>
+</Relationships>`;
+
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", contentTypes);
+  zip.file("_rels/.rels", rootRels);
+  zip.file("ppt/presentation.xml", presentationXml);
+  zip.file("ppt/_rels/presentation.xml.rels", presentationRels);
+  zip.file("ppt/slides/slide1.xml", slideWithSmartArt);
+  zip.file("ppt/slides/_rels/slide1.xml.rels", slideRelsWithSmartArt);
+  zip.file("ppt/slideMasters/slideMaster1.xml", slideMaster1);
+  zip.file("ppt/slideMasters/_rels/slideMaster1.xml.rels", slideMaster1Rels);
+  zip.file("ppt/slideLayouts/slideLayout1.xml", slideLayout1);
+  zip.file("ppt/slideLayouts/_rels/slideLayout1.xml.rels", slideLayout1Rels);
+  zip.file("ppt/theme/theme1.xml", theme1);
+  zip.file("ppt/diagrams/data1.xml", `<dgm:dataModel/>`);
+  zip.file("ppt/diagrams/_rels/data1.xml.rels", diagramDataRels);
+  zip.file(
+    "ppt/diagrams/drawing1.xml",
+    `<dsp:drawing xmlns:dsp="http://schemas.microsoft.com/office/drawing/2008/diagram"/>`,
+  );
   return zip.generateAsync({ type: "nodebuffer" });
 }
 

--- a/packages/core/src/converter.text-output.test.ts
+++ b/packages/core/src/converter.text-output.test.ts
@@ -310,11 +310,8 @@ function convertOptions(extra?: Record<string, unknown>) {
 describe("textOutput: text SVG output", () => {
   it("Contains the <text> element and @font-face, but does not include the glyph outline path", async () => {
     const pptx = await createTestPptx("ABA AB");
-    const { slides: results } = await convertPptxToSvg(
-      pptx,
-      convertOptions({ textOutput: "text" }),
-    );
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const svg = slides[0].svg;
 
     expect(svg).toContain("<text");
     expect(svg).toContain("@font-face");
@@ -328,11 +325,8 @@ describe("textOutput: text SVG output", () => {
 
   it("If there are only characters that are not included in the font, do not embed @font-face and output only <text>", async () => {
     const pptx = await createTestPptx("XYZ");
-    const { slides: results } = await convertPptxToSvg(
-      pptx,
-      convertOptions({ textOutput: "text" }),
-    );
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const svg = slides[0].svg;
 
     expect(svg).toContain("<text");
     expect(svg).toContain("XYZ");
@@ -342,11 +336,8 @@ describe("textOutput: text SVG output", () => {
   it("embeds bullet glyphs using the text run font when buFont is omitted", async () => {
     // buChar="B" / no buFont. Bullet B is drawn and embedded in the run font (EmbedTestFont).
     const pptx = await createTestPptx("A", { pPr: '<a:pPr><a:buChar char="B"/></a:pPr>' });
-    const { slides: results } = await convertPptxToSvg(
-      pptx,
-      convertOptions({ textOutput: "text" }),
-    );
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const svg = slides[0].svg;
 
     expect(svg).toContain("@font-face");
     // Bullet tspan's font-family includes run's font
@@ -362,11 +353,8 @@ describe("textOutput: text SVG output", () => {
     const pptx = await createTestPptx("A", {
       pPr: '<a:pPr><a:buFont typeface="BulletTestFont"/><a:buChar char="C"/></a:pPr>',
     });
-    const { slides: results } = await convertPptxToSvg(
-      pptx,
-      convertOptions({ textOutput: "text" }),
-    );
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const svg = slides[0].svg;
 
     // Two @font-faces are embedded, one for runs and one for bullet points.
     expect(svg).toContain('font-family:"EmbedTestFont"');
@@ -379,14 +367,14 @@ describe("textOutput: text SVG output", () => {
 
   it("Fonts resolved with fontMapping are embedded with PPTX font names", async () => {
     const pptx = await createTestPptx("ABA", { typeface: "MappedCorpFont" });
-    const { slides: results } = await convertPptxToSvg(
+    const { slides } = await convertPptxToSvg(
       pptx,
       convertOptions({
         textOutput: "text",
         fontMapping: { MappedCorpFont: "EmbedTestFont" },
       }),
     );
-    const svg = results[0].svg;
+    const svg = slides[0].svg;
 
     // @font-face is declared with the PPTX font name referenced by tspan
     expect(svg).toContain('font-family:"MappedCorpFont"');
@@ -400,8 +388,8 @@ describe("textOutput: text SVG output", () => {
 describe("textOutput: path SVG output", () => {
   it("omits @font-face from the default path output", async () => {
     const pptx = await createTestPptx("ABA AB");
-    const { slides: results } = await convertPptxToSvg(pptx, convertOptions());
-    const svg = results[0].svg;
+    const { slides } = await convertPptxToSvg(pptx, convertOptions());
+    const svg = slides[0].svg;
 
     expect(svg).toContain("<path");
     expect(svg).not.toContain("<text");
@@ -423,14 +411,11 @@ describe("textOutput: path SVG output", () => {
 describe("textOutput: PNG conversion", () => {
   it('converts PNG through path output even when textOutput: "text" is specified', async () => {
     const pptx = await createTestPptx("ABA AB");
-    const { slides: results } = await convertPptxToPng(
-      pptx,
-      convertOptions({ textOutput: "text" }),
-    );
+    const { slides } = await convertPptxToPng(pptx, convertOptions({ textOutput: "text" }));
 
-    expect(results).toHaveLength(1);
+    expect(slides).toHaveLength(1);
     // PNG magic bytes
-    expect(results[0].png[0]).toBe(0x89);
-    expect(results[0].png[1]).toBe(0x50);
+    expect(slides[0].png[0]).toBe(0x89);
+    expect(slides[0].png[1]).toBe(0x50);
   });
 });

--- a/packages/core/src/converter.text-output.test.ts
+++ b/packages/core/src/converter.text-output.test.ts
@@ -310,7 +310,10 @@ function convertOptions(extra?: Record<string, unknown>) {
 describe("textOutput: text SVG output", () => {
   it("Contains the <text> element and @font-face, but does not include the glyph outline path", async () => {
     const pptx = await createTestPptx("ABA AB");
-    const results = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const { slides: results } = await convertPptxToSvg(
+      pptx,
+      convertOptions({ textOutput: "text" }),
+    );
     const svg = results[0].svg;
 
     expect(svg).toContain("<text");
@@ -325,7 +328,10 @@ describe("textOutput: text SVG output", () => {
 
   it("If there are only characters that are not included in the font, do not embed @font-face and output only <text>", async () => {
     const pptx = await createTestPptx("XYZ");
-    const results = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const { slides: results } = await convertPptxToSvg(
+      pptx,
+      convertOptions({ textOutput: "text" }),
+    );
     const svg = results[0].svg;
 
     expect(svg).toContain("<text");
@@ -336,7 +342,10 @@ describe("textOutput: text SVG output", () => {
   it("embeds bullet glyphs using the text run font when buFont is omitted", async () => {
     // buChar="B" / no buFont. Bullet B is drawn and embedded in the run font (EmbedTestFont).
     const pptx = await createTestPptx("A", { pPr: '<a:pPr><a:buChar char="B"/></a:pPr>' });
-    const results = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const { slides: results } = await convertPptxToSvg(
+      pptx,
+      convertOptions({ textOutput: "text" }),
+    );
     const svg = results[0].svg;
 
     expect(svg).toContain("@font-face");
@@ -353,7 +362,10 @@ describe("textOutput: text SVG output", () => {
     const pptx = await createTestPptx("A", {
       pPr: '<a:pPr><a:buFont typeface="BulletTestFont"/><a:buChar char="C"/></a:pPr>',
     });
-    const results = await convertPptxToSvg(pptx, convertOptions({ textOutput: "text" }));
+    const { slides: results } = await convertPptxToSvg(
+      pptx,
+      convertOptions({ textOutput: "text" }),
+    );
     const svg = results[0].svg;
 
     // Two @font-faces are embedded, one for runs and one for bullet points.
@@ -367,7 +379,7 @@ describe("textOutput: text SVG output", () => {
 
   it("Fonts resolved with fontMapping are embedded with PPTX font names", async () => {
     const pptx = await createTestPptx("ABA", { typeface: "MappedCorpFont" });
-    const results = await convertPptxToSvg(
+    const { slides: results } = await convertPptxToSvg(
       pptx,
       convertOptions({
         textOutput: "text",
@@ -388,7 +400,7 @@ describe("textOutput: text SVG output", () => {
 describe("textOutput: path SVG output", () => {
   it("omits @font-face from the default path output", async () => {
     const pptx = await createTestPptx("ABA AB");
-    const results = await convertPptxToSvg(pptx, convertOptions());
+    const { slides: results } = await convertPptxToSvg(pptx, convertOptions());
     const svg = results[0].svg;
 
     expect(svg).toContain("<path");
@@ -398,8 +410,11 @@ describe("textOutput: path SVG output", () => {
 
   it('matches the default output when textOutput: "path" is specified explicitly', async () => {
     const pptx = await createTestPptx("ABA AB");
-    const defaultResults = await convertPptxToSvg(pptx, convertOptions());
-    const pathResults = await convertPptxToSvg(pptx, convertOptions({ textOutput: "path" }));
+    const { slides: defaultResults } = await convertPptxToSvg(pptx, convertOptions());
+    const { slides: pathResults } = await convertPptxToSvg(
+      pptx,
+      convertOptions({ textOutput: "path" }),
+    );
 
     expect(pathResults[0].svg).toBe(defaultResults[0].svg);
   });
@@ -408,7 +423,10 @@ describe("textOutput: path SVG output", () => {
 describe("textOutput: PNG conversion", () => {
   it('converts PNG through path output even when textOutput: "text" is specified', async () => {
     const pptx = await createTestPptx("ABA AB");
-    const results = await convertPptxToPng(pptx, convertOptions({ textOutput: "text" }));
+    const { slides: results } = await convertPptxToPng(
+      pptx,
+      convertOptions({ textOutput: "text" }),
+    );
 
     expect(results).toHaveLength(1);
     // PNG magic bytes

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -224,7 +224,7 @@ export interface PngConversionReport {
  * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
  * @param options Conversion options. `slides` uses 1-based slide numbers; when
  * omitted, all slides are converted.
- * @returns One SVG result per converted slide, preserving original slide numbers.
+ * @returns A conversion report containing converted slides, diagnostics, and support coverage.
  *
  * Text is emitted as SVG paths by default for portable rendering. Set
  * `textOutput: "text"` to emit native `<text>` elements with embedded subset
@@ -244,8 +244,7 @@ export async function convertPptxToSvg(
  * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
  * @param options Conversion options. `slides` uses 1-based slide numbers; when
  * omitted, all slides are converted.
- * @returns One PNG result per converted slide, preserving original slide numbers
- * and reporting the actual rasterized image size.
+ * @returns A conversion report containing converted PNG slides, diagnostics, and support coverage.
  *
  * PNG conversion first renders each slide to SVG and then rasterizes it with
  * resvg. The `textOutput` option is intentionally ignored: PNG rendering always
@@ -335,6 +334,9 @@ async function convertPptxToSvgReport(
 
     return { slides, diagnostics, supportCoverage };
   } finally {
+    if (logLevel === "off") {
+      initWarningLogger("off");
+    }
     resetTextMeasurer();
     resetTextPathFontResolver();
     resetFontUsageCollector();
@@ -463,19 +465,23 @@ function buildSupportCoverage(
     );
     return { slideNumber: slide.slideNumber, ...counts };
   });
+  const slideTotals = slides.reduce<SupportCoverageCounts>(
+    (total, slide) => ({
+      inputElements: total.inputElements + slide.inputElements,
+      outputElements: total.outputElements + slide.outputElements,
+      skippedElements: total.skippedElements + slide.skippedElements,
+      unresolvedElements: total.unresolvedElements + slide.unresolvedElements,
+      fallbackElements: total.fallbackElements + slide.fallbackElements,
+      warnings: total.warnings + slide.warnings,
+    }),
+    emptySupportCoverageCounts(),
+  );
 
   return {
-    overall: slides.reduce<SupportCoverageCounts>(
-      (total, slide) => ({
-        inputElements: total.inputElements + slide.inputElements,
-        outputElements: total.outputElements + slide.outputElements,
-        skippedElements: total.skippedElements + slide.skippedElements,
-        unresolvedElements: total.unresolvedElements + slide.unresolvedElements,
-        fallbackElements: total.fallbackElements + slide.fallbackElements,
-        warnings: total.warnings + slide.warnings,
-      }),
-      emptySupportCoverageCounts(),
-    ),
+    overall: {
+      ...slideTotals,
+      warnings: diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length,
+    },
     slides,
   };
 }
@@ -491,7 +497,10 @@ function buildSlideSupportCoverage(
   return {
     inputElements: countComputedElements(computedSlide.elements),
     outputElements: renderedSlide !== undefined ? countRenderedElements(renderedSlide.elements) : 0,
-    skippedElements: countDiagnosticsByCode(slideDiagnostics, (code) => code.includes("skipped")),
+    skippedElements: countDiagnosticsByCode(
+      slideDiagnostics,
+      (code) => code.includes("skipped") && !code.includes("unresolved"),
+    ),
     unresolvedElements: countDiagnosticsByCode(slideDiagnostics, (code) =>
       code.includes("unresolved"),
     ),

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -1,8 +1,20 @@
 import { readFileSync, statSync } from "node:fs";
 
+import type {
+  ComputedElement,
+  ComputedSlide,
+  Diagnostic,
+  PptxComputedView,
+  SourceHandle,
+} from "@pptx-glimpse/document";
 import { createComputedView, readPptx } from "@pptx-glimpse/document";
-import type { FontMapping } from "@pptx-glimpse/renderer";
-import type { LogLevel } from "@pptx-glimpse/renderer";
+import type {
+  FontMapping,
+  LogLevel,
+  Slide,
+  SlideElement,
+  WarningEntry,
+} from "@pptx-glimpse/renderer";
 import {
   buildFontFaceStyle,
   collectFontFilePaths,
@@ -11,6 +23,7 @@ import {
   DEFAULT_OUTPUT_WIDTH,
   flushWarnings,
   FontUsageCollector,
+  getWarningEntries,
   initWarningLogger,
   renderSlideToSvg,
   resetFontMapping,
@@ -63,8 +76,10 @@ export interface ConvertOptions {
   /**
    * Warning log level for unsupported or approximated PPTX features.
    *
-   * Defaults to `"off"`. Use `"warn"` to collect and print summaries, or
-   * `"debug"` to print individual warning entries as they are recorded.
+   * Defaults to `"off"`. Diagnostics are always collected in the conversion
+   * report; this option only controls console output. Use `"warn"` to print
+   * summaries, or `"debug"` to print individual warning entries as they are
+   * recorded.
    */
   logLevel?: LogLevel;
   /**
@@ -141,16 +156,66 @@ export interface SlideImage {
   height: number;
 }
 
-type ConversionDiagnostic = RendererAdapterDiagnostic;
-
-interface SvgConversionResult {
-  readonly slides: readonly SlideSvg[];
-  readonly diagnostics: readonly ConversionDiagnostic[];
+export interface ConversionDiagnostic {
+  readonly source: "document" | "computed-view" | "renderer-adapter" | "renderer";
+  readonly severity: "info" | "warning" | "error";
+  readonly code: string;
+  readonly message: string;
+  readonly slideNumber?: number;
+  readonly sourcePartPath?: string;
+  readonly context?: string;
+  readonly handle?: SourceHandle;
 }
 
-interface PngConversionResult {
+export interface SupportCoverageCounts {
+  /**
+   * Number of PPTX source/computed elements considered for rendering.
+   */
+  readonly inputElements: number;
+  /**
+   * Number of renderer-model elements produced for SVG / PNG output.
+   */
+  readonly outputElements: number;
+  /**
+   * Elements or raw nodes skipped because they are outside the supported render subset.
+   */
+  readonly skippedElements: number;
+  /**
+   * Elements skipped because a referenced PPTX part or relationship could not be resolved.
+   */
+  readonly unresolvedElements: number;
+  /**
+   * Elements or properties rendered with a fallback or ignored unsupported property.
+   */
+  readonly fallbackElements: number;
+  /**
+   * Diagnostics with warning severity that affect support/renderability confidence.
+   */
+  readonly warnings: number;
+}
+
+export interface SlideSupportCoverage extends SupportCoverageCounts {
+  readonly slideNumber: number;
+}
+
+export interface SupportCoverage {
+  /**
+   * Support/renderability coverage summary. This is not a visual-match or pixel accuracy metric.
+   */
+  readonly overall: SupportCoverageCounts;
+  readonly slides: readonly SlideSupportCoverage[];
+}
+
+export interface SvgConversionReport {
+  readonly slides: readonly SlideSvg[];
+  readonly diagnostics: readonly ConversionDiagnostic[];
+  readonly supportCoverage: SupportCoverage;
+}
+
+export interface PngConversionReport {
   readonly slides: readonly SlideImage[];
   readonly diagnostics: readonly ConversionDiagnostic[];
+  readonly supportCoverage: SupportCoverage;
 }
 
 /**
@@ -169,9 +234,8 @@ interface PngConversionResult {
 export async function convertPptxToSvg(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
-): Promise<SlideSvg[]> {
-  const result = await convertPptxToSvgInternal(input, options);
-  return [...result.slides];
+): Promise<SvgConversionReport> {
+  return convertPptxToSvgReport(input, options);
 }
 
 /**
@@ -192,16 +256,16 @@ export async function convertPptxToSvg(
 export async function convertPptxToPng(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
-): Promise<SlideImage[]> {
-  const result = await convertPptxToPngInternal(input, options);
-  return [...result.slides];
+): Promise<PngConversionReport> {
+  return convertPptxToPngReport(input, options);
 }
 
-async function convertPptxToSvgInternal(
+async function convertPptxToSvgReport(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
-): Promise<SvgConversionResult> {
+): Promise<SvgConversionReport> {
   const textOutput = options?.textOutput ?? "path";
+  const logLevel = options?.logLevel ?? "off";
   const setup = await createOpentypeSetupFromSystem(
     options?.fontDirs,
     options?.fontMapping,
@@ -221,7 +285,7 @@ async function convertPptxToSvgInternal(
   setFontMapping(createFontMapping(options?.fontMapping));
 
   try {
-    initWarningLogger(options?.logLevel ?? "off");
+    initWarningLogger(logLevel === "off" ? "warn" : logLevel);
 
     const source = readPptx(input);
     const scriptFontScheme = findScriptFontScheme(source);
@@ -235,7 +299,6 @@ async function convertPptxToSvgInternal(
 
     const computed = createComputedView(source, { slides: options?.slides });
     const adapted = adaptComputedViewToRendererModel(computed);
-    const diagnostics = adapted.diagnostics;
     const slideSize = adapted.slideSize;
     if (slideSize === undefined && adapted.slides.length > 0) {
       throw new Error("Converter requires a computed slide size");
@@ -255,8 +318,22 @@ async function convertPptxToSvgInternal(
       slides.push({ slideNumber: slide.slideNumber, svg });
     }
 
-    flushWarnings();
-    return { slides, diagnostics };
+    const rendererWarningEntries = [...getWarningEntries()];
+    if (logLevel === "off") {
+      initWarningLogger("off");
+    } else {
+      flushWarnings();
+    }
+
+    const diagnostics: ConversionDiagnostic[] = [
+      ...normalizeDocumentDiagnostics(source.diagnostics),
+      ...collectComputedViewDiagnostics(computed),
+      ...normalizeRendererAdapterDiagnostics(adapted.diagnostics),
+      ...normalizeRendererWarningDiagnostics(rendererWarningEntries),
+    ];
+    const supportCoverage = buildSupportCoverage(computed, adapted.slides, diagnostics);
+
+    return { slides, diagnostics, supportCoverage };
   } finally {
     resetTextMeasurer();
     resetTextPathFontResolver();
@@ -276,11 +353,11 @@ function findScriptFontScheme(source: ReturnType<typeof readPptx>) {
   );
 }
 
-async function convertPptxToPngInternal(
+async function convertPptxToPngReport(
   input: Buffer | Uint8Array,
   options?: ConvertOptions,
-): Promise<PngConversionResult> {
-  const svgResult = await convertPptxToSvgInternal(input, {
+): Promise<PngConversionReport> {
+  const svgResult = await convertPptxToSvgReport(input, {
     ...options,
     textOutput: "path",
   });
@@ -299,7 +376,178 @@ async function convertPptxToPngInternal(
     });
   }
 
-  return { slides, diagnostics: svgResult.diagnostics };
+  return {
+    slides,
+    diagnostics: svgResult.diagnostics,
+    supportCoverage: svgResult.supportCoverage,
+  };
+}
+
+function normalizeDocumentDiagnostics(diagnostics: readonly Diagnostic[]): ConversionDiagnostic[] {
+  return diagnostics.map((diagnostic) => ({
+    source: "document",
+    severity: diagnostic.severity,
+    code: diagnostic.code,
+    message: diagnostic.message,
+    ...(diagnostic.handle !== undefined ? { handle: diagnostic.handle } : {}),
+    ...(diagnostic.handle?.partPath !== undefined
+      ? { sourcePartPath: diagnostic.handle.partPath }
+      : {}),
+  }));
+}
+
+function collectComputedViewDiagnostics(computed: PptxComputedView): ConversionDiagnostic[] {
+  const diagnostics: ConversionDiagnostic[] = [];
+  for (const slide of computed.slides) {
+    for (const element of flattenComputedElements(slide.elements)) {
+      if (element.kind !== "smartArt" || element.diagramDrawing === undefined) continue;
+      for (const diagnostic of element.diagramDrawing.diagnostics) {
+        diagnostics.push({
+          source: "computed-view",
+          severity: diagnostic.severity,
+          code: diagnostic.code,
+          message: diagnostic.message,
+          slideNumber: slide.slideNumber,
+          sourcePartPath: diagnostic.sourcePartPath,
+        });
+      }
+    }
+  }
+  return diagnostics;
+}
+
+function normalizeRendererAdapterDiagnostics(
+  diagnostics: readonly RendererAdapterDiagnostic[],
+): ConversionDiagnostic[] {
+  return diagnostics.map((diagnostic) => ({
+    source: "renderer-adapter",
+    severity: diagnostic.severity,
+    code: diagnostic.code,
+    message: diagnostic.message,
+    ...(diagnostic.slideNumber !== undefined ? { slideNumber: diagnostic.slideNumber } : {}),
+    ...(diagnostic.sourcePartPath !== undefined
+      ? { sourcePartPath: diagnostic.sourcePartPath }
+      : {}),
+  }));
+}
+
+function normalizeRendererWarningDiagnostics(
+  warnings: readonly WarningEntry[],
+): ConversionDiagnostic[] {
+  return warnings.map((warning) => ({
+    source: "renderer",
+    severity: "warning",
+    code: `renderer.${warning.feature}`,
+    message: warning.message,
+    ...(warning.context !== undefined ? { context: warning.context } : {}),
+    ...slideNumberFromWarningContext(warning.context),
+  }));
+}
+
+function slideNumberFromWarningContext(context: string | undefined): { slideNumber?: number } {
+  const match = /^Slide\s+(\d+)$/.exec(context ?? "");
+  return match === null ? {} : { slideNumber: Number(match[1]) };
+}
+
+function buildSupportCoverage(
+  computed: PptxComputedView,
+  renderedSlides: readonly Slide[],
+  diagnostics: readonly ConversionDiagnostic[],
+): SupportCoverage {
+  const renderedBySlide = new Map(renderedSlides.map((slide) => [slide.slideNumber, slide]));
+  const slides = computed.slides.map((slide) => {
+    const counts = buildSlideSupportCoverage(
+      slide,
+      renderedBySlide.get(slide.slideNumber),
+      diagnostics,
+    );
+    return { slideNumber: slide.slideNumber, ...counts };
+  });
+
+  return {
+    overall: slides.reduce<SupportCoverageCounts>(
+      (total, slide) => ({
+        inputElements: total.inputElements + slide.inputElements,
+        outputElements: total.outputElements + slide.outputElements,
+        skippedElements: total.skippedElements + slide.skippedElements,
+        unresolvedElements: total.unresolvedElements + slide.unresolvedElements,
+        fallbackElements: total.fallbackElements + slide.fallbackElements,
+        warnings: total.warnings + slide.warnings,
+      }),
+      emptySupportCoverageCounts(),
+    ),
+    slides,
+  };
+}
+
+function buildSlideSupportCoverage(
+  computedSlide: ComputedSlide,
+  renderedSlide: Slide | undefined,
+  diagnostics: readonly ConversionDiagnostic[],
+): SupportCoverageCounts {
+  const slideDiagnostics = diagnostics.filter(
+    (diagnostic) => diagnostic.slideNumber === computedSlide.slideNumber,
+  );
+  return {
+    inputElements: countComputedElements(computedSlide.elements),
+    outputElements: renderedSlide !== undefined ? countRenderedElements(renderedSlide.elements) : 0,
+    skippedElements: countDiagnosticsByCode(slideDiagnostics, (code) => code.includes("skipped")),
+    unresolvedElements: countDiagnosticsByCode(slideDiagnostics, (code) =>
+      code.includes("unresolved"),
+    ),
+    fallbackElements: countDiagnosticsByCode(
+      slideDiagnostics,
+      (code) => code.includes("missing-transform") || code.includes("ignored"),
+    ),
+    warnings: slideDiagnostics.filter((diagnostic) => diagnostic.severity === "warning").length,
+  };
+}
+
+function emptySupportCoverageCounts(): SupportCoverageCounts {
+  return {
+    inputElements: 0,
+    outputElements: 0,
+    skippedElements: 0,
+    unresolvedElements: 0,
+    fallbackElements: 0,
+    warnings: 0,
+  };
+}
+
+function countDiagnosticsByCode(
+  diagnostics: readonly ConversionDiagnostic[],
+  predicate: (code: string) => boolean,
+): number {
+  return diagnostics.filter((diagnostic) => predicate(diagnostic.code)).length;
+}
+
+function countComputedElements(elements: readonly ComputedElement[]): number {
+  return flattenComputedElements(elements).length;
+}
+
+function flattenComputedElements(elements: readonly ComputedElement[]): ComputedElement[] {
+  const flattened: ComputedElement[] = [];
+  for (const element of elements) {
+    flattened.push(element);
+    if (element.kind === "group") {
+      flattened.push(...flattenComputedElements(element.children));
+    }
+    if (element.kind === "smartArt" && element.diagramDrawing !== undefined) {
+      flattened.push(...flattenComputedElements(element.diagramDrawing.children));
+    }
+  }
+  return flattened;
+}
+
+function countRenderedElements(elements: readonly SlideElement[]): number {
+  let count = 0;
+  for (const element of elements) {
+    count++;
+    if (element.type === "group") {
+      count += countRenderedElements(element.children);
+    }
+  }
+  return count;
 }
 
 function injectIntoSvgDefs(svg: string, content: string): string {

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -326,7 +326,7 @@ async function convertPptxToSvgReport(
 
     const diagnostics: ConversionDiagnostic[] = [
       ...normalizeDocumentDiagnostics(source.diagnostics),
-      ...collectComputedViewDiagnostics(computed),
+      ...collectSmartArtComputedViewDiagnostics(computed),
       ...normalizeRendererAdapterDiagnostics(adapted.diagnostics),
       ...normalizeRendererWarningDiagnostics(rendererWarningEntries),
     ];
@@ -398,7 +398,9 @@ function normalizeDocumentDiagnostics(diagnostics: readonly Diagnostic[]): Conve
   }));
 }
 
-function collectComputedViewDiagnostics(computed: PptxComputedView): ConversionDiagnostic[] {
+function collectSmartArtComputedViewDiagnostics(
+  computed: PptxComputedView,
+): ConversionDiagnostic[] {
   const diagnostics: ConversionDiagnostic[] = [];
   for (const slide of computed.slides) {
     for (const element of flattenComputedElements(slide.elements)) {
@@ -497,17 +499,9 @@ function buildSlideSupportCoverage(
   return {
     inputElements: countComputedElements(computedSlide.elements),
     outputElements: renderedSlide !== undefined ? countRenderedElements(renderedSlide.elements) : 0,
-    skippedElements: countDiagnosticsByCode(
-      slideDiagnostics,
-      (code) => code.includes("skipped") && !code.includes("unresolved"),
-    ),
-    unresolvedElements: countDiagnosticsByCode(slideDiagnostics, (code) =>
-      code.includes("unresolved"),
-    ),
-    fallbackElements: countDiagnosticsByCode(
-      slideDiagnostics,
-      (code) => code.includes("missing-transform") || code.includes("ignored"),
-    ),
+    skippedElements: countDiagnosticsByCode(slideDiagnostics, isSkippedDiagnosticCode),
+    unresolvedElements: countDiagnosticsByCode(slideDiagnostics, isUnresolvedDiagnosticCode),
+    fallbackElements: countDiagnosticsByCode(slideDiagnostics, isFallbackDiagnosticCode),
     warnings: slideDiagnostics.filter((diagnostic) => diagnostic.severity === "warning").length,
   };
 }
@@ -528,6 +522,26 @@ function countDiagnosticsByCode(
   predicate: (code: string) => boolean,
 ): number {
   return diagnostics.filter((diagnostic) => predicate(diagnostic.code)).length;
+}
+
+function isSkippedDiagnosticCode(code: string): boolean {
+  return code === "pptx-computed-view-adapter.raw-element-skipped";
+}
+
+function isUnresolvedDiagnosticCode(code: string): boolean {
+  return (
+    code === "pptx-computed-view-adapter.unresolved-chart-skipped" ||
+    code === "pptx-computed-view-adapter.unresolved-smartart-skipped" ||
+    code === "pptx-computed-view-adapter.unresolved-image-skipped"
+  );
+}
+
+function isFallbackDiagnosticCode(code: string): boolean {
+  return (
+    code === "pptx-computed-view-adapter.missing-transform" ||
+    code === "pptx-computed-view-adapter.raw-background-ignored" ||
+    code === "pptx-computed-view-adapter.raw-fill-ignored"
+  );
 }
 
 function countComputedElements(elements: readonly ComputedElement[]): number {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,14 @@
-export type { ConvertOptions, SlideImage, SlideSvg } from "./converter.js";
+export type {
+  ConversionDiagnostic,
+  ConvertOptions,
+  PngConversionReport,
+  SlideImage,
+  SlideSupportCoverage,
+  SlideSvg,
+  SupportCoverage,
+  SupportCoverageCounts,
+  SvgConversionReport,
+} from "./converter.js";
 export { convertPptxToPng, convertPptxToSvg } from "./converter.js";
 export type { UsedFonts } from "./font/font-collector.js";
 export { collectUsedFonts } from "./font/font-collector.js";

--- a/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
+++ b/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
@@ -111,15 +111,15 @@ describe("PptxSourceModel PoC end-to-end round-trip", () => {
     const input = readFixture("real-basic-theme.pptx");
     const noEditOutput = writePptx(readPptx(input));
 
-    const originalSvgResults = await convertPptxToSvg(input, {
+    const { slides: originalSvgResults } = await convertPptxToSvg(input, {
       textOutput: "text",
       skipSystemFonts: true,
     });
-    const roundTrippedSvgResults = await convertPptxToSvg(noEditOutput, {
+    const { slides: roundTrippedSvgResults } = await convertPptxToSvg(noEditOutput, {
       textOutput: "text",
       skipSystemFonts: true,
     });
-    const pngResults = await convertPptxToPng(noEditOutput, {
+    const { slides: pngResults } = await convertPptxToPng(noEditOutput, {
       width: 240,
       skipSystemFonts: true,
     });
@@ -139,7 +139,7 @@ describe("PptxSourceModel PoC end-to-end round-trip", () => {
     const editedOutput = writePptx(
       replaceTextRunPlainText(editedSource, editable.run.handle, EDITED_TEXT),
     );
-    const editedSvgResults = await convertPptxToSvg(editedOutput, {
+    const { slides: editedSvgResults } = await convertPptxToSvg(editedOutput, {
       slides: [editable.slideNumber],
       textOutput: "text",
       skipSystemFonts: true,

--- a/scripts/dev-server-render.ts
+++ b/scripts/dev-server-render.ts
@@ -9,7 +9,7 @@ async function main(): Promise<void> {
   }
 
   const input = readFileSync(pptxPath);
-  const slides = await convertPptxToSvg(input, { logLevel: "warn" });
+  const { slides } = await convertPptxToSvg(input, { logLevel: "warn" });
 
   process.stdout.write(JSON.stringify(slides));
 }

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -95,17 +95,17 @@ TESTEOF
 
 cat > test-types.ts << 'TESTEOF'
 import { convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
-import type { ConvertOptions, SlideImage, SlideSvg } from "pptx-glimpse";
+import type { ConvertOptions, PngConversionReport, SvgConversionReport } from "pptx-glimpse";
 
 // Verify function signatures
-const _svgFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<SlideSvg[]> =
+const _svgFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<SvgConversionReport> =
   convertPptxToSvg;
-const _pngFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<SlideImage[]> =
+const _pngFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<PngConversionReport> =
   convertPptxToPng;
 
 // Verify SlideImage.png is Buffer
 async function _verifyPngType(input: Uint8Array) {
-  const results = await convertPptxToPng(input);
+  const { slides: results } = await convertPptxToPng(input);
   const _png: Buffer = results[0].png;
   void _png;
 }

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -105,8 +105,8 @@ const _pngFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<
 
 // Verify SlideImage.png is Buffer
 async function _verifyPngType(input: Uint8Array) {
-  const { slides: results } = await convertPptxToPng(input);
-  const _png: Buffer = results[0].png;
+  const { slides } = await convertPptxToPng(input);
+  const _png: Buffer = slides[0].png;
   void _png;
 }
 

--- a/scripts/test-render.ts
+++ b/scripts/test-render.ts
@@ -25,8 +25,8 @@ async function main() {
   console.log(`Output dir: ${outputDir}`);
   console.log("");
 
-  const svgResults = await convertPptxToSvg(input, { logLevel: "warn" });
-  const pngResults = await convertPptxToPng(input);
+  const { slides: svgResults } = await convertPptxToSvg(input, { logLevel: "warn" });
+  const { slides: pngResults } = await convertPptxToPng(input);
 
   for (const svg of svgResults) {
     const svgPath = join(outputDir, `${name}-slide${svg.slideNumber}.svg`);

--- a/vrt/libreoffice/regression.test.ts
+++ b/vrt/libreoffice/regression.test.ts
@@ -71,7 +71,7 @@ describeOrSkip("LibreOffice Visual Regression Tests", { timeout: 60000 }, () => 
     describe(name, () => {
       itOrSkip("should match LibreOffice reference", async () => {
         const input = readFileSync(fixturePath);
-        const results = await convertPptxToPng(input);
+        const { slides: results } = await convertPptxToPng(input);
 
         for (const result of results) {
           const refPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);

--- a/vrt/libreoffice/regression.test.ts
+++ b/vrt/libreoffice/regression.test.ts
@@ -71,12 +71,12 @@ describeOrSkip("LibreOffice Visual Regression Tests", { timeout: 60000 }, () => 
     describe(name, () => {
       itOrSkip("should match LibreOffice reference", async () => {
         const input = readFileSync(fixturePath);
-        const { slides: results } = await convertPptxToPng(input);
+        const { slides } = await convertPptxToPng(input);
 
-        for (const result of results) {
-          const refPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);
-          const diffPath = join(DIFF_DIR, `${name}-slide${result.slideNumber}-diff.png`);
-          const comparison = await compareImages(result.png, refPath, diffPath, {
+        for (const slide of slides) {
+          const refPath = join(SNAPSHOT_DIR, `${name}-slide${slide.slideNumber}.png`);
+          const diffPath = join(DIFF_DIR, `${name}-slide${slide.slideNumber}-diff.png`);
+          const comparison = await compareImages(slide.png, refPath, diffPath, {
             pixelThreshold: PIXEL_THRESHOLD,
             mismatchTolerance: tolerance,
             resizeRef: true,
@@ -84,14 +84,14 @@ describeOrSkip("LibreOffice Visual Regression Tests", { timeout: 60000 }, () => 
 
           // Always output measured values for tolerance adjustment.
           console.log(
-            `[lo-vrt] ${name} slide${result.slideNumber}: ` +
+            `[lo-vrt] ${name} slide${slide.slideNumber}: ` +
               `${(comparison.mismatchPercentage * 100).toFixed(3)}% ` +
               `(tolerance ${(tolerance * 100).toFixed(1)}%)`,
           );
 
           expect(
             comparison.passed,
-            `${name} slide ${result.slideNumber}: ` +
+            `${name} slide ${slide.slideNumber}: ` +
               `${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ ` +
               `(${comparison.mismatchedPixels}/${comparison.totalPixels}). ` +
               `Tolerance: ${tolerance * 100}%`,

--- a/vrt/snapshot/regression.test.ts
+++ b/vrt/snapshot/regression.test.ts
@@ -32,7 +32,7 @@ describe("Visual Regression Tests", { timeout: 60000 }, () => {
         }
 
         const input = readFileSync(fixturePath);
-        const results = await convertPptxToPng(input, await getVrtRenderOptions());
+        const { slides: results } = await convertPptxToPng(input, await getVrtRenderOptions());
 
         for (const result of results) {
           const refPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);
@@ -62,7 +62,7 @@ describe("Visual Regression Tests (shared fixtures)", { timeout: 60000 }, () => 
         }
 
         const input = readFileSync(fixturePath);
-        const results = await convertPptxToPng(input, await getVrtRenderOptions());
+        const { slides: results } = await convertPptxToPng(input, await getVrtRenderOptions());
 
         for (const result of results) {
           const refPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);

--- a/vrt/snapshot/regression.test.ts
+++ b/vrt/snapshot/regression.test.ts
@@ -32,19 +32,19 @@ describe("Visual Regression Tests", { timeout: 60000 }, () => {
         }
 
         const input = readFileSync(fixturePath);
-        const { slides: results } = await convertPptxToPng(input, await getVrtRenderOptions());
+        const { slides } = await convertPptxToPng(input, await getVrtRenderOptions());
 
-        for (const result of results) {
-          const refPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);
-          const diffPath = join(DIFF_DIR, `${name}-slide${result.slideNumber}-diff.png`);
-          const comparison = await compareImages(result.png, refPath, diffPath, {
+        for (const slide of slides) {
+          const refPath = join(SNAPSHOT_DIR, `${name}-slide${slide.slideNumber}.png`);
+          const diffPath = join(DIFF_DIR, `${name}-slide${slide.slideNumber}-diff.png`);
+          const comparison = await compareImages(slide.png, refPath, diffPath, {
             pixelThreshold: PIXEL_THRESHOLD,
             mismatchTolerance: MISMATCH_TOLERANCE,
           });
 
           expect(
             comparison.passed,
-            `${name} slide ${result.slideNumber}: ${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ (${comparison.mismatchedPixels}/${comparison.totalPixels})`,
+            `${name} slide ${slide.slideNumber}: ${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ (${comparison.mismatchedPixels}/${comparison.totalPixels})`,
           ).toBe(true);
         }
       });
@@ -62,19 +62,19 @@ describe("Visual Regression Tests (shared fixtures)", { timeout: 60000 }, () => 
         }
 
         const input = readFileSync(fixturePath);
-        const { slides: results } = await convertPptxToPng(input, await getVrtRenderOptions());
+        const { slides } = await convertPptxToPng(input, await getVrtRenderOptions());
 
-        for (const result of results) {
-          const refPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);
-          const diffPath = join(DIFF_DIR, `${name}-slide${result.slideNumber}-diff.png`);
-          const comparison = await compareImages(result.png, refPath, diffPath, {
+        for (const slide of slides) {
+          const refPath = join(SNAPSHOT_DIR, `${name}-slide${slide.slideNumber}.png`);
+          const diffPath = join(DIFF_DIR, `${name}-slide${slide.slideNumber}-diff.png`);
+          const comparison = await compareImages(slide.png, refPath, diffPath, {
             pixelThreshold: SHARED_PIXEL_THRESHOLD,
             mismatchTolerance: SHARED_MISMATCH_TOLERANCE,
           });
 
           expect(
             comparison.passed,
-            `${name} slide ${result.slideNumber}: ${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ (${comparison.mismatchedPixels}/${comparison.totalPixels})`,
+            `${name} slide ${slide.slideNumber}: ${(comparison.mismatchPercentage * 100).toFixed(2)}% pixels differ (${comparison.mismatchedPixels}/${comparison.totalPixels})`,
           ).toBe(true);
         }
       });

--- a/vrt/snapshot/update-snapshots.ts
+++ b/vrt/snapshot/update-snapshots.ts
@@ -16,7 +16,7 @@ const CONCURRENCY = 4;
 async function processFixture(fixturePath: string, name: string): Promise<number> {
   const input = readFileSync(fixturePath);
   console.log(`Processing: ${name}`);
-  const results = await convertPptxToPng(input, await getVrtRenderOptions());
+  const { slides: results } = await convertPptxToPng(input, await getVrtRenderOptions());
   let count = 0;
 
   for (const result of results) {

--- a/vrt/snapshot/update-snapshots.ts
+++ b/vrt/snapshot/update-snapshots.ts
@@ -16,13 +16,13 @@ const CONCURRENCY = 4;
 async function processFixture(fixturePath: string, name: string): Promise<number> {
   const input = readFileSync(fixturePath);
   console.log(`Processing: ${name}`);
-  const { slides: results } = await convertPptxToPng(input, await getVrtRenderOptions());
+  const { slides } = await convertPptxToPng(input, await getVrtRenderOptions());
   let count = 0;
 
-  for (const result of results) {
-    const snapshotPath = join(SNAPSHOT_DIR, `${name}-slide${result.slideNumber}.png`);
-    writeFileSync(snapshotPath, result.png);
-    console.log(`  Updated: ${snapshotPath} (${result.width}x${result.height})`);
+  for (const slide of slides) {
+    const snapshotPath = join(SNAPSHOT_DIR, `${name}-slide${slide.slideNumber}.png`);
+    writeFileSync(snapshotPath, slide.png);
+    console.log(`  Updated: ${snapshotPath} (${slide.width}x${slide.height})`);
     count++;
   }
 


### PR DESCRIPTION
close #413

## 目的

`convertPptxToSvg` / `convertPptxToPng` の戻り値を slide 配列から conversion report object に変更し、変換結果と diagnostics / supportCoverage を標準 API で取得できるようにします。

## 変更内容

- `SvgConversionReport` / `PngConversionReport` / `ConversionDiagnostic` / `SupportCoverage` 系の public 型を追加
- `convertPptxToSvg` / `convertPptxToPng` の戻り値を `{ slides, diagnostics, supportCoverage }` に変更
- document reader / SmartArt computed-view diagnostics / renderer adapter diagnostics / renderer warning を report の `diagnostics` に統合
- `logLevel: "off"` でも diagnostics は収集し、console 出力のみ抑制する挙動に変更
- support/renderability coverage として input/output/skipped/unresolved/fallback/warning 件数を集計
- README の usage / migration 例、package verification script、demo/scripts/VRT/e2e/tests の呼び出し側を `report.slides` 参照に更新
- 破壊的変更として major changeset を追加

## 影響パス

- `packages/core/src/converter.ts`
- `packages/core/src/index.ts`
- `packages/core/src/converter.test.ts`
- `packages/core/src/converter.text-output.test.ts`
- `packages/core/src/pptx-source-model-round-trip.e2e.test.ts`
- `e2e/`, `vrt/`, `scripts/`, `demo/`
- `README.md`
- `.changeset/conversion-report-api.md`

## ローカル検証

- `npm run knip`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run test:package`
