### PR TITLE
editor-core: selection state を導入する

### DIFF
--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -128,6 +128,99 @@ describe("EditorSession text-run commands", () => {
   });
 });
 
+describe("EditorSession selection", () => {
+  it("selects and deselects a shape without changing undo history", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstShape(source).handle);
+
+    const selected = session.selectShape(handle);
+
+    expect(selected).toEqual({
+      ok: true,
+      selection: { shapeHandle: handle },
+    });
+    expect(session.selection).toEqual({ shapeHandle: handle });
+    expect(session.undoDepth).toBe(0);
+    expect(session.redoDepth).toBe(0);
+
+    session.deselectShape();
+
+    expect(session.selection).toBeUndefined();
+    expect(session.undoDepth).toBe(0);
+    expect(session.redoDepth).toBe(0);
+  });
+
+  it("rejects missing shape selection without changing selection", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstShape(source).handle);
+    const missingHandle = {
+      partPath: asPartPath("ppt/slides/slide1.xml"),
+      nodeId: asSourceNodeId("999"),
+      orderingSlot: 99,
+    } satisfies SourceHandle;
+
+    expect(session.selectShape(handle)).toMatchObject({ ok: true });
+    const rejected = session.selectShape(missingHandle);
+
+    expect(rejected).toMatchObject({
+      ok: false,
+      code: "invalid-selection",
+    });
+    expect(rejected.ok).toBe(false);
+    if (!rejected.ok) {
+      expect(rejected.message).toMatch(/shape handle was not found/);
+    }
+    expect(session.selection).toEqual({ shapeHandle: handle });
+    expect(session.undoDepth).toBe(0);
+    expect(session.redoDepth).toBe(0);
+  });
+
+  it("keeps shape selection across move and resize edits, undo, and redo", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstShape(source).handle);
+
+    expect(session.selectShape(handle)).toMatchObject({ ok: true });
+    expectApplied(
+      session.apply({
+        kind: "moveShape",
+        handle,
+        offsetX: asEmu(1000),
+        offsetY: asEmu(2000),
+      }),
+    );
+    expectApplied(
+      session.apply({
+        kind: "resizeShape",
+        handle,
+        width: asEmu(3000),
+        height: asEmu(4000),
+      }),
+    );
+
+    expect(session.selection).toEqual({ shapeHandle: handle });
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
+
+    expectHistory(session.undo());
+    expect(session.selection).toEqual({ shapeHandle: handle });
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
+
+    expectHistory(session.undo());
+    expect(session.selection).toEqual({ shapeHandle: handle });
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
+
+    expectHistory(session.redo());
+    expect(session.selection).toEqual({ shapeHandle: handle });
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
+
+    expectHistory(session.redo());
+    expect(session.selection).toEqual({ shapeHandle: handle });
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
+  });
+});
+
 describe("EditorSession xfrm commands", () => {
   it("applies move and resize edits and persists them through write/read round-trip", async () => {
     const source = readPptx(await buildTextEditFixture());

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -56,6 +56,21 @@ export type EditorHistoryResult =
       readonly reason: "empty-undo-stack" | "empty-redo-stack";
     };
 
+export interface EditorSelection {
+  readonly shapeHandle: SourceHandle;
+}
+
+export type EditorSelectShapeResult =
+  | {
+      readonly ok: true;
+      readonly selection: EditorSelection;
+    }
+  | {
+      readonly ok: false;
+      readonly code: "invalid-selection";
+      readonly message: string;
+    };
+
 interface HistoryEntry {
   readonly before: PptxSourceModel;
   readonly after: PptxSourceModel;
@@ -63,6 +78,7 @@ interface HistoryEntry {
 
 export class EditorSession {
   #document: PptxSourceModel;
+  #selection: EditorSelection | undefined;
   readonly #undoStack: HistoryEntry[] = [];
   readonly #redoStack: HistoryEntry[] = [];
 
@@ -72,6 +88,10 @@ export class EditorSession {
 
   get document(): PptxSourceModel {
     return this.#document;
+  }
+
+  get selection(): EditorSelection | undefined {
+    return this.#selection;
   }
 
   get canUndo(): boolean {
@@ -88,6 +108,24 @@ export class EditorSession {
 
   get redoDepth(): number {
     return this.#redoStack.length;
+  }
+
+  selectShape(handle: SourceHandle): EditorSelectShapeResult {
+    if (findShapeNodeBySourceHandle(this.#document, handle) === undefined) {
+      return {
+        ok: false,
+        code: "invalid-selection",
+        message: "selectShape: shape handle was not found in PptxSourceModel source",
+      };
+    }
+
+    const selection = { shapeHandle: handle };
+    this.#selection = selection;
+    return { ok: true, selection };
+  }
+
+  deselectShape(): void {
+    this.#selection = undefined;
   }
 
   apply(command: EditorCommand): EditorApplyCommandResult {


### PR DESCRIPTION
close #580

## 目的

フェーズ B の UI 要件に向けて、`@pptx-glimpse/editor-core` の `EditorSession` に headless な単一 shape selection state を追加します。

## 変更内容

- `EditorSession` に `selection` getter、`selectShape(handle)`、`deselectShape()` を追加
- 存在しない shape handle の selection を `invalid-selection` として reject し、既存 selection を維持
- selection を undo/redo 履歴とは独立した session state として扱い、move / resize および undo / redo をまたいでも維持
- `packages/editor-core/src/index.test.ts` に DOM 不要の vitest を追加

## 影響パッケージ / パス

- `packages/editor-core/src/index.ts`
- `packages/editor-core/src/index.test.ts`

## 検証

- `npm run test -- packages/editor-core/src/index.test.ts`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run build`

## 補足

- `@pptx-glimpse/editor-core` は private package のため changeset は追加していません。
- `npm run build` では既存の `import.meta` CJS warning が renderer/core で表示されますが、ビルドは成功しています。
