### PR TITLE
editor-core: shape move / resize command（xfrm）を追加する

### DIFF
--- a/e2e/editor-core-xfrm.test.ts
+++ b/e2e/editor-core-xfrm.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { convertPptxToSvg } from "../packages/core/src/converter.js";
+import {
+  asEmu,
+  findShapeNodeBySourceHandle,
+  type PptxSourceModel,
+  readPptx,
+  type SourceHandle,
+  type SourceShapeNode,
+  type SourceTransform,
+  writePptx,
+} from "../packages/document/src/index.js";
+import {
+  createEditorSession,
+  type EditorApplyCommandResult,
+} from "../packages/editor-core/src/index.js";
+
+describe("editor-core xfrm rendering integration", () => {
+  it("renders edited shape position and size after move and resize commands", async () => {
+    const input = readSharedFixture("real-product-page.pptx");
+    const source = readPptx(input);
+    const editable = firstTransformShape(source);
+    const session = createEditorSession(source);
+
+    expectApplied(
+      session.apply({
+        kind: "moveShape",
+        handle: editable.shape.handle,
+        offsetX: asEmu(914400),
+        offsetY: asEmu(1828800),
+      }),
+    );
+    const edited = expectApplied(
+      session.apply({
+        kind: "resizeShape",
+        handle: editable.shape.handle,
+        width: asEmu(2743200),
+        height: asEmu(914400),
+      }),
+    );
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const rereadShape = findShapeNodeBySourceHandle(reread, editable.shape.handle);
+
+    expect(rereadShape?.transform).toMatchObject({
+      offsetX: 914400,
+      offsetY: 1828800,
+      width: 2743200,
+      height: 914400,
+    });
+
+    const { slides } = await convertPptxToSvg(output, {
+      slides: [editable.slideNumber],
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+
+    expect(slides).toHaveLength(1);
+    expect(slides[0].svg).toContain('transform="translate(96, 192)"');
+    expect(slides[0].svg).toContain('width="288" height="96"');
+  });
+});
+
+interface EditableShape {
+  readonly slideNumber: number;
+  readonly shape: SourceShapeNode & {
+    readonly handle: SourceHandle;
+    readonly transform: SourceTransform;
+  };
+}
+
+function readSharedFixture(name: string): Buffer {
+  return readFileSync(fileURLToPath(new URL(`../shared-fixtures/${name}`, import.meta.url)));
+}
+
+function firstTransformShape(source: PptxSourceModel): EditableShape {
+  for (const [slideIndex, slide] of source.slides.entries()) {
+    for (const shape of slide.shapes) {
+      if (shape.kind === "raw" || shape.handle === undefined || shape.transform === undefined) {
+        continue;
+      }
+      return { slideNumber: slideIndex + 1, shape };
+    }
+  }
+  throw new Error("editable shape not found");
+}
+
+function expectApplied(result: EditorApplyCommandResult): PptxSourceModel {
+  if (!result.ok) throw new Error(result.message);
+  return result.document;
+}

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -1,10 +1,13 @@
 import {
+  asEmu,
   asPartPath,
   asSourceNodeId,
+  findShapeNodeBySourceHandle,
   type PptxSourceModel,
   readPptx,
   type SourceHandle,
   type SourceShape,
+  type SourceShapeNode,
   writePptx,
 } from "@pptx-glimpse/document";
 import JSZip from "jszip";
@@ -125,6 +128,151 @@ describe("EditorSession text-run commands", () => {
   });
 });
 
+describe("EditorSession xfrm commands", () => {
+  it("applies move and resize edits and persists them through write/read round-trip", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstShape(source).handle);
+
+    expectApplied(
+      session.apply({
+        kind: "moveShape",
+        handle,
+        offsetX: asEmu(914400),
+        offsetY: asEmu(1828800),
+      }),
+    );
+    const edited = expectApplied(
+      session.apply({
+        kind: "resizeShape",
+        handle,
+        width: asEmu(2743200),
+        height: asEmu(914400),
+      }),
+    );
+    const reread = readPptx(writePptx(edited));
+    const rereadShape = requireShape(findShapeNodeBySourceHandle(reread, handle));
+
+    expect(firstShape(source).transform).toMatchObject({
+      offsetX: 100,
+      offsetY: 200,
+      width: 300,
+      height: 400,
+    });
+    expect(requireShape(findShapeNodeBySourceHandle(edited, handle)).transform).toMatchObject({
+      offsetX: 914400,
+      offsetY: 1828800,
+      width: 2743200,
+      height: 914400,
+    });
+    expect(rereadShape.transform).toMatchObject({
+      offsetX: 914400,
+      offsetY: 1828800,
+      width: 2743200,
+      height: 914400,
+    });
+    expect(edited.edits?.filter((edit) => edit.kind === "updateShapeTransform")).toHaveLength(1);
+  });
+
+  it("undoes and redoes a move edit", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstShape(source).handle);
+
+    expectApplied(
+      session.apply({
+        kind: "moveShape",
+        handle,
+        offsetX: asEmu(1000),
+        offsetY: asEmu(2000),
+      }),
+    );
+
+    const undone = expectHistory(session.undo());
+    const redone = expectHistory(session.redo());
+
+    expect(requireShape(findShapeNodeBySourceHandle(undone, handle)).transform).toMatchObject({
+      offsetX: 100,
+      offsetY: 200,
+      width: 300,
+      height: 400,
+    });
+    expect(
+      requireShape(findShapeNodeBySourceHandle(readPptx(writePptx(undone)), handle)).transform,
+    ).toMatchObject({
+      offsetX: 100,
+      offsetY: 200,
+      width: 300,
+      height: 400,
+    });
+    expect(requireShape(findShapeNodeBySourceHandle(redone, handle)).transform).toMatchObject({
+      offsetX: 1000,
+      offsetY: 2000,
+      width: 300,
+      height: 400,
+    });
+    expect(
+      requireShape(findShapeNodeBySourceHandle(readPptx(writePptx(redone)), handle)).transform,
+    ).toMatchObject({
+      offsetX: 1000,
+      offsetY: 2000,
+      width: 300,
+      height: 400,
+    });
+  });
+
+  it("rejects invalid xfrm commands without changing document state or undo history", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const before = session.document;
+    const noXfrmHandle = requireHandle(shapeWithoutTransform(source).handle);
+    const missingHandle = {
+      partPath: asPartPath("ppt/slides/slide1.xml"),
+      nodeId: asSourceNodeId("999"),
+      orderingSlot: 99,
+    } satisfies SourceHandle;
+
+    const noXfrmResult = session.apply({
+      kind: "moveShape",
+      handle: noXfrmHandle,
+      offsetX: asEmu(1000),
+      offsetY: asEmu(2000),
+    });
+    const missingHandleResult = session.apply({
+      kind: "resizeShape",
+      handle: missingHandle,
+      width: asEmu(3000),
+      height: asEmu(4000),
+    });
+
+    expect(noXfrmResult).toMatchObject({
+      ok: false,
+      code: "invalid-command",
+    });
+    expect(noXfrmResult.ok).toBe(false);
+    if (!noXfrmResult.ok) {
+      expect(noXfrmResult.message).toMatch(/does not reference a shape with xfrm/);
+    }
+    expect(missingHandleResult).toMatchObject({
+      ok: false,
+      code: "invalid-command",
+    });
+    expect(missingHandleResult.ok).toBe(false);
+    if (!missingHandleResult.ok) {
+      expect(missingHandleResult.message).toMatch(/shape handle was not found/);
+    }
+    expect(session.document).toBe(before);
+    expect(firstShape(session.document).transform).toMatchObject({
+      offsetX: 100,
+      offsetY: 200,
+      width: 300,
+      height: 400,
+    });
+    expect(session.undoDepth).toBe(0);
+    expect(session.redoDepth).toBe(0);
+  });
+});
+
 async function buildTextEditFixture(): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file(
@@ -173,6 +321,9 @@ async function buildTextEditFixture(): Promise<Uint8Array> {
         `<p:txBody><a:bodyPr/><a:lstStyle/>` +
         `<a:p><a:r><a:t>Original</a:t></a:r><a:r><a:t xml:space="preserve"> Keep </a:t></a:r></a:p>` +
         `</p:txBody></p:sp>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="11" name="No xfrm"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>No xfrm</a:t></a:r></a:p></p:txBody></p:sp>` +
         `</p:spTree></p:cSld>` +
         `</p:sld>`,
     ),
@@ -203,6 +354,23 @@ function firstParagraph(source: PptxSourceModel) {
 
 function firstRun(source: PptxSourceModel) {
   return firstParagraph(source).runs[0];
+}
+
+function shapeWithoutTransform(source: PptxSourceModel): SourceShape {
+  const shape = source.slides[0].shapes.find(
+    (node): node is SourceShape => node.kind === "shape" && node.transform === undefined,
+  );
+  if (shape === undefined) throw new Error("shape without transform not found");
+  return shape;
+}
+
+function requireShape(shape: SourceShapeNode | undefined): SourceShapeNode & {
+  readonly transform: NonNullable<SourceShapeNode["transform"]>;
+} {
+  if (shape === undefined || shape.kind === "raw" || shape.transform === undefined) {
+    throw new Error("transform shape not found");
+  }
+  return shape;
 }
 
 function requireHandle(handle: SourceHandle | undefined): SourceHandle {

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -244,6 +244,12 @@ describe("EditorSession xfrm commands", () => {
       width: asEmu(3000),
       height: asEmu(4000),
     });
+    const invalidExtentResult = session.apply({
+      kind: "resizeShape",
+      handle: requireHandle(firstShape(source).handle),
+      width: asEmu(0),
+      height: asEmu(Number.NaN),
+    });
 
     expect(noXfrmResult).toMatchObject({
       ok: false,
@@ -260,6 +266,14 @@ describe("EditorSession xfrm commands", () => {
     expect(missingHandleResult.ok).toBe(false);
     if (!missingHandleResult.ok) {
       expect(missingHandleResult.message).toMatch(/shape handle was not found/);
+    }
+    expect(invalidExtentResult).toMatchObject({
+      ok: false,
+      code: "invalid-command",
+    });
+    expect(invalidExtentResult.ok).toBe(false);
+    if (!invalidExtentResult.ok) {
+      expect(invalidExtentResult.message).toMatch(/finite positive EMU value/);
     }
     expect(session.document).toBe(before);
     expect(firstShape(session.document).transform).toMatchObject({

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,9 +1,15 @@
 import {
+  type Emu,
+  findShapeNodeBySourceHandle,
   type PptxSourceModel,
   type PptxSourceModelEdit,
+  type PptxSourceModelShapeTransformEdit,
   type PptxSourceModelTextRunEdit,
   replaceTextRunPlainText,
   type SourceHandle,
+  type SourceShapeNode,
+  type SourceTransform,
+  updateShapeTransform,
 } from "@pptx-glimpse/document";
 
 export interface ReplaceTextRunPlainTextCommand {
@@ -12,7 +18,21 @@ export interface ReplaceTextRunPlainTextCommand {
   readonly text: string;
 }
 
-export type EditorCommand = ReplaceTextRunPlainTextCommand;
+export interface MoveShapeCommand {
+  readonly kind: "moveShape";
+  readonly handle: SourceHandle;
+  readonly offsetX: Emu;
+  readonly offsetY: Emu;
+}
+
+export interface ResizeShapeCommand {
+  readonly kind: "resizeShape";
+  readonly handle: SourceHandle;
+  readonly width: Emu;
+  readonly height: Emu;
+}
+
+export type EditorCommand = ReplaceTextRunPlainTextCommand | MoveShapeCommand | ResizeShapeCommand;
 
 export type EditorApplyCommandResult =
   | {
@@ -124,7 +144,52 @@ function applyCommandToDocument(
   switch (command.kind) {
     case "replaceTextRunPlainText":
       return replaceTextRunPlainText(document, command.handle, command.text);
+    case "moveShape":
+      return moveShape(document, command);
+    case "resizeShape":
+      return resizeShape(document, command);
   }
+}
+
+function moveShape(document: PptxSourceModel, command: MoveShapeCommand): PptxSourceModel {
+  const current = requireEditableShapeTransform(document, command.handle, "moveShape");
+  return updateShapeTransform(document, command.handle, {
+    offsetX: command.offsetX,
+    offsetY: command.offsetY,
+    width: current.width,
+    height: current.height,
+  });
+}
+
+function resizeShape(document: PptxSourceModel, command: ResizeShapeCommand): PptxSourceModel {
+  const current = requireEditableShapeTransform(document, command.handle, "resizeShape");
+  return updateShapeTransform(document, command.handle, {
+    offsetX: current.offsetX,
+    offsetY: current.offsetY,
+    width: command.width,
+    height: command.height,
+  });
+}
+
+function requireEditableShapeTransform(
+  document: PptxSourceModel,
+  handle: SourceHandle,
+  commandName: "moveShape" | "resizeShape",
+): SourceTransform {
+  const shape = findShapeNodeBySourceHandle(document, handle);
+  if (shape === undefined) {
+    throw new Error(`${commandName}: shape handle was not found in PptxSourceModel source`);
+  }
+  if (!hasTransform(shape)) {
+    throw new Error(`${commandName}: shape handle does not reference a shape with xfrm`);
+  }
+  return shape.transform;
+}
+
+function hasTransform(shape: SourceShapeNode): shape is SourceShapeNode & {
+  readonly transform: SourceTransform;
+} {
+  return shape.kind !== "raw" && shape.transform !== undefined;
 }
 
 function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
@@ -132,14 +197,20 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
   if (edits === undefined) return document;
 
   const seenTextRuns = new Set<string>();
+  const seenShapeTransforms = new Set<string>();
   const normalizedReversed: PptxSourceModelEdit[] = [];
 
   for (let index = edits.length - 1; index >= 0; index -= 1) {
     const edit = edits[index];
     if (edit.kind === "replaceTextRunPlainText") {
-      const key = textRunEditKey(edit);
+      const key = editHandleNodeKey(edit);
       if (seenTextRuns.has(key)) continue;
       seenTextRuns.add(key);
+    }
+    if (edit.kind === "updateShapeTransform") {
+      const key = editHandleNodeKey(edit);
+      if (seenShapeTransforms.has(key)) continue;
+      seenShapeTransforms.add(key);
     }
     normalizedReversed.push(edit);
   }
@@ -151,7 +222,9 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
   };
 }
 
-function textRunEditKey(edit: PptxSourceModelTextRunEdit): string {
+function editHandleNodeKey(
+  edit: PptxSourceModelTextRunEdit | PptxSourceModelShapeTransformEdit,
+): string {
   return [edit.handle.partPath, edit.handle.nodeId ?? "", edit.handle.relationshipId ?? ""].join(
     "\u0000",
   );

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -152,6 +152,9 @@ function applyCommandToDocument(
 }
 
 function moveShape(document: PptxSourceModel, command: MoveShapeCommand): PptxSourceModel {
+  requireFiniteEmu(command.offsetX, "moveShape", "offsetX");
+  requireFiniteEmu(command.offsetY, "moveShape", "offsetY");
+
   const current = requireEditableShapeTransform(document, command.handle, "moveShape");
   return updateShapeTransform(document, command.handle, {
     offsetX: command.offsetX,
@@ -162,6 +165,9 @@ function moveShape(document: PptxSourceModel, command: MoveShapeCommand): PptxSo
 }
 
 function resizeShape(document: PptxSourceModel, command: ResizeShapeCommand): PptxSourceModel {
+  requirePositiveFiniteEmu(command.width, "resizeShape", "width");
+  requirePositiveFiniteEmu(command.height, "resizeShape", "height");
+
   const current = requireEditableShapeTransform(document, command.handle, "resizeShape");
   return updateShapeTransform(document, command.handle, {
     offsetX: current.offsetX,
@@ -184,6 +190,26 @@ function requireEditableShapeTransform(
     throw new Error(`${commandName}: shape handle does not reference a shape with xfrm`);
   }
   return shape.transform;
+}
+
+function requireFiniteEmu(
+  value: Emu,
+  commandName: "moveShape" | "resizeShape",
+  fieldName: string,
+): void {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${commandName}: ${fieldName} must be a finite EMU value`);
+  }
+}
+
+function requirePositiveFiniteEmu(
+  value: Emu,
+  commandName: "moveShape" | "resizeShape",
+  fieldName: string,
+): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${commandName}: ${fieldName} must be a finite positive EMU value`);
+  }
 }
 
 function hasTransform(shape: SourceShapeNode): shape is SourceShapeNode & {


### PR DESCRIPTION
close #569

## 目的

editor-core に shape の移動・リサイズ command を追加し、document writer の `updateShapeTransform` 編集スライスへ接続します。これにより、headless 編集 API から xfrm の offset / extent を更新し、undo / redo と write/read round-trip まで扱えるようにします。

## 変更内容

- `packages/editor-core/src/index.ts`
  - `moveShape` / `resizeShape` command を追加
  - 現在の transform を保持しながら offset または extent の片側だけを更新
  - 同一 shape への xfrm edit を最新 1 件に正規化
  - invalid handle / xfrm なし shape / 不正な extent 値を reject
- `packages/editor-core/src/index.test.ts`
  - move + resize の round-trip、undo / redo、invalid command rejection を追加
- `e2e/editor-core-xfrm.test.ts`
  - editor-core command 適用後の PPTX を SVG 変換し、位置・サイズ変更がレンダリングに反映されることを検証

## ローカル検証

- `npm run test -- packages/editor-core/src/index.test.ts e2e/editor-core-xfrm.test.ts`
- `npm run test`
- `npm run knip`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`

`npm run build` は既存の `renderer/src/png/png-converter.ts` に関する `import.meta` CJS warning を出しますが、ビルド自体は成功しています。

## 補足

cross-review で指摘された `resizeShape` の width / height 実値検証不足は、追加 commit で対応済みです。
