### PR TITLE
writer: xfrm 編集スライスを追加する

### DIFF
--- a/.changeset/tall-shapes-move.md
+++ b/.changeset/tall-shapes-move.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": patch
+---
+
+Add PptxSourceModel shape transform editing and writer round-trip support for xfrm offset and extent updates.

--- a/.changeset/tall-shapes-move.md
+++ b/.changeset/tall-shapes-move.md
@@ -2,4 +2,4 @@
 "pptx-glimpse": patch
 ---
 
-Add PptxSourceModel shape transform editing and writer round-trip support for xfrm offset and extent updates.
+Add document-path foundation support for shape transform edits, enabling internal writer round-trips for xfrm offset and extent updates.

--- a/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
+++ b/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
@@ -2,7 +2,9 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import {
+  asEmu,
   createComputedView,
+  findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
   type MediaPart,
   type PptxSourceModel,
@@ -10,7 +12,9 @@ import {
   replaceTextRunPlainText,
   type SourceParagraph,
   type SourceShape,
+  type SourceShapeNode,
   type SourceTextRun,
+  updateShapeTransform,
   writePptx,
 } from "@pptx-glimpse/document";
 import { renderSlideToSvg } from "@pptx-glimpse/renderer";
@@ -151,6 +155,39 @@ describe("PptxSourceModel PoC end-to-end round-trip", () => {
     // No-edit writer output is asserted to keep public SVG stable for the
     // selected shared fixture, so this e2e coverage does not need VRT snapshots.
   });
+
+  it("writes, re-reads, and renders one shape xfrm edit through convertPptxToSvg", async () => {
+    const input = readFixture("real-product-page.pptx");
+    const source = readPptx(input);
+    const editable = firstTransformShape(source);
+    const editedOutput = writePptx(
+      updateShapeTransform(source, editable.shape.handle, {
+        offsetX: asEmu(914400),
+        offsetY: asEmu(1828800),
+        width: asEmu(2743200),
+        height: asEmu(914400),
+      }),
+    );
+    const reread = readPptx(editedOutput);
+    const rereadShape = findShapeNodeBySourceHandle(reread, editable.shape.handle);
+
+    expect(rereadShape?.transform).toMatchObject({
+      offsetX: 914400,
+      offsetY: 1828800,
+      width: 2743200,
+      height: 914400,
+    });
+
+    const { slides } = await convertPptxToSvg(editedOutput, {
+      slides: [editable.slideNumber],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+
+    expect(slides).toHaveLength(1);
+    expect(slides[0].svg).toContain('transform="translate(96, 192)"');
+    expect(slides[0].svg).toContain('width="288" height="96"');
+  });
 });
 
 const textDecoder = new TextDecoder();
@@ -230,6 +267,28 @@ function firstEditableRun(source: PptxSourceModel): {
     }
   }
   throw new Error("No editable text run found in selected PptxSourceModel fixture");
+}
+
+function firstTransformShape(source: PptxSourceModel): {
+  readonly slideNumber: number;
+  readonly shape: TransformEditableShape;
+} {
+  for (const slide of source.slides) {
+    const slideNumber = source.presentation.slidePartPaths.indexOf(slide.partPath) + 1;
+    if (slideNumber <= 0) continue;
+    const shape = slide.shapes.find(isTransformEditableShape);
+    if (shape !== undefined) return { slideNumber, shape };
+  }
+  throw new Error("No editable shape transform found in selected PptxSourceModel fixture");
+}
+
+type TransformEditableShape = SourceShapeNode & {
+  readonly handle: NonNullable<SourceShapeNode["handle"]>;
+  readonly transform: NonNullable<SourceShape["transform"]>;
+};
+
+function isTransformEditableShape(shape: SourceShapeNode): shape is TransformEditableShape {
+  return shape.kind !== "raw" && shape.handle !== undefined && shape.transform !== undefined;
 }
 
 type EditableTextRun = SourceTextRun & {

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -71,6 +71,7 @@ export type {
   PartRelationships,
   PptxSourceModel,
   PptxSourceModelEdit,
+  PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
   Pt,
   RawOoxmlNode,
@@ -159,8 +160,14 @@ export type {
   SourceThemeFormatScheme,
   SourceTransform,
   SourceVerticalAnchor,
+  UpdateShapeTransformInput,
 } from "./source/index.js";
-export { findTextRunBySourceHandle, replaceTextRunPlainText } from "./source/index.js";
+export {
+  findShapeNodeBySourceHandle,
+  findTextRunBySourceHandle,
+  replaceTextRunPlainText,
+  updateShapeTransform,
+} from "./source/index.js";
 export {
   asEmu,
   asHundredthPt,

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -85,7 +85,7 @@ export function findShapeNodeBySourceHandle(
   handle: SourceHandle,
 ): SourceShapeNode | undefined {
   for (const slide of source.slides) {
-    const shape = slide.shapes.find((node) => sourceHandlesEqual(node.handle, handle));
+    const shape = findShapeNodeInTree(slide.shapes, handle);
     if (shape !== undefined) return shape;
   }
   return undefined;
@@ -102,6 +102,9 @@ export function updateShapeTransform(
     ...slide,
     shapes: slide.shapes.map((shape) => {
       if (!sourceHandlesEqual(shape.handle, handle)) return shape;
+      if (hasAlternateContentSidecar(shape)) {
+        throw new Error("updateShapeTransform: shapes inside AlternateContent are not supported");
+      }
       if (!hasEditableTransform(shape)) {
         throw new Error("updateShapeTransform: shape handle does not reference a shape with xfrm");
       }
@@ -120,6 +123,9 @@ export function updateShapeTransform(
   }));
 
   if (!updated) {
+    if (source.slides.some((slide) => hasNestedShapeNodeWithHandle(slide.shapes, handle))) {
+      throw new Error("updateShapeTransform: nested group shape editing is not supported");
+    }
     throw new Error("updateShapeTransform: shape handle was not found in PptxSourceModel source");
   }
 
@@ -153,6 +159,37 @@ function hasEditableTransform(shape: SourceShapeNode): shape is TransformableSha
   readonly transform: NonNullable<TransformableShapeNode["transform"]>;
 } {
   return shape.kind !== "raw" && shape.transform !== undefined;
+}
+
+function findShapeNodeInTree(
+  shapes: readonly SourceShapeNode[],
+  handle: SourceHandle,
+): SourceShapeNode | undefined {
+  for (const shape of shapes) {
+    if (sourceHandlesEqual(shape.handle, handle)) return shape;
+    if (shape.kind === "group") {
+      const child = findShapeNodeInTree(shape.children, handle);
+      if (child !== undefined) return child;
+    }
+  }
+  return undefined;
+}
+
+function hasNestedShapeNodeWithHandle(
+  shapes: readonly SourceShapeNode[],
+  handle: SourceHandle,
+): boolean {
+  return shapes.some(
+    (shape) =>
+      shape.kind === "group" &&
+      (findShapeNodeInTree(shape.children, handle) !== undefined ||
+        hasNestedShapeNodeWithHandle(shape.children, handle)),
+  );
+}
+
+function hasAlternateContentSidecar(shape: SourceShapeNode): boolean {
+  if (shape.kind === "raw") return false;
+  return shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent") ?? false;
 }
 
 function sourceHandlesEqual(left: SourceHandle | undefined, right: SourceHandle): boolean {

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -96,6 +96,10 @@ export function updateShapeTransform(
   handle: SourceHandle,
   transform: UpdateShapeTransformInput,
 ): PptxSourceModel {
+  if (handle.nodeId === undefined) {
+    throw new Error("updateShapeTransform: shape transform edit requires a node id");
+  }
+
   let updated = false;
 
   const slides = source.slides.map((slide) => ({

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1,10 +1,14 @@
 import type {
+  Emu,
   PptxSourceModel,
   SourceHandle,
   SourceParagraph,
   SourceShape,
+  SourceShapeNode,
   SourceTextRun,
 } from "./index.js";
+
+type TransformableShapeNode = Exclude<SourceShapeNode, { readonly kind: "raw" }>;
 
 export function findTextRunBySourceHandle(
   source: PptxSourceModel,
@@ -69,6 +73,73 @@ export function replaceTextRunPlainText(
   };
 }
 
+export interface UpdateShapeTransformInput {
+  readonly offsetX: Emu;
+  readonly offsetY: Emu;
+  readonly width: Emu;
+  readonly height: Emu;
+}
+
+export function findShapeNodeBySourceHandle(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+): SourceShapeNode | undefined {
+  for (const slide of source.slides) {
+    const shape = slide.shapes.find((node) => sourceHandlesEqual(node.handle, handle));
+    if (shape !== undefined) return shape;
+  }
+  return undefined;
+}
+
+export function updateShapeTransform(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+  transform: UpdateShapeTransformInput,
+): PptxSourceModel {
+  let updated = false;
+
+  const slides = source.slides.map((slide) => ({
+    ...slide,
+    shapes: slide.shapes.map((shape) => {
+      if (!sourceHandlesEqual(shape.handle, handle)) return shape;
+      if (!hasEditableTransform(shape)) {
+        throw new Error("updateShapeTransform: shape handle does not reference a shape with xfrm");
+      }
+      updated = true;
+      return {
+        ...shape,
+        transform: {
+          ...shape.transform,
+          offsetX: transform.offsetX,
+          offsetY: transform.offsetY,
+          width: transform.width,
+          height: transform.height,
+        },
+      };
+    }),
+  }));
+
+  if (!updated) {
+    throw new Error("updateShapeTransform: shape handle was not found in PptxSourceModel source");
+  }
+
+  return {
+    ...source,
+    slides,
+    edits: [
+      ...(source.edits ?? []),
+      {
+        kind: "updateShapeTransform",
+        handle,
+        offsetX: transform.offsetX,
+        offsetY: transform.offsetY,
+        width: transform.width,
+        height: transform.height,
+      },
+    ],
+  };
+}
+
 function findTextRunInShape(shape: SourceShape, handle: SourceHandle): SourceTextRun | undefined {
   for (const paragraph of shape.textBody?.paragraphs ?? []) {
     for (const run of paragraph.runs) {
@@ -76,6 +147,12 @@ function findTextRunInShape(shape: SourceShape, handle: SourceHandle): SourceTex
     }
   }
   return undefined;
+}
+
+function hasEditableTransform(shape: SourceShapeNode): shape is TransformableShapeNode & {
+  readonly transform: NonNullable<TransformableShapeNode["transform"]>;
+} {
+  return shape.kind !== "raw" && shape.transform !== undefined;
 }
 
 function sourceHandlesEqual(left: SourceHandle | undefined, right: SourceHandle): boolean {

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -3,7 +3,13 @@
  */
 
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
-export { findTextRunBySourceHandle, replaceTextRunPlainText } from "./editing.js";
+export type { UpdateShapeTransformInput } from "./editing.js";
+export {
+  findShapeNodeBySourceHandle,
+  findTextRunBySourceHandle,
+  replaceTextRunPlainText,
+  updateShapeTransform,
+} from "./editing.js";
 export type {
   PartPath,
   RawSidecarId,
@@ -26,6 +32,7 @@ export type {
 export type {
   PptxSourceModel,
   PptxSourceModelEdit,
+  PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
 } from "./pptx-source-model.js";
 export type {

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -32,6 +32,7 @@ import type {
   SourceSlideMaster,
   SourceTheme,
 } from "./presentation.js";
+import type { Emu } from "./units.js";
 
 export interface PptxSourceModel {
   /** Structure of package part / relationship / content type / media. */
@@ -47,10 +48,19 @@ export interface PptxSourceModel {
   readonly edits?: readonly PptxSourceModelEdit[];
 }
 
-export type PptxSourceModelEdit = PptxSourceModelTextRunEdit;
+export type PptxSourceModelEdit = PptxSourceModelTextRunEdit | PptxSourceModelShapeTransformEdit;
 
 export interface PptxSourceModelTextRunEdit {
   readonly kind: "replaceTextRunPlainText";
   readonly handle: SourceHandle;
   readonly text: string;
+}
+
+export interface PptxSourceModelShapeTransformEdit {
+  readonly kind: "updateShapeTransform";
+  readonly handle: SourceHandle;
+  readonly offsetX: Emu;
+  readonly offsetY: Emu;
+  readonly width: Emu;
+  readonly height: Emu;
 }

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -5,8 +5,14 @@ import { unzipSync, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 
 // Import via the actual public surface (`@pptx-glimpse/document`).
-import { readPptx, writePptx } from "../index.js";
-import { findTextRunBySourceHandle, replaceTextRunPlainText, type SourceShape } from "../index.js";
+import { asEmu, asSourceNodeId, readPptx, writePptx } from "../index.js";
+import {
+  findShapeNodeBySourceHandle,
+  findTextRunBySourceHandle,
+  replaceTextRunPlainText,
+  type SourceShape,
+  updateShapeTransform,
+} from "../index.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -340,6 +346,87 @@ describe("writePptx - one plain text-run edit", () => {
 
     const edited = replaceTextRunPlainText(source, run.handle!, "Edited via slot");
     expect(firstRun(readPptx(writePptx(edited))).text).toBe("Edited via slot");
+  });
+});
+
+describe("writePptx - shape xfrm edit", () => {
+  it("Apply offset and extent update to PptxSourceModel source and reflect in PPTX after write", () => {
+    const source = readPptx(buildTextEditFixture());
+    const shape = firstShape(source);
+    const handle = shape.handle!;
+
+    const edited = updateShapeTransform(source, handle, {
+      offsetX: asEmu(1111),
+      offsetY: asEmu(2222),
+      width: asEmu(3333),
+      height: asEmu(4444),
+    });
+    const reread = readPptx(writePptx(edited));
+    const editedShape = findShapeNodeBySourceHandle(reread, handle);
+
+    expect(firstShape(edited).transform).toMatchObject({
+      offsetX: 1111,
+      offsetY: 2222,
+      width: 3333,
+      height: 4444,
+    });
+    expect(editedShape?.transform).toMatchObject({
+      offsetX: 1111,
+      offsetY: 2222,
+      width: 3333,
+      height: 4444,
+    });
+  });
+
+  it("Preserves unrelated package material while replacing only dirty slide XML", () => {
+    const input = buildTextEditFixture();
+    const source = readPptx(input);
+    const edited = updateShapeTransform(source, firstShape(source).handle!, {
+      offsetX: asEmu(1111),
+      offsetY: asEmu(2222),
+      width: asEmu(3333),
+      height: asEmu(4444),
+    });
+    const output = writePptx(edited);
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(slideXml).toContain('<a:off x="1111" y="2222"');
+    expect(slideXml).toContain('<a:ext cx="3333" cy="4444"');
+    expect(getEntry(output, "docProps/custom.xml")).toEqual(getEntry(input, "docProps/custom.xml"));
+    expect(getEntry(output, "ppt/media/image1.png")).toEqual(
+      getEntry(input, "ppt/media/image1.png"),
+    );
+  });
+
+  it("Rejects shape handles that do not have xfrm", () => {
+    const source = readPptx(buildSlotHandleTextEditFixture());
+    const shapeWithoutXfrm = firstShape(source);
+
+    expect(() =>
+      updateShapeTransform(source, shapeWithoutXfrm.handle!, {
+        offsetX: asEmu(1),
+        offsetY: asEmu(2),
+        width: asEmu(3),
+        height: asEmu(4),
+      }),
+    ).toThrow(/does not reference a shape with xfrm/);
+  });
+
+  it("Rejects nonexistent shape handles", () => {
+    const source = readPptx(buildTextEditFixture());
+    const handle = {
+      ...firstShape(source).handle!,
+      nodeId: asSourceNodeId("999"),
+    };
+
+    expect(() =>
+      updateShapeTransform(source, handle, {
+        offsetX: asEmu(1),
+        offsetY: asEmu(2),
+        width: asEmu(3),
+        height: asEmu(4),
+      }),
+    ).toThrow(/shape handle was not found/);
   });
 });
 

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -428,6 +428,57 @@ describe("writePptx - shape xfrm edit", () => {
       }),
     ).toThrow(/shape handle was not found/);
   });
+
+  it("Rejects nested group child shape handles for this writer slice", () => {
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<p:grpSp>` +
+          `<p:nvGrpSpPr><p:cNvPr id="30" name="Group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>` +
+          `<p:grpSpPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="300" cy="400"/><a:chOff x="0" y="0"/><a:chExt cx="300" cy="400"/></a:xfrm></p:grpSpPr>` +
+          `<p:sp><p:nvSpPr><p:cNvPr id="31" name="Child"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+          `</p:sp>` +
+          `</p:grpSp>`,
+      ),
+    );
+    const group = source.slides[0].shapes[0];
+    if (group.kind !== "group") throw new Error("group not found");
+    const child = group.children[0];
+
+    expect(findShapeNodeBySourceHandle(source, child.handle!)).toBe(child);
+    expect(() =>
+      updateShapeTransform(source, child.handle!, {
+        offsetX: asEmu(1),
+        offsetY: asEmu(2),
+        width: asEmu(3),
+        height: asEmu(4),
+      }),
+    ).toThrow(/nested group shape editing is not supported/);
+  });
+
+  it("Rejects AlternateContent fallback shape handles for this writer slice", () => {
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">` +
+          `<mc:Fallback>` +
+          `<p:sp><p:nvSpPr><p:cNvPr id="40" name="Fallback"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+          `</p:sp>` +
+          `</mc:Fallback>` +
+          `</mc:AlternateContent>`,
+      ),
+    );
+    const shape = firstShape(source);
+
+    expect(() =>
+      updateShapeTransform(source, shape.handle!, {
+        offsetX: asEmu(1),
+        offsetY: asEmu(2),
+        width: asEmu(3),
+        height: asEmu(4),
+      }),
+    ).toThrow(/AlternateContent/);
+  });
 });
 
 function firstShape(source: ReturnType<typeof readPptx>): SourceShape {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -399,7 +399,13 @@ describe("writePptx - shape xfrm edit", () => {
   });
 
   it("Rejects shape handles that do not have xfrm", () => {
-    const source = readPptx(buildSlotHandleTextEditFixture());
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<p:sp><p:nvSpPr><p:cNvPr id="50" name="No xfrm"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+          `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Text</a:t></a:r></a:p></p:txBody></p:sp>`,
+      ),
+    );
     const shapeWithoutXfrm = firstShape(source);
 
     expect(() =>
@@ -410,6 +416,27 @@ describe("writePptx - shape xfrm edit", () => {
         height: asEmu(4),
       }),
     ).toThrow(/does not reference a shape with xfrm/);
+  });
+
+  it("Rejects shape transform handles without node ids", () => {
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<p:sp><p:nvSpPr><p:cNvPr name="No Id Shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+          `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Text</a:t></a:r></a:p></p:txBody></p:sp>`,
+      ),
+    );
+    const shape = firstShape(source);
+
+    expect(shape.handle?.nodeId).toBeUndefined();
+    expect(() =>
+      updateShapeTransform(source, shape.handle!, {
+        offsetX: asEmu(1),
+        offsetY: asEmu(2),
+        width: asEmu(3),
+        height: asEmu(4),
+      }),
+    ).toThrow(/requires a node id/);
   });
 
   it("Rejects nonexistent shape handles", () => {

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -8,8 +8,9 @@
  * non-bookkeeping raw parts prefer the raw package material preserved by the reader.
  * Only dirty scopes are updated according to supported PptxSourceModel operations.
  *
- * The current slice supports one plain text-run edit, reserializing the dirty slide XML
- * part and replacing only the target run's `a:t` value via a stable source handle.
+ * The current slice supports plain text-run replacement and top-level shape transform
+ * offset/extent edits, reserializing dirty slide XML parts and replacing only the
+ * targeted values via stable source handles.
  * Node-level XML splicing, precise unsupported raw-sidecar invalidation, and package
  * topology rewrites belong to later writer slices, but the API and dirty-scope tracking
  * remain shaped for that extension path.

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -200,14 +200,12 @@ interface TextRunLocator {
 }
 
 interface ShapeLocator {
-  readonly nodeId?: string;
-  readonly orderingSlot?: number;
+  readonly nodeId: string;
 }
 
 function parseShapeLocator(handle: PptxSourceModelShapeTransformEdit["handle"]): ShapeLocator {
   if (handle.nodeId !== undefined) return { nodeId: String(handle.nodeId) };
-  if (handle.orderingSlot !== undefined) return { orderingSlot: handle.orderingSlot };
-  throw new Error("writePptx: shape transform edit requires nodeId or orderingSlot in handle");
+  throw new Error("writePptx: shape transform edit requires nodeId in handle");
 }
 
 function parseTextRunLocator(
@@ -253,21 +251,16 @@ function locateShapeTreeNode(
 ): XmlNode | undefined {
   const shapeKeys = new Set(["sp", "pic", "cxnSp", "graphicFrame", "grpSp"]);
   if (!spTree) return undefined;
-  if (locator.nodeId !== undefined) {
-    for (const key of Object.keys(spTree)) {
-      if (key.startsWith("@_") || !shapeKeys.has(localName(key))) continue;
-      const value = spTree[key];
-      const items = Array.isArray(value) ? unsafeOoxmlBoundaryAssertion<unknown[]>(value) : [value];
-      const found = items.find(
-        (item) =>
-          getShapeTreeNodeId(unsafeOoxmlBoundaryAssertion<XmlNode>(item)) === locator.nodeId,
-      );
-      if (found !== undefined) return unsafeOoxmlBoundaryAssertion<XmlNode>(found);
-    }
-    return undefined;
+  for (const key of Object.keys(spTree)) {
+    if (key.startsWith("@_") || !shapeKeys.has(localName(key))) continue;
+    const value = spTree[key];
+    const items = Array.isArray(value) ? unsafeOoxmlBoundaryAssertion<unknown[]>(value) : [value];
+    const found = items.find(
+      (item) => getShapeTreeNodeId(unsafeOoxmlBoundaryAssertion<XmlNode>(item)) === locator.nodeId,
+    );
+    if (found !== undefined) return unsafeOoxmlBoundaryAssertion<XmlNode>(found);
   }
-  if (locator.orderingSlot === undefined) return undefined;
-  return getShapeTreeNodeByOrderingSlot(spTree, locator.orderingSlot);
+  return undefined;
 }
 
 function getShapeByOrderingSlot(
@@ -288,28 +281,6 @@ function getShapeByOrderingSlot(
       if (currentSlot === orderingSlot) {
         return local === "sp" ? unsafeOoxmlBoundaryAssertion<XmlNode>(item) : undefined;
       }
-      currentSlot++;
-    }
-  }
-  return undefined;
-}
-
-function getShapeTreeNodeByOrderingSlot(
-  spTree: XmlNode | undefined,
-  orderingSlot: number,
-): XmlNode | undefined {
-  if (!spTree) return undefined;
-
-  let currentSlot = 0;
-  for (const key of Object.keys(spTree)) {
-    if (key.startsWith("@_")) continue;
-    const local = localName(key);
-    if (local === "nvGrpSpPr" || local === "grpSpPr") continue;
-
-    const value = spTree[key];
-    const items = Array.isArray(value) ? value : [value];
-    for (const item of items) {
-      if (currentSlot === orderingSlot) return unsafeOoxmlBoundaryAssertion<XmlNode>(item);
       currentSlot++;
     }
   }

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -31,6 +31,7 @@ import type {
   PartRelationships,
   PptxSourceModel,
   PptxSourceModelEdit,
+  PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
   RawOoxmlNode,
   RawPackagePart,
@@ -65,7 +66,10 @@ const xmlBuilder = new XMLBuilder({
  */
 export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const textRunEdits = source.edits?.filter(isTextRunEdit) ?? [];
-  const dirtyPartPaths = new Set(textRunEdits.map((edit) => edit.handle.partPath));
+  const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
+  const dirtyPartPaths = new Set(
+    [...textRunEdits, ...shapeTransformEdits].map((edit) => edit.handle.partPath),
+  );
   const files: Record<string, Uint8Array> = {
     [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
   };
@@ -90,7 +94,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   }
 
   for (const partPath of dirtyPartPaths) {
-    files[partPath] = serializeDirtyXmlPart(source, partPath, textRunEdits);
+    files[partPath] = serializeDirtyXmlPart(source, partPath, textRunEdits, shapeTransformEdits);
     written.add(partPath);
   }
 
@@ -110,10 +114,17 @@ function isTextRunEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelTextRu
   return edit.kind === "replaceTextRunPlainText";
 }
 
+function isShapeTransformEdit(
+  edit: PptxSourceModelEdit,
+): edit is PptxSourceModelShapeTransformEdit {
+  return edit.kind === "updateShapeTransform";
+}
+
 function serializeDirtyXmlPart(
   source: PptxSourceModel,
   partPath: PartPath,
   textRunEdits: readonly PptxSourceModelTextRunEdit[],
+  shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
 ): Uint8Array {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
   if (rawPart === undefined) {
@@ -124,9 +135,11 @@ function serializeDirtyXmlPart(
   }
 
   const root = parseXml(textDecoder.decode(rawPart.bytes));
-  const edits = textRunEdits.filter((edit) => edit.handle.partPath === partPath);
-  for (const edit of edits) {
+  for (const edit of textRunEdits.filter((edit) => edit.handle.partPath === partPath)) {
     applyTextRunEdit(root, edit);
+  }
+  for (const edit of shapeTransformEdits.filter((edit) => edit.handle.partPath === partPath)) {
+    applyShapeTransformEdit(root, edit);
   }
   return encodeXml(XML_DECLARATION + xmlBuilder.build(root));
 }
@@ -150,11 +163,50 @@ function applyTextRunEdit(root: XmlNode, edit: PptxSourceModelTextRunEdit): void
   setChildText(run, "t", edit.text);
 }
 
+function applyShapeTransformEdit(root: XmlNode, edit: PptxSourceModelShapeTransformEdit): void {
+  const locator = parseShapeLocator(edit.handle);
+  const slide = getChild(root, "sld");
+  const cSld = getChild(slide, "cSld");
+  const spTree = getChild(cSld, "spTree");
+  const shape = locateShapeTreeNode(spTree, locator);
+  const xfrm = getShapeTransformNode(shape);
+
+  if (xfrm === undefined) {
+    throw new Error(
+      `writePptx: shape transform handle '${String(
+        edit.handle.nodeId ?? edit.handle.orderingSlot ?? "",
+      )}' no longer matches source XML with xfrm`,
+    );
+  }
+
+  const off = getChild(xfrm, "off");
+  const ext = getChild(xfrm, "ext");
+  if (off === undefined || ext === undefined) {
+    throw new Error("writePptx: shape transform xfrm must contain off and ext");
+  }
+
+  off["@_x"] = String(edit.offsetX);
+  off["@_y"] = String(edit.offsetY);
+  ext["@_cx"] = String(edit.width);
+  ext["@_cy"] = String(edit.height);
+}
+
 interface TextRunLocator {
   readonly shapeNodeId?: string;
   readonly shapeOrderingSlot?: number;
   readonly paragraphIndex: number;
   readonly runIndex: number;
+}
+
+interface ShapeLocator {
+  readonly nodeId?: string;
+  readonly orderingSlot?: number;
+}
+
+function parseShapeLocator(handle: PptxSourceModelShapeTransformEdit["handle"]): ShapeLocator {
+  if (handle.nodeId !== undefined) return { nodeId: String(handle.nodeId) };
+  if (handle.orderingSlot !== undefined) return { orderingSlot: handle.orderingSlot };
+  throw new Error("writePptx: shape transform edit requires nodeId or orderingSlot in handle");
 }
 
 function parseTextRunLocator(
@@ -194,6 +246,29 @@ function locateShape(spTree: XmlNode | undefined, locator: TextRunLocator): XmlN
   return getShapeByOrderingSlot(spTree, locator.shapeOrderingSlot);
 }
 
+function locateShapeTreeNode(
+  spTree: XmlNode | undefined,
+  locator: ShapeLocator,
+): XmlNode | undefined {
+  const shapeKeys = new Set(["sp", "pic", "cxnSp", "graphicFrame", "grpSp"]);
+  if (!spTree) return undefined;
+  if (locator.nodeId !== undefined) {
+    for (const key of Object.keys(spTree)) {
+      if (key.startsWith("@_") || !shapeKeys.has(localName(key))) continue;
+      const value = spTree[key];
+      const items = Array.isArray(value) ? unsafeOoxmlBoundaryAssertion<unknown[]>(value) : [value];
+      const found = items.find(
+        (item) =>
+          getShapeTreeNodeId(unsafeOoxmlBoundaryAssertion<XmlNode>(item)) === locator.nodeId,
+      );
+      if (found !== undefined) return unsafeOoxmlBoundaryAssertion<XmlNode>(found);
+    }
+    return undefined;
+  }
+  if (locator.orderingSlot === undefined) return undefined;
+  return getShapeTreeNodeByOrderingSlot(spTree, locator.orderingSlot);
+}
+
 function getShapeByOrderingSlot(
   spTree: XmlNode | undefined,
   orderingSlot: number,
@@ -216,6 +291,47 @@ function getShapeByOrderingSlot(
     }
   }
   return undefined;
+}
+
+function getShapeTreeNodeByOrderingSlot(
+  spTree: XmlNode | undefined,
+  orderingSlot: number,
+): XmlNode | undefined {
+  if (!spTree) return undefined;
+
+  let currentSlot = 0;
+  for (const key of Object.keys(spTree)) {
+    if (key.startsWith("@_")) continue;
+    const local = localName(key);
+    if (local === "nvGrpSpPr" || local === "grpSpPr") continue;
+
+    const value = spTree[key];
+    const items = Array.isArray(value) ? value : [value];
+    for (const item of items) {
+      if (currentSlot === orderingSlot) return unsafeOoxmlBoundaryAssertion<XmlNode>(item);
+      currentSlot++;
+    }
+  }
+  return undefined;
+}
+
+function getShapeTreeNodeId(node: XmlNode): string | undefined {
+  const nonVisualProperties =
+    getChild(node, "nvSpPr") ??
+    getChild(node, "nvPicPr") ??
+    getChild(node, "nvCxnSpPr") ??
+    getChild(node, "nvGrpSpPr") ??
+    getChild(node, "nvGraphicFramePr");
+  return getAttr(getChild(nonVisualProperties, "cNvPr"), "id");
+}
+
+function getShapeTransformNode(shape: XmlNode | undefined): XmlNode | undefined {
+  if (shape === undefined) return undefined;
+  return (
+    getChild(getChild(shape, "spPr"), "xfrm") ??
+    getChild(getChild(shape, "grpSpPr"), "xfrm") ??
+    getChild(shape, "xfrm")
+  );
 }
 
 function setChildText(node: XmlNode, name: string, text: string): void {


### PR DESCRIPTION
close #566

## 目的

PptxSourceModel の typed operation と writer dirty slide XML 更新に、shape transform (`xfrm`) の offset / extent 編集を追加します。headless 編集 MVP に向けた shape move / resize の writer 基盤です。

## 変更内容

- `@pptx-glimpse/document` に `updateShapeTransform` / `findShapeNodeBySourceHandle` と `PptxSourceModelShapeTransformEdit` を追加
- writer で top-level shape tree node の `a:off` / `a:ext` または `p:xfrm` 配下の値を dirty slide XML に反映
- `xfrm` なし、存在しない handle、node id なし、group child、`mc:AlternateContent` 由来 shape は明示的に reject
- round-trip / structural preservation / `convertPptxToSvg` 反映テストを追加
- published package 用 changeset を追加

## 影響範囲

- `packages/document/src/source/*`
- `packages/document/src/writer/write-pptx.ts`
- `packages/document/src/writer/write-pptx.test.ts`
- `packages/core/src/pptx-source-model-round-trip.e2e.test.ts`

## 検証

- `npm run format:check`
- `npm run knip`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## レビュー対応

- cross-review 指摘により、group child / AlternateContent 由来 shape を明示 reject
- slot-only transform edit は mixed shape tree で誤更新リスクがあるため node id 必須に制限
- writer module comment と changeset 文言を実装範囲に合わせて更新
