### PR TITLE
CI でブラウザ内 PPTX 変換を検証する

### DIFF
--- a/.changeset/browser-png-playwright-ci.md
+++ b/.changeset/browser-png-playwright-ci.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+Expose browser PNG conversion after explicit resvg WASM initialization and add Playwright coverage for browser-only SVG/PNG conversion.

--- a/README.md
+++ b/README.md
@@ -189,14 +189,18 @@ const setup = await createOpentypeSetupFromBuffers([
 
 PNG conversion uses `@resvg/resvg-wasm`. In Node.js, `convertPptxToPng` initializes the bundled WASM automatically on first use. In browser-like runtimes that call the PNG conversion path, fetch or bundle the `.wasm` file yourself and pass it to `initResvgWasm` before PNG conversion so no Node.js filesystem loading is needed.
 
-The browser export currently exposes `initResvgWasm` for explicit WASM initialization, but `convertPptxToPng` remains unavailable from the browser export until the PNG result API and browser conversion verification are completed.
-
 ```typescript
-import { initResvgWasm } from "pptx-glimpse";
+import { convertPptxToPng, initResvgWasm } from "pptx-glimpse";
 
 // A Response can be passed directly.
 const wasmResponse = await fetch("/assets/resvg.wasm");
 await initResvgWasm(wasmResponse);
+
+const pptx = new Uint8Array(await pptxFile.arrayBuffer());
+const { slides } = await convertPptxToPng(pptx, {
+  fonts: loadedFonts,
+  skipSystemFonts: true,
+});
 ```
 
 `initResvgWasm` also accepts raw WASM bytes when your bundler or application already loaded them:
@@ -395,6 +399,13 @@ const { slides } = await convertPptxToSvg(pptx, {
 The local editor preview (`npm run dev -- <pptx-file>`) includes an MVP text editing
 overlay for text shapes. IME behavior is intentionally not automated in CI; verify IME
 composition manually as part of the release checklist before shipping editor changes.
+
+Browser conversion smoke tests run with Playwright and cover browser-only SVG conversion
+plus PNG conversion after explicit resvg WASM initialization:
+
+```bash
+npm run test:playwright
+```
 
 <details>
 <summary>Test rendering</summary>

--- a/e2e/browser-standalone-viewer.playwright.ts
+++ b/e2e/browser-standalone-viewer.playwright.ts
@@ -21,6 +21,7 @@ const vrtFixtures = resolve(repoRoot, "vrt/snapshot/fixtures");
 const execFileAsync = promisify(execFile);
 const coreRequire = createRequire(resolve(corePackageRoot, "package.json"));
 let coreDistBuildPromise: Promise<void> | null = null;
+let vrtFixturesPromise: Promise<void> | null = null;
 
 test("runs a browser-only PPTX to SVG viewer for shared fixtures", async ({ page }) => {
   const viewer = await startStandaloneViewer();
@@ -42,6 +43,7 @@ test("runs a browser-only PPTX to SVG viewer for shared fixtures", async ({ page
 });
 
 test("runs browser-only PPTX to SVG conversion for a VRT fixture", async ({ page }) => {
+  await ensureVrtFixtures();
   const viewer = await startStandaloneViewer();
   try {
     await page.goto(viewer.url);
@@ -184,6 +186,18 @@ async function runPackageBuild(packageRoot: string): Promise<void> {
     cwd: packageRoot,
     maxBuffer: 10 * 1024 * 1024,
   });
+}
+
+async function ensureVrtFixtures(): Promise<void> {
+  vrtFixturesPromise ??= execFileAsync(
+    resolve(repoRoot, "node_modules/.bin/tsx"),
+    ["vrt/snapshot/create-fixtures.ts"],
+    {
+      cwd: repoRoot,
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  ).then(() => undefined);
+  await vrtFixturesPromise;
 }
 
 async function createPackageResolveDir(): Promise<string> {

--- a/e2e/browser-standalone-viewer.playwright.ts
+++ b/e2e/browser-standalone-viewer.playwright.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,8 +13,13 @@ import { build } from "esbuild";
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..");
 const corePackageRoot = resolve(repoRoot, "packages/core");
+const documentPackageRoot = resolve(repoRoot, "packages/document");
+const editorCorePackageRoot = resolve(repoRoot, "packages/editor-core");
+const rendererPackageRoot = resolve(repoRoot, "packages/renderer");
 const sharedFixtures = resolve(repoRoot, "shared-fixtures");
+const vrtFixtures = resolve(repoRoot, "vrt/snapshot/fixtures");
 const execFileAsync = promisify(execFile);
+const coreRequire = createRequire(resolve(corePackageRoot, "package.json"));
 let coreDistBuildPromise: Promise<void> | null = null;
 
 test("runs a browser-only PPTX to SVG viewer for shared fixtures", async ({ page }) => {
@@ -30,6 +36,47 @@ test("runs a browser-only PPTX to SVG viewer for shared fixtures", async ({ page
       const slideCount = await page.getByTestId("slide").count();
       expect(slideCount).toBeGreaterThan(0);
     }
+  } finally {
+    await viewer.close();
+  }
+});
+
+test("runs browser-only PPTX to SVG conversion for a VRT fixture", async ({ page }) => {
+  const viewer = await startStandaloneViewer();
+  try {
+    await page.goto(viewer.url);
+
+    await page.getByTestId("pptx-input").setInputFiles(resolve(vrtFixtures, "shapes.pptx"));
+    await expect(page.getByTestId("status")).toContainText("slides rendered");
+    await expect(page.getByTestId("slide").first()).toBeVisible();
+    await expect(page.locator("svg").first()).toBeVisible();
+  } finally {
+    await viewer.close();
+  }
+});
+
+test("runs browser-only PPTX to PNG conversion after explicit WASM initialization", async ({
+  page,
+}) => {
+  const viewer = await startStandaloneViewer();
+  try {
+    await page.goto(viewer.url);
+
+    await page
+      .getByTestId("pptx-input")
+      .setInputFiles(resolve(sharedFixtures, "real-basic-theme.pptx"));
+    await expect(page.getByTestId("status")).toContainText("slides rendered");
+
+    const pngSmoke = await page.evaluate(() => {
+      return window.__pptxGlimpseSmoke?.runPngSmoke?.();
+    });
+
+    expect(pngSmoke).toEqual({
+      pngSignature: [0x89, 0x50, 0x4e, 0x47],
+      slideCount: 1,
+      width: 480,
+      height: 270,
+    });
   } finally {
     await viewer.close();
   }
@@ -65,6 +112,7 @@ interface ViewerServer {
 
 async function startStandaloneViewer(): Promise<ViewerServer> {
   const appBundle = await buildStandaloneViewerBundle();
+  const wasm = await readFile(coreRequire.resolve("@resvg/resvg-wasm/index_bg.wasm"));
   const server = createServer((request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
     if (url.pathname === "/" || url.pathname === "/index.html") {
@@ -75,6 +123,11 @@ async function startStandaloneViewer(): Promise<ViewerServer> {
     if (url.pathname === "/app.js") {
       response.setHeader("Content-Type", "text/javascript; charset=utf-8");
       response.end(appBundle);
+      return;
+    }
+    if (url.pathname === "/resvg.wasm") {
+      response.setHeader("Content-Type", "application/wasm");
+      response.end(wasm);
       return;
     }
     response.statusCode = 404;
@@ -117,11 +170,20 @@ async function buildStandaloneViewerBundle(): Promise<string> {
 }
 
 async function ensureCoreDist(): Promise<void> {
-  coreDistBuildPromise ??= execFileAsync("pnpm", ["run", "build"], {
-    cwd: repoRoot,
-    maxBuffer: 10 * 1024 * 1024,
-  }).then(() => undefined);
+  coreDistBuildPromise ??= (async () => {
+    await runPackageBuild(documentPackageRoot);
+    await runPackageBuild(editorCorePackageRoot);
+    await runPackageBuild(rendererPackageRoot);
+    await runPackageBuild(corePackageRoot);
+  })();
   await coreDistBuildPromise;
+}
+
+async function runPackageBuild(packageRoot: string): Promise<void> {
+  await execFileAsync(resolve(repoRoot, "node_modules/.bin/tsup"), ["--config", "tsup.config.ts"], {
+    cwd: packageRoot,
+    maxBuffer: 10 * 1024 * 1024,
+  });
 }
 
 async function createPackageResolveDir(): Promise<string> {
@@ -160,7 +222,7 @@ const viewerHtml = `<!doctype html>
 </html>`;
 
 const viewerAppSource = `
-import { convertPptxToSvg } from "pptx-glimpse";
+import { convertPptxToPng, convertPptxToSvg, initResvgWasm } from "pptx-glimpse";
 
 const pptxInput = document.getElementById("pptx-input");
 const fontInput = document.getElementById("font-input");
@@ -169,6 +231,8 @@ const status = document.getElementById("status");
 const slides = document.getElementById("slides");
 
 let fonts = [];
+let lastPptxInput = null;
+let resvgReady = null;
 
 fontInput.addEventListener("change", async () => {
   fonts = await Promise.all(
@@ -185,9 +249,14 @@ pptxInput.addEventListener("change", async () => {
   if (!file) return;
   status.textContent = "Converting";
   slides.textContent = "";
-  const input = new Uint8Array(await file.arrayBuffer());
+  lastPptxInput = new Uint8Array(await file.arrayBuffer());
+  const input = new Uint8Array(lastPptxInput);
   const report = await convertPptxToSvg(input, { fonts, skipSystemFonts: true });
-  window.__pptxGlimpseSmoke = { fontCount: fonts.length, slideCount: report.slides.length };
+  window.__pptxGlimpseSmoke = {
+    fontCount: fonts.length,
+    slideCount: report.slides.length,
+    runPngSmoke,
+  };
   slides.innerHTML = report.slides
     .map((slide) => '<article class="slide" data-testid="slide">' + slide.svg + "</article>")
     .join("");
@@ -198,6 +267,34 @@ pptxInput.addEventListener("change", async () => {
     " font file" +
     (fonts.length === 1 ? "" : "s");
 });
+
+async function runPngSmoke() {
+  if (!lastPptxInput) {
+    throw new Error("load a PPTX before running PNG smoke");
+  }
+  resvgReady ??= fetch("/resvg.wasm").then((response) => initResvgWasm(response));
+  await resvgReady;
+  const report = await convertPptxToPng(new Uint8Array(lastPptxInput), {
+    fonts,
+    skipSystemFonts: true,
+    slides: [1],
+    width: 480,
+  });
+  const slide = report.slides[0];
+  const signature = Array.from(slide.png.slice(0, 4));
+  window.__pptxGlimpseSmoke = {
+    ...window.__pptxGlimpseSmoke,
+    pngSignature: signature,
+    pngWidth: slide.width,
+    pngHeight: slide.height,
+  };
+  return {
+    pngSignature: signature,
+    slideCount: report.slides.length,
+    width: slide.width,
+    height: slide.height,
+  };
+}
 `;
 
 async function createTestFontBuffer(familyName: string): Promise<ArrayBuffer> {
@@ -271,6 +368,15 @@ declare global {
     __pptxGlimpseSmoke?: {
       fontCount: number;
       slideCount: number;
+      runPngSmoke?: () => Promise<{
+        pngSignature: number[];
+        slideCount: number;
+        width: number;
+        height: number;
+      }>;
+      pngSignature?: number[];
+      pngWidth?: number;
+      pngHeight?: number;
     };
   }
 }

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -13,6 +13,9 @@ const config: KnipConfig = {
         "e2e/browser-standalone-viewer.playwright.ts",
       ],
     },
+    "packages/core": {
+      ignoreDependencies: ["@resvg/resvg-wasm"],
+    },
   },
 };
 

--- a/packages/core/src/browser-entry.test.ts
+++ b/packages/core/src/browser-entry.test.ts
@@ -7,10 +7,20 @@ import { describe, expect, it, vi } from "vitest";
 
 const resvgMocks = vi.hoisted(() => ({
   initWasm: vi.fn().mockResolvedValue(undefined),
+  MockResvg: class {
+    render() {
+      return {
+        asPng: () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        width: 1,
+        height: 1,
+      };
+    }
+  },
 }));
 
 vi.mock("@resvg/resvg-wasm", () => ({
   initWasm: resvgMocks.initWasm,
+  Resvg: resvgMocks.MockResvg,
 }));
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -61,7 +71,7 @@ describe("browser entry", () => {
     const result = await build({
       stdin: {
         contents:
-          'import { convertPptxToSvg, initResvgWasm } from "pptx-glimpse"; console.log(convertPptxToSvg, initResvgWasm);',
+          'import { convertPptxToPng, convertPptxToSvg, initResvgWasm } from "pptx-glimpse"; console.log(convertPptxToPng, convertPptxToSvg, initResvgWasm);',
         resolveDir: here,
         sourcefile: "browser-entry-smoke.ts",
         loader: "ts",
@@ -91,6 +101,9 @@ describe("browser entry", () => {
             }));
             build.onResolve({ filter: /^@pptx-glimpse\/renderer\/png$/ }, () => ({
               path: resolve(packageRoot, "../renderer/src/png.ts"),
+            }));
+            build.onResolve({ filter: /^@pptx-glimpse\/renderer\/png\/browser$/ }, () => ({
+              path: resolve(packageRoot, "../renderer/src/png-browser.ts"),
             }));
           },
         },

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -1,3 +1,12 @@
+import { DEFAULT_OUTPUT_WIDTH } from "@pptx-glimpse/renderer";
+import {
+  initResvgWasm as initRendererResvgWasm,
+  type ResvgWasmInput,
+  svgToPng,
+} from "@pptx-glimpse/renderer/png/browser";
+
+import { type ConvertOptions, convertPptxToSvg as convertPptxToSvgBase } from "./svg-converter.js";
+
 export type { PngConversionReport, SlideImage } from "./converter.js";
 export type { UsedFonts } from "./font/font-collector.js";
 export { collectUsedFonts } from "./font/font-collector.js";
@@ -21,24 +30,42 @@ export {
   createOpentypeTextMeasurerFromBuffers,
 } from "@pptx-glimpse/renderer";
 export { getWarningEntries, getWarningSummary } from "@pptx-glimpse/renderer";
+export type { ResvgWasmInput } from "@pptx-glimpse/renderer/png/browser";
 
-export type ResvgWasmInput = ArrayBuffer | Uint8Array | Response;
+export async function convertPptxToPng(
+  input: Uint8Array,
+  options?: ConvertOptions,
+): Promise<import("./converter.js").PngConversionReport> {
+  const svgResult = await convertPptxToSvgBase(input, {
+    ...options,
+    textOutput: "path",
+  });
+  const width = options?.width ?? DEFAULT_OUTPUT_WIDTH;
+  const height = options?.height;
+  const fontBuffers = options?.fonts?.map((font) => toUint8Array(font.data)) ?? [];
 
-export function convertPptxToPng(): Promise<never> {
-  return Promise.reject(
-    new Error(
-      "convertPptxToPng is not available from the browser entry. Use convertPptxToSvg or the Node.js entry.",
-    ),
-  );
+  const slides: import("./converter.js").SlideImage[] = [];
+  for (const { slideNumber, svg } of svgResult.slides) {
+    const pngResult = await svgToPng(svg, { width, height, fontBuffers });
+    slides.push({
+      slideNumber,
+      png: new Uint8Array(pngResult.png),
+      width: pngResult.width,
+      height: pngResult.height,
+    });
+  }
+
+  return {
+    slides,
+    diagnostics: svgResult.diagnostics,
+    supportCoverage: svgResult.supportCoverage,
+  };
 }
 
-export async function initResvgWasm(wasm: ResvgWasmInput): Promise<void> {
-  const { initWasm } = await import("@resvg/resvg-wasm");
-  const wasmInput =
-    wasm instanceof Response
-      ? await wasm.arrayBuffer()
-      : wasm instanceof Uint8Array
-        ? new Uint8Array(wasm)
-        : wasm;
-  await initWasm(wasmInput);
+export function initResvgWasm(wasm: ResvgWasmInput): Promise<void> {
+  return initRendererResvgWasm(wasm);
+}
+
+function toUint8Array(data: ArrayBuffer | Uint8Array): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts", "src/browser.ts"],
   format: ["cjs", "esm"],
-  dts: { resolve: ["@pptx-glimpse/renderer"] },
+  dts: {
+    resolve: [
+      "@pptx-glimpse/renderer",
+      "@pptx-glimpse/renderer/png",
+      "@pptx-glimpse/renderer/png/browser",
+    ],
+  },
   clean: true,
   noExternal: ["@pptx-glimpse/document", "@pptx-glimpse/renderer"],
 });

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -19,6 +19,10 @@
     "./png": {
       "types": "./dist/png.d.ts",
       "default": "./src/png.ts"
+    },
+    "./png/browser": {
+      "types": "./dist/png-browser.d.ts",
+      "default": "./src/png-browser.ts"
     }
   },
   "scripts": {

--- a/packages/renderer/src/png-browser.ts
+++ b/packages/renderer/src/png-browser.ts
@@ -1,0 +1,2 @@
+export { initResvgWasm, svgToPng } from "./png/browser-png-converter.js";
+export type { PngConvertOptions, ResvgWasmInput, SvgToPngResult } from "./png/types.js";

--- a/packages/renderer/src/png/browser-png-converter.test.ts
+++ b/packages/renderer/src/png/browser-png-converter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const initWasm = vi.fn().mockResolvedValue(undefined);
+  const MockResvg = vi.fn().mockImplementation(function (_svg: string, _opts?: unknown) {
+    return {
+      render: () => ({
+        asPng: () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        width: 960,
+        height: 540,
+      }),
+    };
+  });
+  return { initWasm, MockResvg };
+});
+
+vi.mock("@resvg/resvg-wasm", () => ({
+  initWasm: mocks.initWasm,
+  Resvg: mocks.MockResvg,
+}));
+
+async function loadBrowserPngConverter() {
+  vi.resetModules();
+  mocks.initWasm.mockReset();
+  mocks.initWasm.mockResolvedValue(undefined);
+  mocks.MockResvg.mockClear();
+  return import("./browser-png-converter.js");
+}
+
+describe("browser initResvgWasm", () => {
+  it("allows retrying after initialization failure", async () => {
+    const { initResvgWasm } = await loadBrowserPngConverter();
+    mocks.initWasm.mockRejectedValueOnce(new Error("bad wasm"));
+
+    await expect(initResvgWasm(new Uint8Array([1]))).rejects.toThrow("bad wasm");
+    await initResvgWasm(new Uint8Array([2]));
+
+    expect(mocks.initWasm).toHaveBeenCalledTimes(2);
+    expect(mocks.initWasm).toHaveBeenNthCalledWith(2, new Uint8Array([2]));
+  });
+
+  it("rejects non-ok Response input before calling initWasm", async () => {
+    const { initResvgWasm } = await loadBrowserPngConverter();
+    const response = new Response("not found", { status: 404 });
+
+    await expect(initResvgWasm(response)).rejects.toThrow("HTTP 404");
+    expect(mocks.initWasm).not.toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/png/browser-png-converter.ts
+++ b/packages/renderer/src/png/browser-png-converter.ts
@@ -9,12 +9,20 @@ async function normalizeWasmInput(wasm: ResvgWasmInput): Promise<ArrayBuffer | U
   if (wasm instanceof ArrayBuffer || wasm instanceof Uint8Array) {
     return wasm;
   }
+  if (!wasm.ok) {
+    throw new Error(`Failed to load resvg WASM: HTTP ${wasm.status.toString()}`);
+  }
   return wasm.arrayBuffer();
 }
 
 export async function initResvgWasm(wasm: ResvgWasmInput): Promise<void> {
   if (!wasmInitPromise) {
-    wasmInitPromise = normalizeWasmInput(wasm).then((wasmInput) => initWasm(wasmInput));
+    wasmInitPromise = normalizeWasmInput(wasm)
+      .then((wasmInput) => initWasm(wasmInput))
+      .catch((error: unknown) => {
+        wasmInitPromise = null;
+        throw error;
+      });
   }
   await wasmInitPromise;
 }

--- a/packages/renderer/src/png/browser-png-converter.ts
+++ b/packages/renderer/src/png/browser-png-converter.ts
@@ -1,0 +1,33 @@
+import { initWasm } from "@resvg/resvg-wasm";
+
+import { renderSvgToPng } from "./render-svg.js";
+import type { PngConvertOptions, ResvgWasmInput, SvgToPngResult } from "./types.js";
+
+let wasmInitPromise: Promise<void> | null = null;
+
+async function normalizeWasmInput(wasm: ResvgWasmInput): Promise<ArrayBuffer | Uint8Array> {
+  if (wasm instanceof ArrayBuffer || wasm instanceof Uint8Array) {
+    return wasm;
+  }
+  return wasm.arrayBuffer();
+}
+
+export async function initResvgWasm(wasm: ResvgWasmInput): Promise<void> {
+  if (!wasmInitPromise) {
+    wasmInitPromise = normalizeWasmInput(wasm).then((wasmInput) => initWasm(wasmInput));
+  }
+  await wasmInitPromise;
+}
+
+export async function svgToPng(
+  svgString: string,
+  options?: PngConvertOptions,
+): Promise<SvgToPngResult> {
+  if (!wasmInitPromise) {
+    throw new Error("initResvgWasm(wasm) must be called before browser PNG conversion.");
+  }
+  await wasmInitPromise;
+  return renderSvgToPng(svgString, options);
+}
+
+export type { PngConvertOptions, ResvgWasmInput, SvgToPngResult } from "./types.js";

--- a/packages/renderer/src/png/png-converter.ts
+++ b/packages/renderer/src/png/png-converter.ts
@@ -1,8 +1,9 @@
-import { initWasm, Resvg, type ResvgRenderOptions } from "@resvg/resvg-wasm";
+import { initWasm } from "@resvg/resvg-wasm";
+
+import { renderSvgToPng } from "./render-svg.js";
+import type { PngConvertOptions, ResvgWasmInput, SvgToPngResult } from "./types.js";
 
 let wasmInitPromise: Promise<void> | null = null;
-
-export type ResvgWasmInput = ArrayBuffer | Uint8Array | Response;
 
 const nodeImportPrefix = "node:";
 const fsModuleName = "fs";
@@ -61,37 +62,12 @@ export async function initResvgWasm(wasm?: ResvgWasmInput): Promise<void> {
   await wasmInitPromise;
 }
 
-interface PngConvertOptions {
-  width?: number;
-  height?: number;
-  /** Font buffers used to render SVG <text> elements */
-  fontBuffers?: Uint8Array[];
-}
-
 export async function svgToPng(
   svgString: string,
   options?: PngConvertOptions,
-): Promise<{ png: Buffer; width: number; height: number }> {
+): Promise<SvgToPngResult> {
   await initResvgWasm();
-
-  const resvgOptions: ResvgRenderOptions = {};
-
-  if (options?.width) {
-    resvgOptions.fitTo = { mode: "width", value: options.width };
-  } else if (options?.height) {
-    resvgOptions.fitTo = { mode: "height", value: options.height };
-  }
-
-  const fontBuffers = options?.fontBuffers;
-  if (fontBuffers && fontBuffers.length > 0) {
-    resvgOptions.font = { fontBuffers };
-  }
-
-  const resvg = new Resvg(svgString, resvgOptions);
-  const rendered = resvg.render();
-  return {
-    png: Buffer.from(rendered.asPng()),
-    width: rendered.width,
-    height: rendered.height,
-  };
+  return renderSvgToPng(svgString, options);
 }
+
+export type { PngConvertOptions, ResvgWasmInput, SvgToPngResult } from "./types.js";

--- a/packages/renderer/src/png/render-svg.ts
+++ b/packages/renderer/src/png/render-svg.ts
@@ -1,0 +1,26 @@
+import { Resvg, type ResvgRenderOptions } from "@resvg/resvg-wasm";
+
+import type { PngConvertOptions, SvgToPngResult } from "./types.js";
+
+export function renderSvgToPng(svgString: string, options?: PngConvertOptions): SvgToPngResult {
+  const resvgOptions: ResvgRenderOptions = {};
+
+  if (options?.width) {
+    resvgOptions.fitTo = { mode: "width", value: options.width };
+  } else if (options?.height) {
+    resvgOptions.fitTo = { mode: "height", value: options.height };
+  }
+
+  const fontBuffers = options?.fontBuffers;
+  if (fontBuffers && fontBuffers.length > 0) {
+    resvgOptions.font = { fontBuffers };
+  }
+
+  const resvg = new Resvg(svgString, resvgOptions);
+  const rendered = resvg.render();
+  return {
+    png: new Uint8Array(rendered.asPng()),
+    width: rendered.width,
+    height: rendered.height,
+  };
+}

--- a/packages/renderer/src/png/types.ts
+++ b/packages/renderer/src/png/types.ts
@@ -1,0 +1,14 @@
+export type ResvgWasmInput = ArrayBuffer | Uint8Array | Response;
+
+export interface PngConvertOptions {
+  width?: number;
+  height?: number;
+  /** Font buffers used to render SVG <text> elements */
+  fontBuffers?: Uint8Array[];
+}
+
+export interface SvgToPngResult {
+  png: Uint8Array;
+  width: number;
+  height: number;
+}

--- a/packages/renderer/tsup.config.ts
+++ b/packages/renderer/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/node.ts", "src/png.ts"],
+  entry: ["src/index.ts", "src/node.ts", "src/png.ts", "src/png-browser.ts"],
   format: ["cjs", "esm"],
   dts: true,
   clean: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
       "@pptx-glimpse/editor-core": ["packages/editor-core/src/index.ts"],
       "@pptx-glimpse/renderer": ["packages/renderer/src/index.ts"],
       "@pptx-glimpse/renderer/node": ["packages/renderer/src/node.ts"],
-      "@pptx-glimpse/renderer/png": ["packages/renderer/src/png.ts"]
+      "@pptx-glimpse/renderer/png": ["packages/renderer/src/png.ts"],
+      "@pptx-glimpse/renderer/png/browser": ["packages/renderer/src/png-browser.ts"]
     }
   },
   "include": ["packages/*/src/**/*"],


### PR DESCRIPTION
close #592

## 目的

ブラウザ内で PPTX から SVG / PNG へ変換できることを Playwright で継続検証し、Node 固有 API の混入や browser bundle 構成のリグレッションを CI で検出できるようにします。

## 変更内容

- browser entry から `convertPptxToPng` を利用できるようにし、ブラウザ専用の resvg WASM 初期化 / PNG helper を追加
- Playwright smoke で shared-fixtures と動的生成した VRT fixture の SVG 変換、明示 WASM 初期化後の PNG 変換を検証
- browser bundle に Node built-in が混入しないことを `browser-entry.test.ts` と Playwright bundle smoke で検査
- README に `npm run test:playwright` と browser PNG/WASM 利用例を追記
- 公開 browser API 追加の changeset を追加

## 影響パッケージ / パス

- `packages/core/src/browser.ts`
- `packages/renderer/src/png*`
- `e2e/browser-standalone-viewer.playwright.ts`
- `README.md`

## ローカル検証

- `node_modules/.bin/prettier --check 'packages/*/src/**/*.ts' 'vrt/**/*.ts' 'scripts/**/*.ts' 'bench/**/*.ts' 'e2e/**/*.ts' README.md .changeset/browser-png-playwright-ci.md packages/core/tsup.config.ts`
- `node_modules/.bin/eslint packages/*/src/ vrt/ scripts/ bench/ e2e/`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/vitest run packages/renderer/src/png/browser-png-converter.test.ts packages/core/src/browser-entry.test.ts packages/renderer/src/png/png-converter.test.ts`
- `node_modules/.bin/playwright test e2e/browser-standalone-viewer.playwright.ts`
- `node_modules/.bin/tsup --config tsup.config.ts`（`packages/renderer` / `packages/core`）
