### PR TITLE
editor: ProseMirror overlay による text editing MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,10 @@ const { slides } = await convertPptxToSvg(pptx, {
 
 ## Development
 
+The local editor preview (`npm run dev -- <pptx-file>`) includes an MVP text editing
+overlay for text shapes. IME behavior is intentionally not automated in CI; verify IME
+composition manually as part of the release checklist before shipping editor changes.
+
 <details>
 <summary>Test rendering</summary>
 

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -63,9 +63,60 @@ test("selects a shape, moves and resizes it, then saves xfrm edits", async ({ pa
   }
 });
 
+test("edits a text shape with the overlay editor, re-renders, and saves text", async ({ page }) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-editor-text-test-"));
+  let serverProcess: ChildProcessWithoutNullStreams | undefined;
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    await writeFile(sourcePath, await buildShapeFixture());
+
+    const port = await findFreePort();
+    serverProcess = await startDevServer(sourcePath, port);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+    await page.goto(baseUrl);
+    await expect(page.getByTestId("shape-hit-area").first()).toBeVisible();
+
+    await dblclickSvgPoint(page, 240, 240);
+    const overlay = page.getByTestId("text-editor-overlay");
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toContainText("Original");
+    await expectOverlayNearSvgBounds(page, { x: 96, y: 192, width: 288, height: 96 });
+
+    const commandResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/text-body") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("text-editor-run").first().fill("Overlay edited");
+    await page.getByTestId("text-editor-done").click();
+    await commandResponse;
+
+    await expect(page.locator("#slide-container")).toContainText("Overlay edited");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+
+    const saved = readPptx(await readFile(savedPath));
+    expect(firstText(saved)).toBe("Overlay edited");
+  } finally {
+    if (serverProcess !== undefined) {
+      serverProcess.kill();
+      await waitForExit(serverProcess);
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 async function clickSvgPoint(page: Page, x: number, y: number) {
   const point = await svgPointToClient(page, x, y);
   await page.mouse.click(point.x, point.y);
+}
+
+async function dblclickSvgPoint(page: Page, x: number, y: number) {
+  const point = await svgPointToClient(page, x, y);
+  await page.mouse.dblclick(point.x, point.y);
 }
 
 async function dragSvgPoint(
@@ -86,6 +137,48 @@ async function dragSvgPoint(
   await page.mouse.move(end.x, end.y, { steps: 6 });
   await page.mouse.up();
   await commandResponse;
+}
+
+async function expectOverlayNearSvgBounds(
+  page: Page,
+  bounds: { x: number; y: number; width: number; height: number },
+) {
+  const rects = await page.evaluate((expected) => {
+    const overlay = document.querySelector('[data-testid="text-editor-overlay"]');
+    const selectionOverlay = document.getElementById("selection-overlay");
+    if (!(overlay instanceof HTMLElement)) throw new Error("text editor overlay not found");
+    if (!(selectionOverlay instanceof SVGSVGElement))
+      throw new Error("selection overlay not found");
+    const point = selectionOverlay.createSVGPoint();
+    const matrix = selectionOverlay.getScreenCTM();
+    if (matrix === null) throw new Error("selection overlay matrix not found");
+    point.x = expected.x;
+    point.y = expected.y;
+    const topLeft = point.matrixTransform(matrix);
+    point.x = expected.x + expected.width;
+    point.y = expected.y + expected.height;
+    const bottomRight = point.matrixTransform(matrix);
+    const overlayRect = overlay.getBoundingClientRect();
+    return {
+      expected: {
+        left: topLeft.x,
+        top: topLeft.y,
+        width: bottomRight.x - topLeft.x,
+        height: bottomRight.y - topLeft.y,
+      },
+      actual: {
+        left: overlayRect.left,
+        top: overlayRect.top,
+        width: overlayRect.width,
+        height: overlayRect.height,
+      },
+    };
+  }, bounds);
+
+  expect(Math.abs(rects.actual.left - rects.expected.left)).toBeLessThan(3);
+  expect(Math.abs(rects.actual.top - rects.expected.top)).toBeLessThan(3);
+  expect(Math.abs(rects.actual.width - rects.expected.width)).toBeLessThan(3);
+  expect(Math.abs(rects.actual.height - rects.expected.height)).toBeLessThan(3);
 }
 
 async function svgPointToClient(
@@ -158,6 +251,9 @@ async function buildShapeFixture(): Promise<Uint8Array> {
         `<p:cSld><p:spTree>` +
         `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Box"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
         `<p:spPr><a:xfrm><a:off x="914400" y="1828800"/><a:ext cx="2743200" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+        `<a:p><a:r><a:rPr sz="2400"><a:latin typeface="Aptos"/></a:rPr><a:t>Original</a:t></a:r></a:p>` +
+        `</p:txBody>` +
         `</p:sp>` +
         `</p:spTree></p:cSld>` +
         `</p:sld>`,
@@ -171,6 +267,12 @@ function firstShape(source: PptxSourceModel): SourceShape {
   const shape = source.slides[0]?.shapes.find((node): node is SourceShape => node.kind === "shape");
   if (shape === undefined) throw new Error("fixture shape not found");
   return shape;
+}
+
+function firstText(source: PptxSourceModel): string {
+  const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
+  if (run === undefined) throw new Error("fixture text run not found");
+  return run.text;
 }
 
 async function findFreePort(): Promise<number> {

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -99,9 +99,22 @@ describe("dev server editor API", () => {
       });
       expect(overlayEdited.slides[0].svg).toContain("Overlay edited");
 
+      await postJson<SlidesResponse>(`${baseUrl}/api/editor/text-body`, {
+        handle: shapes.shapes[0].handle,
+        docJson: {
+          ...shapes.shapes[0].editableTextBody?.docJson,
+          content: [
+            {
+              ...shapes.shapes[0].editableTextBody?.docJson.content?.[0],
+              content: [],
+            },
+          ],
+        },
+      });
+
       const saved = await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
       expect(saved).toMatchObject({ ok: true, path: savedPath });
-      expect(firstRun(readPptx(await readFile(savedPath)))).toBe("Overlay edited");
+      expect(firstRun(readPptx(await readFile(savedPath)))).toBe("");
 
       const rejectedSave = await postJsonError(`${baseUrl}/api/editor/save`, {
         path: join(tmpdir(), "outside-dev-server-save.pptx"),

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -52,6 +52,15 @@ describe("dev server editor API", () => {
         bounds: { x: 96, y: 192, width: 288, height: 96 },
       });
       expect(shapes.shapes[0].textRuns[0]).toMatchObject({ text: "Original" });
+      expect(shapes.shapes[0].editableTextBody?.docJson).toMatchObject({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Original" }],
+          },
+        ],
+      });
 
       const edited = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
         command: {
@@ -71,9 +80,28 @@ describe("dev server editor API", () => {
       expect(redone.slides[0].svg).toContain("Edited");
       expect(redone.history).toMatchObject({ canUndo: true, canRedo: false });
 
+      const overlayEdited = await postJson<SlidesResponse>(`${baseUrl}/api/editor/text-body`, {
+        handle: shapes.shapes[0].handle,
+        docJson: {
+          ...shapes.shapes[0].editableTextBody?.docJson,
+          content: [
+            {
+              ...shapes.shapes[0].editableTextBody?.docJson.content?.[0],
+              content: [
+                {
+                  ...shapes.shapes[0].editableTextBody?.docJson.content?.[0]?.content?.[0],
+                  text: "Overlay edited",
+                },
+              ],
+            },
+          ],
+        },
+      });
+      expect(overlayEdited.slides[0].svg).toContain("Overlay edited");
+
       const saved = await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
       expect(saved).toMatchObject({ ok: true, path: savedPath });
-      expect(firstRun(readPptx(await readFile(savedPath)))).toBe("Edited");
+      expect(firstRun(readPptx(await readFile(savedPath)))).toBe("Overlay edited");
 
       const rejectedSave = await postJsonError(`${baseUrl}/api/editor/save`, {
         path: join(tmpdir(), "outside-dev-server-save.pptx"),
@@ -103,10 +131,21 @@ describe("dev server editor API", () => {
 
 interface ShapesResponse {
   shapes: Array<{
+    handle: unknown;
     id: string;
     name?: string;
     bounds?: { x: number; y: number; width: number; height: number };
     textRuns: Array<{ text: string; handle: unknown }>;
+    editableTextBody?: {
+      docJson: {
+        type: "doc";
+        content?: Array<{
+          type: "paragraph";
+          attrs?: unknown;
+          content?: Array<{ type: "text"; text: string; marks?: unknown }>;
+        }>;
+      };
+    };
   }>;
 }
 

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -688,8 +688,17 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     var EMU_PER_PIXEL = ${String(EMU_PER_INCH / DEFAULT_DPI)};
 
     function selectSlide(index) {
+      if (activeTextEditor) {
+        commitTextEditor()
+          .then(function () {
+            selectSlide(index);
+          })
+          .catch(function () {
+            // Keep the editor open; commitTextEditor already reported the failure.
+          });
+        return;
+      }
       var slideChanged = currentIndex !== index;
-      closeTextEditor(false);
       currentIndex = index;
       shapeOptions = [];
       textRunOptions = [];
@@ -939,6 +948,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
       beginDrag("move", null, event);
+      window.setTimeout(renderSelectionOverlay, 0);
       postJson("/api/editor/select", { handle: shape.handle })
         .then(function (data) {
           updateHistory(data.history);
@@ -958,7 +968,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         dragState = null;
         detachDragListeners();
       }
-      closeTextEditor(false);
+      closeTextEditor();
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
       renderSelectionOverlay();
@@ -977,7 +987,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       done.textContent = "Done";
       done.setAttribute("data-testid", "text-editor-done");
       done.addEventListener("click", function () {
-        commitTextEditor();
+        commitTextEditor().catch(function () {});
       });
       actions.appendChild(done);
       overlay.appendChild(actions);
@@ -985,18 +995,18 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       overlay.addEventListener("keydown", function (event) {
         if (event.key === "Enter" && !event.shiftKey) {
           event.preventDefault();
-          commitTextEditor();
+          commitTextEditor().catch(function () {});
         }
         if (event.key === "Escape") {
           event.preventDefault();
-          closeTextEditor(false);
+          closeTextEditor();
         }
       });
       overlay.addEventListener("focusout", function (event) {
         window.setTimeout(function () {
           if (!activeTextEditor) return;
           if (event.relatedTarget && activeTextEditor.element.contains(event.relatedTarget)) return;
-          commitTextEditor();
+          commitTextEditor().catch(function () {});
         }, 0);
       });
 
@@ -1116,17 +1126,18 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         docJson: docJson
       })
         .then(function (data) {
-          closeTextEditor(false);
+          closeTextEditor();
           applyEditorResponse(data);
           setEditorMessage("Applied", false);
         })
         .catch(function (err) {
           editor.committing = false;
           setEditorMessage(err.message, true);
+          throw err;
         });
     }
 
-    function closeTextEditor(_commit) {
+    function closeTextEditor() {
       if (!activeTextEditor) return;
       activeTextEditor.element.remove();
       activeTextEditor = null;

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -947,13 +947,34 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
 
     function selectShape(shape, event) {
       if (activeTextEditor) {
-        commitTextEditor().catch(function () {});
+        commitTextEditor()
+          .then(function () {
+            selectShapeAfterCommit(shape);
+          })
+          .catch(function () {});
         return;
       }
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
       beginDrag("move", null, event);
       window.setTimeout(renderSelectionOverlay, 0);
+      postJson("/api/editor/select", { handle: shape.handle })
+        .then(function (data) {
+          updateHistory(data.history);
+          if (data.selection && data.selection.shapeHandle) {
+            selectedShapeKey = handleKey(data.selection.shapeHandle);
+          }
+          renderSelectionOverlay();
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
+    function selectShapeAfterCommit(shape) {
+      selectedShapeKey = shapeKey(shape);
+      selectedShape = cloneShape(shape);
+      renderSelectionOverlay();
       postJson("/api/editor/select", { handle: shape.handle })
         .then(function (data) {
           updateHistory(data.history);
@@ -1114,18 +1135,25 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           '.text-editor-paragraph[data-paragraph-index="' + paragraphIndex + '"]'
         );
         var content = [];
+        var emptyRunCount = 0;
         (paragraph.content || []).forEach(function (textNode, runIndex) {
           var runElement = paragraphElement
             ? paragraphElement.querySelector('.text-editor-run[data-run-index="' + runIndex + '"]')
             : null;
           var text = runElement ? runElement.textContent || "" : textNode.text || "";
-          if (text.length === 0) return;
+          if (text.length === 0) {
+            emptyRunCount += 1;
+            return;
+          }
           content.push({
             type: "text",
             text: text,
             marks: textNode.marks || []
           });
         });
+        if (emptyRunCount > 0 && content.length > 0) {
+          throw new Error("Clearing individual runs in multi-run text is unsupported.");
+        }
         paragraphs.push({
           type: "paragraph",
           attrs: paragraph.attrs || {},

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -13,13 +13,21 @@ import {
   asPartPath,
   asRelationshipId,
   asSourceNodeId,
+  findShapeNodeBySourceHandle,
   readPptx,
   type SourceHandle,
   type SourceShapeNode,
+  type SourceTextBody,
   type SourceTextRun,
   writePptx,
 } from "../packages/document/src/index.js";
-import { createEditorSession, type EditorCommand } from "../packages/editor-core/src/index.js";
+import {
+  createEditorSession,
+  type EditorCommand,
+  type PptxTextBodyProseMirrorDocJson,
+  proseMirrorDocJsonToEditorCommands,
+  textBodyToProseMirrorDocJson,
+} from "../packages/editor-core/src/index.js";
 import { unsafeScriptInputAssertion } from "./unsafe-type-assertion.js";
 
 const DEFAULT_PORT = 3000;
@@ -57,6 +65,10 @@ interface EditorTextRunInfo {
   handle: SourceHandle;
 }
 
+interface EditorTextBodyInfo {
+  docJson: PptxTextBodyProseMirrorDocJson;
+}
+
 interface EditorShapeInfo {
   id: string;
   kind: SourceShapeNode["kind"];
@@ -65,6 +77,7 @@ interface EditorShapeInfo {
   bounds?: ShapeBoundsPx;
   editableTransform?: boolean;
   textRuns?: EditorTextRunInfo[];
+  editableTextBody?: EditorTextBodyInfo;
 }
 
 interface EditorSlidesResponse {
@@ -190,6 +203,27 @@ export class DevEditorBackend {
     });
   }
 
+  async applyTextBodyDocJson(
+    handle: SourceHandle,
+    docJson: unknown,
+  ): Promise<EditorSlidesResponse> {
+    return this.#enqueueMutation(async () => {
+      const textBody = this.#requireEditableShapeTextBody(handle);
+      const commands = proseMirrorDocJsonToEditorCommands(textBody, docJson);
+      if (commands.length === 0) return this.response();
+
+      for (const command of commands) {
+        const result = this.#session.apply(command);
+        if (!result.ok) {
+          throw new Error(result.message);
+        }
+      }
+      this.#dirty = true;
+      await this.renderCurrentSlides();
+      return this.response();
+    });
+  }
+
   async selectShape(handle: SourceHandle): Promise<EditorSlidesResponse> {
     return this.#enqueueMutation(() => {
       const result = this.#session.selectShape(handle);
@@ -241,6 +275,17 @@ export class DevEditorBackend {
       () => undefined,
     );
     return queued;
+  }
+
+  #requireEditableShapeTextBody(handle: SourceHandle): SourceTextBody {
+    const shape = findShapeNodeBySourceHandle(this.#session.document, handle);
+    if (shape === undefined) {
+      throw new Error("text body edit: shape handle was not found in PptxSourceModel source");
+    }
+    if (shape.kind !== "shape" || shape.textBody === undefined) {
+      throw new Error("text body edit: shape does not have editable text body");
+    }
+    return shape.textBody;
   }
 }
 
@@ -304,6 +349,9 @@ function shapeInfo(
           ),
         }
       : {}),
+    ...(shape.kind === "shape" && shape.textBody !== undefined && shape.transform !== undefined
+      ? editableTextBody(shape.textBody)
+      : {}),
   };
 
   if (shape.kind !== "group") return [base];
@@ -329,6 +377,16 @@ function collectTextRuns(runs: readonly SourceTextRun[]): EditorTextRunInfo[] {
     if (run.handle === undefined) return [];
     return [{ text: run.text, handle: run.handle }];
   });
+}
+
+function editableTextBody(
+  textBody: SourceTextBody,
+): Partial<Pick<EditorShapeInfo, "editableTextBody">> {
+  try {
+    return { editableTextBody: { docJson: textBodyToProseMirrorDocJson(textBody) } };
+  } catch {
+    return {};
+  }
 }
 
 function transformBoundsPx(transform: {
@@ -518,6 +576,46 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       height: 100%;
       overflow: visible;
       touch-action: none;
+      z-index: 2;
+    }
+    #text-editor-overlay {
+      position: absolute;
+      min-width: 40px;
+      min-height: 28px;
+      padding: 4px;
+      border: 1px solid #2563eb;
+      background: rgba(255, 255, 255, 0.96);
+      color: #111827;
+      z-index: 3;
+      overflow: hidden;
+      box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.25);
+    }
+    .text-editor-paragraph {
+      min-height: 20px;
+      line-height: 1.25;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+    .text-editor-run {
+      outline: none;
+      white-space: pre-wrap;
+    }
+    .text-editor-actions {
+      position: absolute;
+      right: 4px;
+      bottom: 4px;
+      display: flex;
+      gap: 4px;
+    }
+    .text-editor-actions button {
+      min-height: 24px;
+      padding: 2px 8px;
+      border: 1px solid #64748b;
+      border-radius: 4px;
+      background: #f8fafc;
+      color: #0f172a;
+      font-size: 11px;
+      font-weight: 600;
     }
     .shape-hit-area {
       cursor: move;
@@ -585,11 +683,13 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     var selectedShapeKey = null;
     var selectedShape = null;
     var dragState = null;
+    var activeTextEditor = null;
     var shapeRequestId = 0;
     var EMU_PER_PIXEL = ${String(EMU_PER_INCH / DEFAULT_DPI)};
 
     function selectSlide(index) {
       var slideChanged = currentIndex !== index;
+      closeTextEditor(false);
       currentIndex = index;
       shapeOptions = [];
       textRunOptions = [];
@@ -679,6 +779,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         id: shape.id,
         name: shape.name,
         handle: shape.handle,
+        editableTextBody: shape.editableTextBody,
         bounds: {
           x: shape.bounds.x,
           y: shape.bounds.y,
@@ -772,8 +873,18 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         hit.setAttribute("data-shape-index", String(index));
         setRectAttributes(hit, shape.bounds);
         hit.addEventListener("pointerdown", function (event) {
-          event.preventDefault();
           selectShape(shape, event);
+        });
+        hit.addEventListener("mousedown", function (event) {
+          if (event.detail >= 2 && shape.editableTextBody) {
+            event.preventDefault();
+            openTextEditor(shape);
+          }
+        });
+        hit.addEventListener("dblclick", function (event) {
+          event.preventDefault();
+          event.stopPropagation();
+          openTextEditor(shape);
         });
         overlay.appendChild(hit);
       });
@@ -805,6 +916,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       }
 
       container.appendChild(overlay);
+      positionActiveTextEditor();
     }
 
     function setRectAttributes(rect, bounds) {
@@ -826,7 +938,6 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     function selectShape(shape, event) {
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
-      renderSelectionOverlay();
       beginDrag("move", null, event);
       postJson("/api/editor/select", { handle: shape.handle })
         .then(function (data) {
@@ -834,10 +945,191 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           if (data.selection && data.selection.shapeHandle) {
             selectedShapeKey = handleKey(data.selection.shapeHandle);
           }
+          renderSelectionOverlay();
         })
         .catch(function (err) {
           setEditorMessage(err.message, true);
         });
+    }
+
+    function openTextEditor(shape) {
+      if (!shape || !shape.handle || !shape.bounds || !shape.editableTextBody) return;
+      if (dragState) {
+        dragState = null;
+        detachDragListeners();
+      }
+      closeTextEditor(false);
+      selectedShapeKey = shapeKey(shape);
+      selectedShape = cloneShape(shape);
+      renderSelectionOverlay();
+
+      var container = document.getElementById("slide-container");
+      var overlay = document.createElement("div");
+      overlay.id = "text-editor-overlay";
+      overlay.setAttribute("data-testid", "text-editor-overlay");
+      overlay.dataset.shapeKey = selectedShapeKey || "";
+      overlay.appendChild(createTextEditorContent(shape.editableTextBody.docJson));
+
+      var actions = document.createElement("div");
+      actions.className = "text-editor-actions";
+      var done = document.createElement("button");
+      done.type = "button";
+      done.textContent = "Done";
+      done.setAttribute("data-testid", "text-editor-done");
+      done.addEventListener("click", function () {
+        commitTextEditor();
+      });
+      actions.appendChild(done);
+      overlay.appendChild(actions);
+
+      overlay.addEventListener("keydown", function (event) {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+          commitTextEditor();
+        }
+        if (event.key === "Escape") {
+          event.preventDefault();
+          closeTextEditor(false);
+        }
+      });
+      overlay.addEventListener("focusout", function (event) {
+        window.setTimeout(function () {
+          if (!activeTextEditor) return;
+          if (event.relatedTarget && activeTextEditor.element.contains(event.relatedTarget)) return;
+          commitTextEditor();
+        }, 0);
+      });
+
+      container.appendChild(overlay);
+      activeTextEditor = {
+        element: overlay,
+        shape: cloneShape(shape),
+        originalDocJson: shape.editableTextBody.docJson,
+        committing: false
+      };
+      positionActiveTextEditor();
+      var firstRun = overlay.querySelector(".text-editor-run");
+      if (firstRun) {
+        firstRun.focus();
+        selectElementContents(firstRun);
+      }
+    }
+
+    function createTextEditorContent(docJson) {
+      var body = document.createElement("div");
+      body.setAttribute("data-testid", "text-editor-content");
+      (docJson.content || []).forEach(function (paragraph, paragraphIndex) {
+        var paragraphElement = document.createElement("div");
+        paragraphElement.className = "text-editor-paragraph";
+        paragraphElement.dataset.paragraphIndex = String(paragraphIndex);
+        (paragraph.content || []).forEach(function (textNode, runIndex) {
+          var run = document.createElement("span");
+          run.className = "text-editor-run";
+          run.setAttribute("data-testid", "text-editor-run");
+          run.contentEditable = "true";
+          run.dataset.paragraphIndex = String(paragraphIndex);
+          run.dataset.runIndex = String(runIndex);
+          run.textContent = textNode.text || "";
+          paragraphElement.appendChild(run);
+        });
+        body.appendChild(paragraphElement);
+      });
+      return body;
+    }
+
+    function selectElementContents(element) {
+      var range = document.createRange();
+      range.selectNodeContents(element);
+      var selection = window.getSelection();
+      if (!selection) return;
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+
+    function positionActiveTextEditor() {
+      if (!activeTextEditor || !activeTextEditor.shape || !activeTextEditor.shape.bounds) return;
+      var container = document.getElementById("slide-container");
+      var renderedSvg = container.querySelector("svg:not(#selection-overlay)");
+      if (!renderedSvg) return;
+      var svgRect = renderedSvg.getBoundingClientRect();
+      var containerRect = container.getBoundingClientRect();
+      var viewBox = parseViewBox(renderedSvg.getAttribute("viewBox") || "0 0 960 540");
+      var bounds = activeTextEditor.shape.bounds;
+      var left = svgRect.left - containerRect.left + ((bounds.x - viewBox.x) / viewBox.width) * svgRect.width;
+      var top = svgRect.top - containerRect.top + ((bounds.y - viewBox.y) / viewBox.height) * svgRect.height;
+      var width = (bounds.width / viewBox.width) * svgRect.width;
+      var height = (bounds.height / viewBox.height) * svgRect.height;
+      activeTextEditor.element.style.left = left + "px";
+      activeTextEditor.element.style.top = top + "px";
+      activeTextEditor.element.style.width = width + "px";
+      activeTextEditor.element.style.height = height + "px";
+    }
+
+    function parseViewBox(value) {
+      var parts = String(value).trim().split(/\\s+/).map(Number);
+      return {
+        x: Number.isFinite(parts[0]) ? parts[0] : 0,
+        y: Number.isFinite(parts[1]) ? parts[1] : 0,
+        width: Number.isFinite(parts[2]) && parts[2] > 0 ? parts[2] : 960,
+        height: Number.isFinite(parts[3]) && parts[3] > 0 ? parts[3] : 540
+      };
+    }
+
+    function textEditorDocJson() {
+      if (!activeTextEditor) return null;
+      var original = activeTextEditor.originalDocJson;
+      var paragraphs = [];
+      (original.content || []).forEach(function (paragraph, paragraphIndex) {
+        var paragraphElement = activeTextEditor.element.querySelector(
+          '.text-editor-paragraph[data-paragraph-index="' + paragraphIndex + '"]'
+        );
+        var content = [];
+        (paragraph.content || []).forEach(function (textNode, runIndex) {
+          var runElement = paragraphElement
+            ? paragraphElement.querySelector('.text-editor-run[data-run-index="' + runIndex + '"]')
+            : null;
+          var text = runElement ? runElement.textContent || "" : textNode.text || "";
+          if (text.length === 0) return;
+          content.push({
+            type: "text",
+            text: text,
+            marks: textNode.marks || []
+          });
+        });
+        paragraphs.push({
+          type: "paragraph",
+          attrs: paragraph.attrs || {},
+          content: content
+        });
+      });
+      return { type: "doc", content: paragraphs };
+    }
+
+    function commitTextEditor() {
+      if (!activeTextEditor || activeTextEditor.committing) return Promise.resolve();
+      var editor = activeTextEditor;
+      var docJson = textEditorDocJson();
+      if (!docJson) return Promise.resolve();
+      editor.committing = true;
+      return postJson("/api/editor/text-body", {
+        handle: editor.shape.handle,
+        docJson: docJson
+      })
+        .then(function (data) {
+          closeTextEditor(false);
+          applyEditorResponse(data);
+          setEditorMessage("Applied", false);
+        })
+        .catch(function (err) {
+          editor.committing = false;
+          setEditorMessage(err.message, true);
+        });
+    }
+
+    function closeTextEditor(_commit) {
+      if (!activeTextEditor) return;
+      activeTextEditor.element.remove();
+      activeTextEditor = null;
     }
 
     function beginDrag(kind, handle, event) {
@@ -1175,6 +1467,14 @@ async function handleRequest(
     const body = await readJsonBody(req);
     const command = normalizeCommand(isRecord(body) ? body.command : undefined);
     sendJson(res, 200, await backend.apply(command));
+    return;
+  }
+
+  if (url.pathname === "/api/editor/text-body" && req.method === "POST") {
+    const body = await readJsonBody(req);
+    const handle = normalizeHandle(isRecord(body) ? body.handle : undefined);
+    const docJson = isRecord(body) ? body.docJson : undefined;
+    sendJson(res, 200, await backend.applyTextBodyDocJson(handle, docJson));
     return;
   }
 

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1111,9 +1111,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
             ? paragraphElement.querySelector('.text-editor-run[data-run-index="' + runIndex + '"]')
             : null;
           var text = runElement ? runElement.textContent || "" : textNode.text || "";
-          if (text.length === 0) {
-            throw new Error("Text editor runs must not be empty.");
-          }
+          if (text.length === 0) return;
           content.push({
             type: "text",
             text: text,

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1040,6 +1040,18 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           run.dataset.paragraphIndex = String(paragraphIndex);
           run.dataset.runIndex = String(runIndex);
           run.textContent = textNode.text || "";
+          run.addEventListener("beforeinput", function (event) {
+            if (event.inputType === "insertParagraph" || event.inputType === "insertLineBreak") {
+              event.preventDefault();
+              commitTextEditor().catch(function () {});
+            }
+          });
+          run.addEventListener("paste", function (event) {
+            event.preventDefault();
+            var text = (event.clipboardData ? event.clipboardData.getData("text/plain") : "")
+              .replace(/\\r?\\n/g, " ");
+            document.execCommand("insertText", false, text);
+          });
           paragraphElement.appendChild(run);
         });
         body.appendChild(paragraphElement);
@@ -1099,7 +1111,9 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
             ? paragraphElement.querySelector('.text-editor-run[data-run-index="' + runIndex + '"]')
             : null;
           var text = runElement ? runElement.textContent || "" : textNode.text || "";
-          if (text.length === 0) return;
+          if (text.length === 0) {
+            throw new Error("Text editor runs must not be empty.");
+          }
           content.push({
             type: "text",
             text: text,

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1147,7 +1147,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         docJson: docJson
       })
         .then(function (data) {
-          closeTextEditor();
+          closeTextEditor(editor);
           applyEditorResponse(data);
           setEditorMessage("Applied", false);
         })
@@ -1160,10 +1160,13 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       return editor.commitPromise;
     }
 
-    function closeTextEditor() {
-      if (!activeTextEditor) return;
-      activeTextEditor.element.remove();
-      activeTextEditor = null;
+    function closeTextEditor(editor) {
+      var target = editor || activeTextEditor;
+      if (!target) return;
+      if (editor && activeTextEditor !== editor) return;
+      if (!editor && target.committing) return;
+      target.element.remove();
+      if (activeTextEditor === target) activeTextEditor = null;
     }
 
     function beginDrag(kind, handle, event) {

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -885,6 +885,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           selectShape(shape, event);
         });
         hit.addEventListener("mousedown", function (event) {
+          if (activeTextEditor) return;
           if (event.detail >= 2 && shape.editableTextBody) {
             event.preventDefault();
             openTextEditor(shape);
@@ -945,6 +946,10 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function selectShape(shape, event) {
+      if (activeTextEditor) {
+        commitTextEditor().catch(function () {});
+        return;
+      }
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
       beginDrag("move", null, event);
@@ -964,6 +969,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
 
     function openTextEditor(shape) {
       if (!shape || !shape.handle || !shape.bounds || !shape.editableTextBody) return;
+      if (activeTextEditor) return;
       if (dragState) {
         dragState = null;
         detachDragListeners();
@@ -993,6 +999,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       overlay.appendChild(actions);
 
       overlay.addEventListener("keydown", function (event) {
+        if (event.isComposing || event.keyCode === 229) return;
         if (event.key === "Enter" && !event.shiftKey) {
           event.preventDefault();
           commitTextEditor().catch(function () {});
@@ -1015,7 +1022,8 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         element: overlay,
         shape: cloneShape(shape),
         originalDocJson: shape.editableTextBody.docJson,
-        committing: false
+        committing: false,
+        commitPromise: null
       };
       positionActiveTextEditor();
       var firstRun = overlay.querySelector(".text-editor-run");
@@ -1128,12 +1136,13 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function commitTextEditor() {
-      if (!activeTextEditor || activeTextEditor.committing) return Promise.resolve();
+      if (!activeTextEditor) return Promise.resolve();
       var editor = activeTextEditor;
+      if (editor.committing) return editor.commitPromise || Promise.resolve();
       var docJson = textEditorDocJson();
       if (!docJson) return Promise.resolve();
       editor.committing = true;
-      return postJson("/api/editor/text-body", {
+      editor.commitPromise = postJson("/api/editor/text-body", {
         handle: editor.shape.handle,
         docJson: docJson
       })
@@ -1144,9 +1153,11 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         })
         .catch(function (err) {
           editor.committing = false;
+          editor.commitPromise = null;
           setEditorMessage(err.message, true);
           throw err;
         });
+      return editor.commitPromise;
     }
 
     function closeTextEditor() {


### PR DESCRIPTION
close #583

## 目的

ローカル dev editor の SVG preview 上で text shape をダブルクリックしたとき、shape bounds に重ねた contenteditable overlay でテキストを編集し、確定時に editor-core の ProseMirror doc JSON 変換経由で `PptxSourceModel` に反映・再レンダリング・保存できる MVP を追加します。

## 変更内容

- `scripts/dev-server.ts`
  - text shape の `editableTextBody.docJson` を `/api/editor/shapes` に追加
  - `/api/editor/text-body` を追加し、ProseMirror doc JSON から editor-core command を生成して適用
  - SVG 上の double-click で text overlay を表示し、Done / blur / Enter で確定
  - overlay positioning、IME composition 中 Enter、paste/改行、commit race を考慮
- `e2e/dev-server-editor.playwright.ts`
  - overlay positioning、編集確定、再レンダリング、保存 PPTX 反映を検証
- `e2e/dev-server-editor.test.ts`
  - text-body API、空テキスト保存、既存 editor API flow を検証
- `README.md`
  - IME は CI 自動化ではなくリリース前手動チェック対象であることを明記

## ローカル検証

- `pnpm exec vitest run e2e/dev-server-editor.test.ts packages/editor-core/src/index.test.ts`
- `pnpm exec playwright test e2e/dev-server-editor.playwright.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`

## 受け入れ条件確認

- text shape double-click で overlay 表示・既存テキスト編集: Playwright で確認
- 確定後の再レンダリング・保存 PPTX 反映: Playwright / API test で確認
- 未編集 run / paragraph property preservation: 既存 editor-core round-trip tests で確認
- overlay positioning / save flow: Playwright で確認
- IME 手動チェック対象明記: README に追記
