### PR TITLE
writer: 複数 text-run 編集と paragraph 置換を追加

### DIFF
--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -71,6 +71,7 @@ export type {
   PartRelationships,
   PptxSourceModel,
   PptxSourceModelEdit,
+  PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
   Pt,
@@ -163,8 +164,10 @@ export type {
   UpdateShapeTransformInput,
 } from "./source/index.js";
 export {
+  findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
+  replaceParagraphPlainText,
   replaceTextRunPlainText,
   updateShapeTransform,
 } from "./source/index.js";

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1,3 +1,4 @@
+import { asSourceNodeId } from "./handles.js";
 import type {
   Emu,
   PptxSourceModel,
@@ -19,6 +20,20 @@ export function findTextRunBySourceHandle(
       if (shape.kind !== "shape") continue;
       const run = findTextRunInShape(shape, handle);
       if (run !== undefined) return run;
+    }
+  }
+  return undefined;
+}
+
+export function findParagraphBySourceHandle(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+): SourceParagraph | undefined {
+  for (const slide of source.slides) {
+    for (const shape of slide.shapes) {
+      if (shape.kind !== "shape") continue;
+      const paragraph = findParagraphInShape(shape, handle);
+      if (paragraph !== undefined) return paragraph;
     }
   }
   return undefined;
@@ -70,6 +85,63 @@ export function replaceTextRunPlainText(
     ...source,
     slides,
     edits: [...(source.edits ?? []), { kind: "replaceTextRunPlainText", handle, text }],
+  };
+}
+
+export function replaceParagraphPlainText(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+  text: string,
+): PptxSourceModel {
+  let replaced = false;
+
+  const slides = source.slides.map((slide) => ({
+    ...slide,
+    shapes: slide.shapes.map((shape) => {
+      if (shape.kind !== "shape" || shape.textBody === undefined) return shape;
+
+      let shapeChanged = false;
+      const paragraphs = shape.textBody.paragraphs.map((paragraph) => {
+        if (!sourceHandlesEqual(paragraph.handle, handle)) return paragraph;
+        const replacementHandle = createReplacementRunHandle(paragraph);
+        replaced = true;
+        shapeChanged = true;
+        return {
+          ...paragraph,
+          runs: [
+            {
+              kind: "textRun",
+              text,
+              ...(paragraph.runs[0]?.properties !== undefined
+                ? { properties: paragraph.runs[0].properties }
+                : {}),
+              ...(replacementHandle !== undefined ? { handle: replacementHandle } : {}),
+            },
+          ],
+        } satisfies SourceParagraph;
+      });
+
+      if (!shapeChanged) return shape;
+      return {
+        ...shape,
+        textBody: {
+          ...shape.textBody,
+          paragraphs,
+        },
+      } satisfies SourceShape;
+    }),
+  }));
+
+  if (!replaced) {
+    throw new Error(
+      "replaceParagraphPlainText: paragraph handle was not found in PptxSourceModel source",
+    );
+  }
+
+  return {
+    ...source,
+    slides,
+    edits: [...(source.edits ?? []), { kind: "replaceParagraphPlainText", handle, text }],
   };
 }
 
@@ -157,6 +229,25 @@ function findTextRunInShape(shape: SourceShape, handle: SourceHandle): SourceTex
     }
   }
   return undefined;
+}
+
+function findParagraphInShape(
+  shape: SourceShape,
+  handle: SourceHandle,
+): SourceParagraph | undefined {
+  return shape.textBody?.paragraphs.find((paragraph) =>
+    sourceHandlesEqual(paragraph.handle, handle),
+  );
+}
+
+function createReplacementRunHandle(paragraph: SourceParagraph): SourceHandle | undefined {
+  if (paragraph.runs[0]?.handle !== undefined) return paragraph.runs[0].handle;
+  if (paragraph.handle?.nodeId === undefined) return undefined;
+  return {
+    ...paragraph.handle,
+    nodeId: asSourceNodeId(`${paragraph.handle.nodeId}:r:0`),
+    orderingSlot: 0,
+  };
 }
 
 function hasEditableTransform(shape: SourceShapeNode): shape is TransformableShapeNode & {

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -5,8 +5,10 @@
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
 export type { UpdateShapeTransformInput } from "./editing.js";
 export {
+  findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
+  replaceParagraphPlainText,
   replaceTextRunPlainText,
   updateShapeTransform,
 } from "./editing.js";
@@ -32,6 +34,7 @@ export type {
 export type {
   PptxSourceModel,
   PptxSourceModelEdit,
+  PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
 } from "./pptx-source-model.js";

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -48,10 +48,19 @@ export interface PptxSourceModel {
   readonly edits?: readonly PptxSourceModelEdit[];
 }
 
-export type PptxSourceModelEdit = PptxSourceModelTextRunEdit | PptxSourceModelShapeTransformEdit;
+export type PptxSourceModelEdit =
+  | PptxSourceModelTextRunEdit
+  | PptxSourceModelParagraphTextEdit
+  | PptxSourceModelShapeTransformEdit;
 
 export interface PptxSourceModelTextRunEdit {
   readonly kind: "replaceTextRunPlainText";
+  readonly handle: SourceHandle;
+  readonly text: string;
+}
+
+export interface PptxSourceModelParagraphTextEdit {
+  readonly kind: "replaceParagraphPlainText";
   readonly handle: SourceHandle;
   readonly text: string;
 }

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -449,6 +449,47 @@ describe("writePptx - paragraph text replacement", () => {
     expect(firstParagraph(reread).runs).toHaveLength(1);
     expect(firstRun(reread).text).toBe(" Trimmed ");
   });
+
+  it("Keeps replacement run before endParaRPr.", () => {
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<p:sp><p:nvSpPr><p:cNvPr id="60" name="End para props"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+          `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+          `<a:p><a:pPr algn="ctr"/><a:r><a:t>Before</a:t></a:r><a:endParaRPr lang="ja-JP"/></a:p>` +
+          `</p:txBody></p:sp>`,
+      ),
+    );
+    const output = writePptx(
+      replaceParagraphPlainText(source, firstParagraph(source).handle!, "After"),
+    );
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(slideXml.indexOf("<a:r>")).toBeGreaterThan(-1);
+    expect(slideXml.indexOf("<a:endParaRPr")).toBeGreaterThan(-1);
+    expect(slideXml.indexOf("<a:r>")).toBeLessThan(slideXml.indexOf("<a:endParaRPr"));
+    expect(firstRun(readPptx(output)).text).toBe("After");
+  });
+
+  it("Rejects paragraph replacement for interleaved bullet paragraphs split by the reader.", () => {
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<p:sp><p:nvSpPr><p:cNvPr id="61" name="Interleaved bullets"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+          `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+          `<a:p>` +
+          `<a:pPr><a:buChar char="&#x2022;"/></a:pPr><a:r><a:t>One</a:t></a:r><a:br/>` +
+          `<a:pPr><a:buChar char="&#x25E6;"/></a:pPr><a:r><a:t>Two</a:t></a:r>` +
+          `</a:p>` +
+          `</p:txBody></p:sp>`,
+      ),
+    );
+
+    expect(firstShape(source).textBody!.paragraphs).toHaveLength(2);
+    const edited = replaceParagraphPlainText(source, firstParagraph(source).handle!, "After");
+
+    expect(() => writePptx(edited)).toThrow(/interleaved bullet paragraph/);
+  });
 });
 
 describe("writePptx - shape xfrm edit", () => {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -7,8 +7,10 @@ import { describe, expect, it } from "vitest";
 // Import via the actual public surface (`@pptx-glimpse/document`).
 import { asEmu, asSourceNodeId, readPptx, writePptx } from "../index.js";
 import {
+  findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
+  replaceParagraphPlainText,
   replaceTextRunPlainText,
   type SourceShape,
   updateShapeTransform,
@@ -82,6 +84,22 @@ function buildSlotHandleTextEditFixture(): Uint8Array {
       `<p:sp><p:nvSpPr><p:cNvPr name="No Id Shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
       `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
       `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Original</a:t></a:r></a:p></p:txBody></p:sp>`,
+  );
+}
+
+function buildMultipleTextEditFixture(): Uint8Array {
+  return buildTextEditFixtureFromSlide(
+    `<p:sp><p:nvSpPr><p:cNvPr id="10" name="First"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+      `<a:p><a:r><a:t>First paragraph</a:t></a:r></a:p>` +
+      `<a:p><a:r><a:t>Second paragraph</a:t></a:r></a:p>` +
+      `</p:txBody></p:sp>` +
+      `<p:sp><p:nvSpPr><p:cNvPr id="11" name="Second"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+      `<a:p><a:r><a:t>Other shape</a:t></a:r></a:p>` +
+      `</p:txBody></p:sp>`,
   );
 }
 
@@ -349,6 +367,90 @@ describe("writePptx - one plain text-run edit", () => {
   });
 });
 
+describe("writePptx - multiple text edits", () => {
+  it("Applies multiple text-run replacements across different shapes and paragraphs in one write.", () => {
+    const source = readPptx(buildMultipleTextEditFixture());
+    const firstShapeSecondParagraphRun = shapeAt(source, 0).textBody!.paragraphs[1].runs[0];
+    const secondShapeRun = shapeAt(source, 1).textBody!.paragraphs[0].runs[0];
+
+    const edited = replaceTextRunPlainText(
+      replaceTextRunPlainText(source, firstShapeSecondParagraphRun.handle!, "Edited paragraph"),
+      secondShapeRun.handle!,
+      "Edited other shape",
+    );
+    const reread = readPptx(writePptx(edited));
+
+    expect(shapeAt(reread, 0).textBody!.paragraphs[0].runs[0].text).toBe("First paragraph");
+    expect(shapeAt(reread, 0).textBody!.paragraphs[1].runs[0].text).toBe("Edited paragraph");
+    expect(shapeAt(reread, 1).textBody!.paragraphs[0].runs[0].text).toBe("Edited other shape");
+  });
+
+  it("Rejects conflicting duplicate edits for the same text run.", () => {
+    const source = readPptx(buildTextEditFixture());
+    const run = firstRun(source);
+    const edited = replaceTextRunPlainText(
+      replaceTextRunPlainText(source, run.handle!, "First edit"),
+      run.handle!,
+      "Second edit",
+    );
+
+    expect(() => writePptx(edited)).toThrow(/conflicting text run edits/);
+  });
+
+  it("Rejects conflicting text-run and paragraph replacements for the same paragraph.", () => {
+    const source = readPptx(buildTextEditFixture());
+    const paragraph = firstParagraph(source);
+    const edited = replaceParagraphPlainText(
+      replaceTextRunPlainText(source, paragraph.runs[0].handle!, "Run edit"),
+      paragraph.handle!,
+      "Paragraph edit",
+    );
+
+    expect(() => writePptx(edited)).toThrow(/conflicting text run and paragraph edits/);
+  });
+});
+
+describe("writePptx - paragraph text replacement", () => {
+  it("Normalizes a multi-run paragraph to one run using the first run properties.", () => {
+    const input = buildTextEditFixture();
+    const source = readPptx(input);
+    const paragraph = firstParagraph(source);
+
+    expect(findParagraphBySourceHandle(source, paragraph.handle!)).toBe(paragraph);
+
+    const edited = replaceParagraphPlainText(source, paragraph.handle!, "Paragraph replacement");
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const editedParagraph = firstParagraph(reread);
+
+    expect(firstParagraph(edited).runs).toHaveLength(1);
+    expect(editedParagraph.runs).toHaveLength(1);
+    expect(editedParagraph.runs[0].text).toBe("Paragraph replacement");
+    expect(editedParagraph.runs[0].properties).toMatchObject({
+      bold: true,
+      italic: true,
+      fontSize: 24,
+      typeface: "Aptos",
+      typefaceEa: "Noto Sans JP",
+      color: { kind: "srgb", hex: "FF0000" },
+    });
+    expect(decoder.decode(getEntry(output, "ppt/slides/slide1.xml"))).not.toContain(" Keep ");
+    expect(getEntry(output, "docProps/custom.xml")).toEqual(getEntry(input, "docProps/custom.xml"));
+    expect(getEntry(output, "ppt/media/image1.png")).toEqual(
+      getEntry(input, "ppt/media/image1.png"),
+    );
+  });
+
+  it("Round-trips paragraph replacement text with significant surrounding whitespace.", () => {
+    const source = readPptx(buildTextEditFixture());
+    const edited = replaceParagraphPlainText(source, firstParagraph(source).handle!, " Trimmed ");
+    const reread = readPptx(writePptx(edited));
+
+    expect(firstParagraph(reread).runs).toHaveLength(1);
+    expect(firstRun(reread).text).toBe(" Trimmed ");
+  });
+});
+
 describe("writePptx - shape xfrm edit", () => {
   it("Apply offset and extent update to PptxSourceModel source and reflect in PPTX after write", () => {
     const source = readPptx(buildTextEditFixture());
@@ -509,7 +611,13 @@ describe("writePptx - shape xfrm edit", () => {
 });
 
 function firstShape(source: ReturnType<typeof readPptx>): SourceShape {
-  const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
+  return shapeAt(source, 0);
+}
+
+function shapeAt(source: ReturnType<typeof readPptx>, index: number): SourceShape {
+  const shape = source.slides[0].shapes.filter(
+    (node): node is SourceShape => node.kind === "shape",
+  )[index];
   if (shape === undefined) throw new Error("shape not found");
   return shape;
 }

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -32,6 +32,7 @@ import type {
   PartRelationships,
   PptxSourceModel,
   PptxSourceModelEdit,
+  PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
   RawOoxmlNode,
@@ -67,9 +68,13 @@ const xmlBuilder = new XMLBuilder({
  */
 export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const textRunEdits = source.edits?.filter(isTextRunEdit) ?? [];
+  const paragraphTextEdits = source.edits?.filter(isParagraphTextEdit) ?? [];
   const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
+  validateEdits(textRunEdits, paragraphTextEdits, shapeTransformEdits);
   const dirtyPartPaths = new Set(
-    [...textRunEdits, ...shapeTransformEdits].map((edit) => edit.handle.partPath),
+    [...textRunEdits, ...paragraphTextEdits, ...shapeTransformEdits].map(
+      (edit) => edit.handle.partPath,
+    ),
   );
   const files: Record<string, Uint8Array> = {
     [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
@@ -95,7 +100,13 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   }
 
   for (const partPath of dirtyPartPaths) {
-    files[partPath] = serializeDirtyXmlPart(source, partPath, textRunEdits, shapeTransformEdits);
+    files[partPath] = serializeDirtyXmlPart(
+      source,
+      partPath,
+      textRunEdits,
+      paragraphTextEdits,
+      shapeTransformEdits,
+    );
     written.add(partPath);
   }
 
@@ -115,6 +126,10 @@ function isTextRunEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelTextRu
   return edit.kind === "replaceTextRunPlainText";
 }
 
+function isParagraphTextEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelParagraphTextEdit {
+  return edit.kind === "replaceParagraphPlainText";
+}
+
 function isShapeTransformEdit(
   edit: PptxSourceModelEdit,
 ): edit is PptxSourceModelShapeTransformEdit {
@@ -125,6 +140,7 @@ function serializeDirtyXmlPart(
   source: PptxSourceModel,
   partPath: PartPath,
   textRunEdits: readonly PptxSourceModelTextRunEdit[],
+  paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
   shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
 ): Uint8Array {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
@@ -136,6 +152,9 @@ function serializeDirtyXmlPart(
   }
 
   const root = parseXml(textDecoder.decode(rawPart.bytes));
+  for (const edit of paragraphTextEdits.filter((edit) => edit.handle.partPath === partPath)) {
+    applyParagraphTextEdit(root, edit);
+  }
   for (const edit of textRunEdits.filter((edit) => edit.handle.partPath === partPath)) {
     applyTextRunEdit(root, edit);
   }
@@ -162,6 +181,23 @@ function applyTextRunEdit(root: XmlNode, edit: PptxSourceModelTextRunEdit): void
   }
 
   setChildText(run, "t", edit.text);
+}
+
+function applyParagraphTextEdit(root: XmlNode, edit: PptxSourceModelParagraphTextEdit): void {
+  const locator = parseParagraphLocator(edit.handle.nodeId);
+  const slide = getChild(root, "sld");
+  const cSld = getChild(slide, "cSld");
+  const spTree = getChild(cSld, "spTree");
+  const shape = locateShape(spTree, locator);
+  const paragraph = getChildArray(getChild(shape, "txBody"), "p")[locator.paragraphIndex];
+
+  if (paragraph === undefined) {
+    throw new Error(
+      `writePptx: paragraph handle '${edit.handle.nodeId}' no longer matches source XML`,
+    );
+  }
+
+  replaceParagraphRunsWithSingleTextRun(paragraph, edit.text);
 }
 
 function applyShapeTransformEdit(root: XmlNode, edit: PptxSourceModelShapeTransformEdit): void {
@@ -199,6 +235,8 @@ interface TextRunLocator {
   readonly runIndex: number;
 }
 
+type ParagraphTextLocator = Omit<TextRunLocator, "runIndex">;
+
 interface ShapeLocator {
   readonly nodeId: string;
 }
@@ -233,7 +271,33 @@ function parseTextRunLocator(
   throw new Error(`writePptx: unsupported text run handle '${value}'`);
 }
 
-function locateShape(spTree: XmlNode | undefined, locator: TextRunLocator): XmlNode | undefined {
+function parseParagraphLocator(
+  nodeId: PptxSourceModelParagraphTextEdit["handle"]["nodeId"],
+): ParagraphTextLocator {
+  const value = String(nodeId ?? "");
+  const byShapeId = /^text:shape:(.+):p:(\d+)$/.exec(value);
+  if (byShapeId !== null) {
+    return {
+      shapeNodeId: byShapeId[1],
+      paragraphIndex: Number(byShapeId[2]),
+    };
+  }
+
+  const byShapeSlot = /^text:shapeSlot:(\d+):p:(\d+)$/.exec(value);
+  if (byShapeSlot !== null) {
+    return {
+      shapeOrderingSlot: Number(byShapeSlot[1]),
+      paragraphIndex: Number(byShapeSlot[2]),
+    };
+  }
+
+  throw new Error(`writePptx: unsupported paragraph handle '${value}'`);
+}
+
+function locateShape(
+  spTree: XmlNode | undefined,
+  locator: TextRunLocator | ParagraphTextLocator,
+): XmlNode | undefined {
   const shapes = getChildArray(spTree, "sp");
   if (locator.shapeNodeId !== undefined) {
     return shapes.find(
@@ -323,6 +387,48 @@ function setChildText(node: XmlNode, name: string, text: string): void {
     : text;
 }
 
+function replaceParagraphRunsWithSingleTextRun(paragraph: XmlNode, text: string): void {
+  const firstRunProperties = getChild(getFirstRunLikeNode(paragraph), "rPr");
+  for (const key of Object.keys(paragraph)) {
+    if (key.startsWith("@_")) continue;
+    if (isRunLikeLocalName(localName(key))) delete paragraph[key];
+  }
+  paragraph["a:r"] = {
+    ...(firstRunProperties !== undefined ? { "a:rPr": cloneXmlNode(firstRunProperties) } : {}),
+    "a:t": textRequiresPreserve(text) ? { "@_xml:space": "preserve", "#text": text } : text,
+  };
+}
+
+function getFirstRunLikeNode(paragraph: XmlNode): XmlNode | undefined {
+  for (const key of Object.keys(paragraph)) {
+    if (key.startsWith("@_")) continue;
+    if (!isRunLikeLocalName(localName(key))) continue;
+    const value = paragraph[key];
+    return Array.isArray(value)
+      ? unsafeOoxmlBoundaryAssertion<XmlNode | undefined>(value[0])
+      : unsafeOoxmlBoundaryAssertion<XmlNode | undefined>(value);
+  }
+  return undefined;
+}
+
+function isRunLikeLocalName(name: string): boolean {
+  return name === "r" || name === "fld" || name === "br";
+}
+
+function cloneXmlNode(node: XmlNode): XmlNode {
+  return Object.fromEntries(
+    Object.entries(node).map(([key, value]) => [key, cloneXmlValue(value)]),
+  );
+}
+
+function cloneXmlValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(cloneXmlValue);
+  if (typeof value === "object" && value !== null) {
+    return cloneXmlNode(unsafeOoxmlBoundaryAssertion<XmlNode>(value));
+  }
+  return value;
+}
+
 function textElementValue(existing: unknown, text: string): unknown {
   if (typeof existing === "object" && existing !== null && !Array.isArray(existing)) {
     const next: XmlNode = { ...unsafeOoxmlBoundaryAssertion<XmlNode>(existing), "#text": text };
@@ -335,6 +441,69 @@ function textElementValue(existing: unknown, text: string): unknown {
 
 function textRequiresPreserve(text: string): boolean {
   return text.startsWith(" ") || text.endsWith(" ");
+}
+
+function validateEdits(
+  textRunEdits: readonly PptxSourceModelTextRunEdit[],
+  paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
+  shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
+): void {
+  const runKeys = new Set<string>();
+  for (const edit of textRunEdits) {
+    const key = editHandleNodeKey(edit);
+    if (runKeys.has(key)) {
+      throw new Error(`writePptx: conflicting text run edits for handle '${edit.handle.nodeId}'`);
+    }
+    runKeys.add(key);
+  }
+
+  const paragraphKeys = new Set<string>();
+  for (const edit of paragraphTextEdits) {
+    const key = editHandleNodeKey(edit);
+    if (paragraphKeys.has(key)) {
+      throw new Error(
+        `writePptx: conflicting paragraph text edits for handle '${edit.handle.nodeId}'`,
+      );
+    }
+    paragraphKeys.add(key);
+  }
+
+  for (const runEdit of textRunEdits) {
+    const paragraphKey = textRunParagraphEditKey(runEdit);
+    if (paragraphKey !== undefined && paragraphKeys.has(paragraphKey)) {
+      throw new Error(
+        `writePptx: conflicting text run and paragraph edits for handle '${runEdit.handle.nodeId}'`,
+      );
+    }
+  }
+
+  const shapeKeys = new Set<string>();
+  for (const edit of shapeTransformEdits) {
+    const key = editHandleNodeKey(edit);
+    if (shapeKeys.has(key)) {
+      throw new Error(
+        `writePptx: conflicting shape transform edits for handle '${String(edit.handle.nodeId)}'`,
+      );
+    }
+    shapeKeys.add(key);
+  }
+}
+
+function editHandleNodeKey(edit: {
+  readonly handle: PptxSourceModelTextRunEdit["handle"];
+}): string {
+  return [edit.handle.partPath, edit.handle.nodeId ?? "", edit.handle.relationshipId ?? ""].join(
+    "\u0000",
+  );
+}
+
+function textRunParagraphEditKey(edit: PptxSourceModelTextRunEdit): string | undefined {
+  const nodeId = String(edit.handle.nodeId ?? "");
+  const byShapeId = /^(text:shape:.+:p:\d+):r:\d+$/.exec(nodeId);
+  const byShapeSlot = /^(text:shapeSlot:\d+:p:\d+):r:\d+$/.exec(nodeId);
+  const paragraphNodeId = byShapeId?.[1] ?? byShapeSlot?.[1];
+  if (paragraphNodeId === undefined) return undefined;
+  return [edit.handle.partPath, paragraphNodeId, edit.handle.relationshipId ?? ""].join("\u0000");
 }
 
 function serializeContentTypes(

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -189,7 +189,8 @@ function applyParagraphTextEdit(root: XmlNode, edit: PptxSourceModelParagraphTex
   const cSld = getChild(slide, "cSld");
   const spTree = getChild(cSld, "spTree");
   const shape = locateShape(spTree, locator);
-  const paragraph = getChildArray(getChild(shape, "txBody"), "p")[locator.paragraphIndex];
+  const paragraphs = getChildArray(getChild(shape, "txBody"), "p");
+  const paragraph = locatePhysicalParagraphForTextEdit(paragraphs, locator, edit.handle.nodeId);
 
   if (paragraph === undefined) {
     throw new Error(
@@ -389,14 +390,35 @@ function setChildText(node: XmlNode, name: string, text: string): void {
 
 function replaceParagraphRunsWithSingleTextRun(paragraph: XmlNode, text: string): void {
   const firstRunProperties = getChild(getFirstRunLikeNode(paragraph), "rPr");
-  for (const key of Object.keys(paragraph)) {
-    if (key.startsWith("@_")) continue;
-    if (isRunLikeLocalName(localName(key))) delete paragraph[key];
-  }
-  paragraph["a:r"] = {
+  const replacementRun: XmlNode = {
     ...(firstRunProperties !== undefined ? { "a:rPr": cloneXmlNode(firstRunProperties) } : {}),
     "a:t": textRequiresPreserve(text) ? { "@_xml:space": "preserve", "#text": text } : text,
   };
+  const attrs: [string, unknown][] = [];
+  const paragraphProperties: [string, unknown][] = [];
+  const middleChildren: [string, unknown][] = [];
+  const endProperties: [string, unknown][] = [];
+
+  for (const [key, value] of Object.entries(paragraph)) {
+    if (key.startsWith("@_")) {
+      attrs.push([key, value]);
+      continue;
+    }
+
+    const local = localName(key);
+    if (isRunLikeLocalName(local)) continue;
+    if (local === "pPr") paragraphProperties.push([key, value]);
+    else if (local === "endParaRPr") endProperties.push([key, value]);
+    else middleChildren.push([key, value]);
+  }
+
+  replaceNodeEntries(paragraph, [
+    ...attrs,
+    ...paragraphProperties,
+    ["a:r", replacementRun],
+    ...middleChildren,
+    ...endProperties,
+  ]);
 }
 
 function getFirstRunLikeNode(paragraph: XmlNode): XmlNode | undefined {
@@ -413,6 +435,44 @@ function getFirstRunLikeNode(paragraph: XmlNode): XmlNode | undefined {
 
 function isRunLikeLocalName(name: string): boolean {
   return name === "r" || name === "fld" || name === "br";
+}
+
+function locatePhysicalParagraphForTextEdit(
+  paragraphs: readonly XmlNode[],
+  locator: ParagraphTextLocator,
+  handleNodeId: PptxSourceModelParagraphTextEdit["handle"]["nodeId"],
+): XmlNode | undefined {
+  let logicalParagraphIndex = 0;
+  for (const paragraph of paragraphs) {
+    const logicalCount = getLogicalParagraphCount(paragraph);
+    if (
+      locator.paragraphIndex >= logicalParagraphIndex &&
+      locator.paragraphIndex < logicalParagraphIndex + logicalCount
+    ) {
+      if (logicalCount > 1) {
+        throw new Error(
+          `writePptx: paragraph handle '${handleNodeId}' references an interleaved bullet paragraph split by the reader; paragraph replacement is not supported for this source XML`,
+        );
+      }
+      return paragraph;
+    }
+    logicalParagraphIndex += logicalCount;
+  }
+  return undefined;
+}
+
+function getLogicalParagraphCount(paragraph: XmlNode): number {
+  const bulletParagraphProperties = getChildArray(paragraph, "pPr").filter(
+    (properties) =>
+      getChild(properties, "buChar") !== undefined ||
+      getChild(properties, "buAutoNum") !== undefined,
+  );
+  return Math.max(1, bulletParagraphProperties.length);
+}
+
+function replaceNodeEntries(node: XmlNode, entries: readonly [string, unknown][]): void {
+  for (const key of Object.keys(node)) delete node[key];
+  for (const [key, value] of entries) node[key] = value;
 }
 
 function cloneXmlNode(node: XmlNode): XmlNode {


### PR DESCRIPTION
close #567

## 概要

writer のテキスト編集スライスを拡張し、1 回の `writePptx` で複数 text-run 編集を適用できるようにしました。あわせて paragraph handle を指定した plain text 置換 operation を追加し、置換後は先頭 run の `rPr` を引き継いだ単一 run に正規化します。

## 影響範囲

- `packages/document/src/source/*`
  - `PptxSourceModelParagraphTextEdit`、`replaceParagraphPlainText`、`findParagraphBySourceHandle` を追加
- `packages/document/src/writer/write-pptx.ts`
  - 複数 text edit の衝突検出
  - paragraph 置換時の dirty XML patch
  - `endParaRPr` 順序維持と interleaved bullet paragraph の明示 reject
- `packages/document/src/writer/write-pptx.test.ts`
  - 複数 run 編集、重複 reject、paragraph 置換、round-trip、structural preservation のテストを追加

## 検証

- `npm run test -- packages/document/src/writer/write-pptx.test.ts`
- `npm run test`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run knip`
- `npm run build`

`npm run build` では既存の renderer CJS build 由来の `import.meta` warning が出ますが、build 自体は成功しています。
