### PR TITLE
編集等価性レンダリングテストのハーネスを追加

### DIFF
--- a/e2e/edit-equivalence.test.ts
+++ b/e2e/edit-equivalence.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { replaceTextRunPlainText } from "../packages/document/src/index.js";
+import {
+  assertEditEquivalence,
+  defineEditEquivalenceTests,
+  type EditEquivalenceFixture,
+  type EditEquivalenceOperation,
+} from "../vrt/edit-equivalence.js";
+import {
+  buildPptx,
+  shapeXml,
+  slideRelsXml,
+  textBodyXmlHelper,
+  wrapSlideXml,
+} from "../vrt/snapshot/create-fixtures.js";
+
+const originalTextRunFixture = textRunFixture("source text-run fixture", "Original text");
+const editedTextRunFixture = textRunFixture("expected edited text-run fixture", "Edited text");
+const mismatchedTextRunFixture = textRunFixture(
+  "mismatched expected text-run fixture",
+  "Unexpected text",
+);
+
+const replaceFirstRunWithEditedText = {
+  name: "replace first text run with edited text",
+  apply: (source) => {
+    const run =
+      source.slides[0]?.shapes[0]?.kind === "shape"
+        ? source.slides[0].shapes[0].textBody?.paragraphs[0]?.runs[0]
+        : undefined;
+    if (run?.handle === undefined) throw new Error("editable text run not found");
+    return replaceTextRunPlainText(source, run.handle, "Edited text");
+  },
+} as const satisfies EditEquivalenceOperation;
+
+defineEditEquivalenceTests([
+  {
+    name: "text-run replacement",
+    sourceFixture: originalTextRunFixture,
+    operations: [replaceFirstRunWithEditedText],
+    expectedFixture: editedTextRunFixture,
+    renderOptions: { width: 480 },
+  },
+]);
+
+describe("edit equivalence rendering oracle", { timeout: 60000 }, () => {
+  it("fails when edit operations and expected fixture intentionally disagree", async () => {
+    await expect(
+      assertEditEquivalence({
+        name: "text-run replacement mismatch proof",
+        sourceFixture: originalTextRunFixture,
+        operations: [replaceFirstRunWithEditedText],
+        expectedFixture: mismatchedTextRunFixture,
+        renderOptions: { width: 480 },
+      }),
+    ).rejects.toThrow(/pixels differ/);
+  });
+});
+
+function textRunFixture(name: string, text: string): EditEquivalenceFixture {
+  return {
+    name,
+    create: async () =>
+      await buildPptx({
+        slides: [
+          {
+            xml: wrapSlideXml(textRunShapeXml(text)),
+            rels: slideRelsXml(),
+          },
+        ],
+      }),
+  };
+}
+
+function textRunShapeXml(text: string): string {
+  return shapeXml(2, "Editable Text", {
+    preset: "rect",
+    x: 914400,
+    y: 914400,
+    cx: 5486400,
+    cy: 1371600,
+    fillXml: `<a:solidFill><a:srgbClr val="4472C4"/></a:solidFill>`,
+    outlineXml: `<a:ln w="12700"><a:solidFill><a:srgbClr val="2F528F"/></a:solidFill></a:ln>`,
+    textBodyXml: textBodyXmlHelper(text, {
+      fontSize: 28,
+      color: "FFFFFF",
+      align: "ctr",
+    }),
+  });
+}

--- a/e2e/edit-equivalence.test.ts
+++ b/e2e/edit-equivalence.test.ts
@@ -26,11 +26,11 @@ const originalTextRunFixture = textRunFixture("source text-run fixture", "Origin
 const editedTextRunFixture = textRunFixture("expected edited text-run fixture", "Edited text");
 const mismatchedTextRunFixture = textRunFixture(
   "mismatched expected text-run fixture",
-  "Unexpected text",
+  "Alterd text",
 );
 
 const TEST_FONT_FAMILY = "Pptx Glimpse Edit Equivalence";
-const TEST_FONT_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-font-v1");
+const TEST_FONT_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-font-v2");
 const TEST_FONT_PATH = join(TEST_FONT_DIR, "PptxGlimpseEditEquivalence-Regular.ttf");
 
 const replaceFirstRunWithEditedText = {
@@ -129,13 +129,13 @@ async function createTinyTestFontDir(): Promise<string> {
       advanceWidth: 600,
       path: createGlyphPath(opentype),
     }),
-    ...Array.from(new Set("EditedOriginalUnexpected text")).map(
+    ...Array.from(new Set("EditedOriginalAlterd text")).map(
       (char) =>
         new opentype.Glyph({
           name: char === " " ? "space" : char,
           unicode: char.codePointAt(0),
-          advanceWidth: char === " " ? 300 : 600,
-          path: char === " " ? new opentype.Path() : createGlyphPath(opentype),
+          advanceWidth: glyphAdvanceWidth(char),
+          path: char === " " ? new opentype.Path() : createGlyphPath(opentype, char),
         }),
     ),
   ];
@@ -152,14 +152,23 @@ async function createTinyTestFontDir(): Promise<string> {
   return TEST_FONT_DIR;
 }
 
-function createGlyphPath(opentype: OpentypeModule): OpentypePath {
+function createGlyphPath(opentype: OpentypeModule, char = ".notdef"): OpentypePath {
+  const codePoint = char.codePointAt(0) ?? 0;
+  const width = 220 + (codePoint % 7) * 45;
+  const top = 520 + (codePoint % 5) * 35;
+  const skew = (codePoint % 3) * 35;
   const path = new opentype.Path();
   path.moveTo(100, 0);
-  path.lineTo(500, 0);
-  path.lineTo(500, 700);
-  path.lineTo(100, 700);
+  path.lineTo(100 + width, 0);
+  path.lineTo(100 + width + skew, top);
+  path.lineTo(100 + skew, top);
   path.close();
   return path;
+}
+
+function glyphAdvanceWidth(char: string): number {
+  if (char === " ") return 300;
+  return 440 + ((char.codePointAt(0) ?? 0) % 6) * 45;
 }
 
 interface OpentypeModule {

--- a/e2e/edit-equivalence.test.ts
+++ b/e2e/edit-equivalence.test.ts
@@ -1,5 +1,11 @@
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
+import type { ConvertOptions } from "../packages/core/src/converter.js";
 import { replaceTextRunPlainText } from "../packages/document/src/index.js";
 import {
   assertEditEquivalence,
@@ -14,6 +20,7 @@ import {
   textBodyXmlHelper,
   wrapSlideXml,
 } from "../vrt/snapshot/create-fixtures.js";
+import { unsafeVrtInteropAssertion } from "../vrt/unsafe-type-assertion.js";
 
 const originalTextRunFixture = textRunFixture("source text-run fixture", "Original text");
 const editedTextRunFixture = textRunFixture("expected edited text-run fixture", "Edited text");
@@ -21,6 +28,10 @@ const mismatchedTextRunFixture = textRunFixture(
   "mismatched expected text-run fixture",
   "Unexpected text",
 );
+
+const TEST_FONT_FAMILY = "Pptx Glimpse Edit Equivalence";
+const TEST_FONT_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-font-v1");
+const TEST_FONT_PATH = join(TEST_FONT_DIR, "PptxGlimpseEditEquivalence-Regular.ttf");
 
 const replaceFirstRunWithEditedText = {
   name: "replace first text run with edited text",
@@ -40,6 +51,7 @@ defineEditEquivalenceTests([
     sourceFixture: originalTextRunFixture,
     operations: [replaceFirstRunWithEditedText],
     expectedFixture: editedTextRunFixture,
+    renderOptionsProvider: getTinyTestFontRenderOptions,
     renderOptions: { width: 480 },
   },
 ]);
@@ -52,6 +64,7 @@ describe("edit equivalence rendering oracle", { timeout: 60000 }, () => {
         sourceFixture: originalTextRunFixture,
         operations: [replaceFirstRunWithEditedText],
         expectedFixture: mismatchedTextRunFixture,
+        renderOptionsProvider: getTinyTestFontRenderOptions,
         renderOptions: { width: 480 },
       }),
     ).rejects.toThrow(/pixels differ/);
@@ -85,7 +98,92 @@ function textRunShapeXml(text: string): string {
     textBodyXml: textBodyXmlHelper(text, {
       fontSize: 28,
       color: "FFFFFF",
+      typeface: TEST_FONT_FAMILY,
       align: "ctr",
     }),
   });
+}
+
+let tinyTestFontDirPromise: Promise<string> | null = null;
+
+async function getTinyTestFontRenderOptions(): Promise<ConvertOptions> {
+  return {
+    fontDirs: [await ensureTinyTestFontDir()],
+    skipSystemFonts: true,
+  };
+}
+
+async function ensureTinyTestFontDir(): Promise<string> {
+  tinyTestFontDirPromise ??= createTinyTestFontDir();
+  return tinyTestFontDirPromise;
+}
+
+async function createTinyTestFontDir(): Promise<string> {
+  await mkdir(TEST_FONT_DIR, { recursive: true });
+  if (existsSync(TEST_FONT_PATH)) return TEST_FONT_DIR;
+
+  const opentype = unsafeVrtInteropAssertion<OpentypeModule>(await import("opentype.js"));
+  const glyphs = [
+    new opentype.Glyph({
+      name: ".notdef",
+      advanceWidth: 600,
+      path: createGlyphPath(opentype),
+    }),
+    ...Array.from(new Set("EditedOriginalUnexpected text")).map(
+      (char) =>
+        new opentype.Glyph({
+          name: char === " " ? "space" : char,
+          unicode: char.codePointAt(0),
+          advanceWidth: char === " " ? 300 : 600,
+          path: char === " " ? new opentype.Path() : createGlyphPath(opentype),
+        }),
+    ),
+  ];
+  const font = new opentype.Font({
+    familyName: TEST_FONT_FAMILY,
+    styleName: "Regular",
+    unitsPerEm: 1000,
+    ascender: 800,
+    descender: -200,
+    glyphs,
+  });
+
+  await writeFile(TEST_FONT_PATH, Buffer.from(font.toArrayBuffer()));
+  return TEST_FONT_DIR;
+}
+
+function createGlyphPath(opentype: OpentypeModule): OpentypePath {
+  const path = new opentype.Path();
+  path.moveTo(100, 0);
+  path.lineTo(500, 0);
+  path.lineTo(500, 700);
+  path.lineTo(100, 700);
+  path.close();
+  return path;
+}
+
+interface OpentypeModule {
+  readonly Font: new (options: {
+    familyName: string;
+    styleName: string;
+    unitsPerEm: number;
+    ascender: number;
+    descender: number;
+    glyphs: readonly unknown[];
+  }) => {
+    toArrayBuffer(): ArrayBuffer;
+  };
+  readonly Glyph: new (options: {
+    name: string;
+    unicode?: number;
+    advanceWidth: number;
+    path: OpentypePath;
+  }) => unknown;
+  readonly Path: new () => OpentypePath;
+}
+
+interface OpentypePath {
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  close(): void;
 }

--- a/vrt/compare-utils.ts
+++ b/vrt/compare-utils.ts
@@ -3,14 +3,14 @@ import { dirname } from "path";
 import pixelmatch from "pixelmatch";
 import sharp from "sharp";
 
-interface CompareResult {
+export interface CompareResult {
   totalPixels: number;
   mismatchedPixels: number;
   mismatchPercentage: number;
   passed: boolean;
 }
 
-interface CompareOptions {
+export interface CompareOptions {
   pixelThreshold: number;
   mismatchTolerance: number;
   /** Resize reference image to actual size and compare (for LibreOffice VRT) */
@@ -32,7 +32,7 @@ export async function compareImages(
   return compareImageBuffers(actualPng, readFileSync(referencePath), diffPath, options);
 }
 
-async function compareImageBuffers(
+export async function compareImageBuffers(
   actualPng: Uint8Array | Buffer,
   referencePng: Uint8Array | Buffer,
   diffPath: string,

--- a/vrt/edit-equivalence.ts
+++ b/vrt/edit-equivalence.ts
@@ -39,6 +39,7 @@ interface EditEquivalenceResult {
 const DEFAULT_COMPARE_OPTIONS = {
   pixelThreshold: 0,
   mismatchTolerance: 0,
+  includeAntiAliased: true,
 } as const satisfies CompareOptions;
 
 const DEFAULT_DIFF_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-diffs");

--- a/vrt/edit-equivalence.ts
+++ b/vrt/edit-equivalence.ts
@@ -25,6 +25,7 @@ interface EditEquivalenceCase {
   readonly sourceFixture: EditEquivalenceFixture;
   readonly operations: readonly EditEquivalenceOperation[];
   readonly expectedFixture: EditEquivalenceFixture;
+  readonly renderOptionsProvider?: () => MaybePromise<ConvertOptions>;
   readonly renderOptions?: ConvertOptions;
   readonly compareOptions?: Partial<CompareOptions>;
   readonly diffDir?: string;
@@ -51,7 +52,9 @@ const DEFAULT_DIFF_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-diffs");
  * cannot detect damage to non-rendered PPTX content such as animations, notes,
  * comments, unsupported raw OOXML, or package relationships that do not affect the
  * rendered slide. Those concerns remain covered by writer structural-preservation
- * tests, not by this rendering-equivalence oracle.
+ * tests, not by this rendering-equivalence oracle. Cases use the deterministic VRT
+ * render options by default, but may inject lighter render options when the case does
+ * not need VRT font subsets.
  */
 export function defineEditEquivalenceTests(cases: readonly EditEquivalenceCase[]): void {
   describe("edit equivalence rendering", { timeout: 60000 }, () => {
@@ -79,8 +82,9 @@ export async function assertEditEquivalence(
     readSourceModel(source),
   );
   const editedPptx = writePptx(edited);
+  const baseRenderOptions = await (testCase.renderOptionsProvider?.() ?? getVrtRenderOptions());
   const renderOptions = {
-    ...(await getVrtRenderOptions()),
+    ...baseRenderOptions,
     ...testCase.renderOptions,
   };
   const [actualReport, expectedReport] = await Promise.all([

--- a/vrt/edit-equivalence.ts
+++ b/vrt/edit-equivalence.ts
@@ -1,0 +1,138 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { type ConvertOptions, convertPptxToPng } from "../packages/core/src/converter.js";
+import { type PptxSourceModel, readPptx, writePptx } from "../packages/document/src/index.js";
+import { compareImageBuffers, type CompareOptions, type CompareResult } from "./compare-utils.js";
+import { getVrtRenderOptions } from "./snapshot/render-options.js";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface EditEquivalenceFixture {
+  readonly name: string;
+  readonly create: () => MaybePromise<Buffer | Uint8Array>;
+}
+
+export interface EditEquivalenceOperation {
+  readonly name: string;
+  readonly apply: (source: PptxSourceModel) => PptxSourceModel;
+}
+
+interface EditEquivalenceCase {
+  readonly name: string;
+  readonly sourceFixture: EditEquivalenceFixture;
+  readonly operations: readonly EditEquivalenceOperation[];
+  readonly expectedFixture: EditEquivalenceFixture;
+  readonly renderOptions?: ConvertOptions;
+  readonly compareOptions?: Partial<CompareOptions>;
+  readonly diffDir?: string;
+}
+
+interface EditEquivalenceResult {
+  readonly slideNumber: number;
+  readonly comparison: CompareResult;
+}
+
+const DEFAULT_COMPARE_OPTIONS = {
+  pixelThreshold: 0,
+  mismatchTolerance: 0,
+} as const satisfies CompareOptions;
+
+const DEFAULT_DIFF_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-diffs");
+
+/**
+ * Defines edit-equivalence rendering tests for source-model editing workflows.
+ *
+ * The harness checks the semantic, rendered result of supported edits by comparing
+ * "source fixture + edit operations + writer" against "expected fixture authored in
+ * the same final state" inside one process and one renderer setup. It intentionally
+ * cannot detect damage to non-rendered PPTX content such as animations, notes,
+ * comments, unsupported raw OOXML, or package relationships that do not affect the
+ * rendered slide. Those concerns remain covered by writer structural-preservation
+ * tests, not by this rendering-equivalence oracle.
+ */
+export function defineEditEquivalenceTests(cases: readonly EditEquivalenceCase[]): void {
+  describe("edit equivalence rendering", { timeout: 60000 }, () => {
+    for (const testCase of cases) {
+      it(`${testCase.name}: edited fixture renders like expected fixture`, async () => {
+        await expect(assertEditEquivalence(testCase)).resolves.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              comparison: expect.objectContaining({ passed: true }),
+            }),
+          ]),
+        );
+      });
+    }
+  });
+}
+
+export async function assertEditEquivalence(
+  testCase: EditEquivalenceCase,
+): Promise<readonly EditEquivalenceResult[]> {
+  const source = await testCase.sourceFixture.create();
+  const expected = await testCase.expectedFixture.create();
+  const edited = testCase.operations.reduce(
+    (document, operation) => operation.apply(document),
+    readSourceModel(source),
+  );
+  const editedPptx = writePptx(edited);
+  const renderOptions = {
+    ...(await getVrtRenderOptions()),
+    ...testCase.renderOptions,
+  };
+  const [actualReport, expectedReport] = await Promise.all([
+    convertPptxToPng(editedPptx, renderOptions),
+    convertPptxToPng(expected, renderOptions),
+  ]);
+
+  expect(actualReport.slides.map((slide) => slide.slideNumber)).toEqual(
+    expectedReport.slides.map((slide) => slide.slideNumber),
+  );
+
+  const compareOptions = {
+    ...DEFAULT_COMPARE_OPTIONS,
+    ...testCase.compareOptions,
+  };
+  const results: EditEquivalenceResult[] = [];
+
+  for (const actualSlide of actualReport.slides) {
+    const expectedSlide = expectedReport.slides.find(
+      (slide) => slide.slideNumber === actualSlide.slideNumber,
+    );
+    if (expectedSlide === undefined) {
+      throw new Error(`Expected fixture did not render slide ${actualSlide.slideNumber}.`);
+    }
+
+    const comparison = await compareImageBuffers(
+      actualSlide.png,
+      expectedSlide.png,
+      join(
+        testCase.diffDir ?? DEFAULT_DIFF_DIR,
+        `${slugify(testCase.name)}-slide${actualSlide.slideNumber}-diff.png`,
+      ),
+      compareOptions,
+    );
+    if (!comparison.passed) {
+      throw new Error(
+        `${testCase.name} slide ${actualSlide.slideNumber}: ${(
+          comparison.mismatchPercentage * 100
+        ).toFixed(2)}% pixels differ (${comparison.mismatchedPixels}/${comparison.totalPixels})`,
+      );
+    }
+
+    results.push({ slideNumber: actualSlide.slideNumber, comparison });
+  }
+
+  return results;
+}
+
+function readSourceModel(input: Buffer | Uint8Array): PptxSourceModel {
+  return readPptx(input);
+}
+
+function slugify(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "case";
+}

--- a/vrt/edit-equivalence.ts
+++ b/vrt/edit-equivalence.ts
@@ -87,10 +87,8 @@ export async function assertEditEquivalence(
     ...baseRenderOptions,
     ...testCase.renderOptions,
   };
-  const [actualReport, expectedReport] = await Promise.all([
-    convertPptxToPng(editedPptx, renderOptions),
-    convertPptxToPng(expected, renderOptions),
-  ]);
+  const actualReport = await convertPptxToPng(editedPptx, renderOptions);
+  const expectedReport = await convertPptxToPng(expected, renderOptions);
 
   expect(actualReport.slides.map((slide) => slide.slideNumber)).toEqual(
     expectedReport.slides.map((slide) => slide.slideNumber),

--- a/vrt/snapshot/create-fixtures.ts
+++ b/vrt/snapshot/create-fixtures.ts
@@ -220,6 +220,7 @@ export function textBodyXmlHelper(
     strikethrough?: boolean;
     fontSize?: number;
     color?: string;
+    typeface?: string;
     align?: string;
     anchor?: string;
     wrap?: string;
@@ -234,6 +235,7 @@ export function textBodyXmlHelper(
   const u = opts?.underline ? ` u="sng"` : "";
   const strike = opts?.strikethrough ? ` strike="sngStrike"` : "";
   const fillColor = opts?.color ?? "000000";
+  const latin = opts?.typeface ? `<a:latin typeface="${opts.typeface}"/>` : "";
   const algn = opts?.align ? ` algn="${opts.align}"` : "";
   const anchor = opts?.anchor ?? "ctr";
   const wrap = opts?.wrap ? ` wrap="${opts.wrap}"` : "";
@@ -258,6 +260,7 @@ export function textBodyXmlHelper(
     <a:r>
       <a:rPr lang="en-US"${sz}${b}${i}${u}${strike}>
         <a:solidFill><a:srgbClr val="${fillColor}"/></a:solidFill>
+        ${latin}
       </a:rPr>
       <a:t>${text}</a:t>
     </a:r>

--- a/vrt/snapshot/create-fixtures.ts
+++ b/vrt/snapshot/create-fixtures.ts
@@ -235,7 +235,7 @@ export function textBodyXmlHelper(
   const u = opts?.underline ? ` u="sng"` : "";
   const strike = opts?.strikethrough ? ` strike="sngStrike"` : "";
   const fillColor = opts?.color ?? "000000";
-  const latin = opts?.typeface ? `<a:latin typeface="${opts.typeface}"/>` : "";
+  const latin = opts?.typeface ? `<a:latin typeface="${escapeXmlAttribute(opts.typeface)}"/>` : "";
   const algn = opts?.align ? ` algn="${opts.align}"` : "";
   const anchor = opts?.anchor ?? "ctr";
   const wrap = opts?.wrap ? ` wrap="${opts.wrap}"` : "";
@@ -262,10 +262,18 @@ export function textBodyXmlHelper(
         <a:solidFill><a:srgbClr val="${fillColor}"/></a:solidFill>
         ${latin}
       </a:rPr>
-      <a:t>${text}</a:t>
+      <a:t>${escapeXmlText(text)}</a:t>
     </a:r>
   </a:p>
 </p:txBody>`;
+}
+
+function escapeXmlText(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replace(/"/g, "&quot;");
 }
 
 export function wrapSlideXml(spTreeContent: string, backgroundXml = ""): string {

--- a/vrt/snapshot/create-fixtures.ts
+++ b/vrt/snapshot/create-fixtures.ts
@@ -7,7 +7,7 @@ import { mkdirSync, writeFileSync } from "fs";
 import JSZip from "jszip";
 import { dirname, join } from "path";
 import sharp from "sharp";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 
 import { VRT_CASES } from "./vrt-cases.js";
 
@@ -143,7 +143,7 @@ function gridPosition(
   };
 }
 
-function shapeXml(
+export function shapeXml(
   id: number,
   name: string,
   opts: {
@@ -211,7 +211,7 @@ function outlineXml(
   return `<a:ln w="${width}"${capAttr}><a:solidFill><a:srgbClr val="${color}"/></a:solidFill>${dash}${joinXml}</a:ln>`;
 }
 
-function textBodyXmlHelper(
+export function textBodyXmlHelper(
   text: string,
   opts?: {
     bold?: boolean;
@@ -265,7 +265,7 @@ function textBodyXmlHelper(
 </p:txBody>`;
 }
 
-function wrapSlideXml(spTreeContent: string, backgroundXml = ""): string {
+export function wrapSlideXml(spTreeContent: string, backgroundXml = ""): string {
   return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <p:sld xmlns:a="${NS.a}" xmlns:r="${NS.r}" xmlns:p="${NS.p}">
   <p:cSld>
@@ -281,7 +281,7 @@ function wrapSlideXml(spTreeContent: string, backgroundXml = ""): string {
 </p:sld>`;
 }
 
-function slideRelsXml(
+export function slideRelsXml(
   extraRels: { id: string; type: string; target: string; targetMode?: string }[] = [],
 ): string {
   const extras = extraRels
@@ -315,7 +315,7 @@ interface PptxBuildOptions {
   defaultTextStyleXml?: string;
 }
 
-async function buildPptx(options: PptxBuildOptions): Promise<Buffer> {
+export async function buildPptx(options: PptxBuildOptions): Promise<Buffer> {
   const zip = new JSZip();
 
   // Content_Types
@@ -7100,4 +7100,6 @@ async function main(): Promise<void> {
   console.log("\nDone!");
 }
 
-main().catch(console.error);
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(console.error);
+}


### PR DESCRIPTION
close #571

## 目的

編集 operation 適用後の PPTX レンダリング結果と、同じ最終状態を直接生成した fixture のレンダリング結果を同一プロセスで比較する、編集等価性レンダリングテスト用の共有ハーネスを追加します。

## 変更内容

- `vrt/edit-equivalence.ts` に、元 fixture・編集 operation 列・期待 fixture を宣言的に定義して PNG 比較する helper を追加
- `vrt/compare-utils.ts` の buffer-to-buffer 画像比較を共有利用できるように export
- `vrt/snapshot/create-fixtures.ts` の fixture builder を副作用なしで import できるようにし、text/typeface の XML escape と typeface 指定を追加
- `e2e/edit-equivalence.test.ts` に text-run 編集の等価性ケースと、期待 fixture 不一致時に失敗する negative case を追加

## 検証

- `pnpm test e2e/edit-equivalence.test.ts`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run knip`
- `pnpm run build`

## 備考

- changeset は不要です。公開 package API ではなく、テスト基盤と VRT fixture helper の変更のみです。
