### PR TITLE
editor-core パッケージを bootstrap する

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,15 +7,32 @@ import prettier from "eslint-config-prettier";
 
 const repoRoot = dirname(fileURLToPath(import.meta.url));
 const documentSource = fileURLToPath(new URL("./packages/document/src/index.ts", import.meta.url));
+const editorCoreSource = fileURLToPath(
+  new URL("./packages/editor-core/src/index.ts", import.meta.url),
+);
 const documentBoundaryRestrictedImportPattern = {
   group: [
     "@pptx-glimpse/renderer",
     "@pptx-glimpse/renderer/*",
+    "@pptx-glimpse/editor-core",
+    "@pptx-glimpse/editor-core/*",
     "pptx-glimpse",
     "pptx-glimpse/*",
   ],
   message:
     "@pptx-glimpse/document is the lower-level OOXML/PptxSourceModel foundation and must not import renderer or the public core package.",
+};
+const editorCoreBoundaryRestrictedImportPattern = {
+  group: [
+    "@pptx-glimpse/renderer",
+    "@pptx-glimpse/renderer/*",
+    "@pptx-glimpse/cli",
+    "@pptx-glimpse/cli/*",
+    "pptx-glimpse",
+    "pptx-glimpse/*",
+  ],
+  message:
+    "@pptx-glimpse/editor-core is a headless command layer above @pptx-glimpse/document and must not import renderer, core, CLI, or UI code.",
 };
 
 export default tseslint.config(
@@ -48,6 +65,7 @@ export default tseslint.config(
           },
           alias: {
             "@pptx-glimpse/document": [documentSource],
+            "@pptx-glimpse/editor-core": [editorCoreSource],
           },
           mainFields: ["module", "main"],
         }),
@@ -65,6 +83,7 @@ export default tseslint.config(
               target: "./packages/document/src",
               from: [
                 "./packages/core/src",
+                "./packages/editor-core/src",
                 "./packages/renderer/src",
                 "./packages/cli/src",
                 "./demo",
@@ -72,6 +91,18 @@ export default tseslint.config(
               ],
               message:
                 "@pptx-glimpse/document is the lower-level OOXML/PptxSourceModel foundation and must not import higher-level packages or app/script code.",
+            },
+            {
+              target: "./packages/editor-core/src",
+              from: [
+                "./packages/core/src",
+                "./packages/renderer/src",
+                "./packages/cli/src",
+                "./demo",
+                "./scripts",
+              ],
+              message:
+                "@pptx-glimpse/editor-core may depend on @pptx-glimpse/document only, not renderer, core, CLI, or app/script code.",
             },
           ],
         },
@@ -228,6 +259,59 @@ export default tseslint.config(
         "error",
         {
           patterns: [documentBoundaryRestrictedImportPattern],
+        },
+      ],
+    },
+  },
+  {
+    files: ["packages/editor-core/src/**/*.ts"],
+    ignores: [
+      "packages/editor-core/src/**/*.test.ts",
+      "packages/editor-core/src/**/*.e2e.test.ts",
+    ],
+    rules: {
+      "import-x/no-extraneous-dependencies": [
+        "error",
+        {
+          packageDir: ["packages/editor-core"],
+          devDependencies: false,
+          includeInternal: true,
+        },
+      ],
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            editorCoreBoundaryRestrictedImportPattern,
+            {
+              group: ["**/unsafe-type-assertion.js"],
+              importNames: ["unsafeFixtureAssertion"],
+              message:
+                "unsafeFixtureAssertion is test-only; production code must use a boundary-specific helper.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      "packages/editor-core/src/**/*.test.ts",
+      "packages/editor-core/src/**/*.e2e.test.ts",
+    ],
+    rules: {
+      "import-x/no-extraneous-dependencies": [
+        "error",
+        {
+          packageDir: ["packages/editor-core", "."],
+          devDependencies: true,
+          includeInternal: true,
+        },
+      ],
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [editorCoreBoundaryRestrictedImportPattern],
         },
       ],
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Workspace root for pptx-glimpse packages.",
   "type": "module",
   "scripts": {
-    "build": "pnpm --filter @pptx-glimpse/document build && pnpm --filter @pptx-glimpse/renderer build && pnpm --filter pptx-glimpse build",
+    "build": "pnpm --filter @pptx-glimpse/document build && pnpm --filter @pptx-glimpse/editor-core build && pnpm --filter @pptx-glimpse/renderer build && pnpm --filter pptx-glimpse build",
     "audit:type-assertions": "tsx scripts/audit-type-assertions.ts",
     "bench": "vitest bench",
     "lint": "eslint packages/*/src/ vrt/ scripts/ bench/ e2e/",

--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@pptx-glimpse/editor-core",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Headless editor command layer for PptxSourceModel.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {
+    "@pptx-glimpse/document": "workspace:*"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -1,0 +1,186 @@
+import {
+  asPartPath,
+  asSourceNodeId,
+  type PptxSourceModel,
+  readPptx,
+  type SourceHandle,
+  type SourceShape,
+  writePptx,
+} from "@pptx-glimpse/document";
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+
+import {
+  createEditorSession,
+  type EditorApplyCommandResult,
+  type EditorHistoryResult,
+} from "./index.js";
+
+const encoder = new TextEncoder();
+
+function xml(content: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+describe("EditorSession text-run commands", () => {
+  it("applies a text-run edit and persists it through write/read round-trip", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const run = firstRun(source);
+
+    const edited = expectApplied(
+      session.apply({
+        kind: "replaceTextRunPlainText",
+        handle: requireHandle(run.handle),
+        text: "Edited text",
+      }),
+    );
+    const reread = readPptx(writePptx(edited));
+
+    expect(firstRun(source).text).toBe("Original");
+    expect(firstRun(session.document).text).toBe("Edited text");
+    expect(firstRun(reread).text).toBe("Edited text");
+    expect(firstParagraph(reread).runs[1].text).toBe(" Keep ");
+  });
+
+  it("undoes and redoes a text-run edit", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+
+    expectApplied(
+      session.apply({
+        kind: "replaceTextRunPlainText",
+        handle: requireHandle(firstRun(source).handle),
+        text: "Edited text",
+      }),
+    );
+
+    const undone = expectHistory(session.undo());
+    const redone = expectHistory(session.redo());
+
+    expect(firstRun(undone).text).toBe("Original");
+    expect(firstRun(readPptx(writePptx(undone))).text).toBe("Original");
+    expect(firstRun(redone).text).toBe("Edited text");
+    expect(firstRun(readPptx(writePptx(redone))).text).toBe("Edited text");
+    expect(session.canUndo).toBe(true);
+    expect(session.canRedo).toBe(false);
+  });
+
+  it("rejects an invalid command without changing document state or undo history", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const before = session.document;
+    const invalidHandle = {
+      partPath: asPartPath("ppt/slides/slide1.xml"),
+      nodeId: asSourceNodeId("text:shape:999:p:0:r:0"),
+      orderingSlot: 0,
+    } satisfies SourceHandle;
+
+    const result = session.apply({
+      kind: "replaceTextRunPlainText",
+      handle: invalidHandle,
+      text: "Should not apply",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "invalid-command",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/text run handle was not found/);
+    }
+    expect(session.document).toBe(before);
+    expect(firstRun(session.document).text).toBe("Original");
+    expect(session.undoDepth).toBe(0);
+    expect(session.redoDepth).toBe(0);
+    expect(session.canUndo).toBe(false);
+    expect(session.canRedo).toBe(false);
+    expect(session.undo()).toEqual({ ok: false, reason: "empty-undo-stack" });
+  });
+});
+
+async function buildTextEditFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300" cy="400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+        `<a:p><a:r><a:t>Original</a:t></a:r><a:r><a:t xml:space="preserve"> Keep </a:t></a:r></a:p>` +
+        `</p:txBody></p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function expectApplied(result: EditorApplyCommandResult): PptxSourceModel {
+  if (!result.ok) throw new Error(result.message);
+  return result.document;
+}
+
+function expectHistory(result: EditorHistoryResult): PptxSourceModel {
+  if (!result.ok) throw new Error(result.reason);
+  return result.document;
+}
+
+function firstShape(source: PptxSourceModel): SourceShape {
+  const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
+  if (shape === undefined) throw new Error("shape not found");
+  return shape;
+}
+
+function firstParagraph(source: PptxSourceModel) {
+  return firstShape(source).textBody!.paragraphs[0];
+}
+
+function firstRun(source: PptxSourceModel) {
+  return firstParagraph(source).runs[0];
+}
+
+function requireHandle(handle: SourceHandle | undefined): SourceHandle {
+  if (handle === undefined) throw new Error("handle not found");
+  return handle;
+}

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -66,6 +66,31 @@ describe("EditorSession text-run commands", () => {
     expect(session.canRedo).toBe(false);
   });
 
+  it("keeps the latest edit when the same text run is edited repeatedly", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstRun(source).handle);
+
+    expectApplied(
+      session.apply({
+        kind: "replaceTextRunPlainText",
+        handle,
+        text: "First edit",
+      }),
+    );
+    const edited = expectApplied(
+      session.apply({
+        kind: "replaceTextRunPlainText",
+        handle,
+        text: "Second edit",
+      }),
+    );
+    const reread = readPptx(writePptx(edited));
+
+    expect(firstRun(edited).text).toBe("Second edit");
+    expect(firstRun(reread).text).toBe("Second edit");
+  });
+
   it("rejects an invalid command without changing document state or undo history", async () => {
     const source = readPptx(await buildTextEditFixture());
     const session = createEditorSession(source);

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,0 +1,127 @@
+import {
+  type PptxSourceModel,
+  replaceTextRunPlainText,
+  type SourceHandle,
+} from "@pptx-glimpse/document";
+
+export interface ReplaceTextRunPlainTextCommand {
+  readonly kind: "replaceTextRunPlainText";
+  readonly handle: SourceHandle;
+  readonly text: string;
+}
+
+export type EditorCommand = ReplaceTextRunPlainTextCommand;
+
+export type EditorApplyCommandResult =
+  | {
+      readonly ok: true;
+      readonly document: PptxSourceModel;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "invalid-command";
+      readonly message: string;
+      readonly cause?: unknown;
+    };
+
+export type EditorHistoryResult =
+  | {
+      readonly ok: true;
+      readonly document: PptxSourceModel;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: "empty-undo-stack" | "empty-redo-stack";
+    };
+
+interface HistoryEntry {
+  readonly command: EditorCommand;
+  readonly before: PptxSourceModel;
+  readonly after: PptxSourceModel;
+}
+
+export class EditorSession {
+  #document: PptxSourceModel;
+  readonly #undoStack: HistoryEntry[] = [];
+  readonly #redoStack: HistoryEntry[] = [];
+
+  constructor(document: PptxSourceModel) {
+    this.#document = document;
+  }
+
+  get document(): PptxSourceModel {
+    return this.#document;
+  }
+
+  get canUndo(): boolean {
+    return this.#undoStack.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this.#redoStack.length > 0;
+  }
+
+  get undoDepth(): number {
+    return this.#undoStack.length;
+  }
+
+  get redoDepth(): number {
+    return this.#redoStack.length;
+  }
+
+  apply(command: EditorCommand): EditorApplyCommandResult {
+    const before = this.#document;
+    let after: PptxSourceModel;
+
+    try {
+      after = applyCommandToDocument(before, command);
+    } catch (error) {
+      return {
+        ok: false,
+        code: "invalid-command",
+        message: error instanceof Error ? error.message : "Editor command was rejected.",
+        cause: error,
+      };
+    }
+
+    this.#document = after;
+    this.#undoStack.push({ command, before, after });
+    this.#redoStack.length = 0;
+
+    return { ok: true, document: after };
+  }
+
+  undo(): EditorHistoryResult {
+    const entry = this.#undoStack.pop();
+    if (entry === undefined) return { ok: false, reason: "empty-undo-stack" };
+
+    this.#document = entry.before;
+    this.#redoStack.push(entry);
+
+    return { ok: true, document: entry.before };
+  }
+
+  redo(): EditorHistoryResult {
+    const entry = this.#redoStack.pop();
+    if (entry === undefined) return { ok: false, reason: "empty-redo-stack" };
+
+    this.#document = entry.after;
+    this.#undoStack.push(entry);
+
+    return { ok: true, document: entry.after };
+  }
+}
+
+export function createEditorSession(document: PptxSourceModel): EditorSession {
+  return new EditorSession(document);
+}
+
+function applyCommandToDocument(
+  document: PptxSourceModel,
+  command: EditorCommand,
+): PptxSourceModel {
+  switch (command.kind) {
+    case "replaceTextRunPlainText":
+      return replaceTextRunPlainText(document, command.handle, command.text);
+  }
+}

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,5 +1,7 @@
 import {
   type PptxSourceModel,
+  type PptxSourceModelEdit,
+  type PptxSourceModelTextRunEdit,
   replaceTextRunPlainText,
   type SourceHandle,
 } from "@pptx-glimpse/document";
@@ -35,7 +37,6 @@ export type EditorHistoryResult =
     };
 
 interface HistoryEntry {
-  readonly command: EditorCommand;
   readonly before: PptxSourceModel;
   readonly after: PptxSourceModel;
 }
@@ -74,7 +75,7 @@ export class EditorSession {
     let after: PptxSourceModel;
 
     try {
-      after = applyCommandToDocument(before, command);
+      after = normalizeEditorEdits(applyCommandToDocument(before, command));
     } catch (error) {
       return {
         ok: false,
@@ -85,7 +86,7 @@ export class EditorSession {
     }
 
     this.#document = after;
-    this.#undoStack.push({ command, before, after });
+    this.#undoStack.push({ before, after });
     this.#redoStack.length = 0;
 
     return { ok: true, document: after };
@@ -124,4 +125,34 @@ function applyCommandToDocument(
     case "replaceTextRunPlainText":
       return replaceTextRunPlainText(document, command.handle, command.text);
   }
+}
+
+function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
+  const edits = document.edits;
+  if (edits === undefined) return document;
+
+  const seenTextRuns = new Set<string>();
+  const normalizedReversed: PptxSourceModelEdit[] = [];
+
+  for (let index = edits.length - 1; index >= 0; index -= 1) {
+    const edit = edits[index];
+    if (edit.kind === "replaceTextRunPlainText") {
+      const key = textRunEditKey(edit);
+      if (seenTextRuns.has(key)) continue;
+      seenTextRuns.add(key);
+    }
+    normalizedReversed.push(edit);
+  }
+
+  if (normalizedReversed.length === edits.length) return document;
+  return {
+    ...document,
+    edits: normalizedReversed.reverse(),
+  };
+}
+
+function textRunEditKey(edit: PptxSourceModelTextRunEdit): string {
+  return [edit.handle.partPath, edit.handle.nodeId ?? "", edit.handle.relationshipId ?? ""].join(
+    "\u0000",
+  );
 }

--- a/packages/editor-core/tsconfig.json
+++ b/packages/editor-core/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@pptx-glimpse/document": ["packages/document/dist/index.d.ts"]
+    },
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/editor-core/tsup.config.ts
+++ b/packages/editor-core/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  external: ["@pptx-glimpse/document"],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,12 @@ importers:
         specifier: ^0.8.2
         version: 0.8.3
 
+  packages/editor-core:
+    dependencies:
+      '@pptx-glimpse/document':
+        specifier: workspace:*
+        version: link:../document
+
   packages/renderer:
     dependencies:
       '@resvg/resvg-wasm':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "baseUrl": ".",
     "paths": {
       "@pptx-glimpse/document": ["packages/document/src/index.ts"],
+      "@pptx-glimpse/editor-core": ["packages/editor-core/src/index.ts"],
       "@pptx-glimpse/renderer": ["packages/renderer/src/index.ts"]
     }
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
       "@pptx-glimpse/document": fileURLToPath(
         new URL("./packages/document/src/index.ts", import.meta.url),
       ),
+      "@pptx-glimpse/editor-core": fileURLToPath(
+        new URL("./packages/editor-core/src/index.ts", import.meta.url),
+      ),
     },
   },
   test: {


### PR DESCRIPTION
close #568

## 目的

`PptxSourceModel` を入力にする headless editor command 層の最小形として、private workspace package `@pptx-glimpse/editor-core` を追加します。

## 変更内容

- `packages/editor-core` を新設し、`EditorSession` / `createEditorSession` / text-run 編集 command を追加
- command 適用、undo / redo、invalid command rejection を実装
- 同一 text run への連続編集は writer の duplicate edit validation に当たらないよう、最新 edit に coalesce
- `@pptx-glimpse/document` のみを依存にし、ESLint / knip / build / TS / Vitest 設定へ組み込み

## 影響パッケージ

- `packages/editor-core`
- root tooling: `eslint.config.mjs`, `tsconfig.json`, `vitest.config.ts`, `package.json`, `pnpm-lock.yaml`

## ローカル検証

- `npm run test -- packages/editor-core/src/index.test.ts`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run knip`
- `npm run build`

## 補足

- cross-review の warning（同一 text run 連続編集で writer が duplicate edit を拒否する可能性）は追加 commit `fix(editor-core): coalesce repeated text run edits` で対応済みです。
