### PR TITLE
editor: PPTX paragraph/run 構造と ProseMirror schema の対応を実装する

### DIFF
--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -19,8 +19,7 @@
   },
   "dependencies": {
     "@pptx-glimpse/document": "workspace:*",
-    "prosemirror-model": "^1.25.9",
-    "prosemirror-transform": "^1.12.0"
+    "prosemirror-model": "^1.25.9"
   },
   "files": [
     "dist"
@@ -28,5 +27,8 @@
   "engines": {
     "node": ">=22"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "prosemirror-transform": "^1.12.0"
+  }
 }

--- a/packages/editor-core/package.json
+++ b/packages/editor-core/package.json
@@ -18,7 +18,9 @@
     "build": "tsup"
   },
   "dependencies": {
-    "@pptx-glimpse/document": "workspace:*"
+    "@pptx-glimpse/document": "workspace:*",
+    "prosemirror-model": "^1.25.9",
+    "prosemirror-transform": "^1.12.0"
   },
   "files": [
     "dist"

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -11,12 +11,18 @@ import {
   writePptx,
 } from "@pptx-glimpse/document";
 import JSZip from "jszip";
+import { Node as ProseMirrorNode } from "prosemirror-model";
+import { Transform } from "prosemirror-transform";
 import { describe, expect, it } from "vitest";
 
 import {
   createEditorSession,
   type EditorApplyCommandResult,
   type EditorHistoryResult,
+  pptxTextBodySchema,
+  proseMirrorDocJsonToEditorCommands,
+  proseMirrorDocJsonToTextBody,
+  textBodyToProseMirrorDocJson,
 } from "./index.js";
 
 const encoder = new TextEncoder();
@@ -125,6 +131,57 @@ describe("EditorSession text-run commands", () => {
     expect(session.canUndo).toBe(false);
     expect(session.canRedo).toBe(false);
     expect(session.undo()).toEqual({ ok: false, reason: "empty-undo-stack" });
+  });
+});
+
+describe("ProseMirror text body conversion", () => {
+  it("round-trips paragraph and run text with source properties", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const textBody = firstTextBody(source);
+    const docJson = textBodyToProseMirrorDocJson(textBody);
+    const roundTripped = proseMirrorDocJsonToTextBody(textBody, docJson);
+
+    expect(roundTripped.paragraphs).toEqual(textBody.paragraphs);
+    expect(roundTripped.paragraphs[0].runs[0].properties).toEqual(
+      textBody.paragraphs[0].runs[0].properties,
+    );
+    expect(roundTripped.paragraphs[0].runs[1].properties).toEqual(
+      textBody.paragraphs[0].runs[1].properties,
+    );
+  });
+
+  it("turns a run-crossing ProseMirror replacement into writer-persisted run edits", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const textBody = firstTextBody(source);
+    const doc = ProseMirrorNode.fromJSON(
+      pptxTextBodySchema,
+      textBodyToProseMirrorDocJson(textBody),
+    );
+    const firstRunMark = doc.firstChild?.child(0).marks[0];
+    if (firstRunMark === undefined) throw new Error("first run mark not found");
+    const transform = new Transform(doc).replaceWith(
+      1 + "Orig".length,
+      1 + "Original Ke".length,
+      pptxTextBodySchema.text("X", [firstRunMark]),
+    );
+    const editedJson: unknown = transform.doc.toJSON();
+    const commands = proseMirrorDocJsonToEditorCommands(textBody, editedJson);
+    const session = createEditorSession(source);
+
+    for (const command of commands) {
+      expectApplied(session.apply(command));
+    }
+    const reread = readPptx(writePptx(session.document));
+
+    expect(commands).toHaveLength(2);
+    expect(firstParagraph(session.document).runs.map((run) => run.text)).toEqual(["OrigX", "ep "]);
+    expect(firstParagraph(reread).runs.map((run) => run.text)).toEqual(["OrigX", "ep "]);
+    expect(firstParagraph(reread).runs[0].properties).toEqual(
+      firstParagraph(source).runs[0].properties,
+    );
+    expect(firstParagraph(reread).runs[1].properties).toEqual(
+      firstParagraph(source).runs[1].properties,
+    );
   });
 });
 
@@ -426,7 +483,10 @@ async function buildTextEditFixture(): Promise<Uint8Array> {
         `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
         `<p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300" cy="400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
         `<p:txBody><a:bodyPr/><a:lstStyle/>` +
-        `<a:p><a:r><a:t>Original</a:t></a:r><a:r><a:t xml:space="preserve"> Keep </a:t></a:r></a:p>` +
+        `<a:p><a:pPr algn="ctr"/>` +
+        `<a:r><a:rPr b="1" sz="2400"><a:latin typeface="Aptos"/><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr><a:t>Original</a:t></a:r>` +
+        `<a:r><a:rPr i="1" sz="1800"><a:latin typeface="Arial"/></a:rPr><a:t xml:space="preserve"> Keep </a:t></a:r>` +
+        `</a:p>` +
         `</p:txBody></p:sp>` +
         `<p:sp><p:nvSpPr><p:cNvPr id="11" name="No xfrm"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
         `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
@@ -457,6 +517,10 @@ function firstShape(source: PptxSourceModel): SourceShape {
 
 function firstParagraph(source: PptxSourceModel) {
   return firstShape(source).textBody!.paragraphs[0];
+}
+
+function firstTextBody(source: PptxSourceModel) {
+  return firstShape(source).textBody!;
 }
 
 function firstRun(source: PptxSourceModel) {

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -220,6 +220,24 @@ describe("ProseMirror text body conversion", () => {
     ]);
     expect(firstParagraph(reread).runs.map((run) => run.text)).toEqual([" Keep Original"]);
   });
+
+  it("rejects text bodies with empty or unsupported run-like content", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const textBody = firstTextBody(source);
+    const paragraph = textBody.paragraphs[0];
+    const run = paragraph.runs[0];
+    const withEmptyRun = {
+      ...textBody,
+      paragraphs: [{ ...paragraph, runs: [{ ...run, text: "" }] }],
+    };
+    const withBreakRun = {
+      ...textBody,
+      paragraphs: [{ ...paragraph, runs: [{ ...run, text: "\n" }] }],
+    };
+
+    expect(() => textBodyToProseMirrorDocJson(withEmptyRun)).toThrow(/empty text runs/);
+    expect(() => textBodyToProseMirrorDocJson(withBreakRun)).toThrow(/unsupported run-like/);
+  });
 });
 
 describe("EditorSession selection", () => {

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -183,6 +183,43 @@ describe("ProseMirror text body conversion", () => {
       firstParagraph(source).runs[1].properties,
     );
   });
+
+  it("falls back to paragraph replacement when run mark order changes", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const textBody = firstTextBody(source);
+    const docJson = textBodyToProseMirrorDocJson(textBody);
+    const paragraph = docJson.content?.[0];
+    const firstText = paragraph?.content?.[0];
+    const secondText = paragraph?.content?.[1];
+    if (paragraph === undefined || firstText === undefined || secondText === undefined) {
+      throw new Error("text body doc fixture is missing expected text nodes");
+    }
+    const editedJson = {
+      type: "doc",
+      content: [
+        {
+          ...paragraph,
+          content: [secondText, firstText],
+        },
+      ],
+    };
+    const commands = proseMirrorDocJsonToEditorCommands(textBody, editedJson);
+    const session = createEditorSession(source);
+
+    for (const command of commands) {
+      expectApplied(session.apply(command));
+    }
+    const reread = readPptx(writePptx(session.document));
+
+    expect(commands).toEqual([
+      {
+        kind: "replaceParagraphPlainText",
+        handle: firstParagraph(source).handle,
+        text: " Keep Original",
+      },
+    ]);
+    expect(firstParagraph(reread).runs.map((run) => run.text)).toEqual([" Keep Original"]);
+  });
 });
 
 describe("EditorSession selection", () => {

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -326,16 +326,25 @@ function editHandleNodeKey(
     | PptxSourceModelParagraphTextEdit
     | PptxSourceModelShapeTransformEdit,
 ): string {
-  return [edit.handle.partPath, edit.handle.nodeId ?? "", edit.handle.relationshipId ?? ""].join(
-    "\u0000",
-  );
+  return [
+    edit.handle.partPath,
+    edit.handle.nodeId ?? "",
+    edit.handle.relationshipId ?? "",
+    edit.handle.orderingSlot ?? "",
+  ].join("\u0000");
 }
 
 function textRunParagraphEditKey(edit: PptxSourceModelTextRunEdit): string | undefined {
   const nodeId = String(edit.handle.nodeId ?? "");
-  const byShapeId = /^(text:shape:.+:p:\d+):r:\d+$/.exec(nodeId);
-  const byShapeSlot = /^(text:shapeSlot:\d+:p:\d+):r:\d+$/.exec(nodeId);
+  const byShapeId = /^(text:shape:.+:p:(\d+)):r:\d+$/.exec(nodeId);
+  const byShapeSlot = /^(text:shapeSlot:\d+:p:(\d+)):r:\d+$/.exec(nodeId);
   const paragraphNodeId = byShapeId?.[1] ?? byShapeSlot?.[1];
+  const paragraphOrderingSlot = byShapeId?.[2] ?? byShapeSlot?.[2] ?? "";
   if (paragraphNodeId === undefined) return undefined;
-  return [edit.handle.partPath, paragraphNodeId, edit.handle.relationshipId ?? ""].join("\u0000");
+  return [
+    edit.handle.partPath,
+    paragraphNodeId,
+    edit.handle.relationshipId ?? "",
+    paragraphOrderingSlot,
+  ].join("\u0000");
 }

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -3,8 +3,10 @@ import {
   findShapeNodeBySourceHandle,
   type PptxSourceModel,
   type PptxSourceModelEdit,
+  type PptxSourceModelParagraphTextEdit,
   type PptxSourceModelShapeTransformEdit,
   type PptxSourceModelTextRunEdit,
+  replaceParagraphPlainText,
   replaceTextRunPlainText,
   type SourceHandle,
   type SourceShapeNode,
@@ -12,8 +14,26 @@ import {
   updateShapeTransform,
 } from "@pptx-glimpse/document";
 
+export {
+  type PptxTextBodyProseMirrorCommand,
+  type PptxTextBodyProseMirrorDocJson,
+  type PptxTextBodyProseMirrorParagraphJson,
+  type PptxTextBodyProseMirrorRunMarkJson,
+  type PptxTextBodyProseMirrorTextJson,
+  pptxTextBodySchema,
+  proseMirrorDocJsonToEditorCommands,
+  proseMirrorDocJsonToTextBody,
+  textBodyToProseMirrorDocJson,
+} from "./prosemirror-text-body.js";
+
 export interface ReplaceTextRunPlainTextCommand {
   readonly kind: "replaceTextRunPlainText";
+  readonly handle: SourceHandle;
+  readonly text: string;
+}
+
+export interface ReplaceParagraphPlainTextCommand {
+  readonly kind: "replaceParagraphPlainText";
   readonly handle: SourceHandle;
   readonly text: string;
 }
@@ -32,7 +52,11 @@ export interface ResizeShapeCommand {
   readonly height: Emu;
 }
 
-export type EditorCommand = ReplaceTextRunPlainTextCommand | MoveShapeCommand | ResizeShapeCommand;
+export type EditorCommand =
+  | ReplaceTextRunPlainTextCommand
+  | ReplaceParagraphPlainTextCommand
+  | MoveShapeCommand
+  | ResizeShapeCommand;
 
 export type EditorApplyCommandResult =
   | {
@@ -182,6 +206,8 @@ function applyCommandToDocument(
   switch (command.kind) {
     case "replaceTextRunPlainText":
       return replaceTextRunPlainText(document, command.handle, command.text);
+    case "replaceParagraphPlainText":
+      return replaceParagraphPlainText(document, command.handle, command.text);
     case "moveShape":
       return moveShape(document, command);
     case "resizeShape":
@@ -261,6 +287,7 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
   if (edits === undefined) return document;
 
   const seenTextRuns = new Set<string>();
+  const seenParagraphs = new Set<string>();
   const seenShapeTransforms = new Set<string>();
   const normalizedReversed: PptxSourceModelEdit[] = [];
 
@@ -268,8 +295,15 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
     const edit = edits[index];
     if (edit.kind === "replaceTextRunPlainText") {
       const key = editHandleNodeKey(edit);
+      const paragraphKey = textRunParagraphEditKey(edit);
+      if (paragraphKey !== undefined && seenParagraphs.has(paragraphKey)) continue;
       if (seenTextRuns.has(key)) continue;
       seenTextRuns.add(key);
+    }
+    if (edit.kind === "replaceParagraphPlainText") {
+      const key = editHandleNodeKey(edit);
+      if (seenParagraphs.has(key)) continue;
+      seenParagraphs.add(key);
     }
     if (edit.kind === "updateShapeTransform") {
       const key = editHandleNodeKey(edit);
@@ -287,9 +321,21 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
 }
 
 function editHandleNodeKey(
-  edit: PptxSourceModelTextRunEdit | PptxSourceModelShapeTransformEdit,
+  edit:
+    | PptxSourceModelTextRunEdit
+    | PptxSourceModelParagraphTextEdit
+    | PptxSourceModelShapeTransformEdit,
 ): string {
   return [edit.handle.partPath, edit.handle.nodeId ?? "", edit.handle.relationshipId ?? ""].join(
     "\u0000",
   );
+}
+
+function textRunParagraphEditKey(edit: PptxSourceModelTextRunEdit): string | undefined {
+  const nodeId = String(edit.handle.nodeId ?? "");
+  const byShapeId = /^(text:shape:.+:p:\d+):r:\d+$/.exec(nodeId);
+  const byShapeSlot = /^(text:shapeSlot:\d+:p:\d+):r:\d+$/.exec(nodeId);
+  const paragraphNodeId = byShapeId?.[1] ?? byShapeSlot?.[1];
+  if (paragraphNodeId === undefined) return undefined;
+  return [edit.handle.partPath, paragraphNodeId, edit.handle.relationshipId ?? ""].join("\u0000");
 }

--- a/packages/editor-core/src/prosemirror-text-body.ts
+++ b/packages/editor-core/src/prosemirror-text-body.ts
@@ -1,0 +1,374 @@
+import {
+  asPartPath,
+  asRelationshipId,
+  asSourceNodeId,
+  type SourceHandle,
+  type SourceParagraph,
+  type SourceRunProperties,
+  type SourceTextBody,
+  type SourceTextRun,
+} from "@pptx-glimpse/document";
+import { Node as ProseMirrorNode, Schema } from "prosemirror-model";
+
+export const pptxTextBodySchema = new Schema({
+  nodes: {
+    doc: { content: "paragraph*" },
+    paragraph: {
+      content: "text*",
+      attrs: {
+        handle: { default: null },
+        properties: { default: null },
+      },
+      toDOM: () => ["p", 0],
+    },
+    text: { group: "inline" },
+  },
+  marks: {
+    pptxRun: {
+      attrs: {
+        handle: { default: null },
+        properties: { default: null },
+      },
+      toDOM: () => ["span", { "data-pptx-run": "" }, 0],
+    },
+  },
+});
+
+export interface PptxTextBodyProseMirrorDocJson {
+  readonly type: "doc";
+  readonly content?: readonly PptxTextBodyProseMirrorParagraphJson[];
+}
+
+export interface PptxTextBodyProseMirrorParagraphJson {
+  readonly type: "paragraph";
+  readonly attrs?: {
+    readonly handle?: SourceHandle | null;
+    readonly properties?: unknown;
+  };
+  readonly content?: readonly PptxTextBodyProseMirrorTextJson[];
+}
+
+export interface PptxTextBodyProseMirrorTextJson {
+  readonly type: "text";
+  readonly text: string;
+  readonly marks?: readonly PptxTextBodyProseMirrorRunMarkJson[];
+}
+
+export interface PptxTextBodyProseMirrorRunMarkJson {
+  readonly type: "pptxRun";
+  readonly attrs?: {
+    readonly handle?: SourceHandle | null;
+    readonly properties?: unknown;
+  };
+}
+
+export type PptxTextBodyProseMirrorCommand =
+  | {
+      readonly kind: "replaceTextRunPlainText";
+      readonly handle: SourceHandle;
+      readonly text: string;
+    }
+  | {
+      readonly kind: "replaceParagraphPlainText";
+      readonly handle: SourceHandle;
+      readonly text: string;
+    };
+
+interface RunGroup {
+  readonly handle?: SourceHandle;
+  readonly properties?: SourceRunProperties;
+  readonly text: string;
+}
+
+export function textBodyToProseMirrorDocJson(
+  textBody: SourceTextBody,
+): PptxTextBodyProseMirrorDocJson {
+  return {
+    type: "doc",
+    content: textBody.paragraphs.map((paragraph) => {
+      const content: PptxTextBodyProseMirrorTextJson[] = paragraph.runs
+        .filter((run) => run.text.length > 0)
+        .map((run) => ({
+          type: "text",
+          text: run.text,
+          marks: [
+            {
+              type: "pptxRun",
+              attrs: {
+                handle: run.handle ?? null,
+                properties: run.properties ?? null,
+              },
+            },
+          ],
+        }));
+
+      return {
+        type: "paragraph",
+        attrs: {
+          handle: paragraph.handle ?? null,
+          properties: paragraph.properties ?? null,
+        },
+        ...(content.length > 0 ? { content } : {}),
+      };
+    }),
+  };
+}
+
+export function proseMirrorDocJsonToTextBody(
+  originalTextBody: SourceTextBody,
+  docJson: unknown,
+): SourceTextBody {
+  const parsed = parsePptxTextBodyProseMirrorDocJson(docJson);
+  validateProseMirrorDocJson(parsed);
+  const paragraphs = (parsed.content ?? []).map((paragraph, index) =>
+    paragraphJsonToSourceParagraph(originalTextBody.paragraphs[index], paragraph),
+  );
+
+  return {
+    ...originalTextBody,
+    paragraphs,
+  };
+}
+
+export function proseMirrorDocJsonToEditorCommands(
+  originalTextBody: SourceTextBody,
+  docJson: unknown,
+): readonly PptxTextBodyProseMirrorCommand[] {
+  const editedTextBody = proseMirrorDocJsonToTextBody(originalTextBody, docJson);
+  if (editedTextBody.paragraphs.length !== originalTextBody.paragraphs.length) {
+    throw new Error("proseMirrorDocJsonToEditorCommands: paragraph count changes are unsupported");
+  }
+
+  return editedTextBody.paragraphs.flatMap<PptxTextBodyProseMirrorCommand>(
+    (editedParagraph, paragraphIndex) => {
+      const originalParagraph = originalTextBody.paragraphs[paragraphIndex];
+      if (originalParagraph === undefined) return [];
+      if (paragraphRunHandlesMatch(originalParagraph, editedParagraph)) {
+        return editedParagraph.runs.flatMap<PptxTextBodyProseMirrorCommand>(
+          (editedRun, runIndex) => {
+            const originalRun = originalParagraph.runs[runIndex];
+            if (originalRun === undefined || editedRun.text === originalRun.text) return [];
+            if (editedRun.handle === undefined) {
+              throw new Error(
+                "proseMirrorDocJsonToEditorCommands: changed text run has no source handle",
+              );
+            }
+            return [
+              {
+                kind: "replaceTextRunPlainText",
+                handle: editedRun.handle,
+                text: editedRun.text,
+              },
+            ];
+          },
+        );
+      }
+
+      if (editedParagraph.handle === undefined) {
+        throw new Error(
+          "proseMirrorDocJsonToEditorCommands: paragraph structure changed but paragraph has no source handle",
+        );
+      }
+      return [
+        {
+          kind: "replaceParagraphPlainText",
+          handle: editedParagraph.handle,
+          text: paragraphPlainText(editedParagraph),
+        },
+      ];
+    },
+  );
+}
+
+function validateProseMirrorDocJson(docJson: PptxTextBodyProseMirrorDocJson): void {
+  const doc = ProseMirrorNode.fromJSON(pptxTextBodySchema, docJson);
+  doc.check();
+}
+
+function paragraphJsonToSourceParagraph(
+  originalParagraph: SourceParagraph | undefined,
+  paragraphJson: PptxTextBodyProseMirrorParagraphJson,
+): SourceParagraph {
+  const originalRunKeys = (originalParagraph?.runs ?? []).map((run) =>
+    run.handle === undefined ? undefined : sourceHandleKey(run.handle),
+  );
+  const groups = collectRunGroups(paragraphJson, originalParagraph);
+  const groupsByKey = new Map(
+    groups.flatMap((group) => {
+      const key = group.handle === undefined ? undefined : sourceHandleKey(group.handle);
+      return key === undefined ? [] : [[key, group]];
+    }),
+  );
+  const emittedKeys = new Set<string>();
+  const orderedRuns: SourceTextRun[] = [];
+
+  for (const originalRun of originalParagraph?.runs ?? []) {
+    const key = originalRun.handle === undefined ? undefined : sourceHandleKey(originalRun.handle);
+    const group = key === undefined ? undefined : groupsByKey.get(key);
+    if (key !== undefined) emittedKeys.add(key);
+    orderedRuns.push(sourceRunFromGroup(group ?? emptyGroupForOriginalRun(originalRun)));
+  }
+
+  for (const group of groups) {
+    const key = group.handle === undefined ? undefined : sourceHandleKey(group.handle);
+    if (key !== undefined && (emittedKeys.has(key) || originalRunKeys.includes(key))) continue;
+    orderedRuns.push(sourceRunFromGroup(group));
+  }
+
+  return {
+    ...(originalParagraph ?? {}),
+    runs: orderedRuns,
+    ...(originalParagraph?.properties !== undefined
+      ? { properties: originalParagraph.properties }
+      : {}),
+    ...(originalParagraph?.handle !== undefined
+      ? { handle: originalParagraph.handle }
+      : sourceHandleFromUnknown(paragraphJson.attrs?.handle) !== undefined
+        ? { handle: sourceHandleFromUnknown(paragraphJson.attrs?.handle) }
+        : {}),
+  };
+}
+
+function collectRunGroups(
+  paragraphJson: PptxTextBodyProseMirrorParagraphJson,
+  originalParagraph: SourceParagraph | undefined,
+): readonly RunGroup[] {
+  const groups: RunGroup[] = [];
+  let previousHandle = originalParagraph?.runs[0]?.handle;
+
+  for (const textNode of paragraphJson.content ?? []) {
+    const mark = textNode.marks?.find((candidate) => candidate.type === "pptxRun");
+    const markedHandle = sourceHandleFromUnknown(mark?.attrs?.handle);
+    const handle = markedHandle ?? previousHandle;
+    const originalRun =
+      handle === undefined ? undefined : findOriginalRun(originalParagraph, handle);
+    const properties = originalRun?.properties;
+    const lastGroup = groups.at(-1);
+
+    if (lastGroup !== undefined && sourceHandlesEqual(lastGroup.handle, handle)) {
+      groups[groups.length - 1] = {
+        ...lastGroup,
+        text: lastGroup.text + textNode.text,
+      };
+    } else {
+      groups.push({
+        ...(handle !== undefined ? { handle } : {}),
+        ...(properties !== undefined ? { properties } : {}),
+        text: textNode.text,
+      });
+    }
+    previousHandle = handle;
+  }
+
+  return groups;
+}
+
+function sourceRunFromGroup(group: RunGroup): SourceTextRun {
+  return {
+    kind: "textRun",
+    text: group.text,
+    ...(group.properties !== undefined ? { properties: group.properties } : {}),
+    ...(group.handle !== undefined ? { handle: group.handle } : {}),
+  };
+}
+
+function emptyGroupForOriginalRun(run: SourceTextRun): RunGroup {
+  return {
+    ...(run.handle !== undefined ? { handle: run.handle } : {}),
+    ...(run.properties !== undefined ? { properties: run.properties } : {}),
+    text: "",
+  };
+}
+
+function findOriginalRun(
+  paragraph: SourceParagraph | undefined,
+  handle: SourceHandle,
+): SourceTextRun | undefined {
+  return paragraph?.runs.find((run) => sourceHandlesEqual(run.handle, handle));
+}
+
+function paragraphRunHandlesMatch(
+  originalParagraph: SourceParagraph,
+  editedParagraph: SourceParagraph,
+): boolean {
+  if (originalParagraph.runs.length !== editedParagraph.runs.length) return false;
+  return originalParagraph.runs.every((run, index) =>
+    sourceHandlesEqual(run.handle, editedParagraph.runs[index]?.handle),
+  );
+}
+
+function paragraphPlainText(paragraph: SourceParagraph): string {
+  return paragraph.runs.map((run) => run.text).join("");
+}
+
+function parsePptxTextBodyProseMirrorDocJson(value: unknown): PptxTextBodyProseMirrorDocJson {
+  if (!isRecord(value) || value.type !== "doc") {
+    throw new Error("ProseMirror text body doc JSON must be a doc node");
+  }
+  if (value.content !== undefined && readArray(value.content, isParagraphJson) === undefined) {
+    throw new Error("ProseMirror text body doc JSON content must contain paragraph nodes");
+  }
+  const content = readArray(value.content, isParagraphJson);
+  return {
+    type: "doc",
+    ...(content !== undefined ? { content } : {}),
+  };
+}
+
+function isParagraphJson(value: unknown): value is PptxTextBodyProseMirrorParagraphJson {
+  if (!isRecord(value) || value.type !== "paragraph") return false;
+  if (value.content !== undefined && readArray(value.content, isTextJson) === undefined) {
+    return false;
+  }
+  return value.attrs === undefined || isRecord(value.attrs);
+}
+
+function isTextJson(value: unknown): value is PptxTextBodyProseMirrorTextJson {
+  if (!isRecord(value) || value.type !== "text" || typeof value.text !== "string") return false;
+  if (value.marks === undefined) return true;
+  return readArray(value.marks, isRunMarkJson) !== undefined;
+}
+
+function isRunMarkJson(value: unknown): value is PptxTextBodyProseMirrorRunMarkJson {
+  if (!isRecord(value) || value.type !== "pptxRun") return false;
+  return value.attrs === undefined || isRecord(value.attrs);
+}
+
+function readArray<T>(
+  value: unknown,
+  itemGuard: (item: unknown) => item is T,
+): readonly T[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return undefined;
+  return value.every(itemGuard) ? value : undefined;
+}
+
+function sourceHandleFromUnknown(value: unknown): SourceHandle | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (!isRecord(value) || typeof value.partPath !== "string") return undefined;
+  const handle = {
+    partPath: asPartPath(value.partPath),
+    ...(typeof value.nodeId === "string" ? { nodeId: asSourceNodeId(value.nodeId) } : {}),
+    ...(typeof value.relationshipId === "string"
+      ? { relationshipId: asRelationshipId(value.relationshipId) }
+      : {}),
+    ...(typeof value.orderingSlot === "number" ? { orderingSlot: value.orderingSlot } : {}),
+  } satisfies SourceHandle;
+  return handle;
+}
+
+function sourceHandlesEqual(
+  left: SourceHandle | undefined,
+  right: SourceHandle | undefined,
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return sourceHandleKey(left) === sourceHandleKey(right);
+}
+
+function sourceHandleKey(handle: SourceHandle): string {
+  return [handle.partPath, handle.nodeId ?? "", handle.relationshipId ?? ""].join("\u0000");
+}
+
+function isRecord(value: unknown): value is { readonly [key: string]: unknown } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/editor-core/src/prosemirror-text-body.ts
+++ b/packages/editor-core/src/prosemirror-text-body.ts
@@ -41,6 +41,7 @@ export interface PptxTextBodyProseMirrorDocJson {
 
 export interface PptxTextBodyProseMirrorParagraphJson {
   readonly type: "paragraph";
+  /** Read-only source metadata. Formatting edits are not applied from ProseMirror JSON. */
   readonly attrs?: {
     readonly handle?: SourceHandle | null;
     readonly properties?: unknown;
@@ -56,6 +57,7 @@ export interface PptxTextBodyProseMirrorTextJson {
 
 export interface PptxTextBodyProseMirrorRunMarkJson {
   readonly type: "pptxRun";
+  /** Read-only source metadata. Formatting edits are not applied from ProseMirror JSON. */
   readonly attrs?: {
     readonly handle?: SourceHandle | null;
     readonly properties?: unknown;
@@ -83,24 +85,23 @@ interface RunGroup {
 export function textBodyToProseMirrorDocJson(
   textBody: SourceTextBody,
 ): PptxTextBodyProseMirrorDocJson {
+  assertSupportedTextBody(textBody);
   return {
     type: "doc",
     content: textBody.paragraphs.map((paragraph) => {
-      const content: PptxTextBodyProseMirrorTextJson[] = paragraph.runs
-        .filter((run) => run.text.length > 0)
-        .map((run) => ({
-          type: "text",
-          text: run.text,
-          marks: [
-            {
-              type: "pptxRun",
-              attrs: {
-                handle: run.handle ?? null,
-                properties: run.properties ?? null,
-              },
+      const content: PptxTextBodyProseMirrorTextJson[] = paragraph.runs.map((run) => ({
+        type: "text",
+        text: run.text,
+        marks: [
+          {
+            type: "pptxRun",
+            attrs: {
+              handle: run.handle ?? null,
+              properties: run.properties ?? null,
             },
-          ],
-        }));
+          },
+        ],
+      }));
 
       return {
         type: "paragraph",
@@ -112,6 +113,23 @@ export function textBodyToProseMirrorDocJson(
       };
     }),
   };
+}
+
+function assertSupportedTextBody(textBody: SourceTextBody): void {
+  textBody.paragraphs.forEach((paragraph, paragraphIndex) => {
+    paragraph.runs.forEach((run, runIndex) => {
+      if (run.text.length === 0) {
+        throw new Error(
+          `textBodyToProseMirrorDocJson: empty text runs are unsupported at paragraph ${paragraphIndex}, run ${runIndex}`,
+        );
+      }
+      if (run.text.includes("\n") || (run.rawSidecars?.length ?? 0) > 0) {
+        throw new Error(
+          `textBodyToProseMirrorDocJson: unsupported run-like content at paragraph ${paragraphIndex}, run ${runIndex}`,
+        );
+      }
+    });
+  });
 }
 
 export function proseMirrorDocJsonToTextBody(

--- a/packages/editor-core/src/prosemirror-text-body.ts
+++ b/packages/editor-core/src/prosemirror-text-body.ts
@@ -189,35 +189,11 @@ function paragraphJsonToSourceParagraph(
   originalParagraph: SourceParagraph | undefined,
   paragraphJson: PptxTextBodyProseMirrorParagraphJson,
 ): SourceParagraph {
-  const originalRunKeys = (originalParagraph?.runs ?? []).map((run) =>
-    run.handle === undefined ? undefined : sourceHandleKey(run.handle),
-  );
   const groups = collectRunGroups(paragraphJson, originalParagraph);
-  const groupsByKey = new Map(
-    groups.flatMap((group) => {
-      const key = group.handle === undefined ? undefined : sourceHandleKey(group.handle);
-      return key === undefined ? [] : [[key, group]];
-    }),
-  );
-  const emittedKeys = new Set<string>();
-  const orderedRuns: SourceTextRun[] = [];
-
-  for (const originalRun of originalParagraph?.runs ?? []) {
-    const key = originalRun.handle === undefined ? undefined : sourceHandleKey(originalRun.handle);
-    const group = key === undefined ? undefined : groupsByKey.get(key);
-    if (key !== undefined) emittedKeys.add(key);
-    orderedRuns.push(sourceRunFromGroup(group ?? emptyGroupForOriginalRun(originalRun)));
-  }
-
-  for (const group of groups) {
-    const key = group.handle === undefined ? undefined : sourceHandleKey(group.handle);
-    if (key !== undefined && (emittedKeys.has(key) || originalRunKeys.includes(key))) continue;
-    orderedRuns.push(sourceRunFromGroup(group));
-  }
 
   return {
     ...(originalParagraph ?? {}),
-    runs: orderedRuns,
+    runs: groups.map(sourceRunFromGroup),
     ...(originalParagraph?.properties !== undefined
       ? { properties: originalParagraph.properties }
       : {}),
@@ -269,14 +245,6 @@ function sourceRunFromGroup(group: RunGroup): SourceTextRun {
     text: group.text,
     ...(group.properties !== undefined ? { properties: group.properties } : {}),
     ...(group.handle !== undefined ? { handle: group.handle } : {}),
-  };
-}
-
-function emptyGroupForOriginalRun(run: SourceTextRun): RunGroup {
-  return {
-    ...(run.handle !== undefined ? { handle: run.handle } : {}),
-    ...(run.properties !== undefined ? { properties: run.properties } : {}),
-    text: "",
   };
 }
 
@@ -366,7 +334,12 @@ function sourceHandlesEqual(
 }
 
 function sourceHandleKey(handle: SourceHandle): string {
-  return [handle.partPath, handle.nodeId ?? "", handle.relationshipId ?? ""].join("\u0000");
+  return [
+    handle.partPath,
+    handle.nodeId ?? "",
+    handle.relationshipId ?? "",
+    handle.orderingSlot ?? "",
+  ].join("\u0000");
 }
 
 function isRecord(value: unknown): value is { readonly [key: string]: unknown } {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,12 @@ importers:
       '@pptx-glimpse/document':
         specifier: workspace:*
         version: link:../document
+      prosemirror-model:
+        specifier: ^1.25.9
+        version: 1.25.9
+      prosemirror-transform:
+        specifier: ^1.12.0
+        version: 1.12.0
 
   packages/renderer:
     dependencies:
@@ -2017,6 +2023,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -2148,6 +2157,12 @@ packages:
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  prosemirror-model@1.25.9:
+    resolution: {integrity: sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4182,6 +4197,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  orderedmap@2.1.1: {}
+
   outdent@0.5.0: {}
 
   oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
@@ -4298,6 +4315,14 @@ snapshots:
   prettier@3.8.3: {}
 
   process-nextick-args@2.0.1: {}
+
+  prosemirror-model@1.25.9:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.9
 
   punycode@2.3.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,7 @@ importers:
       prosemirror-model:
         specifier: ^1.25.9
         version: 1.25.9
+    devDependencies:
       prosemirror-transform:
         specifier: ^1.12.0
         version: 1.12.0


### PR DESCRIPTION
close #581

## 目的

PPTX の text body と ProseMirror doc JSON の双方向変換を editor-core に追加し、フェーズ B の text editing MVP で使う headless 変換基盤を用意します。

## 変更内容

- `packages/editor-core` に PPTX paragraph/run 用の ProseMirror schema と JSON 変換 API を追加
- ProseMirror doc JSON から editor-core command 列へ戻す処理を追加
- writer 対応範囲外の空 run / unsupported run-like content は lossy 変換せず reject
- run 順序が崩れた場合は paragraph replacement にフォールバック
- `document` には ProseMirror 依存を追加せず、依存は editor-core に限定

## 検証

- `pnpm exec vitest run packages/editor-core/src/index.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test`
- `pnpm run build`

`pnpm run build` では既存の `import.meta` CJS warning が出ますが、ビルド自体は成功しています。