### PR TITLE
公開 API を Uint8Array ベースに統一

### DIFF
--- a/.changeset/public-uint8array-api.md
+++ b/.changeset/public-uint8array-api.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": major
+---
+
+Remove Node.js Buffer types from the public conversion and font-collection APIs in favor of Uint8Array.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This file provides guidance to AI coding agents, including Codex and Claude Code
 ## Project Overview
 
 pptx-glimpse is a TypeScript library that converts PPTX slides to SVG / PNG.
-Input: `Buffer | Uint8Array`, Output: SVG string or PNG Buffer.
+Input: `Uint8Array` (Node.js `Buffer` is accepted as a subclass), Output: SVG string or PNG `Uint8Array`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const { slides: svgResults } = await convertPptxToSvg(pptx);
 
 // Convert to PNG
 const { slides: pngResults } = await convertPptxToPng(pptx);
-// [{ slideNumber: 1, png: Buffer, width: 960, height: 540 }, ...]
+// [{ slideNumber: 1, png: Uint8Array, width: 960, height: 540 }, ...]
 
 writeFileSync("slide1.png", pngResults[0].png);
 ```

--- a/packages/core/src/converter.test.ts
+++ b/packages/core/src/converter.test.ts
@@ -333,6 +333,23 @@ describe("public conversion orchestration", () => {
     expect([...pngSlide.png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
   });
 
+  it("keeps Node Buffer input working while returning Uint8Array PNG bytes", async () => {
+    const input = Buffer.from(readSharedFixture("real-basic-theme.pptx"));
+    const { slides: result } = await convertPptxToPng(input, {
+      slides: [1],
+      width: 240,
+    });
+
+    const pngSlide = result[0];
+    if (pngSlide === undefined) {
+      throw new Error("Expected one PNG slide from the public converter");
+    }
+
+    expect(pngSlide.png).toBeInstanceOf(Uint8Array);
+    expect(Buffer.isBuffer(pngSlide.png)).toBe(false);
+    expect([...pngSlide.png.subarray(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
   it("uses the source model reader and renderer adapter for SVG conversion", async () => {
     const readPptxSpy = vi.spyOn(document, "readPptx");
     const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -29,7 +29,7 @@ export interface SlideImage {
   /**
    * PNG image bytes for the rendered slide.
    */
-  png: Buffer;
+  png: Uint8Array;
   /**
    * Actual output image width in pixels after rasterization.
    */
@@ -49,7 +49,7 @@ export interface PngConversionReport {
 /**
  * Convert a PPTX file to SVG documents.
  *
- * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
+ * @param input PPTX binary data.
  * @param options Conversion options. `slides` uses 1-based slide numbers; when
  * omitted, all slides are converted.
  * @returns A conversion report containing converted slides, diagnostics, and support coverage.
@@ -60,7 +60,7 @@ export interface PngConversionReport {
  * control how PPTX font names are resolved for text measurement and text output.
  */
 export async function convertPptxToSvg(
-  input: Buffer | Uint8Array,
+  input: Uint8Array,
   options?: ConvertOptions,
 ): Promise<SvgConversionReport> {
   return convertPptxToSvgBase(input, options, loadSystemFontSetup);
@@ -69,7 +69,7 @@ export async function convertPptxToSvg(
 /**
  * Convert a PPTX file to PNG images.
  *
- * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
+ * @param input PPTX binary data.
  * @param options Conversion options. `slides` uses 1-based slide numbers; when
  * omitted, all slides are converted.
  * @returns A conversion report containing converted PNG slides, diagnostics, and support coverage.
@@ -81,7 +81,7 @@ export async function convertPptxToSvg(
  * options are still used to resolve glyph outlines and text metrics.
  */
 export async function convertPptxToPng(
-  input: Buffer | Uint8Array,
+  input: Uint8Array,
   options?: ConvertOptions,
 ): Promise<PngConversionReport> {
   const svgResult = await convertPptxToSvg(input, {
@@ -97,7 +97,7 @@ export async function convertPptxToPng(
     const pngResult = await convertSvgToPng(svg, { width, height, fontBuffers });
     slides.push({
       slideNumber,
-      png: pngResult.png,
+      png: toPlainUint8Array(pngResult.png),
       width: pngResult.width,
       height: pngResult.height,
     });
@@ -151,4 +151,8 @@ function shouldLoadSystemFonts(options: ConvertOptions | undefined): boolean {
 
 function toUint8Array(data: ArrayBuffer | Uint8Array): Uint8Array {
   return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+function toPlainUint8Array(data: Uint8Array): Uint8Array {
+  return new Uint8Array(data);
 }

--- a/packages/core/src/font/font-collector.ts
+++ b/packages/core/src/font/font-collector.ts
@@ -62,10 +62,10 @@ const DEFAULT_THEME_FONTS: ResolvedThemeFontScheme = {
  * fonts should be installed, bundled, or mapped before calling the conversion
  * APIs.
  *
- * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
+ * @param input PPTX binary data.
  * @returns Theme font slots and a unique sorted list of referenced font names.
  */
-export function collectUsedFonts(input: Buffer | Uint8Array): UsedFonts {
+export function collectUsedFonts(input: Uint8Array): UsedFonts {
   const source = readPptx(input);
   const defaultFontScheme = findDefaultThemeFontScheme(source);
   const computed = createComputedView(source);

--- a/packages/core/src/svg-converter.ts
+++ b/packages/core/src/svg-converter.ts
@@ -204,7 +204,7 @@ export type SystemFontSetupLoader = (
 /**
  * Convert a PPTX file to SVG documents.
  *
- * @param input PPTX binary data as a Node.js `Buffer` or `Uint8Array`.
+ * @param input PPTX binary data.
  * @param options Conversion options. `slides` uses 1-based slide numbers; when
  * omitted, all slides are converted.
  * @returns A conversion report containing converted slides, diagnostics, and support coverage.
@@ -215,7 +215,7 @@ export type SystemFontSetupLoader = (
  * control how PPTX font names are resolved for text measurement and text output.
  */
 export async function convertPptxToSvg(
-  input: Buffer | Uint8Array,
+  input: Uint8Array,
   options?: ConvertOptions,
   loadSystemFontSetup?: SystemFontSetupLoader,
 ): Promise<SvgConversionReport> {

--- a/packages/document/src/reader/read-pptx.ts
+++ b/packages/document/src/reader/read-pptx.ts
@@ -60,7 +60,7 @@ import {
   type XmlOrderedNode,
 } from "./xml.js";
 
-/** Input for `readPptx`. `Buffer` is accepted as a subclass of `Uint8Array`. */
+/** Input bytes for `readPptx`. */
 export type ReadPptxInput = Uint8Array;
 
 const CONTENT_TYPES_PART = "[Content_Types].xml";

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -94,28 +94,38 @@ cat > tsconfig.json << 'TESTEOF'
 TESTEOF
 
 cat > test-types.ts << 'TESTEOF'
-import { convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
-import type { ConvertOptions, PngConversionReport, SvgConversionReport } from "pptx-glimpse";
+import { collectUsedFonts, convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
+import type { ConvertOptions, PngConversionReport, SvgConversionReport, UsedFonts } from "pptx-glimpse";
 
 // Verify function signatures
-const _svgFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<SvgConversionReport> =
+const _svgFn: (input: Uint8Array, options?: ConvertOptions) => Promise<SvgConversionReport> =
   convertPptxToSvg;
-const _pngFn: (input: Buffer | Uint8Array, options?: ConvertOptions) => Promise<PngConversionReport> =
+const _pngFn: (input: Uint8Array, options?: ConvertOptions) => Promise<PngConversionReport> =
   convertPptxToPng;
+const _fontFn: (input: Uint8Array) => UsedFonts = collectUsedFonts;
 
-// Verify SlideImage.png is Buffer
+// Verify SlideImage.png is Uint8Array
 async function _verifyPngType(input: Uint8Array) {
   const { slides } = await convertPptxToPng(input);
-  const _png: Buffer = slides[0].png;
+  const _png: Uint8Array = slides[0].png;
   void _png;
+}
+
+// Verify Node Buffer remains accepted as a Uint8Array subclass.
+function _verifyBufferInput(input: Buffer) {
+  void convertPptxToSvg(input);
+  void convertPptxToPng(input);
+  void collectUsedFonts(input);
 }
 
 // Verify ConvertOptions includes fontDirs
 const _options: ConvertOptions = { slides: [1], width: 960, fontDirs: ["/custom/fonts"] };
 void _svgFn;
 void _pngFn;
+void _fontFn;
 void _options;
 void _verifyPngType;
+void _verifyBufferInput;
 TESTEOF
 npx tsc --noEmit
 echo "TypeScript type resolution test passed!"


### PR DESCRIPTION
close #590

## 概要

公開 API の PPTX 入力型と PNG 出力型を `Uint8Array` ベースに統一し、Node.js `Buffer` 型への公開型依存を削除しました。

## 変更内容

- `convertPptxToSvg` / `convertPptxToPng` / `collectUsedFonts` の入力型を `Uint8Array` に統一
- `SlideImage.png` の公開型を `Uint8Array` に変更し、PNG 変換結果も plain `Uint8Array` として返すように調整
- `@pptx-glimpse/document` の `readPptx` JSDoc と README / AGENTS / package type verification を更新
- Node.js `Buffer` 入力が `Uint8Array` サブクラスとして引き続き動作する後方互換テストを追加
- major changeset を追加

## 影響範囲

- `packages/core/src/converter.ts`
- `packages/core/src/svg-converter.ts`
- `packages/core/src/font/font-collector.ts`
- `packages/document/src/reader/read-pptx.ts`
- `scripts/test-package.sh`
- `README.md` / `AGENTS.md`

## 検証

- `npm run test -- packages/core/src/converter.test.ts packages/core/src/font/font-collector.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run test:package`
- `npm run test`
- 公開 source / d.ts 対象の `Buffer` 検索で no match を確認
