### PR TITLE
PNG変換のWASM外部初期化APIを追加

### DIFF
--- a/.changeset/browser-resvg-wasm.md
+++ b/.changeset/browser-resvg-wasm.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+Allow `initResvgWasm` to accept externally loaded WASM bytes or a `Response`, enabling browser-like runtimes to initialize PNG conversion without Node.js filesystem loading.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ getMappedFont("calibri", mapping); // "Ubuntu"
 <details>
 <summary>Custom Font Loading</summary>
 
-When font files are loaded outside Node.js filesystem scanning, pass the bytes directly with the `fonts` option. This is the font-loading path to use for browser or Edge Runtime integrations that fetch fonts from a URL, application bundle, File input, or any other source. Other browser runtime requirements, such as resvg WASM loading for PNG output, are handled separately.
+When font files are loaded outside Node.js filesystem scanning, pass the bytes directly with the `fonts` option. This is the font-loading path to use for browser or Edge Runtime integrations that fetch fonts from a URL, application bundle, File input, or any other source.
 
 ```typescript
 import { convertPptxToSvg } from "pptx-glimpse";
@@ -181,6 +181,35 @@ const setup = await createOpentypeSetupFromBuffers([
 // setup.measurer — text width measurement
 // setup.fontResolver — text-to-SVG-path conversion
 ```
+
+</details>
+
+<details>
+<summary>Browser resvg WASM Loading for PNG</summary>
+
+PNG conversion uses `@resvg/resvg-wasm`. In Node.js, `convertPptxToPng` initializes the bundled WASM automatically on first use. In browser-like runtimes, fetch or bundle the `.wasm` file yourself and pass it to `initResvgWasm` before PNG conversion so no Node.js filesystem loading is needed.
+
+```typescript
+import { initResvgWasm } from "pptx-glimpse";
+
+// A Response can be passed directly.
+const wasmResponse = await fetch("/assets/resvg.wasm");
+await initResvgWasm(wasmResponse);
+```
+
+`initResvgWasm` also accepts raw WASM bytes when your bundler or application already loaded them:
+
+```typescript
+import { initResvgWasm } from "pptx-glimpse";
+
+const wasm = await fetch("/assets/resvg.wasm").then((response) => response.arrayBuffer());
+await initResvgWasm(wasm);
+
+// Uint8Array is accepted too.
+await initResvgWasm(new Uint8Array(wasm));
+```
+
+In Node.js, calling `initResvgWasm()` with no arguments preserves the default bundled WASM loading behavior.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ const setup = await createOpentypeSetupFromBuffers([
 <details>
 <summary>Browser resvg WASM Loading for PNG</summary>
 
-PNG conversion uses `@resvg/resvg-wasm`. In Node.js, `convertPptxToPng` initializes the bundled WASM automatically on first use. In browser-like runtimes, fetch or bundle the `.wasm` file yourself and pass it to `initResvgWasm` before PNG conversion so no Node.js filesystem loading is needed.
+PNG conversion uses `@resvg/resvg-wasm`. In Node.js, `convertPptxToPng` initializes the bundled WASM automatically on first use. In browser-like runtimes that call the PNG conversion path, fetch or bundle the `.wasm` file yourself and pass it to `initResvgWasm` before PNG conversion so no Node.js filesystem loading is needed.
+
+The browser export currently exposes `initResvgWasm` for explicit WASM initialization, but `convertPptxToPng` remains unavailable from the browser export until the PNG result API and browser conversion verification are completed.
 
 ```typescript
 import { initResvgWasm } from "pptx-glimpse";

--- a/packages/core/src/browser-entry.test.ts
+++ b/packages/core/src/browser-entry.test.ts
@@ -3,7 +3,15 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { build } from "esbuild";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const rendererPngMocks = vi.hoisted(() => ({
+  initResvgWasm: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@pptx-glimpse/renderer/png", () => ({
+  initResvgWasm: rendererPngMocks.initResvgWasm,
+}));
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, "..");
@@ -30,6 +38,16 @@ function isCorePackageJson(value: unknown): value is CorePackageJson {
 }
 
 describe("browser entry", () => {
+  it("forwards explicit WASM input to the renderer PNG initializer", async () => {
+    rendererPngMocks.initResvgWasm.mockClear();
+    const { initResvgWasm } = await import("./browser.js");
+    const wasm = new Uint8Array([1, 2, 3]);
+
+    await initResvgWasm(wasm);
+
+    expect(rendererPngMocks.initResvgWasm).toHaveBeenCalledWith(wasm);
+  });
+
   it("bundles browser-safe entry APIs without Node built-ins", async () => {
     const packageJson: unknown = JSON.parse(
       readFileSync(resolve(packageRoot, "package.json"), "utf8"),

--- a/packages/core/src/browser-entry.test.ts
+++ b/packages/core/src/browser-entry.test.ts
@@ -30,7 +30,7 @@ function isCorePackageJson(value: unknown): value is CorePackageJson {
 }
 
 describe("browser entry", () => {
-  it("bundles convertPptxToSvg for browser without Node built-ins", async () => {
+  it("bundles browser-safe entry APIs without Node built-ins", async () => {
     const packageJson: unknown = JSON.parse(
       readFileSync(resolve(packageRoot, "package.json"), "utf8"),
     );
@@ -42,7 +42,8 @@ describe("browser entry", () => {
 
     const result = await build({
       stdin: {
-        contents: 'import { convertPptxToSvg } from "pptx-glimpse"; console.log(convertPptxToSvg);',
+        contents:
+          'import { convertPptxToSvg, initResvgWasm } from "pptx-glimpse"; console.log(convertPptxToSvg, initResvgWasm);',
         resolveDir: here,
         sourcefile: "browser-entry-smoke.ts",
         loader: "ts",
@@ -69,6 +70,9 @@ describe("browser entry", () => {
             }));
             build.onResolve({ filter: /^@pptx-glimpse\/renderer$/ }, () => ({
               path: resolve(packageRoot, "../renderer/src/index.ts"),
+            }));
+            build.onResolve({ filter: /^@pptx-glimpse\/renderer\/png$/ }, () => ({
+              path: resolve(packageRoot, "../renderer/src/png.ts"),
             }));
           },
         },

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -21,6 +21,7 @@ export {
   createOpentypeTextMeasurerFromBuffers,
 } from "@pptx-glimpse/renderer";
 export { getWarningEntries, getWarningSummary } from "@pptx-glimpse/renderer";
+export type { ResvgWasmInput } from "@pptx-glimpse/renderer/png";
 
 export function convertPptxToPng(): Promise<never> {
   return Promise.reject(
@@ -30,10 +31,9 @@ export function convertPptxToPng(): Promise<never> {
   );
 }
 
-export function initResvgWasm(): Promise<never> {
-  return Promise.reject(
-    new Error(
-      "initResvgWasm is not available from the browser entry. Browser PNG/WASM loading is tracked separately.",
-    ),
-  );
+export async function initResvgWasm(
+  wasm: import("@pptx-glimpse/renderer/png").ResvgWasmInput,
+): Promise<void> {
+  const { initResvgWasm: initRendererResvgWasm } = await import("@pptx-glimpse/renderer/png");
+  return initRendererResvgWasm(wasm);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,8 +22,11 @@ export {
   createOpentypeTextMeasurerFromBuffers,
 } from "@pptx-glimpse/renderer";
 export { getWarningEntries, getWarningSummary } from "@pptx-glimpse/renderer";
+export type { ResvgWasmInput } from "@pptx-glimpse/renderer/png";
 
-export async function initResvgWasm(): Promise<void> {
+export async function initResvgWasm(
+  wasm?: import("@pptx-glimpse/renderer/png").ResvgWasmInput,
+): Promise<void> {
   const { initResvgWasm: initRendererResvgWasm } = await import("@pptx-glimpse/renderer/png");
-  return initRendererResvgWasm();
+  return initRendererResvgWasm(wasm);
 }

--- a/packages/renderer/src/png.ts
+++ b/packages/renderer/src/png.ts
@@ -1,1 +1,2 @@
+export type { ResvgWasmInput } from "./png/png-converter.js";
 export { initResvgWasm, svgToPng } from "./png/png-converter.js";

--- a/packages/renderer/src/png/png-converter.test.ts
+++ b/packages/renderer/src/png/png-converter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
+  const initWasm = vi.fn().mockResolvedValue(undefined);
   const mockRender = vi.fn(() => ({
     asPng: () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
     width: 960,
@@ -11,26 +12,94 @@ const mocks = vi.hoisted(() => {
       render: mockRender,
     };
   });
-  return { MockResvg, mockRender };
+  const readFile = vi.fn().mockResolvedValue(new Uint8Array([0]));
+  const requireResolve = vi.fn().mockReturnValue("/mock/resvg.wasm");
+  const createRequire = vi.fn().mockReturnValue({ resolve: requireResolve });
+  return { createRequire, initWasm, MockResvg, mockRender, readFile, requireResolve };
 });
 
 vi.mock("@resvg/resvg-wasm", () => ({
-  initWasm: vi.fn().mockResolvedValue(undefined),
+  initWasm: mocks.initWasm,
   Resvg: mocks.MockResvg,
 }));
 
-vi.mock("fs/promises", () => ({
-  readFile: vi.fn().mockResolvedValue(Buffer.alloc(0)),
+vi.mock("node:fs/promises", () => ({
+  readFile: mocks.readFile,
+}));
+
+vi.mock("node:module", () => ({
+  createRequire: mocks.createRequire,
 }));
 
 import { unsafeFixtureAssertion } from "../unsafe-type-assertion.js";
-import { svgToPng } from "./png-converter.js";
 
 const MINIMAL_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg>';
 
+async function loadPngConverter() {
+  vi.resetModules();
+  mocks.initWasm.mockClear();
+  mocks.MockResvg.mockClear();
+  mocks.mockRender.mockClear();
+  mocks.readFile.mockClear();
+  mocks.createRequire.mockClear();
+  mocks.requireResolve.mockClear();
+  return import("./png-converter.js");
+}
+
+describe("initResvgWasm", () => {
+  it("loads the bundled WASM through Node.js APIs when no input is specified", async () => {
+    const { initResvgWasm } = await loadPngConverter();
+
+    await initResvgWasm();
+
+    expect(mocks.createRequire).toHaveBeenCalledTimes(1);
+    expect(mocks.requireResolve).toHaveBeenCalledWith("@resvg/resvg-wasm/index_bg.wasm");
+    expect(mocks.readFile).toHaveBeenCalledWith("/mock/resvg.wasm");
+    expect(mocks.initWasm).toHaveBeenCalledWith(new Uint8Array([0]));
+  });
+
+  it("initializes from an ArrayBuffer without executing Node.js WASM loading", async () => {
+    const { initResvgWasm } = await loadPngConverter();
+    const wasm = new Uint8Array([1, 2, 3]).buffer;
+
+    await initResvgWasm(wasm);
+
+    expect(mocks.initWasm).toHaveBeenCalledWith(wasm);
+    expect(mocks.createRequire).not.toHaveBeenCalled();
+    expect(mocks.readFile).not.toHaveBeenCalled();
+  });
+
+  it("initializes from a Uint8Array without executing Node.js WASM loading", async () => {
+    const { initResvgWasm } = await loadPngConverter();
+    const wasm = new Uint8Array([1, 2, 3]);
+
+    await initResvgWasm(wasm);
+
+    expect(mocks.initWasm).toHaveBeenCalledWith(wasm);
+    expect(mocks.createRequire).not.toHaveBeenCalled();
+    expect(mocks.readFile).not.toHaveBeenCalled();
+  });
+
+  it("initializes from a Response without executing Node.js WASM loading", async () => {
+    const { initResvgWasm } = await loadPngConverter();
+    const wasm = new Uint8Array([1, 2, 3]).buffer;
+    const response = new Response(wasm);
+
+    await initResvgWasm(response);
+
+    const actual = unsafeFixtureAssertion<ArrayBuffer | Uint8Array>(
+      mocks.initWasm.mock.calls[0]?.[0],
+    );
+    expect([...new Uint8Array(actual)]).toEqual([1, 2, 3]);
+    expect(mocks.createRequire).not.toHaveBeenCalled();
+    expect(mocks.readFile).not.toHaveBeenCalled();
+  });
+});
+
 describe("svgToPng", () => {
   it("Do not pass font option to Resvg when fontBuffers is not specified", async () => {
-    mocks.MockResvg.mockClear();
+    const { svgToPng } = await loadPngConverter();
+
     await svgToPng(MINIMAL_SVG);
     const opts = unsafeFixtureAssertion<Record<string, unknown> | undefined>(
       mocks.MockResvg.mock.calls[0]?.[1],
@@ -39,7 +108,8 @@ describe("svgToPng", () => {
   });
 
   it("Do not pass font option to Resvg when fontBuffers is empty array", async () => {
-    mocks.MockResvg.mockClear();
+    const { svgToPng } = await loadPngConverter();
+
     await svgToPng(MINIMAL_SVG, { fontBuffers: [] });
     const opts = unsafeFixtureAssertion<Record<string, unknown> | undefined>(
       mocks.MockResvg.mock.calls[0]?.[1],
@@ -48,8 +118,9 @@ describe("svgToPng", () => {
   });
 
   it("If fontBuffers is specified, it will be passed to Resvg as font: { fontBuffers }", async () => {
+    const { svgToPng } = await loadPngConverter();
     const fontBuffers = [new Uint8Array([1, 2, 3])];
-    mocks.MockResvg.mockClear();
+
     await svgToPng(MINIMAL_SVG, { fontBuffers });
     const opts = unsafeFixtureAssertion<Record<string, unknown> | undefined>(
       mocks.MockResvg.mock.calls[0]?.[1],

--- a/packages/renderer/src/png/png-converter.ts
+++ b/packages/renderer/src/png/png-converter.ts
@@ -1,10 +1,15 @@
 import { initWasm, Resvg, type ResvgRenderOptions } from "@resvg/resvg-wasm";
-import { readFile } from "fs/promises";
-import { createRequire } from "module";
 
 let wasmInitPromise: Promise<void> | null = null;
 
-function resolveWasmPath(): string {
+export type ResvgWasmInput = ArrayBuffer | Uint8Array | Response;
+
+const nodeImportPrefix = "node:";
+const fsModuleName = "fs";
+const fsPromisesSegment = "promises";
+const moduleModuleName = "module";
+
+function resolveWasmPath(createRequire: (filename: string) => { resolve: (id: string) => string }) {
   // ESM: import.meta.url is available
   // CJS: tsup replaces import.meta with empty object, so fall back to __filename
   const baseUrl = import.meta.url || `file://${__filename}`;
@@ -12,19 +17,45 @@ function resolveWasmPath(): string {
   return require.resolve("@resvg/resvg-wasm/index_bg.wasm");
 }
 
+async function loadBundledWasm(): Promise<Uint8Array> {
+  const [{ readFile }, { createRequire }] = await Promise.all([
+    importNodeFsPromises(),
+    importNodeModule(),
+  ]);
+  const wasmPath = resolveWasmPath(createRequire);
+  return readFile(wasmPath);
+}
+
+function importNodeFsPromises(): Promise<typeof import("node:fs/promises")> {
+  return import(`${nodeImportPrefix}${fsModuleName}/${fsPromisesSegment}`);
+}
+
+function importNodeModule(): Promise<typeof import("node:module")> {
+  return import(`${nodeImportPrefix}${moduleModuleName}`);
+}
+
+async function normalizeWasmInput(wasm: ResvgWasmInput): Promise<ArrayBuffer | Uint8Array> {
+  if (wasm instanceof ArrayBuffer || wasm instanceof Uint8Array) {
+    return wasm;
+  }
+  return wasm.arrayBuffer();
+}
+
 /**
  * Initialize the resvg-wasm module used for PNG conversion.
  *
  * Calling this is optional because `convertPptxToPng` initializes resvg-wasm on
  * first use. Applications may call it during startup to pay the WASM loading
- * cost before handling the first conversion request.
+ * cost before handling the first conversion request. Pass the WASM binary
+ * explicitly in browser-like environments where Node.js filesystem APIs are not
+ * available.
  */
-export async function initResvgWasm(): Promise<void> {
+export async function initResvgWasm(wasm?: ResvgWasmInput): Promise<void> {
   if (!wasmInitPromise) {
     wasmInitPromise = (async () => {
-      const wasmPath = resolveWasmPath();
-      const wasmBuffer = await readFile(wasmPath);
-      await initWasm(wasmBuffer);
+      const wasmInput =
+        wasm === undefined ? await loadBundledWasm() : await normalizeWasmInput(wasm);
+      await initWasm(wasmInput);
     })();
   }
   await wasmInitPromise;


### PR DESCRIPTION
close #370

## 目的

PNG 変換で使う `@resvg/resvg-wasm` の初期化 API に、外部から読み込んだ WASM バイナリを渡せるようにします。Node.js では引き続き引数なしで bundled WASM を自動読み込みし、外部 WASM を渡した経路では Node.js の `fs` / `createRequire` を実行しないようにします。

## 変更内容

- `initResvgWasm(wasm?)` を `ArrayBuffer` / `Uint8Array` / `Response` 対応に拡張
- Node.js の bundled WASM 読み込みを引数なしの fallback 経路に遅延
- browser entry から explicit WASM 初期化 API を公開
- README にブラウザ向け WASM 読み込み例を追加
- minor changeset を追加

## 影響パス

- `packages/renderer/src/png/*`
- `packages/core/src/index.ts`
- `packages/core/src/browser.ts`
- `packages/core/src/browser-entry.test.ts`
- `README.md`
- `.changeset/browser-resvg-wasm.md`

## 検証

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- acceptance-check: 受け入れ条件 5/5 件すべて ✓
- cross-review: warning 1件 / info 1件を追加 commit で対応済み

## 補足

`SlideImage.png` の `Buffer` → `Uint8Array` 変更、フォント読み込み抽象化、ブラウザ内 PNG 変換 CI は issue のスコープ外として残しています。
