### PR TITLE
editor: dev server に Node バックエンドを追加

### DIFF
--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -1,0 +1,216 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import JSZip from "jszip";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  type PptxSourceModel,
+  readPptx,
+  type SourceShape,
+} from "../packages/document/src/index.js";
+import { createDevServerRequestHandler, DevEditorBackend } from "../scripts/dev-server.js";
+import { unsafeScriptInputAssertion } from "../scripts/unsafe-type-assertion.js";
+
+const encoder = new TextEncoder();
+
+function xml(content: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+describe("dev server editor API", () => {
+  const servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.map((server) => closeServer(server)));
+    servers.length = 0;
+  });
+
+  it("applies text commands, undo/redo, exposes bounds, and saves edited PPTX", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-test-"));
+    try {
+      const sourcePath = join(dir, "fixture.pptx");
+      const savedPath = join(dir, "saved.pptx");
+      await writeFile(sourcePath, await buildTextEditFixture());
+
+      const backend = await DevEditorBackend.load(sourcePath, renderPreview);
+      const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
+      servers.push(server);
+      const baseUrl = await listen(server);
+
+      const shapes = await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`);
+      expect(shapes.shapes[0]).toMatchObject({
+        id: "10",
+        name: "Title",
+        bounds: { x: 96, y: 192, width: 288, height: 96 },
+      });
+      expect(shapes.shapes[0].textRuns[0]).toMatchObject({ text: "Original" });
+
+      const edited = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "replaceTextRunPlainText",
+          handle: shapes.shapes[0].textRuns[0].handle,
+          text: "Edited",
+        },
+      });
+      expect(edited.slides[0].svg).toContain("Edited");
+      expect(edited.history).toMatchObject({ canUndo: true, canRedo: false });
+
+      const undone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/undo`, {});
+      expect(undone.slides[0].svg).toContain("Original");
+      expect(undone.history).toMatchObject({ canUndo: false, canRedo: true });
+
+      const redone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/redo`, {});
+      expect(redone.slides[0].svg).toContain("Edited");
+      expect(redone.history).toMatchObject({ canUndo: true, canRedo: false });
+
+      const saved = await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
+      expect(saved).toMatchObject({ ok: true, path: savedPath });
+      expect(firstRun(readPptx(await readFile(savedPath)))).toBe("Edited");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+interface ShapesResponse {
+  shapes: Array<{
+    id: string;
+    name?: string;
+    bounds?: { x: number; y: number; width: number; height: number };
+    textRuns: Array<{ text: string; handle: unknown }>;
+  }>;
+}
+
+interface SlidesResponse {
+  slides: Array<{ slideNumber: number; svg: string }>;
+  history: { canUndo: boolean; canRedo: boolean };
+}
+
+interface SaveResponse {
+  ok: true;
+  path: string;
+}
+
+function renderPreview(input: Uint8Array): Promise<Array<{ slideNumber: number; svg: string }>> {
+  const source = readPptx(input);
+  return Promise.resolve([
+    { slideNumber: 1, svg: `<svg><text>${escapeXml(firstRun(source))}</text></svg>` },
+  ]);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test server did not expose a TCP port");
+  }
+  return `http://127.0.0.1:${String(address.port)}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  return parseJson<T>(response);
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return parseJson<T>(response);
+}
+
+async function parseJson<T>(response: Response): Promise<T> {
+  const json: unknown = await response.json();
+  if (!response.ok) {
+    throw new Error(JSON.stringify(json));
+  }
+  return unsafeScriptInputAssertion<T>(json);
+}
+
+async function buildTextEditFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="914400" y="1828800"/><a:ext cx="2743200" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+        `<a:p><a:r><a:t>Original</a:t></a:r></a:p>` +
+        `</p:txBody></p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function firstRun(source: PptxSourceModel): string {
+  const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
+  const run = shape?.textBody?.paragraphs[0].runs[0];
+  if (run === undefined) throw new Error("fixture text run not found");
+  return run.text;
+}

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -30,6 +30,7 @@ describe("dev server editor API", () => {
 
   it("applies text commands, undo/redo, exposes bounds, and saves edited PPTX", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-test-"));
+    let outsideDir: string | undefined;
     try {
       const sourcePath = join(dir, "fixture.pptx");
       const savedPath = join(dir, "saved.pptx");
@@ -74,8 +75,24 @@ describe("dev server editor API", () => {
         path: join(tmpdir(), "outside-dev-server-save.pptx"),
       });
       expect(rejectedSave.error).toMatch(/inside the source PPTX directory/);
+
+      const rejectedExtension = await postJsonError(`${baseUrl}/api/editor/save`, {
+        path: join(dir, "saved.txt"),
+      });
+      expect(rejectedExtension.error).toMatch(/\.pptx extension/);
+
+      outsideDir = await mkdtemp(join(tmpdir(), "pptx-glimpse-outside-save-"));
+      const linkPath = join(dir, "outside-link");
+      await symlink(outsideDir, linkPath);
+      const rejectedSymlinkDir = await postJsonError(`${baseUrl}/api/editor/save`, {
+        path: join(linkPath, "saved.pptx"),
+      });
+      expect(rejectedSymlinkDir.error).toMatch(/inside the source PPTX directory/);
     } finally {
       await rm(dir, { recursive: true, force: true });
+      if (outsideDir !== undefined) {
+        await rm(outsideDir, { recursive: true, force: true });
+      }
     }
   });
 });

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -69,6 +69,11 @@ describe("dev server editor API", () => {
       const saved = await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
       expect(saved).toMatchObject({ ok: true, path: savedPath });
       expect(firstRun(readPptx(await readFile(savedPath)))).toBe("Edited");
+
+      const rejectedSave = await postJsonError(`${baseUrl}/api/editor/save`, {
+        path: join(tmpdir(), "outside-dev-server-save.pptx"),
+      });
+      expect(rejectedSave.error).toMatch(/inside the source PPTX directory/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -142,6 +147,17 @@ async function postJson<T>(url: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
   });
   return parseJson<T>(response);
+}
+
+async function postJsonError(url: string, body: unknown): Promise<{ error: string }> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json: unknown = await response.json();
+  expect(response.ok).toBe(false);
+  return unsafeScriptInputAssertion<{ error: string }>(json);
 }
 
 async function parseJson<T>(response: Response): Promise<T> {

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -36,6 +36,10 @@ describe("dev server editor API", () => {
       const savedPath = join(dir, "saved.pptx");
       await writeFile(sourcePath, await buildTextEditFixture());
 
+      const defaultRenderedBackend = await DevEditorBackend.load(sourcePath);
+      expect(defaultRenderedBackend.slides[0].svg).toContain("<svg");
+      expect(defaultRenderedBackend.slides[0].svg).toContain("<text");
+
       const backend = await DevEditorBackend.load(sourcePath, renderPreview);
       const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
       servers.push(server);

--- a/scripts/dev-server-render.ts
+++ b/scripts/dev-server-render.ts
@@ -9,7 +9,11 @@ async function main(): Promise<void> {
   }
 
   const input = readFileSync(pptxPath);
-  const { slides } = await convertPptxToSvg(input, { logLevel: "warn" });
+  const { slides } = await convertPptxToSvg(input, {
+    logLevel: "warn",
+    skipSystemFonts: true,
+    textOutput: "text",
+  });
 
   process.stdout.write(JSON.stringify(slides));
 }

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -3,7 +3,7 @@ import { watch } from "fs";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import { tmpdir } from "os";
-import { basename, dirname, extname, join, resolve } from "path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "path";
 import { pathToFileURL } from "url";
 import { promisify } from "util";
 import { type WebSocket, WebSocketServer } from "ws";
@@ -24,12 +24,7 @@ import { unsafeScriptInputAssertion } from "./unsafe-type-assertion.js";
 
 const DEFAULT_PORT = 3000;
 const DEBOUNCE_MS = 300;
-const WATCH_DIRS = [
-  resolve("packages/core/src"),
-  resolve("packages/document/src"),
-  resolve("packages/editor-core/src"),
-  resolve("packages/renderer/src"),
-];
+const WATCH_DIRS = [resolve("packages/core/src"), resolve("packages/renderer/src")];
 const RENDER_TIMEOUT_MS = 30_000;
 const MAX_BUFFER = 50 * 1024 * 1024;
 const EMU_PER_INCH = 914400;
@@ -108,6 +103,7 @@ async function renderPptxBytes(input: Uint8Array): Promise<SlideSvg[]> {
 export class DevEditorBackend {
   #session: ReturnType<typeof createEditorSession>;
   #slides: SlideSvg[] = [];
+  #dirty = false;
   readonly #render: RenderPptxBytes;
 
   private constructor(
@@ -125,7 +121,7 @@ export class DevEditorBackend {
   ): Promise<DevEditorBackend> {
     const input = await readFile(pptxPath);
     const backend = new DevEditorBackend(pptxPath, readPptx(input), render);
-    await backend.renderCurrentSlides();
+    await backend.renderSlidesFromBytes(input);
     return backend;
   }
 
@@ -153,7 +149,16 @@ export class DevEditorBackend {
   }
 
   async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
-    this.#slides = await this.#render(writePptx(this.#session.document));
+    if (this.#dirty) {
+      await this.renderSlidesFromBytes(writePptx(this.#session.document));
+      return this.#slides;
+    }
+    await this.renderSlidesFromBytes(await readFile(this.sourcePath));
+    return this.#slides;
+  }
+
+  async renderSlidesFromBytes(input: Uint8Array): Promise<readonly SlideSvg[]> {
+    this.#slides = await this.#render(input);
     return this.#slides;
   }
 
@@ -162,6 +167,7 @@ export class DevEditorBackend {
     if (!result.ok) {
       throw new Error(result.message);
     }
+    this.#dirty = true;
     await this.renderCurrentSlides();
     return this.response();
   }
@@ -171,6 +177,7 @@ export class DevEditorBackend {
     if (!result.ok) {
       throw new Error(result.reason);
     }
+    this.#dirty = this.#session.undoDepth > 0;
     await this.renderCurrentSlides();
     return this.response();
   }
@@ -180,12 +187,13 @@ export class DevEditorBackend {
     if (!result.ok) {
       throw new Error(result.reason);
     }
+    this.#dirty = this.#session.undoDepth > 0;
     await this.renderCurrentSlides();
     return this.response();
   }
 
   async save(outputPath?: string): Promise<EditorSaveResponse> {
-    const path = outputPath ?? defaultEditedPath(this.sourcePath);
+    const path = resolveSavePath(this.sourcePath, outputPath);
     const output = writePptx(this.#session.document);
     readPptx(output);
     await writeFile(path, output);
@@ -197,6 +205,22 @@ function defaultEditedPath(sourcePath: string): string {
   const extension = extname(sourcePath);
   const base = basename(sourcePath, extension);
   return join(dirname(sourcePath), `${base}.edited${extension || ".pptx"}`);
+}
+
+function resolveSavePath(sourcePath: string, outputPath?: string): string {
+  const sourceDir = dirname(sourcePath);
+  const path =
+    outputPath === undefined
+      ? defaultEditedPath(sourcePath)
+      : resolve(isAbsolute(outputPath) ? outputPath : join(sourceDir, outputPath));
+  const relativePath = relative(sourceDir, path);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    throw new Error("save path must be inside the source PPTX directory");
+  }
+  if (extname(path).toLowerCase() !== ".pptx") {
+    throw new Error("save path must use the .pptx extension");
+  }
+  return path;
 }
 
 function shapeInfo(shape: SourceShapeNode, index: number): EditorShapeInfo[] {
@@ -449,6 +473,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     var slides = ${jsonForScript(slides)};
     var editorHistory = { canUndo: false, canRedo: false, undoDepth: 0, redoDepth: 0 };
     var textRunOptions = [];
+    var shapeRequestId = 0;
 
     function selectSlide(index) {
       currentIndex = index;
@@ -509,12 +534,14 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function loadShapeOptions(slideNumber) {
+      var requestId = ++shapeRequestId;
       fetch("/api/editor/shapes?slide=" + slideNumber)
         .then(function (res) {
           if (!res.ok) throw new Error("shape request failed");
           return res.json();
         })
         .then(function (data) {
+          if (requestId !== shapeRequestId || slideNumber !== currentIndex + 1) return;
           textRunOptions = [];
           data.shapes.forEach(function (shape) {
             (shape.textRuns || []).forEach(function (run, index) {
@@ -766,7 +793,7 @@ async function handleRequest(
   if (url.pathname === "/api/editor/save" && req.method === "POST") {
     const body = await readJsonBody(req);
     const path = isRecord(body) ? body.path : undefined;
-    sendJson(res, 200, await backend.save(typeof path === "string" ? resolve(path) : undefined));
+    sendJson(res, 200, await backend.save(typeof path === "string" ? path : undefined));
     return;
   }
 
@@ -872,6 +899,9 @@ function parseCliArgs(argv: readonly string[]): { pptxPath?: string; port: numbe
   const args = argv[0] === "--" ? argv.slice(1) : [...argv];
   const portArgIdx = args.indexOf("--port");
   const port = portArgIdx !== -1 ? Number(args[portArgIdx + 1]) : DEFAULT_PORT;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error("--port must be an integer between 1 and 65535");
+  }
   const pptxPath = args.find((arg, index) => {
     if (arg === "--port") return false;
     if (index > 0 && args[index - 1] === "--port") return false;

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,17 +1,39 @@
 import { execFile } from "child_process";
 import { watch } from "fs";
-import { createServer } from "http";
-import { basename, resolve } from "path";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "http";
+import { tmpdir } from "os";
+import { basename, dirname, extname, join, resolve } from "path";
+import { pathToFileURL } from "url";
 import { promisify } from "util";
 import { type WebSocket, WebSocketServer } from "ws";
 
+import {
+  asEmu,
+  asPartPath,
+  asRelationshipId,
+  asSourceNodeId,
+  readPptx,
+  type SourceHandle,
+  type SourceShapeNode,
+  type SourceTextRun,
+  writePptx,
+} from "../packages/document/src/index.js";
+import { createEditorSession, type EditorCommand } from "../packages/editor-core/src/index.js";
 import { unsafeScriptInputAssertion } from "./unsafe-type-assertion.js";
 
 const DEFAULT_PORT = 3000;
 const DEBOUNCE_MS = 300;
-const WATCH_DIRS = [resolve("packages/core/src"), resolve("packages/renderer/src")];
+const WATCH_DIRS = [
+  resolve("packages/core/src"),
+  resolve("packages/document/src"),
+  resolve("packages/editor-core/src"),
+  resolve("packages/renderer/src"),
+];
 const RENDER_TIMEOUT_MS = 30_000;
 const MAX_BUFFER = 50 * 1024 * 1024;
+const EMU_PER_INCH = 914400;
+const DEFAULT_DPI = 96;
 
 const execFileAsync = promisify(execFile);
 
@@ -19,6 +41,47 @@ interface SlideSvg {
   slideNumber: number;
   svg: string;
 }
+
+interface EditorHistoryState {
+  canUndo: boolean;
+  canRedo: boolean;
+  undoDepth: number;
+  redoDepth: number;
+}
+
+interface ShapeBoundsPx {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface EditorTextRunInfo {
+  text: string;
+  handle: SourceHandle;
+}
+
+interface EditorShapeInfo {
+  id: string;
+  kind: SourceShapeNode["kind"];
+  name?: string;
+  handle?: SourceHandle;
+  bounds?: ShapeBoundsPx;
+  textRuns?: EditorTextRunInfo[];
+}
+
+interface EditorSlidesResponse {
+  slides: SlideSvg[];
+  history: EditorHistoryState;
+}
+
+interface EditorSaveResponse {
+  ok: true;
+  path: string;
+  history: EditorHistoryState;
+}
+
+type RenderPptxBytes = (input: Uint8Array) => Promise<SlideSvg[]>;
 
 // --- Rendering via child process ---
 
@@ -29,6 +92,162 @@ async function renderSlides(pptxPath: string): Promise<SlideSvg[]> {
     timeout: RENDER_TIMEOUT_MS,
   });
   return unsafeScriptInputAssertion<SlideSvg[]>(JSON.parse(stdout));
+}
+
+async function renderPptxBytes(input: Uint8Array): Promise<SlideSvg[]> {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-"));
+  const pptxPath = join(dir, "document.pptx");
+  try {
+    await writeFile(pptxPath, input);
+    return await renderSlides(pptxPath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+export class DevEditorBackend {
+  #session: ReturnType<typeof createEditorSession>;
+  #slides: SlideSvg[] = [];
+  readonly #render: RenderPptxBytes;
+
+  private constructor(
+    readonly sourcePath: string,
+    source: ReturnType<typeof readPptx>,
+    render: RenderPptxBytes,
+  ) {
+    this.#session = createEditorSession(source);
+    this.#render = render;
+  }
+
+  static async load(
+    pptxPath: string,
+    render: RenderPptxBytes = renderPptxBytes,
+  ): Promise<DevEditorBackend> {
+    const input = await readFile(pptxPath);
+    const backend = new DevEditorBackend(pptxPath, readPptx(input), render);
+    await backend.renderCurrentSlides();
+    return backend;
+  }
+
+  get slides(): readonly SlideSvg[] {
+    return this.#slides;
+  }
+
+  get history(): EditorHistoryState {
+    return {
+      canUndo: this.#session.canUndo,
+      canRedo: this.#session.canRedo,
+      undoDepth: this.#session.undoDepth,
+      redoDepth: this.#session.redoDepth,
+    };
+  }
+
+  response(): EditorSlidesResponse {
+    return { slides: this.#slides, history: this.history };
+  }
+
+  shapes(slideNumber: number): EditorShapeInfo[] {
+    const slide = this.#session.document.slides[slideNumber - 1];
+    if (slide === undefined) return [];
+    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index));
+  }
+
+  async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
+    this.#slides = await this.#render(writePptx(this.#session.document));
+    return this.#slides;
+  }
+
+  async apply(command: EditorCommand): Promise<EditorSlidesResponse> {
+    const result = this.#session.apply(command);
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    await this.renderCurrentSlides();
+    return this.response();
+  }
+
+  async undo(): Promise<EditorSlidesResponse> {
+    const result = this.#session.undo();
+    if (!result.ok) {
+      throw new Error(result.reason);
+    }
+    await this.renderCurrentSlides();
+    return this.response();
+  }
+
+  async redo(): Promise<EditorSlidesResponse> {
+    const result = this.#session.redo();
+    if (!result.ok) {
+      throw new Error(result.reason);
+    }
+    await this.renderCurrentSlides();
+    return this.response();
+  }
+
+  async save(outputPath?: string): Promise<EditorSaveResponse> {
+    const path = outputPath ?? defaultEditedPath(this.sourcePath);
+    const output = writePptx(this.#session.document);
+    readPptx(output);
+    await writeFile(path, output);
+    return { ok: true, path, history: this.history };
+  }
+}
+
+function defaultEditedPath(sourcePath: string): string {
+  const extension = extname(sourcePath);
+  const base = basename(sourcePath, extension);
+  return join(dirname(sourcePath), `${base}.edited${extension || ".pptx"}`);
+}
+
+function shapeInfo(shape: SourceShapeNode, index: number): EditorShapeInfo[] {
+  const base: EditorShapeInfo = {
+    id: String(shape.nodeId ?? shape.handle?.nodeId ?? `${shape.kind}:${String(index)}`),
+    kind: shape.kind,
+    ...(shapeName(shape) !== undefined ? { name: shapeName(shape) } : {}),
+    ...(shape.handle !== undefined ? { handle: shape.handle } : {}),
+    ...(shape.kind !== "raw" && shape.transform !== undefined
+      ? { bounds: transformBoundsPx(shape.transform) }
+      : {}),
+    ...("textBody" in shape && shape.textBody !== undefined
+      ? {
+          textRuns: collectTextRuns(
+            shape.textBody.paragraphs.flatMap((paragraph) => paragraph.runs),
+          ),
+        }
+      : {}),
+  };
+
+  if (shape.kind !== "group") return [base];
+  return [base, ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex))];
+}
+
+function shapeName(shape: SourceShapeNode): string | undefined {
+  return "name" in shape ? shape.name : undefined;
+}
+
+function collectTextRuns(runs: readonly SourceTextRun[]): EditorTextRunInfo[] {
+  return runs.flatMap((run) => {
+    if (run.handle === undefined) return [];
+    return [{ text: run.text, handle: run.handle }];
+  });
+}
+
+function transformBoundsPx(transform: {
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly width: number;
+  readonly height: number;
+}): ShapeBoundsPx {
+  return {
+    x: emuToPixels(transform.offsetX),
+    y: emuToPixels(transform.offsetY),
+    width: emuToPixels(transform.width),
+    height: emuToPixels(transform.height),
+  };
+}
+
+function emuToPixels(value: number): number {
+  return (value / EMU_PER_INCH) * DEFAULT_DPI;
 }
 
 // --- WebSocket ---
@@ -67,15 +286,7 @@ function watchSourceFiles(onChange: () => void): void {
 // --- HTML template ---
 
 function generateHtml(slides: SlideSvg[], pptxName: string): string {
-  const thumbnailsHtml = slides
-    .map(
-      (s, i) =>
-        `<div class="thumbnail${i === 0 ? " active" : ""}" data-index="${i}">` +
-        `<div class="thumb-label">Slide ${String(s.slideNumber)}</div>` +
-        `<div class="thumb-svg">${s.svg}</div>` +
-        `</div>`,
-    )
-    .join("");
+  const thumbnailsHtml = generateThumbnailsHtml(slides);
 
   const firstSvg = slides.length > 0 ? slides[0].svg : "<p>No slides</p>";
 
@@ -110,6 +321,61 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       background: #16213e;
       padding: 8px;
       border-right: 1px solid #2a2a4a;
+    }
+    #editor-panel {
+      width: 260px;
+      background: #111827;
+      border-left: 1px solid #2a2a4a;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    #editor-panel label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      color: #a0a0c0;
+      font-size: 11px;
+      font-weight: 600;
+    }
+    #editor-panel select,
+    #editor-panel input {
+      width: 100%;
+      min-height: 32px;
+      border: 1px solid #334155;
+      border-radius: 4px;
+      background: #0f172a;
+      color: #e5e7eb;
+      padding: 6px 8px;
+      font: inherit;
+    }
+    #editor-panel button {
+      min-height: 32px;
+      border: 1px solid #475569;
+      border-radius: 4px;
+      background: #1f2937;
+      color: #f8fafc;
+      cursor: pointer;
+      font: inherit;
+      font-weight: 600;
+    }
+    #editor-panel button:hover:not(:disabled) { background: #334155; }
+    #editor-panel button:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+    #editor-actions {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px;
+    }
+    #save-button { grid-column: 1 / -1; }
+    #editor-message {
+      min-height: 18px;
+      color: #94a3b8;
+      font-size: 11px;
+      overflow-wrap: anywhere;
     }
     .thumbnail {
       margin-bottom: 8px;
@@ -164,11 +430,25 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     <div id="viewer">
       <div id="slide-container">${firstSvg}</div>
     </div>
+    <div id="editor-panel">
+      <label>Text run<select id="text-run-select"></select></label>
+      <label>Text<input id="text-run-input" type="text"></label>
+      <button id="apply-text-button" type="button">Apply</button>
+      <div id="editor-actions">
+        <button id="undo-button" type="button">Undo</button>
+        <button id="redo-button" type="button">Redo</button>
+        <button id="save-button" type="button">Save</button>
+      </div>
+      <div id="editor-message"></div>
+    </div>
   </div>
   <div id="info">Slide 1 / ${String(slides.length)}</div>
   <script>
     var currentIndex = 0;
     var slideCount = ${String(slides.length)};
+    var slides = ${jsonForScript(slides)};
+    var editorHistory = { canUndo: false, canRedo: false, undoDepth: 0, redoDepth: 0 };
+    var textRunOptions = [];
 
     function selectSlide(index) {
       currentIndex = index;
@@ -180,9 +460,8 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           thumbs[i].classList.remove("active");
         }
       }
-      var thumb = thumbs[index];
-      var svgHtml = thumb.querySelector(".thumb-svg").innerHTML;
-      document.getElementById("slide-container").innerHTML = svgHtml;
+      document.getElementById("slide-container").innerHTML =
+        slides[index] ? slides[index].svg : "<p>No slides</p>";
       var svg = document.querySelector("#slide-container svg");
       if (svg) {
         svg.removeAttribute("width");
@@ -192,17 +471,165 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       }
       document.getElementById("info").textContent =
         "Slide " + (index + 1) + " / " + slideCount;
+      loadShapeOptions(index + 1);
     }
 
-    // Click handlers for thumbnails
-    var thumbs = document.querySelectorAll(".thumbnail");
-    for (var i = 0; i < thumbs.length; i++) {
-      (function (idx) {
-        thumbs[idx].addEventListener("click", function () {
-          selectSlide(idx);
-        });
-      })(i);
+    function renderThumbnails() {
+      var sidebar = document.getElementById("sidebar");
+      sidebar.innerHTML = slides
+        .map(function (s, i) {
+          return '<div class="thumbnail' + (i === currentIndex ? ' active' : '') +
+            '" data-index="' + i + '">' +
+            '<div class="thumb-label">Slide ' + s.slideNumber + '</div>' +
+            '<div class="thumb-svg">' + s.svg + '</div>' +
+            '</div>';
+        })
+        .join("");
+
+      var thumbs = document.querySelectorAll(".thumbnail");
+      for (var i = 0; i < thumbs.length; i++) {
+        (function (idx) {
+          thumbs[idx].addEventListener("click", function () {
+            selectSlide(idx);
+          });
+        })(i);
+      }
     }
+
+    function updateHistory(history) {
+      editorHistory = history || editorHistory;
+      document.getElementById("undo-button").disabled = !editorHistory.canUndo;
+      document.getElementById("redo-button").disabled = !editorHistory.canRedo;
+    }
+
+    function setEditorMessage(message, isError) {
+      var element = document.getElementById("editor-message");
+      element.textContent = message;
+      element.style.color = isError ? "#fca5a5" : "#94a3b8";
+    }
+
+    function loadShapeOptions(slideNumber) {
+      fetch("/api/editor/shapes?slide=" + slideNumber)
+        .then(function (res) {
+          if (!res.ok) throw new Error("shape request failed");
+          return res.json();
+        })
+        .then(function (data) {
+          textRunOptions = [];
+          data.shapes.forEach(function (shape) {
+            (shape.textRuns || []).forEach(function (run, index) {
+              textRunOptions.push({
+                label: (shape.name || shape.id) + " / " + (index + 1),
+                text: run.text,
+                handle: run.handle
+              });
+            });
+          });
+          var select = document.getElementById("text-run-select");
+          select.innerHTML = textRunOptions
+            .map(function (option, index) {
+              return '<option value="' + index + '">' + escapeHtmlClient(option.label) + '</option>';
+            })
+            .join("");
+          select.disabled = textRunOptions.length === 0;
+          document.getElementById("apply-text-button").disabled = textRunOptions.length === 0;
+          syncTextInput();
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
+    function syncTextInput() {
+      var select = document.getElementById("text-run-select");
+      var input = document.getElementById("text-run-input");
+      var option = textRunOptions[Number(select.value || "0")];
+      input.value = option ? option.text : "";
+      input.disabled = !option;
+    }
+
+    function applyEditorResponse(data) {
+      slides = data.slides || slides;
+      slideCount = slides.length;
+      updateHistory(data.history);
+      renderThumbnails();
+      selectSlide(Math.min(currentIndex, Math.max(slides.length - 1, 0)));
+    }
+
+    function postJson(url, payload) {
+      return fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload || {})
+      }).then(function (res) {
+        return res.json().then(function (data) {
+          if (!res.ok) throw new Error(data.error || "request failed");
+          return data;
+        });
+      });
+    }
+
+    function escapeHtmlClient(value) {
+      return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+    }
+
+    renderThumbnails();
+    updateHistory(editorHistory);
+    loadShapeOptions(1);
+
+    document.getElementById("text-run-select").addEventListener("change", syncTextInput);
+    document.getElementById("apply-text-button").addEventListener("click", function () {
+      var option = textRunOptions[Number(document.getElementById("text-run-select").value || "0")];
+      if (!option) return;
+      postJson("/api/editor/command", {
+        command: {
+          kind: "replaceTextRunPlainText",
+          handle: option.handle,
+          text: document.getElementById("text-run-input").value
+        }
+      })
+        .then(function (data) {
+          applyEditorResponse(data);
+          setEditorMessage("Applied", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    });
+    document.getElementById("undo-button").addEventListener("click", function () {
+      postJson("/api/editor/undo")
+        .then(function (data) {
+          applyEditorResponse(data);
+          setEditorMessage("Undone", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    });
+    document.getElementById("redo-button").addEventListener("click", function () {
+      postJson("/api/editor/redo")
+        .then(function (data) {
+          applyEditorResponse(data);
+          setEditorMessage("Redone", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    });
+    document.getElementById("save-button").addEventListener("click", function () {
+      postJson("/api/editor/save")
+        .then(function (data) {
+          updateHistory(data.history);
+          setEditorMessage("Saved: " + data.path, false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    });
 
     // WebSocket for live reload
     function connect() {
@@ -257,6 +684,18 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
 </html>`;
 }
 
+function generateThumbnailsHtml(slides: SlideSvg[]): string {
+  return slides
+    .map(
+      (s, i) =>
+        `<div class="thumbnail${i === 0 ? " active" : ""}" data-index="${i}">` +
+        `<div class="thumb-label">Slide ${String(s.slideNumber)}</div>` +
+        `<div class="thumb-svg">${s.svg}</div>` +
+        `</div>`,
+    )
+    .join("");
+}
+
 function escapeHtml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
@@ -265,35 +704,198 @@ function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
+function jsonForScript(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+// --- HTTP API ---
+
+export function createDevServerRequestHandler(
+  backend: DevEditorBackend,
+  pptxName: string,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    void handleRequest(req, res, backend, pptxName).catch((error: unknown) => {
+      sendError(res, error);
+    });
+  };
+}
+
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  backend: DevEditorBackend,
+  pptxName: string,
+): Promise<void> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+
+  if (req.method === "GET" && (url.pathname === "/" || url.pathname === "/index.html")) {
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(generateHtml([...backend.slides], pptxName));
+    return;
+  }
+
+  if (url.pathname === "/api/editor/slides" && req.method === "GET") {
+    sendJson(res, 200, backend.response());
+    return;
+  }
+
+  if (url.pathname === "/api/editor/shapes" && req.method === "GET") {
+    const slide = Number(url.searchParams.get("slide") ?? "1");
+    sendJson(res, 200, { slideNumber: slide, shapes: backend.shapes(slide) });
+    return;
+  }
+
+  if (url.pathname === "/api/editor/command" && req.method === "POST") {
+    const body = await readJsonBody(req);
+    const command = normalizeCommand(isRecord(body) ? body.command : undefined);
+    sendJson(res, 200, await backend.apply(command));
+    return;
+  }
+
+  if (url.pathname === "/api/editor/undo" && req.method === "POST") {
+    sendJson(res, 200, await backend.undo());
+    return;
+  }
+
+  if (url.pathname === "/api/editor/redo" && req.method === "POST") {
+    sendJson(res, 200, await backend.redo());
+    return;
+  }
+
+  if (url.pathname === "/api/editor/save" && req.method === "POST") {
+    const body = await readJsonBody(req);
+    const path = isRecord(body) ? body.path : undefined;
+    sendJson(res, 200, await backend.save(typeof path === "string" ? resolve(path) : undefined));
+    return;
+  }
+
+  res.writeHead(404);
+  res.end("Not Found");
+}
+
+function sendJson(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
+
+function sendError(res: ServerResponse, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  sendJson(res, 400, { ok: false, error: message });
+}
+
+function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolveBody, reject) => {
+    let raw = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      raw += chunk;
+      if (raw.length > 1024 * 1024) {
+        req.destroy(new Error("Request body is too large"));
+      }
+    });
+    req.on("end", () => {
+      if (raw.trim() === "") {
+        resolveBody({});
+        return;
+      }
+      try {
+        resolveBody(JSON.parse(raw));
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function normalizeCommand(command: unknown): EditorCommand {
+  if (!isRecord(command)) throw new Error("command must be an object");
+  if (command.kind === "replaceTextRunPlainText") {
+    if (typeof command.text !== "string") {
+      throw new Error("replaceTextRunPlainText.text must be a string");
+    }
+    return {
+      kind: "replaceTextRunPlainText",
+      handle: normalizeHandle(command.handle),
+      text: command.text,
+    };
+  }
+  if (command.kind === "moveShape") {
+    return {
+      kind: "moveShape",
+      handle: normalizeHandle(command.handle),
+      offsetX: asEmu(requireFiniteNumber(command.offsetX, "moveShape.offsetX")),
+      offsetY: asEmu(requireFiniteNumber(command.offsetY, "moveShape.offsetY")),
+    };
+  }
+  if (command.kind === "resizeShape") {
+    return {
+      kind: "resizeShape",
+      handle: normalizeHandle(command.handle),
+      width: asEmu(requireFiniteNumber(command.width, "resizeShape.width")),
+      height: asEmu(requireFiniteNumber(command.height, "resizeShape.height")),
+    };
+  }
+  throw new Error("unsupported command kind");
+}
+
+function normalizeHandle(value: unknown): SourceHandle {
+  if (!isRecord(value)) throw new Error("command.handle must be an object");
+  if (typeof value.partPath !== "string") {
+    throw new Error("command.handle.partPath must be a string");
+  }
+  return {
+    partPath: asPartPath(value.partPath),
+    ...(typeof value.nodeId === "string" ? { nodeId: asSourceNodeId(value.nodeId) } : {}),
+    ...(typeof value.relationshipId === "string"
+      ? { relationshipId: asRelationshipId(value.relationshipId) }
+      : {}),
+    ...(typeof value.orderingSlot === "number" ? { orderingSlot: value.orderingSlot } : {}),
+  };
+}
+
+function requireFiniteNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} must be a finite number`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 // --- Main ---
 
+function parseCliArgs(argv: readonly string[]): { pptxPath?: string; port: number } {
+  const args = argv[0] === "--" ? argv.slice(1) : [...argv];
+  const portArgIdx = args.indexOf("--port");
+  const port = portArgIdx !== -1 ? Number(args[portArgIdx + 1]) : DEFAULT_PORT;
+  const pptxPath = args.find((arg, index) => {
+    if (arg === "--port") return false;
+    if (index > 0 && args[index - 1] === "--port") return false;
+    return true;
+  });
+  return { pptxPath, port };
+}
+
 async function main(): Promise<void> {
-  const pptxPath = process.argv[2];
+  const { pptxPath, port } = parseCliArgs(process.argv.slice(2));
   if (!pptxPath) {
     console.error("Usage: npm run dev -- <pptx-file> [--port <port>]");
     process.exit(1);
   }
-
-  const portArgIdx = process.argv.indexOf("--port");
-  const port = portArgIdx !== -1 ? Number(process.argv[portArgIdx + 1]) : DEFAULT_PORT;
 
   const resolvedPath = resolve(pptxPath);
   const pptxName = basename(resolvedPath);
 
   console.log(`Loading: ${resolvedPath}`);
 
-  let slides = await renderSlides(resolvedPath);
-  console.log(`Rendered ${String(slides.length)} slide(s)`);
+  const backend = await DevEditorBackend.load(resolvedPath);
+  console.log(`Rendered ${String(backend.slides.length)} slide(s)`);
 
-  const server = createServer((req, res) => {
-    if (req.url === "/" || req.url === "/index.html") {
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(generateHtml(slides, pptxName));
-    } else {
-      res.writeHead(404);
-      res.end("Not Found");
-    }
-  });
+  const server = createServer(createDevServerRequestHandler(backend, pptxName));
 
   const wss = new WebSocketServer({ server });
   wss.on("connection", (_ws: WebSocket) => {
@@ -314,10 +916,10 @@ async function main(): Promise<void> {
     console.log("Re-rendering...");
     broadcast(wss, { type: "rendering" });
 
-    renderSlides(resolvedPath)
+    backend
+      .renderCurrentSlides()
       .then((result) => {
-        slides = result;
-        console.log(`Re-rendered ${String(slides.length)} slide(s)`);
+        console.log(`Re-rendered ${String(result.length)} slide(s)`);
         broadcast(wss, { type: "reload" });
       })
       .catch((err: unknown) => {
@@ -331,7 +933,9 @@ async function main(): Promise<void> {
   });
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import { watch } from "fs";
-import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { lstat, mkdtemp, readFile, realpath, rm, writeFile } from "fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import { tmpdir } from "os";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "path";
@@ -24,6 +24,7 @@ import { unsafeScriptInputAssertion } from "./unsafe-type-assertion.js";
 
 const DEFAULT_PORT = 3000;
 const DEBOUNCE_MS = 300;
+// The in-process editor session imports document/editor-core once; restart the server for those changes.
 const WATCH_DIRS = [resolve("packages/core/src"), resolve("packages/renderer/src")];
 const RENDER_TIMEOUT_MS = 30_000;
 const MAX_BUFFER = 50 * 1024 * 1024;
@@ -104,6 +105,7 @@ export class DevEditorBackend {
   #session: ReturnType<typeof createEditorSession>;
   #slides: SlideSvg[] = [];
   #dirty = false;
+  #mutationQueue: Promise<void> = Promise.resolve();
   readonly #render: RenderPptxBytes;
 
   private constructor(
@@ -163,41 +165,58 @@ export class DevEditorBackend {
   }
 
   async apply(command: EditorCommand): Promise<EditorSlidesResponse> {
-    const result = this.#session.apply(command);
-    if (!result.ok) {
-      throw new Error(result.message);
-    }
-    this.#dirty = true;
-    await this.renderCurrentSlides();
-    return this.response();
+    return this.#enqueueMutation(async () => {
+      const result = this.#session.apply(command);
+      if (!result.ok) {
+        throw new Error(result.message);
+      }
+      this.#dirty = true;
+      await this.renderCurrentSlides();
+      return this.response();
+    });
   }
 
   async undo(): Promise<EditorSlidesResponse> {
-    const result = this.#session.undo();
-    if (!result.ok) {
-      throw new Error(result.reason);
-    }
-    this.#dirty = this.#session.undoDepth > 0;
-    await this.renderCurrentSlides();
-    return this.response();
+    return this.#enqueueMutation(async () => {
+      const result = this.#session.undo();
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      this.#dirty = this.#session.undoDepth > 0;
+      await this.renderCurrentSlides();
+      return this.response();
+    });
   }
 
   async redo(): Promise<EditorSlidesResponse> {
-    const result = this.#session.redo();
-    if (!result.ok) {
-      throw new Error(result.reason);
-    }
-    this.#dirty = this.#session.undoDepth > 0;
-    await this.renderCurrentSlides();
-    return this.response();
+    return this.#enqueueMutation(async () => {
+      const result = this.#session.redo();
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      this.#dirty = this.#session.undoDepth > 0;
+      await this.renderCurrentSlides();
+      return this.response();
+    });
   }
 
   async save(outputPath?: string): Promise<EditorSaveResponse> {
-    const path = resolveSavePath(this.sourcePath, outputPath);
-    const output = writePptx(this.#session.document);
-    readPptx(output);
-    await writeFile(path, output);
-    return { ok: true, path, history: this.history };
+    return this.#enqueueMutation(async () => {
+      const path = await resolveSavePath(this.sourcePath, outputPath);
+      const output = writePptx(this.#session.document);
+      readPptx(output);
+      await writeFile(path, output);
+      return { ok: true, path, history: this.history };
+    });
+  }
+
+  #enqueueMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const queued = this.#mutationQueue.then(operation, operation);
+    this.#mutationQueue = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
   }
 }
 
@@ -207,20 +226,35 @@ function defaultEditedPath(sourcePath: string): string {
   return join(dirname(sourcePath), `${base}.edited${extension || ".pptx"}`);
 }
 
-function resolveSavePath(sourcePath: string, outputPath?: string): string {
+async function resolveSavePath(sourcePath: string, outputPath?: string): Promise<string> {
   const sourceDir = dirname(sourcePath);
   const path =
     outputPath === undefined
       ? defaultEditedPath(sourcePath)
       : resolve(isAbsolute(outputPath) ? outputPath : join(sourceDir, outputPath));
-  const relativePath = relative(sourceDir, path);
-  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
-    throw new Error("save path must be inside the source PPTX directory");
-  }
   if (extname(path).toLowerCase() !== ".pptx") {
     throw new Error("save path must use the .pptx extension");
   }
+
+  const existingTarget = await lstat(path).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") return null;
+    throw error;
+  });
+  if (existingTarget?.isSymbolicLink()) {
+    throw new Error("save path must not be a symbolic link");
+  }
+
+  const sourceDirRealPath = await realpath(sourceDir);
+  const outputDirRealPath = await realpath(dirname(path));
+  const relativePath = relative(sourceDirRealPath, outputDirRealPath);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    throw new Error("save path must be inside the source PPTX directory");
+  }
   return path;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }
 
 function shapeInfo(shape: SourceShapeNode, index: number): EditorShapeInfo[] {


### PR DESCRIPTION
close #579

## 目的

フェーズ B ローカルエディターの bootstrap として、既存の `npm run dev` サーバーを拡張し、Node 側で `EditorSession` を保持する HTTP API と最小ブラウザ UI を追加しました。

UI コードは `packages/editor-ui` 新設ではなく、既存 dev server の用途に合わせて `scripts/dev-server.ts` の拡張として配置しています。現時点ではローカル検証用の薄い UI / API 基盤であり、selection handles や text overlay は後続 issue の範囲に残しています。

## 変更内容

- `scripts/dev-server.ts`
  - PPTX 読み込み時に `readPptx` → `createEditorSession` で Node 側 session を保持
  - `/api/editor/slides` / `/api/editor/shapes` / `/api/editor/command` / `/api/editor/undo` / `/api/editor/redo` / `/api/editor/save` を追加
  - text-run 置換の最小 UI、undo / redo / save ボタンを追加
  - shape ID と bounding box(px)、text run handle を API で返却
  - editor mutation を直列化し、保存先を元 PPTX ディレクトリ配下の `.pptx` に制限
- `scripts/dev-server-render.ts`
  - dev preview 用 SVG は system font 全走査を避けるため `skipSystemFonts: true` + `textOutput: "text"` でレンダリング
- `e2e/dev-server-editor.test.ts`
  - HTTP API 経由の command / undo / redo / save / shapes API を検証
  - 保存先制限と dev render worker のデフォルト経路を検証

## ローカル検証

- `pnpm run knip`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run test -- e2e/dev-server-editor.test.ts`
- `npx tsx scripts/dev-server-render.ts shared-fixtures/real-basic-theme.pptx`
- `pnpm run dev -- shared-fixtures/real-basic-theme.pptx --port 3305`
  - `/`
  - `/api/editor/slides`
  - `/api/editor/shapes?slide=1`
