### PR TITLE
ローカルエディターに shape 選択・移動・リサイズ UI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Test with coverage
         run: pnpm run test:coverage
 
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Playwright tests
+        run: pnpm run test:playwright
+
       - name: Upload coverage report
         if: matrix.node-version == 22
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.tgz
 .DS_Store
 coverage/
+test-results/
 output/
 scripts/fonts/
 vrt/snapshot/diffs/

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -193,31 +193,37 @@ async function startDevServer(
     },
   );
 
-  await new Promise<void>((resolve, reject) => {
-    let output = "";
-    const timeout = setTimeout(() => {
-      reject(new Error(`dev server did not start:\n${output}`));
-    }, 30_000);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      let output = "";
+      const timeout = setTimeout(() => {
+        reject(new Error(`dev server did not start:\n${output}`));
+      }, 30_000);
 
-    child.stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString("utf8");
-      if (output.includes("Dev server running")) {
+      child.stdout.on("data", (chunk: Buffer) => {
+        output += chunk.toString("utf8");
+        if (output.includes("Dev server running")) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        output += chunk.toString("utf8");
+      });
+      child.on("error", (error) => {
         clearTimeout(timeout);
-        resolve();
-      }
+        reject(error);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        reject(new Error(`dev server exited with code ${String(code)}:\n${output}`));
+      });
     });
-    child.stderr.on("data", (chunk: Buffer) => {
-      output += chunk.toString("utf8");
-    });
-    child.on("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
-    });
-    child.on("exit", (code) => {
-      clearTimeout(timeout);
-      reject(new Error(`dev server exited with code ${String(code)}:\n${output}`));
-    });
-  });
+  } catch (error) {
+    child.kill();
+    await waitForExit(child);
+    throw error;
+  }
 
   return child;
 }
@@ -233,7 +239,7 @@ async function closeServer(server: Server): Promise<void> {
 }
 
 async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
-  if (child.exitCode !== null || child.killed) return;
+  if (child.exitCode !== null || child.signalCode !== null) return;
   await new Promise<void>((resolve) => {
     child.once("exit", () => resolve());
   });

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -75,10 +75,17 @@ async function dragSvgPoint(
 ) {
   const start = await svgPointToClient(page, from.x, from.y);
   const end = await svgPointToClient(page, to.x, to.y);
+  const commandResponse = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/editor/command") &&
+      response.request().method() === "POST" &&
+      response.ok(),
+  );
   await page.mouse.move(start.x, start.y);
   await page.mouse.down();
   await page.mouse.move(end.x, end.y, { steps: 6 });
   await page.mouse.up();
+  await commandResponse;
 }
 
 async function svgPointToClient(
@@ -169,7 +176,7 @@ function firstShape(source: PptxSourceModel): SourceShape {
 async function findFreePort(): Promise<number> {
   const server = createServer();
   await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
+    server.listen(0, resolve);
   });
   const address = server.address();
   if (address === null || typeof address === "string") {

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -1,0 +1,240 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, type Page, test } from "@playwright/test";
+import JSZip from "jszip";
+
+import {
+  type PptxSourceModel,
+  readPptx,
+  type SourceShape,
+} from "../packages/document/src/index.js";
+
+const encoder = new TextEncoder();
+const EMU_PER_PIXEL = 9525;
+
+test("selects a shape, moves and resizes it, then saves xfrm edits", async ({ page }) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-editor-ui-test-"));
+  let serverProcess: ChildProcessWithoutNullStreams | undefined;
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    await writeFile(sourcePath, await buildShapeFixture());
+
+    const port = await findFreePort();
+    serverProcess = await startDevServer(sourcePath, port);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+    await page.goto(baseUrl);
+    const hitArea = page.getByTestId("shape-hit-area").first();
+    await expect(hitArea).toBeVisible();
+
+    await clickSvgPoint(page, 240, 240);
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "96");
+    await expect(page.getByTestId("selection-handle-se")).toBeVisible();
+
+    await dragSvgPoint(page, { x: 240, y: 240 }, { x: 264, y: 256 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "120");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "208");
+
+    await dragSvgPoint(page, { x: 408, y: 304 }, { x: 456, y: 328 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("height", "120");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+
+    const saved = readPptx(await readFile(savedPath));
+    expect(firstShape(saved).transform).toMatchObject({
+      offsetX: 120 * EMU_PER_PIXEL,
+      offsetY: 208 * EMU_PER_PIXEL,
+      width: 336 * EMU_PER_PIXEL,
+      height: 120 * EMU_PER_PIXEL,
+    });
+  } finally {
+    if (serverProcess !== undefined) {
+      serverProcess.kill();
+      await waitForExit(serverProcess);
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function clickSvgPoint(page: Page, x: number, y: number) {
+  const point = await svgPointToClient(page, x, y);
+  await page.mouse.click(point.x, point.y);
+}
+
+async function dragSvgPoint(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+) {
+  const start = await svgPointToClient(page, from.x, from.y);
+  const end = await svgPointToClient(page, to.x, to.y);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x, end.y, { steps: 6 });
+  await page.mouse.up();
+}
+
+async function svgPointToClient(
+  page: Page,
+  x: number,
+  y: number,
+): Promise<{ x: number; y: number }> {
+  return page.evaluate(
+    ({ svgX, svgY }) => {
+      const overlay = document.getElementById("selection-overlay");
+      if (!(overlay instanceof SVGSVGElement)) throw new Error("selection overlay not found");
+      const point = overlay.createSVGPoint();
+      point.x = svgX;
+      point.y = svgY;
+      const matrix = overlay.getScreenCTM();
+      if (matrix === null) throw new Error("selection overlay matrix not found");
+      const screenPoint = point.matrixTransform(matrix);
+      return { x: screenPoint.x, y: screenPoint.y };
+    },
+    { svgX: x, svgY: y },
+  );
+}
+
+function xml(content: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+async function buildShapeFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Box"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="914400" y="1828800"/><a:ext cx="2743200" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `</p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function firstShape(source: PptxSourceModel): SourceShape {
+  const shape = source.slides[0]?.shapes.find((node): node is SourceShape => node.kind === "shape");
+  if (shape === undefined) throw new Error("fixture shape not found");
+  return shape;
+}
+
+async function findFreePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test server did not expose a TCP port");
+  }
+  const port = address.port;
+  await closeServer(server);
+  return port;
+}
+
+async function startDevServer(
+  sourcePath: string,
+  port: number,
+): Promise<ChildProcessWithoutNullStreams> {
+  const child = spawn(
+    "pnpm",
+    ["exec", "tsx", "scripts/dev-server.ts", sourcePath, "--port", String(port)],
+    {
+      cwd: new URL("..", import.meta.url),
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    let output = "";
+    const timeout = setTimeout(() => {
+      reject(new Error(`dev server did not start:\n${output}`));
+    }, 30_000);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+      if (output.includes("Dev server running")) {
+        clearTimeout(timeout);
+        resolve();
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`dev server exited with code ${String(code)}:\n${output}`));
+    });
+  });
+
+  return child;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.killed) return;
+  await new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+  });
+}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -13,6 +13,7 @@ const config: KnipConfig = {
         "scripts/extract-font-metrics.ts",
         "vrt/snapshot/update-snapshots.ts",
         "bench/conversion.bench.ts",
+        "e2e/dev-server-editor.playwright.ts",
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write 'packages/*/src/**/*.ts' 'vrt/**/*.ts' 'scripts/**/*.ts' 'bench/**/*.ts' 'e2e/**/*.ts'",
     "format:check": "prettier --check 'packages/*/src/**/*.ts' 'vrt/**/*.ts' 'scripts/**/*.ts' 'bench/**/*.ts' 'e2e/**/*.ts'",
     "test": "vitest run",
-    "test:playwright": "pnpm run build && playwright test",
+    "test:playwright": "playwright test",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write 'packages/*/src/**/*.ts' 'vrt/**/*.ts' 'scripts/**/*.ts' 'bench/**/*.ts' 'e2e/**/*.ts'",
     "format:check": "prettier --check 'packages/*/src/**/*.ts' 'vrt/**/*.ts' 'scripts/**/*.ts' 'bench/**/*.ts' 'e2e/**/*.ts'",
     "test": "vitest run",
+    "test:playwright": "pnpm run build && playwright test",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^25.2.2",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "4.1.0",

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -426,6 +426,40 @@ describe("EditorSession xfrm commands", () => {
     });
   });
 
+  it("applies a full transform edit as one undoable command", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstShape(source).handle);
+
+    const edited = expectApplied(
+      session.apply({
+        kind: "setShapeTransform",
+        handle,
+        offsetX: asEmu(1000),
+        offsetY: asEmu(2000),
+        width: asEmu(3000),
+        height: asEmu(4000),
+      }),
+    );
+
+    expect(session.undoDepth).toBe(1);
+    expect(requireShape(findShapeNodeBySourceHandle(edited, handle)).transform).toMatchObject({
+      offsetX: 1000,
+      offsetY: 2000,
+      width: 3000,
+      height: 4000,
+    });
+    expect(edited.edits?.filter((edit) => edit.kind === "updateShapeTransform")).toHaveLength(1);
+
+    expectHistory(session.undo());
+    expect(firstShape(session.document).transform).toMatchObject({
+      offsetX: 100,
+      offsetY: 200,
+      width: 300,
+      height: 400,
+    });
+  });
+
   it("rejects invalid xfrm commands without changing document state or undo history", async () => {
     const source = readPptx(await buildTextEditFixture());
     const session = createEditorSession(source);

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -52,11 +52,21 @@ export interface ResizeShapeCommand {
   readonly height: Emu;
 }
 
+export interface SetShapeTransformCommand {
+  readonly kind: "setShapeTransform";
+  readonly handle: SourceHandle;
+  readonly offsetX: Emu;
+  readonly offsetY: Emu;
+  readonly width: Emu;
+  readonly height: Emu;
+}
+
 export type EditorCommand =
   | ReplaceTextRunPlainTextCommand
   | ReplaceParagraphPlainTextCommand
   | MoveShapeCommand
-  | ResizeShapeCommand;
+  | ResizeShapeCommand
+  | SetShapeTransformCommand;
 
 export type EditorApplyCommandResult =
   | {
@@ -212,6 +222,8 @@ function applyCommandToDocument(
       return moveShape(document, command);
     case "resizeShape":
       return resizeShape(document, command);
+    case "setShapeTransform":
+      return setShapeTransform(document, command);
   }
 }
 
@@ -241,10 +253,28 @@ function resizeShape(document: PptxSourceModel, command: ResizeShapeCommand): Pp
   });
 }
 
+function setShapeTransform(
+  document: PptxSourceModel,
+  command: SetShapeTransformCommand,
+): PptxSourceModel {
+  requireFiniteEmu(command.offsetX, "setShapeTransform", "offsetX");
+  requireFiniteEmu(command.offsetY, "setShapeTransform", "offsetY");
+  requirePositiveFiniteEmu(command.width, "setShapeTransform", "width");
+  requirePositiveFiniteEmu(command.height, "setShapeTransform", "height");
+
+  requireEditableShapeTransform(document, command.handle, "setShapeTransform");
+  return updateShapeTransform(document, command.handle, {
+    offsetX: command.offsetX,
+    offsetY: command.offsetY,
+    width: command.width,
+    height: command.height,
+  });
+}
+
 function requireEditableShapeTransform(
   document: PptxSourceModel,
   handle: SourceHandle,
-  commandName: "moveShape" | "resizeShape",
+  commandName: "moveShape" | "resizeShape" | "setShapeTransform",
 ): SourceTransform {
   const shape = findShapeNodeBySourceHandle(document, handle);
   if (shape === undefined) {
@@ -258,7 +288,7 @@ function requireEditableShapeTransform(
 
 function requireFiniteEmu(
   value: Emu,
-  commandName: "moveShape" | "resizeShape",
+  commandName: "moveShape" | "resizeShape" | "setShapeTransform",
   fieldName: string,
 ): void {
   if (!Number.isFinite(value)) {
@@ -268,7 +298,7 @@ function requireFiniteEmu(
 
 function requirePositiveFiniteEmu(
   value: Emu,
-  commandName: "moveShape" | "resizeShape",
+  commandName: "moveShape" | "resizeShape" | "setShapeTransform",
   fieldName: string,
 ): void {
   if (!Number.isFinite(value) || value <= 0) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /.*\.playwright\.ts/,
+  timeout: 60_000,
+  use: {
+    browserName: "chromium",
+    viewport: { width: 1280, height: 720 },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.31.0(@types/node@25.9.1)
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@types/node':
         specifier: ^25.2.2
         version: 25.9.1
@@ -901,6 +904,11 @@ packages:
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@resvg/resvg-wasm@2.6.2':
     resolution: {integrity: sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==}
     engines: {node: '>= 10'}
@@ -1775,6 +1783,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2115,6 +2128,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -3170,6 +3193,10 @@ snapshots:
 
   '@package-json/types@0.0.12': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@resvg/resvg-wasm@2.6.2': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
@@ -3958,6 +3985,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4291,6 +4321,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@7.0.0: {}
 

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -190,12 +190,14 @@ export class DevEditorBackend {
     });
   }
 
-  selectShape(handle: SourceHandle): EditorSlidesResponse {
-    const result = this.#session.selectShape(handle);
-    if (!result.ok) {
-      throw new Error(result.message);
-    }
-    return this.response();
+  async selectShape(handle: SourceHandle): Promise<EditorSlidesResponse> {
+    return this.#enqueueMutation(() => {
+      const result = this.#session.selectShape(handle);
+      if (!result.ok) {
+        throw new Error(result.message);
+      }
+      return Promise.resolve(this.response());
+    });
   }
 
   async undo(): Promise<EditorSlidesResponse> {
@@ -290,7 +292,10 @@ function shapeInfo(
     ...(shapeName(shape) !== undefined ? { name: shapeName(shape) } : {}),
     ...(shape.handle !== undefined ? { handle: shape.handle } : {}),
     ...(shape.kind !== "raw" && shape.transform !== undefined
-      ? { bounds: transformBoundsPx(shape.transform), editableTransform }
+      ? {
+          bounds: transformBoundsPx(shape.transform),
+          editableTransform: editableTransform && isEditableTransformShape(shape),
+        }
       : {}),
     ...("textBody" in shape && shape.textBody !== undefined
       ? {
@@ -310,6 +315,13 @@ function shapeInfo(
 
 function shapeName(shape: SourceShapeNode): string | undefined {
   return "name" in shape ? shape.name : undefined;
+}
+
+function isEditableTransformShape(shape: SourceShapeNode): boolean {
+  if (shape.kind === "raw" || shape.transform === undefined || shape.handle?.nodeId === undefined) {
+    return false;
+  }
+  return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
 }
 
 function collectTextRuns(runs: readonly SourceTextRun[]): EditorTextRunInfo[] {
@@ -946,38 +958,22 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     function applyShapeBoundsEdit(startBounds, nextBounds) {
       if (!selectedShape || !selectedShape.handle) return Promise.resolve();
       var handle = selectedShape.handle;
-      var moved =
+      var changed =
         Math.round(startBounds.x) !== Math.round(nextBounds.x) ||
-        Math.round(startBounds.y) !== Math.round(nextBounds.y);
-      var resized =
+        Math.round(startBounds.y) !== Math.round(nextBounds.y) ||
         Math.round(startBounds.width) !== Math.round(nextBounds.width) ||
         Math.round(startBounds.height) !== Math.round(nextBounds.height);
-      var promise = Promise.resolve(null);
-      if (moved) {
-        promise = promise.then(function () {
-          return postJson("/api/editor/command", {
-            command: {
-              kind: "moveShape",
-              handle: handle,
-              offsetX: Math.round(nextBounds.x * EMU_PER_PIXEL),
-              offsetY: Math.round(nextBounds.y * EMU_PER_PIXEL)
-            }
-          });
-        });
-      }
-      if (resized) {
-        promise = promise.then(function () {
-          return postJson("/api/editor/command", {
-            command: {
-              kind: "resizeShape",
-              handle: handle,
-              width: Math.round(nextBounds.width * EMU_PER_PIXEL),
-              height: Math.round(nextBounds.height * EMU_PER_PIXEL)
-            }
-          });
-        });
-      }
-      return promise.then(function (data) {
+      if (!changed) return Promise.resolve();
+      return postJson("/api/editor/command", {
+        command: {
+          kind: "setShapeTransform",
+          handle: handle,
+          offsetX: Math.round(nextBounds.x * EMU_PER_PIXEL),
+          offsetY: Math.round(nextBounds.y * EMU_PER_PIXEL),
+          width: Math.round(nextBounds.width * EMU_PER_PIXEL),
+          height: Math.round(nextBounds.height * EMU_PER_PIXEL)
+        }
+      }).then(function (data) {
         if (data) {
           applyEditorResponse(data);
           setEditorMessage("Applied", false);
@@ -1185,7 +1181,7 @@ async function handleRequest(
   if (url.pathname === "/api/editor/select" && req.method === "POST") {
     const body = await readJsonBody(req);
     const handle = normalizeHandle(isRecord(body) ? body.handle : undefined);
-    sendJson(res, 200, backend.selectShape(handle));
+    sendJson(res, 200, await backend.selectShape(handle));
     return;
   }
 
@@ -1271,6 +1267,16 @@ function normalizeCommand(command: unknown): EditorCommand {
       handle: normalizeHandle(command.handle),
       width: asEmu(requireFiniteNumber(command.width, "resizeShape.width")),
       height: asEmu(requireFiniteNumber(command.height, "resizeShape.height")),
+    };
+  }
+  if (command.kind === "setShapeTransform") {
+    return {
+      kind: "setShapeTransform",
+      handle: normalizeHandle(command.handle),
+      offsetX: asEmu(requireFiniteNumber(command.offsetX, "setShapeTransform.offsetX")),
+      offsetY: asEmu(requireFiniteNumber(command.offsetY, "setShapeTransform.offsetY")),
+      width: asEmu(requireFiniteNumber(command.width, "setShapeTransform.width")),
+      height: asEmu(requireFiniteNumber(command.height, "setShapeTransform.height")),
     };
   }
   throw new Error("unsupported command kind");

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -69,12 +69,17 @@ interface EditorShapeInfo {
 interface EditorSlidesResponse {
   slides: SlideSvg[];
   history: EditorHistoryState;
+  selection?: EditorSelectionInfo;
 }
 
 interface EditorSaveResponse {
   ok: true;
   path: string;
   history: EditorHistoryState;
+}
+
+interface EditorSelectionInfo {
+  shapeHandle: SourceHandle;
 }
 
 type RenderPptxBytes = (input: Uint8Array) => Promise<SlideSvg[]>;
@@ -140,8 +145,16 @@ export class DevEditorBackend {
     };
   }
 
+  get selection(): EditorSelectionInfo | undefined {
+    return this.#session.selection;
+  }
+
   response(): EditorSlidesResponse {
-    return { slides: this.#slides, history: this.history };
+    return {
+      slides: this.#slides,
+      history: this.history,
+      ...(this.selection !== undefined ? { selection: this.selection } : {}),
+    };
   }
 
   shapes(slideNumber: number): EditorShapeInfo[] {
@@ -174,6 +187,14 @@ export class DevEditorBackend {
       await this.renderCurrentSlides();
       return this.response();
     });
+  }
+
+  selectShape(handle: SourceHandle): EditorSlidesResponse {
+    const result = this.#session.selectShape(handle);
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    return this.response();
   }
 
   async undo(): Promise<EditorSlidesResponse> {
@@ -467,8 +488,41 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
       max-width: 100%;
       max-height: 100%;
+      position: relative;
     }
     #slide-container svg { display: block; width: 100%; height: auto; }
+    #selection-overlay {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      overflow: visible;
+      touch-action: none;
+    }
+    .shape-hit-area {
+      cursor: move;
+      fill: transparent;
+      pointer-events: all;
+    }
+    .selection-box {
+      fill: none;
+      stroke: #0f766e;
+      stroke-width: 1.5;
+      vector-effect: non-scaling-stroke;
+      pointer-events: none;
+    }
+    .selection-handle {
+      fill: #f8fafc;
+      stroke: #0f766e;
+      stroke-width: 1.5;
+      cursor: nwse-resize;
+      vector-effect: non-scaling-stroke;
+      pointer-events: all;
+    }
+    .selection-handle[data-handle="ne"],
+    .selection-handle[data-handle="sw"] {
+      cursor: nesw-resize;
+    }
     #info {
       padding: 4px 20px;
       background: #16213e;
@@ -507,7 +561,12 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     var slides = ${jsonForScript(slides)};
     var editorHistory = { canUndo: false, canRedo: false, undoDepth: 0, redoDepth: 0 };
     var textRunOptions = [];
+    var shapeOptions = [];
+    var selectedShapeKey = null;
+    var selectedShape = null;
+    var dragState = null;
     var shapeRequestId = 0;
+    var EMU_PER_PIXEL = ${String(EMU_PER_INCH / DEFAULT_DPI)};
 
     function selectSlide(index) {
       currentIndex = index;
@@ -530,6 +589,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       }
       document.getElementById("info").textContent =
         "Slide " + (index + 1) + " / " + slideCount;
+      renderSelectionOverlay();
       loadShapeOptions(index + 1);
     }
 
@@ -561,6 +621,48 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       document.getElementById("redo-button").disabled = !editorHistory.canRedo;
     }
 
+    function shapeKey(shape) {
+      return shape && shape.handle ? handleKey(shape.handle) : "";
+    }
+
+    function handleKey(handle) {
+      return [
+        handle.partPath || "",
+        handle.nodeId || "",
+        handle.relationshipId || "",
+        handle.orderingSlot == null ? "" : String(handle.orderingSlot)
+      ].join("\\u0000");
+    }
+
+    function syncSelection(selection) {
+      selectedShapeKey = selection && selection.shapeHandle ? handleKey(selection.shapeHandle) : selectedShapeKey;
+      selectedShape = null;
+      if (selectedShapeKey) {
+        for (var i = 0; i < shapeOptions.length; i++) {
+          if (shapeKey(shapeOptions[i]) === selectedShapeKey && shapeOptions[i].bounds) {
+            selectedShape = cloneShape(shapeOptions[i]);
+            break;
+          }
+        }
+      }
+      if (!selectedShape) selectedShapeKey = null;
+      renderSelectionOverlay();
+    }
+
+    function cloneShape(shape) {
+      return {
+        id: shape.id,
+        name: shape.name,
+        handle: shape.handle,
+        bounds: {
+          x: shape.bounds.x,
+          y: shape.bounds.y,
+          width: shape.bounds.width,
+          height: shape.bounds.height
+        }
+      };
+    }
+
     function setEditorMessage(message, isError) {
       var element = document.getElementById("editor-message");
       element.textContent = message;
@@ -576,6 +678,9 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         })
         .then(function (data) {
           if (requestId !== shapeRequestId || slideNumber !== currentIndex + 1) return;
+          shapeOptions = (data.shapes || []).filter(function (shape) {
+            return shape.handle && shape.bounds;
+          });
           textRunOptions = [];
           data.shapes.forEach(function (shape) {
             (shape.textRuns || []).forEach(function (run, index) {
@@ -595,6 +700,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           select.disabled = textRunOptions.length === 0;
           document.getElementById("apply-text-button").disabled = textRunOptions.length === 0;
           syncTextInput();
+          syncSelection();
         })
         .catch(function (err) {
           setEditorMessage(err.message, true);
@@ -613,8 +719,258 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       slides = data.slides || slides;
       slideCount = slides.length;
       updateHistory(data.history);
+      if (data.selection && data.selection.shapeHandle) {
+        selectedShapeKey = handleKey(data.selection.shapeHandle);
+      }
       renderThumbnails();
       selectSlide(Math.min(currentIndex, Math.max(slides.length - 1, 0)));
+    }
+
+    function renderSelectionOverlay() {
+      var container = document.getElementById("slide-container");
+      var renderedSvg = container.querySelector("svg:not(#selection-overlay)");
+      var existing = document.getElementById("selection-overlay");
+      if (existing) existing.remove();
+      if (!renderedSvg) return;
+
+      var viewBox = renderedSvg.getAttribute("viewBox") || "0 0 960 540";
+      var overlay = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      overlay.setAttribute("id", "selection-overlay");
+      overlay.setAttribute("viewBox", viewBox);
+      overlay.setAttribute("data-testid", "selection-overlay");
+
+      shapeOptions.forEach(function (shape, index) {
+        if (!shape.bounds) return;
+        var hit = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        hit.setAttribute("class", "shape-hit-area");
+        hit.setAttribute("data-testid", "shape-hit-area");
+        hit.setAttribute("data-shape-index", String(index));
+        setRectAttributes(hit, shape.bounds);
+        hit.addEventListener("pointerdown", function (event) {
+          event.preventDefault();
+          selectShape(shape, event);
+        });
+        overlay.appendChild(hit);
+      });
+
+      if (selectedShape && selectedShape.bounds) {
+        var box = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        box.setAttribute("class", "selection-box");
+        box.setAttribute("data-testid", "selection-box");
+        setRectAttributes(box, selectedShape.bounds);
+        overlay.appendChild(box);
+
+        ["nw", "ne", "sw", "se"].forEach(function (handle) {
+          var point = handlePoint(selectedShape.bounds, handle);
+          var rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+          rect.setAttribute("class", "selection-handle");
+          rect.setAttribute("data-testid", "selection-handle-" + handle);
+          rect.setAttribute("data-handle", handle);
+          rect.setAttribute("x", String(point.x - 4));
+          rect.setAttribute("y", String(point.y - 4));
+          rect.setAttribute("width", "8");
+          rect.setAttribute("height", "8");
+          rect.addEventListener("pointerdown", function (event) {
+            event.preventDefault();
+            event.stopPropagation();
+            beginDrag("resize", handle, event);
+          });
+          overlay.appendChild(rect);
+        });
+
+        box.addEventListener("pointerdown", function (event) {
+          event.preventDefault();
+          beginDrag("move", null, event);
+        });
+      }
+
+      container.appendChild(overlay);
+    }
+
+    function setRectAttributes(rect, bounds) {
+      rect.setAttribute("x", String(bounds.x));
+      rect.setAttribute("y", String(bounds.y));
+      rect.setAttribute("width", String(bounds.width));
+      rect.setAttribute("height", String(bounds.height));
+    }
+
+    function handlePoint(bounds, handle) {
+      var right = bounds.x + bounds.width;
+      var bottom = bounds.y + bounds.height;
+      if (handle === "nw") return { x: bounds.x, y: bounds.y };
+      if (handle === "ne") return { x: right, y: bounds.y };
+      if (handle === "sw") return { x: bounds.x, y: bottom };
+      return { x: right, y: bottom };
+    }
+
+    function selectShape(shape, event) {
+      selectedShapeKey = shapeKey(shape);
+      selectedShape = cloneShape(shape);
+      renderSelectionOverlay();
+      beginDrag("move", null, event);
+      postJson("/api/editor/select", { handle: shape.handle })
+        .then(function (data) {
+          updateHistory(data.history);
+          if (data.selection && data.selection.shapeHandle) {
+            selectedShapeKey = handleKey(data.selection.shapeHandle);
+          }
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
+    function beginDrag(kind, handle, event) {
+      if (!selectedShape || !selectedShape.bounds) return;
+      var overlay = document.getElementById("selection-overlay");
+      if (!overlay) return;
+      var point = eventPoint(overlay, event);
+      dragState = {
+        kind: kind,
+        handle: handle,
+        pointerId: event.pointerId,
+        startPoint: point,
+        startBounds: {
+          x: selectedShape.bounds.x,
+          y: selectedShape.bounds.y,
+          width: selectedShape.bounds.width,
+          height: selectedShape.bounds.height
+        }
+      };
+      try {
+        overlay.setPointerCapture(event.pointerId);
+      } catch (_error) {
+        // Pointer capture can be unavailable after a fast re-render; window listeners still cover drag.
+      }
+      window.addEventListener("pointermove", updateDrag);
+      window.addEventListener("pointerup", finishDrag);
+      window.addEventListener("pointercancel", cancelDrag);
+    }
+
+    function updateDrag(event) {
+      if (!dragState || event.pointerId !== dragState.pointerId || !selectedShape) return;
+      var overlay = document.getElementById("selection-overlay");
+      if (!overlay) return;
+      var point = eventPoint(overlay, event);
+      var dx = point.x - dragState.startPoint.x;
+      var dy = point.y - dragState.startPoint.y;
+      selectedShape.bounds =
+        dragState.kind === "move"
+          ? movedBounds(dragState.startBounds, dx, dy)
+          : resizedBounds(dragState.startBounds, dragState.handle, dx, dy);
+      renderSelectionOverlay();
+    }
+
+    function finishDrag(event) {
+      if (!dragState || event.pointerId !== dragState.pointerId || !selectedShape) return;
+      var nextBounds = selectedShape.bounds;
+      var previousDrag = dragState;
+      dragState = null;
+      detachDragListeners();
+      applyShapeBoundsEdit(previousDrag.startBounds, nextBounds).catch(function (err) {
+        setEditorMessage(err.message, true);
+        selectedShape.bounds = previousDrag.startBounds;
+        renderSelectionOverlay();
+      });
+    }
+
+    function cancelDrag(event) {
+      if (!dragState || event.pointerId !== dragState.pointerId || !selectedShape) return;
+      selectedShape.bounds = dragState.startBounds;
+      dragState = null;
+      detachDragListeners();
+      renderSelectionOverlay();
+    }
+
+    function detachDragListeners() {
+      window.removeEventListener("pointermove", updateDrag);
+      window.removeEventListener("pointerup", finishDrag);
+      window.removeEventListener("pointercancel", cancelDrag);
+    }
+
+    function eventPoint(svg, event) {
+      var point = svg.createSVGPoint();
+      point.x = event.clientX;
+      point.y = event.clientY;
+      return point.matrixTransform(svg.getScreenCTM().inverse());
+    }
+
+    function movedBounds(bounds, dx, dy) {
+      return {
+        x: bounds.x + dx,
+        y: bounds.y + dy,
+        width: bounds.width,
+        height: bounds.height
+      };
+    }
+
+    function resizedBounds(bounds, handle, dx, dy) {
+      var minSize = 8;
+      var right = bounds.x + bounds.width;
+      var bottom = bounds.y + bounds.height;
+      var next = {
+        x: bounds.x,
+        y: bounds.y,
+        width: bounds.width,
+        height: bounds.height
+      };
+      if (handle === "nw" || handle === "sw") {
+        next.x = Math.min(bounds.x + dx, right - minSize);
+        next.width = right - next.x;
+      }
+      if (handle === "ne" || handle === "se") {
+        next.width = Math.max(minSize, bounds.width + dx);
+      }
+      if (handle === "nw" || handle === "ne") {
+        next.y = Math.min(bounds.y + dy, bottom - minSize);
+        next.height = bottom - next.y;
+      }
+      if (handle === "sw" || handle === "se") {
+        next.height = Math.max(minSize, bounds.height + dy);
+      }
+      return next;
+    }
+
+    function applyShapeBoundsEdit(startBounds, nextBounds) {
+      if (!selectedShape || !selectedShape.handle) return Promise.resolve();
+      var handle = selectedShape.handle;
+      var moved =
+        Math.round(startBounds.x) !== Math.round(nextBounds.x) ||
+        Math.round(startBounds.y) !== Math.round(nextBounds.y);
+      var resized =
+        Math.round(startBounds.width) !== Math.round(nextBounds.width) ||
+        Math.round(startBounds.height) !== Math.round(nextBounds.height);
+      var promise = Promise.resolve(null);
+      if (moved) {
+        promise = promise.then(function () {
+          return postJson("/api/editor/command", {
+            command: {
+              kind: "moveShape",
+              handle: handle,
+              offsetX: Math.round(nextBounds.x * EMU_PER_PIXEL),
+              offsetY: Math.round(nextBounds.y * EMU_PER_PIXEL)
+            }
+          });
+        });
+      }
+      if (resized) {
+        promise = promise.then(function () {
+          return postJson("/api/editor/command", {
+            command: {
+              kind: "resizeShape",
+              handle: handle,
+              width: Math.round(nextBounds.width * EMU_PER_PIXEL),
+              height: Math.round(nextBounds.height * EMU_PER_PIXEL)
+            }
+          });
+        });
+      }
+      return promise.then(function (data) {
+        if (data) {
+          applyEditorResponse(data);
+          setEditorMessage("Applied", false);
+        }
+      });
     }
 
     function postJson(url, payload) {
@@ -811,6 +1167,13 @@ async function handleRequest(
     const body = await readJsonBody(req);
     const command = normalizeCommand(isRecord(body) ? body.command : undefined);
     sendJson(res, 200, await backend.apply(command));
+    return;
+  }
+
+  if (url.pathname === "/api/editor/select" && req.method === "POST") {
+    const body = await readJsonBody(req);
+    const handle = normalizeHandle(isRecord(body) ? body.handle : undefined);
+    sendJson(res, 200, backend.selectShape(handle));
     return;
   }
 

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -63,6 +63,7 @@ interface EditorShapeInfo {
   name?: string;
   handle?: SourceHandle;
   bounds?: ShapeBoundsPx;
+  editableTransform?: boolean;
   textRuns?: EditorTextRunInfo[];
 }
 
@@ -278,14 +279,18 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
 
-function shapeInfo(shape: SourceShapeNode, index: number): EditorShapeInfo[] {
+function shapeInfo(
+  shape: SourceShapeNode,
+  index: number,
+  editableTransform = true,
+): EditorShapeInfo[] {
   const base: EditorShapeInfo = {
     id: String(shape.nodeId ?? shape.handle?.nodeId ?? `${shape.kind}:${String(index)}`),
     kind: shape.kind,
     ...(shapeName(shape) !== undefined ? { name: shapeName(shape) } : {}),
     ...(shape.handle !== undefined ? { handle: shape.handle } : {}),
     ...(shape.kind !== "raw" && shape.transform !== undefined
-      ? { bounds: transformBoundsPx(shape.transform) }
+      ? { bounds: transformBoundsPx(shape.transform), editableTransform }
       : {}),
     ...("textBody" in shape && shape.textBody !== undefined
       ? {
@@ -297,7 +302,10 @@ function shapeInfo(shape: SourceShapeNode, index: number): EditorShapeInfo[] {
   };
 
   if (shape.kind !== "group") return [base];
-  return [base, ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex))];
+  return [
+    base,
+    ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex, false)),
+  ];
 }
 
 function shapeName(shape: SourceShapeNode): string | undefined {
@@ -569,7 +577,12 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     var EMU_PER_PIXEL = ${String(EMU_PER_INCH / DEFAULT_DPI)};
 
     function selectSlide(index) {
+      var slideChanged = currentIndex !== index;
       currentIndex = index;
+      shapeOptions = [];
+      textRunOptions = [];
+      selectedShape = null;
+      if (slideChanged) selectedShapeKey = null;
       var thumbs = document.querySelectorAll(".thumbnail");
       for (var i = 0; i < thumbs.length; i++) {
         if (i === index) {
@@ -679,7 +692,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         .then(function (data) {
           if (requestId !== shapeRequestId || slideNumber !== currentIndex + 1) return;
           shapeOptions = (data.shapes || []).filter(function (shape) {
-            return shape.handle && shape.bounds;
+            return shape.handle && shape.bounds && shape.editableTransform;
           });
           textRunOptions = [];
           data.shapes.forEach(function (shape) {
@@ -777,11 +790,6 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           });
           overlay.appendChild(rect);
         });
-
-        box.addEventListener("pointerdown", function (event) {
-          event.preventDefault();
-          beginDrag("move", null, event);
-        });
       }
 
       container.appendChild(overlay);
@@ -825,6 +833,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       var overlay = document.getElementById("selection-overlay");
       if (!overlay) return;
       var point = eventPoint(overlay, event);
+      if (!point) return;
       dragState = {
         kind: kind,
         handle: handle,
@@ -852,6 +861,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       var overlay = document.getElementById("selection-overlay");
       if (!overlay) return;
       var point = eventPoint(overlay, event);
+      if (!point) return;
       var dx = point.x - dragState.startPoint.x;
       var dy = point.y - dragState.startPoint.y;
       selectedShape.bounds =
@@ -889,10 +899,12 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function eventPoint(svg, event) {
+      var matrix = svg.getScreenCTM();
+      if (!matrix) return null;
       var point = svg.createSVGPoint();
       point.x = event.clientX;
       point.y = event.clientY;
-      return point.matrixTransform(svg.getScreenCTM().inverse());
+      return point.matrixTransform(matrix.inverse());
     }
 
     function movedBounds(bounds, dx, dy) {


### PR DESCRIPTION
close #582

## 概要

- SVG preview 上に shape hit area / selection box / corner handles を overlay 表示する UI を追加
- ドラッグ確定時に editor-core の xfrm 更新を適用し、再レンダリング結果と保存 PPTX に反映
- selection / move / resize / save flow を検証する Playwright テストと CI 実行を追加

## 動作確認

- pnpm run knip
- pnpm run lint
- pnpm run format:check
- pnpm run typecheck
- pnpm run test
- pnpm run test:playwright

## 受け入れ条件チェック

- ✓ shape クリックで選択され、selection handles が shape 位置に表示される
- ✓ ドラッグで move、handle ドラッグで resize でき、確定後に再レンダリングへ反映される
- ✓ 保存した PPTX に xfrm 編集が反映されている
- ✓ selection と save flow を検証する Playwright テストがある

## レビュー

- cross-review 実施済み。初回指摘を修正後、追跡レビューで critical / warning / info なし。