### PR TITLE
editor: ブラウザ単体の編集セッションを追加

### DIFF
--- a/.changeset/browser-standalone-editor.md
+++ b/.changeset/browser-standalone-editor.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+Add a browser-only PPTX editor session API for loading, editing, undoing, redoing, rendering, and downloading edited presentations without a Node backend.

--- a/e2e/browser-standalone-editor.playwright.ts
+++ b/e2e/browser-standalone-editor.playwright.ts
@@ -1,0 +1,794 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { expect, type Page, test } from "@playwright/test";
+import { build } from "esbuild";
+import JSZip from "jszip";
+
+import {
+  type PptxSourceModel,
+  readPptx,
+  type SourceShape,
+} from "../packages/document/src/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const corePackageRoot = resolve(repoRoot, "packages/core");
+const documentPackageRoot = resolve(repoRoot, "packages/document");
+const editorCorePackageRoot = resolve(repoRoot, "packages/editor-core");
+const rendererPackageRoot = resolve(repoRoot, "packages/renderer");
+const execFileAsync = promisify(execFile);
+const encoder = new TextEncoder();
+const EMU_PER_PIXEL = 9525;
+let coreDistBuildPromise: Promise<void> | null = null;
+
+test("runs a browser-only editor move, resize, text, undo, redo, download, and reopen flow", async ({
+  page,
+}) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-browser-editor-test-"));
+  const editor = await startStandaloneEditor();
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    await writeFile(sourcePath, await buildShapeFixture());
+
+    await page.goto(editor.url);
+    await page.getByTestId("pptx-input").setInputFiles(sourcePath);
+    await expect(page.getByTestId("status")).toContainText("1 slide ready");
+    await expect(page.getByTestId("shape-hit-area").first()).toBeVisible();
+
+    await clickSvgPoint(page, 240, 240);
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "96");
+    await expect(page.getByTestId("selection-handle-se")).toBeVisible();
+
+    await dragSvgPoint(page, { x: 240, y: 240 }, { x: 264, y: 256 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "120");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "208");
+
+    await dragSvgPoint(page, { x: 408, y: 304 }, { x: 456, y: 328 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("height", "120");
+
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "288");
+    await page.getByRole("button", { name: "Redo" }).click();
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+
+    expect(await page.evaluate(() => window.__pptxGlimpseEditorSmoke?.hasEditableTextBody)).toBe(
+      true,
+    );
+    await dblclickSvgPoint(page, 240, 240);
+    const overlay = page.getByTestId("text-editor-overlay");
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toContainText("Original");
+    await expectOverlayNearSvgBounds(page, { x: 120, y: 208, width: 336, height: 120 });
+
+    await page.getByTestId("text-editor-run").first().fill("Browser edited");
+    await page.getByTestId("text-editor-done").click();
+    await expect(page.locator("#slide-container")).toContainText("Browser edited");
+
+    const download = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Download" }).click();
+    await (await download).saveAs(savedPath);
+
+    const saved = readPptx(await readFile(savedPath));
+    expect(firstShape(saved).transform).toMatchObject({
+      offsetX: 120 * EMU_PER_PIXEL,
+      offsetY: 208 * EMU_PER_PIXEL,
+      width: 336 * EMU_PER_PIXEL,
+      height: 120 * EMU_PER_PIXEL,
+    });
+    expect(firstText(saved)).toBe("Browser edited");
+
+    await page.getByTestId("pptx-input").setInputFiles(savedPath);
+    await expect(page.getByTestId("status")).toContainText("1 slide ready");
+    await expect(page.locator("#slide-container")).toContainText("Browser edited");
+  } finally {
+    await editor.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function clickSvgPoint(page: Page, x: number, y: number) {
+  const point = await svgPointToClient(page, x, y);
+  await page.mouse.click(point.x, point.y);
+}
+
+async function dblclickSvgPoint(page: Page, x: number, y: number) {
+  const point = await svgPointToClient(page, x, y);
+  await page.mouse.dblclick(point.x, point.y);
+}
+
+async function dragSvgPoint(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+) {
+  const start = await svgPointToClient(page, from.x, from.y);
+  const end = await svgPointToClient(page, to.x, to.y);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x, end.y, { steps: 6 });
+  await page.mouse.up();
+}
+
+async function svgPointToClient(
+  page: Page,
+  x: number,
+  y: number,
+): Promise<{ x: number; y: number }> {
+  return page.evaluate(
+    ({ svgX, svgY }) => {
+      const overlay = document.getElementById("selection-overlay");
+      if (!(overlay instanceof SVGSVGElement)) throw new Error("selection overlay not found");
+      const point = overlay.createSVGPoint();
+      point.x = svgX;
+      point.y = svgY;
+      const matrix = overlay.getScreenCTM();
+      if (matrix === null) throw new Error("selection overlay matrix not found");
+      const screenPoint = point.matrixTransform(matrix);
+      return { x: screenPoint.x, y: screenPoint.y };
+    },
+    { svgX: x, svgY: y },
+  );
+}
+
+async function expectOverlayNearSvgBounds(
+  page: Page,
+  bounds: { x: number; y: number; width: number; height: number },
+) {
+  const rects = await page.evaluate((expected) => {
+    const overlay = document.querySelector('[data-testid="text-editor-overlay"]');
+    const selectionOverlay = document.getElementById("selection-overlay");
+    if (!(overlay instanceof HTMLElement)) throw new Error("text editor overlay not found");
+    if (!(selectionOverlay instanceof SVGSVGElement))
+      throw new Error("selection overlay not found");
+    const point = selectionOverlay.createSVGPoint();
+    const matrix = selectionOverlay.getScreenCTM();
+    if (matrix === null) throw new Error("selection overlay matrix not found");
+    point.x = expected.x;
+    point.y = expected.y;
+    const topLeft = point.matrixTransform(matrix);
+    point.x = expected.x + expected.width;
+    point.y = expected.y + expected.height;
+    const bottomRight = point.matrixTransform(matrix);
+    const overlayRect = overlay.getBoundingClientRect();
+    return {
+      expected: {
+        left: topLeft.x,
+        top: topLeft.y,
+        width: bottomRight.x - topLeft.x,
+        height: bottomRight.y - topLeft.y,
+      },
+      actual: {
+        left: overlayRect.left,
+        top: overlayRect.top,
+        width: overlayRect.width,
+        height: overlayRect.height,
+      },
+    };
+  }, bounds);
+
+  expect(Math.abs(rects.actual.left - rects.expected.left)).toBeLessThan(3);
+  expect(Math.abs(rects.actual.top - rects.expected.top)).toBeLessThan(3);
+  expect(Math.abs(rects.actual.width - rects.expected.width)).toBeLessThan(3);
+  expect(Math.abs(rects.actual.height - rects.expected.height)).toBeLessThan(3);
+}
+
+interface EditorServer {
+  readonly url: string;
+  close(): Promise<void>;
+}
+
+async function startStandaloneEditor(): Promise<EditorServer> {
+  const appBundle = await buildStandaloneEditorBundle();
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      response.setHeader("Content-Type", "text/html; charset=utf-8");
+      response.end(editorHtml);
+      return;
+    }
+    if (url.pathname === "/app.js") {
+      response.setHeader("Content-Type", "text/javascript; charset=utf-8");
+      response.end(appBundle);
+      return;
+    }
+    response.statusCode = 404;
+    response.end("Not found");
+  });
+  const url = await listen(server);
+  return { url, close: () => closeServer(server) };
+}
+
+async function buildStandaloneEditorBundle(): Promise<string> {
+  await ensureCoreDist();
+  const packageResolveDir = await createPackageResolveDir();
+  try {
+    const result = await build({
+      stdin: {
+        contents: editorAppSource,
+        resolveDir: packageResolveDir,
+        sourcefile: "browser-standalone-editor.ts",
+        loader: "ts",
+      },
+      bundle: true,
+      write: false,
+      format: "esm",
+      platform: "browser",
+      conditions: ["browser", "import"],
+      logLevel: "silent",
+      absWorkingDir: repoRoot,
+    });
+    const bundled = result.outputFiles[0].text;
+    expect(bundled).not.toMatch(
+      /(?:node:fs|node:path|node:os|node:buffer|fs\/promises|from "fs"|from "path"|from "os"|from "module")/,
+    );
+    return bundled;
+  } finally {
+    await rm(packageResolveDir, { recursive: true, force: true });
+  }
+}
+
+async function ensureCoreDist(): Promise<void> {
+  coreDistBuildPromise ??= (async () => {
+    await runPackageBuild(documentPackageRoot);
+    await runPackageBuild(editorCorePackageRoot);
+    await runPackageBuild(rendererPackageRoot);
+    await runPackageBuild(corePackageRoot);
+  })();
+  await coreDistBuildPromise;
+}
+
+async function runPackageBuild(packageRoot: string): Promise<void> {
+  await execFileAsync(resolve(repoRoot, "node_modules/.bin/tsup"), ["--config", "tsup.config.ts"], {
+    cwd: packageRoot,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+async function createPackageResolveDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-browser-editor-resolve-"));
+  const nodeModules = join(dir, "node_modules");
+  await mkdir(nodeModules);
+  await symlink(corePackageRoot, join(nodeModules, "pptx-glimpse"), "dir");
+  return dir;
+}
+
+const editorHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>pptx-glimpse browser editor smoke</title>
+    <style>
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; background: #20242a; color: #e5e7eb; font-family: ui-sans-serif, system-ui, sans-serif; }
+      main { display: grid; grid-template-columns: 1fr 220px; gap: 16px; height: 100vh; padding: 16px; }
+      #workspace { display: grid; place-items: center; min-width: 0; overflow: auto; background: #2d333b; }
+      #slide-container { position: relative; width: min(960px, 100%); background: #fff; box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28); }
+      #slide-container svg:not(#selection-overlay) { display: block; width: 100%; height: auto; }
+      #selection-overlay { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; touch-action: none; z-index: 2; }
+      #panel { display: flex; flex-direction: column; gap: 10px; padding: 12px; background: #111827; border-left: 1px solid #384252; }
+      button, input { min-height: 32px; border: 1px solid #4b5563; border-radius: 4px; background: #1f2937; color: #f9fafb; font: inherit; }
+      button { cursor: pointer; font-weight: 650; }
+      button:disabled { opacity: 0.45; cursor: not-allowed; }
+      #status, #message { min-height: 18px; font-size: 12px; color: #a7f3d0; overflow-wrap: anywhere; }
+      .shape-hit-area { cursor: move; fill: transparent; pointer-events: all; }
+      .selection-box { fill: none; stroke: #0f766e; stroke-width: 1.5; vector-effect: non-scaling-stroke; pointer-events: none; }
+      .selection-handle { fill: #f8fafc; stroke: #0f766e; stroke-width: 1.5; cursor: nwse-resize; vector-effect: non-scaling-stroke; pointer-events: all; }
+      #text-editor-overlay { position: absolute; min-width: 40px; min-height: 28px; padding: 4px; border: 1px solid #2563eb; background: rgba(255, 255, 255, 0.96); color: #111827; z-index: 3; overflow: hidden; }
+      .text-editor-run { outline: none; white-space: pre-wrap; }
+      .text-editor-actions { position: absolute; right: 4px; bottom: 4px; }
+      .text-editor-actions button { min-height: 24px; color: #111827; background: #f8fafc; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section id="workspace"><div id="slide-container"></div></section>
+      <aside id="panel">
+        <input data-testid="pptx-input" id="pptx-input" type="file" accept=".pptx">
+        <button id="undo-button" type="button" disabled>Undo</button>
+        <button id="redo-button" type="button" disabled>Redo</button>
+        <button id="download-button" type="button" disabled>Download</button>
+        <div data-testid="status" id="status">Ready</div>
+        <div id="message"></div>
+      </aside>
+    </main>
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>`;
+
+const editorAppSource = `
+import { createBrowserPptxEditorSession } from "pptx-glimpse";
+
+const pptxInput = document.getElementById("pptx-input");
+const status = document.getElementById("status");
+const message = document.getElementById("message");
+const container = document.getElementById("slide-container");
+const undoButton = document.getElementById("undo-button");
+const redoButton = document.getElementById("redo-button");
+const downloadButton = document.getElementById("download-button");
+const EMU_PER_PIXEL = 9525;
+
+let editor = null;
+let fileName = "edited.pptx";
+let shapes = [];
+let selectedShape = null;
+let selectedShapeKey = null;
+let dragState = null;
+let activeTextEditor = null;
+
+pptxInput.addEventListener("change", async () => {
+  const file = pptxInput.files?.[0];
+  if (!file) return;
+  fileName = file.name.replace(/\\.pptx$/i, ".edited.pptx");
+  status.textContent = "Opening";
+  editor = await createBrowserPptxEditorSession(new Uint8Array(await file.arrayBuffer()), {
+    skipSystemFonts: true,
+    textOutput: "text",
+  });
+  render();
+  status.textContent = editor.slides.length + " slide" + (editor.slides.length === 1 ? "" : "s") + " ready";
+  downloadButton.disabled = false;
+});
+
+undoButton.addEventListener("click", async () => {
+  if (!editor) return;
+  await editor.undo();
+  render();
+  message.textContent = "Undone";
+});
+
+redoButton.addEventListener("click", async () => {
+  if (!editor) return;
+  await editor.redo();
+  render();
+  message.textContent = "Redone";
+});
+
+downloadButton.addEventListener("click", () => {
+  if (!editor) return;
+  const saved = editor.save();
+  updateHistory(saved.history);
+  const href = URL.createObjectURL(new Blob([saved.pptx], {
+    type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  }));
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(href);
+  message.textContent = "Downloaded";
+});
+
+function render() {
+  if (!editor) return;
+  const slide = editor.slides[0];
+  container.innerHTML = slide ? slide.svg : "";
+  const svg = container.querySelector("svg");
+  if (svg) {
+    svg.removeAttribute("width");
+    svg.removeAttribute("height");
+    svg.style.width = "100%";
+    svg.style.height = "auto";
+  }
+  shapes = editor.shapes(1).filter((shape) => shape.handle && shape.bounds && shape.editableTransform);
+  window.__pptxGlimpseEditorSmoke = {
+    hasEditableTextBody: shapes.some((shape) => Boolean(shape.editableTextBody)),
+  };
+  selectedShape = selectedShapeKey
+    ? shapes.find((shape) => shapeKey(shape) === selectedShapeKey) || null
+    : null;
+  updateHistory(editor.history);
+  renderSelectionOverlay();
+}
+
+function updateHistory(history) {
+  undoButton.disabled = !history.canUndo;
+  redoButton.disabled = !history.canRedo;
+}
+
+function renderSelectionOverlay() {
+  const renderedSvg = container.querySelector("svg:not(#selection-overlay)");
+  const existing = document.getElementById("selection-overlay");
+  if (existing) existing.remove();
+  if (!renderedSvg) return;
+
+  const overlay = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  overlay.id = "selection-overlay";
+  overlay.setAttribute("data-testid", "selection-overlay");
+  overlay.setAttribute("viewBox", renderedSvg.getAttribute("viewBox") || "0 0 960 540");
+
+  shapes.forEach((shape, index) => {
+    const hit = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    hit.setAttribute("class", "shape-hit-area");
+    hit.setAttribute("data-testid", "shape-hit-area");
+    hit.setAttribute("data-shape-index", String(index));
+    setRectAttributes(hit, shape.bounds);
+    hit.addEventListener("pointerdown", (event) => selectShape(shape, event));
+    hit.addEventListener("mousedown", (event) => {
+      if (event.detail >= 2 && shape.editableTextBody) {
+        event.preventDefault();
+        openTextEditor(shape);
+      }
+    });
+    hit.addEventListener("dblclick", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openTextEditor(shape);
+    });
+    overlay.appendChild(hit);
+  });
+
+  if (selectedShape?.bounds) {
+    const box = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    box.setAttribute("class", "selection-box");
+    box.setAttribute("data-testid", "selection-box");
+    setRectAttributes(box, selectedShape.bounds);
+    overlay.appendChild(box);
+
+    ["nw", "ne", "sw", "se"].forEach((handle) => {
+      const point = handlePoint(selectedShape.bounds, handle);
+      const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+      rect.setAttribute("class", "selection-handle");
+      rect.setAttribute("data-testid", "selection-handle-" + handle);
+      rect.setAttribute("x", String(point.x - 4));
+      rect.setAttribute("y", String(point.y - 4));
+      rect.setAttribute("width", "8");
+      rect.setAttribute("height", "8");
+      rect.addEventListener("pointerdown", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        beginDrag("resize", handle, event);
+      });
+      overlay.appendChild(rect);
+    });
+  }
+
+  container.appendChild(overlay);
+  positionActiveTextEditor();
+}
+
+function selectShape(shape, event) {
+  selectedShape = cloneShape(shape);
+  selectedShapeKey = shapeKey(shape);
+  editor.selectShape(shape.handle);
+  beginDrag("move", null, event);
+  window.setTimeout(renderSelectionOverlay, 0);
+}
+
+function beginDrag(kind, handle, event) {
+  if (!selectedShape?.bounds) return;
+  const overlay = document.getElementById("selection-overlay");
+  const point = eventPoint(overlay, event);
+  if (!point) return;
+  dragState = {
+    kind,
+    handle,
+    pointerId: event.pointerId,
+    startPoint: point,
+    startBounds: { ...selectedShape.bounds },
+  };
+  window.addEventListener("pointermove", updateDrag);
+  window.addEventListener("pointerup", finishDrag);
+}
+
+function updateDrag(event) {
+  if (!dragState || event.pointerId !== dragState.pointerId || !selectedShape) return;
+  const point = eventPoint(document.getElementById("selection-overlay"), event);
+  if (!point) return;
+  const dx = point.x - dragState.startPoint.x;
+  const dy = point.y - dragState.startPoint.y;
+  selectedShape.bounds =
+    dragState.kind === "move"
+      ? movedBounds(dragState.startBounds, dx, dy)
+      : resizedBounds(dragState.startBounds, dragState.handle, dx, dy);
+  renderSelectionOverlay();
+}
+
+async function finishDrag(event) {
+  if (!dragState || event.pointerId !== dragState.pointerId || !selectedShape) return;
+  const startBounds = dragState.startBounds;
+  const nextBounds = selectedShape.bounds;
+  dragState = null;
+  window.removeEventListener("pointermove", updateDrag);
+  window.removeEventListener("pointerup", finishDrag);
+  if (
+    Math.round(startBounds.x) === Math.round(nextBounds.x) &&
+    Math.round(startBounds.y) === Math.round(nextBounds.y) &&
+    Math.round(startBounds.width) === Math.round(nextBounds.width) &&
+    Math.round(startBounds.height) === Math.round(nextBounds.height)
+  ) {
+    return;
+  }
+  await editor.apply({
+    kind: "setShapeTransform",
+    handle: selectedShape.handle,
+    offsetX: Math.round(nextBounds.x * EMU_PER_PIXEL),
+    offsetY: Math.round(nextBounds.y * EMU_PER_PIXEL),
+    width: Math.round(nextBounds.width * EMU_PER_PIXEL),
+    height: Math.round(nextBounds.height * EMU_PER_PIXEL),
+  });
+  render();
+  message.textContent = "Applied";
+}
+
+function openTextEditor(shape) {
+  if (!shape.editableTextBody || !shape.bounds) return;
+  closeTextEditor();
+  selectedShape = cloneShape(shape);
+  selectedShapeKey = shapeKey(shape);
+  renderSelectionOverlay();
+
+  const overlay = document.createElement("div");
+  overlay.id = "text-editor-overlay";
+  overlay.setAttribute("data-testid", "text-editor-overlay");
+  overlay.appendChild(createTextEditorContent(shape.editableTextBody.docJson));
+  const actions = document.createElement("div");
+  actions.className = "text-editor-actions";
+  const done = document.createElement("button");
+  done.type = "button";
+  done.textContent = "Done";
+  done.setAttribute("data-testid", "text-editor-done");
+  done.addEventListener("click", () => commitTextEditor());
+  actions.appendChild(done);
+  overlay.appendChild(actions);
+  container.appendChild(overlay);
+  activeTextEditor = { element: overlay, shape: cloneShape(shape), originalDocJson: shape.editableTextBody.docJson };
+  positionActiveTextEditor();
+  const firstRun = overlay.querySelector(".text-editor-run");
+  if (firstRun) firstRun.focus();
+}
+
+function createTextEditorContent(docJson) {
+  const body = document.createElement("div");
+  (docJson.content || []).forEach((paragraph, paragraphIndex) => {
+    const paragraphElement = document.createElement("div");
+    paragraphElement.dataset.paragraphIndex = String(paragraphIndex);
+    (paragraph.content || []).forEach((textNode, runIndex) => {
+      const run = document.createElement("span");
+      run.className = "text-editor-run";
+      run.setAttribute("data-testid", "text-editor-run");
+      run.contentEditable = "true";
+      run.dataset.paragraphIndex = String(paragraphIndex);
+      run.dataset.runIndex = String(runIndex);
+      run.textContent = textNode.text || "";
+      paragraphElement.appendChild(run);
+    });
+    body.appendChild(paragraphElement);
+  });
+  return body;
+}
+
+async function commitTextEditor() {
+  if (!activeTextEditor) return;
+  const docJson = textEditorDocJson();
+  const handle = activeTextEditor.shape.handle;
+  closeTextEditor();
+  await editor.applyTextBodyDocJson(handle, docJson);
+  render();
+  message.textContent = "Applied";
+}
+
+function textEditorDocJson() {
+  const original = activeTextEditor.originalDocJson;
+  return {
+    type: "doc",
+    content: (original.content || []).map((paragraph, paragraphIndex) => {
+      const paragraphElement = activeTextEditor.element.querySelector(
+        '.text-editor-run[data-paragraph-index="' + paragraphIndex + '"]'
+      )?.parentElement;
+      return {
+        type: "paragraph",
+        attrs: paragraph.attrs || {},
+        content: (paragraph.content || []).flatMap((textNode, runIndex) => {
+          const runElement = paragraphElement?.querySelector(
+            '.text-editor-run[data-run-index="' + runIndex + '"]'
+          );
+          const text = runElement ? runElement.textContent || "" : textNode.text || "";
+          return text.length === 0 ? [] : [{ type: "text", text, marks: textNode.marks || [] }];
+        }),
+      };
+    }),
+  };
+}
+
+function closeTextEditor() {
+  if (!activeTextEditor) return;
+  activeTextEditor.element.remove();
+  activeTextEditor = null;
+}
+
+function positionActiveTextEditor() {
+  if (!activeTextEditor?.shape?.bounds) return;
+  const renderedSvg = container.querySelector("svg:not(#selection-overlay)");
+  if (!renderedSvg) return;
+  const svgRect = renderedSvg.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  const viewBox = parseViewBox(renderedSvg.getAttribute("viewBox") || "0 0 960 540");
+  const bounds = activeTextEditor.shape.bounds;
+  activeTextEditor.element.style.left =
+    svgRect.left - containerRect.left + ((bounds.x - viewBox.x) / viewBox.width) * svgRect.width + "px";
+  activeTextEditor.element.style.top =
+    svgRect.top - containerRect.top + ((bounds.y - viewBox.y) / viewBox.height) * svgRect.height + "px";
+  activeTextEditor.element.style.width = (bounds.width / viewBox.width) * svgRect.width + "px";
+  activeTextEditor.element.style.height = (bounds.height / viewBox.height) * svgRect.height + "px";
+}
+
+function shapeKey(shape) {
+  return [
+    shape.handle?.partPath || "",
+    shape.handle?.nodeId || "",
+    shape.handle?.relationshipId || "",
+    shape.handle?.orderingSlot == null ? "" : String(shape.handle.orderingSlot),
+  ].join("\\u0000");
+}
+
+function cloneShape(shape) {
+  return { ...shape, bounds: { ...shape.bounds } };
+}
+
+function setRectAttributes(rect, bounds) {
+  rect.setAttribute("x", String(bounds.x));
+  rect.setAttribute("y", String(bounds.y));
+  rect.setAttribute("width", String(bounds.width));
+  rect.setAttribute("height", String(bounds.height));
+}
+
+function handlePoint(bounds, handle) {
+  const right = bounds.x + bounds.width;
+  const bottom = bounds.y + bounds.height;
+  if (handle === "nw") return { x: bounds.x, y: bounds.y };
+  if (handle === "ne") return { x: right, y: bounds.y };
+  if (handle === "sw") return { x: bounds.x, y: bottom };
+  return { x: right, y: bottom };
+}
+
+function eventPoint(svg, event) {
+  const matrix = svg?.getScreenCTM();
+  if (!matrix) return null;
+  const point = svg.createSVGPoint();
+  point.x = event.clientX;
+  point.y = event.clientY;
+  return point.matrixTransform(matrix.inverse());
+}
+
+function movedBounds(bounds, dx, dy) {
+  return { x: bounds.x + dx, y: bounds.y + dy, width: bounds.width, height: bounds.height };
+}
+
+function resizedBounds(bounds, handle, dx, dy) {
+  const minSize = 8;
+  const right = bounds.x + bounds.width;
+  const bottom = bounds.y + bounds.height;
+  const next = { ...bounds };
+  if (handle === "nw" || handle === "sw") {
+    next.x = Math.min(bounds.x + dx, right - minSize);
+    next.width = right - next.x;
+  }
+  if (handle === "ne" || handle === "se") next.width = Math.max(minSize, bounds.width + dx);
+  if (handle === "nw" || handle === "ne") {
+    next.y = Math.min(bounds.y + dy, bottom - minSize);
+    next.height = bottom - next.y;
+  }
+  if (handle === "sw" || handle === "se") next.height = Math.max(minSize, bounds.height + dy);
+  return next;
+}
+
+function parseViewBox(value) {
+  const parts = String(value).trim().split(/\\s+/).map(Number);
+  return {
+    x: Number.isFinite(parts[0]) ? parts[0] : 0,
+    y: Number.isFinite(parts[1]) ? parts[1] : 0,
+    width: Number.isFinite(parts[2]) && parts[2] > 0 ? parts[2] : 960,
+    height: Number.isFinite(parts[3]) && parts[3] > 0 ? parts[3] : 540,
+  };
+}
+`;
+
+function xml(content: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+async function buildShapeFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Box"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="914400" y="1828800"/><a:ext cx="2743200" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+        `<a:p><a:r><a:rPr sz="2400"><a:latin typeface="Aptos"/></a:rPr><a:t>Original</a:t></a:r></a:p>` +
+        `</p:txBody>` +
+        `</p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function firstShape(source: PptxSourceModel): SourceShape {
+  const shape = source.slides[0]?.shapes.find((node): node is SourceShape => node.kind === "shape");
+  if (shape === undefined) throw new Error("fixture shape not found");
+  return shape;
+}
+
+function firstText(source: PptxSourceModel): string {
+  const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
+  if (run === undefined) throw new Error("fixture text run not found");
+  return run.text;
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolveListener) => {
+    server.listen(0, "127.0.0.1", resolveListener);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("server did not expose a TCP port");
+  }
+  return `http://127.0.0.1:${address.port.toString()}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => {
+      if (error) rejectClose(error);
+      else resolveClose();
+    });
+  });
+}
+
+declare global {
+  interface Window {
+    __pptxGlimpseEditorSmoke?: {
+      hasEditableTextBody: boolean;
+    };
+  }
+}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -11,6 +11,7 @@ const config: KnipConfig = {
         "bench/conversion.bench.ts",
         "e2e/dev-server-editor.playwright.ts",
         "e2e/browser-standalone-viewer.playwright.ts",
+        "e2e/browser-standalone-editor.playwright.ts",
       ],
     },
     "packages/core": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@pptx-glimpse/document": "workspace:*",
+    "@pptx-glimpse/editor-core": "workspace:*",
     "@pptx-glimpse/renderer": "workspace:*"
   }
 }

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -1,0 +1,130 @@
+import { asEmu, readPptx, type SourceShape } from "@pptx-glimpse/document";
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+
+import { createBrowserPptxEditorSession } from "./browser-editor.js";
+
+const encoder = new TextEncoder();
+
+describe("BrowserPptxEditorSession", () => {
+  it("edits, renders, undoes, redoes, and saves a browser editor session", async () => {
+    const editor = await createBrowserPptxEditorSession(await buildShapeFixture(), {
+      skipSystemFonts: true,
+    });
+    const shape = editor.shapes(1)[0];
+    if (shape?.handle === undefined) throw new Error("shape handle not found");
+
+    expect(editor.slides).toHaveLength(1);
+    expect(shape.bounds).toEqual({ x: 96, y: 192, width: 288, height: 96 });
+    expect(shape.editableTextBody).toBeDefined();
+
+    await editor.apply({
+      kind: "setShapeTransform",
+      handle: shape.handle,
+      offsetX: asEmu(120 * 9525),
+      offsetY: asEmu(208 * 9525),
+      width: asEmu(336 * 9525),
+      height: asEmu(120 * 9525),
+    });
+    await editor.applyTextBodyDocJson(shape.handle, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          attrs: {},
+          content: [{ type: "text", text: "Browser edited", marks: [] }],
+        },
+      ],
+    });
+
+    expect(editor.history.undoDepth).toBe(2);
+    expect(editor.slides[0]?.svg).toContain("Browser edited");
+
+    expect((await editor.undo()).history).toMatchObject({ canRedo: true, undoDepth: 1 });
+    expect(firstText(editor.document)).toBe("Original");
+    expect((await editor.redo()).history).toMatchObject({ canUndo: true, redoDepth: 0 });
+    expect(firstText(editor.document)).toBe("Browser edited");
+
+    const saved = readPptx(editor.save().pptx);
+    expect(firstText(saved)).toBe("Browser edited");
+    expect(firstShape(saved).transform).toMatchObject({
+      offsetX: 120 * 9525,
+      offsetY: 208 * 9525,
+      width: 336 * 9525,
+      height: 120 * 9525,
+    });
+  });
+});
+
+function xml(content: string): Uint8Array {
+  return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+async function buildShapeFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Box"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="914400" y="1828800"/><a:ext cx="2743200" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+        `<a:p><a:r><a:rPr sz="2400"><a:latin typeface="Aptos"/></a:rPr><a:t>Original</a:t></a:r></a:p>` +
+        `</p:txBody>` +
+        `</p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function firstShape(source: ReturnType<typeof readPptx>): SourceShape {
+  const shape = source.slides[0]?.shapes.find((node): node is SourceShape => node.kind === "shape");
+  if (shape === undefined) throw new Error("fixture shape not found");
+  return shape;
+}
+
+function firstText(source: ReturnType<typeof readPptx>): string {
+  const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
+  if (run === undefined) throw new Error("fixture text run not found");
+  return run.text;
+}

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -154,11 +154,9 @@ export class BrowserPptxEditorSession {
     const commands = proseMirrorDocJsonToEditorCommands(textBody, docJson);
     if (commands.length === 0) return this.response();
 
-    for (const command of commands) {
-      const result = this.#session.apply(command);
-      if (!result.ok) {
-        throw new Error(result.message);
-      }
+    const result = this.#session.applyAll(commands);
+    if (!result.ok) {
+      throw new Error(result.message);
     }
     await this.renderCurrentSlides();
     return this.response();
@@ -220,15 +218,20 @@ function shapeInfo(
   index: number,
   editableTransform = true,
 ): BrowserEditorShapeInfo[] {
+  const canEditTransform =
+    shape.kind !== "raw" &&
+    shape.transform !== undefined &&
+    editableTransform &&
+    isEditableTransformShape(shape);
   const base: BrowserEditorShapeInfo = {
     id: String(shape.nodeId ?? shape.handle?.nodeId ?? `${shape.kind}:${String(index)}`),
     kind: shape.kind,
     ...(shapeName(shape) !== undefined ? { name: shapeName(shape) } : {}),
     ...(shape.handle !== undefined ? { handle: shape.handle } : {}),
-    ...(shape.kind !== "raw" && shape.transform !== undefined
+    ...(canEditTransform
       ? {
           bounds: transformBoundsPx(shape.transform),
-          editableTransform: editableTransform && isEditableTransformShape(shape),
+          editableTransform: true,
         }
       : {}),
     ...("textBody" in shape && shape.textBody !== undefined
@@ -238,7 +241,7 @@ function shapeInfo(
           ),
         }
       : {}),
-    ...(shape.kind === "shape" && shape.textBody !== undefined && shape.transform !== undefined
+    ...(shape.kind === "shape" && canEditTransform && shape.textBody !== undefined
       ? editableTextBody(shape.textBody)
       : {}),
   };

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -1,0 +1,297 @@
+import {
+  findShapeNodeBySourceHandle,
+  type PptxSourceModel,
+  readPptx,
+  type SourceHandle,
+  type SourceShapeNode,
+  type SourceTextBody,
+  type SourceTextRun,
+  writePptx,
+} from "@pptx-glimpse/document";
+import {
+  createEditorSession,
+  type EditorCommand,
+  type PptxTextBodyProseMirrorDocJson,
+  proseMirrorDocJsonToEditorCommands,
+  textBodyToProseMirrorDocJson,
+} from "@pptx-glimpse/editor-core";
+
+import { type ConvertOptions, convertPptxToSvg, type SlideSvg } from "./svg-converter.js";
+
+const EMU_PER_INCH = 914400;
+const DEFAULT_DPI = 96;
+
+export interface BrowserEditorHistoryState {
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
+  readonly undoDepth: number;
+  readonly redoDepth: number;
+}
+
+export interface BrowserEditorSelectionInfo {
+  readonly shapeHandle: SourceHandle;
+}
+
+export interface BrowserEditorTextRunInfo {
+  readonly text: string;
+  readonly handle: SourceHandle;
+}
+
+export interface BrowserEditorTextBodyInfo {
+  readonly docJson: PptxTextBodyProseMirrorDocJson;
+}
+
+export interface BrowserEditorShapeBoundsPx {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface BrowserEditorShapeInfo {
+  readonly id: string;
+  readonly kind: SourceShapeNode["kind"];
+  readonly name?: string;
+  readonly handle?: SourceHandle;
+  readonly bounds?: BrowserEditorShapeBoundsPx;
+  readonly editableTransform?: boolean;
+  readonly textRuns?: readonly BrowserEditorTextRunInfo[];
+  readonly editableTextBody?: BrowserEditorTextBodyInfo;
+}
+
+export interface BrowserEditorSlidesResponse {
+  readonly slides: readonly SlideSvg[];
+  readonly history: BrowserEditorHistoryState;
+  readonly selection?: BrowserEditorSelectionInfo;
+}
+
+export interface BrowserEditorSaveResponse {
+  readonly ok: true;
+  readonly pptx: Uint8Array;
+  readonly history: BrowserEditorHistoryState;
+}
+
+export type BrowserEditorRenderOptions = Omit<ConvertOptions, "slides">;
+
+export class BrowserPptxEditorSession {
+  #session: ReturnType<typeof createEditorSession>;
+  #slides: readonly SlideSvg[] = [];
+  readonly #renderOptions: BrowserEditorRenderOptions;
+
+  private constructor(source: PptxSourceModel, renderOptions: BrowserEditorRenderOptions) {
+    this.#session = createEditorSession(source);
+    this.#renderOptions = renderOptions;
+  }
+
+  static async create(
+    input: Uint8Array,
+    renderOptions: BrowserEditorRenderOptions = {},
+  ): Promise<BrowserPptxEditorSession> {
+    const editor = new BrowserPptxEditorSession(readPptx(input), renderOptions);
+    await editor.renderCurrentSlides();
+    return editor;
+  }
+
+  get document(): PptxSourceModel {
+    return this.#session.document;
+  }
+
+  get slides(): readonly SlideSvg[] {
+    return this.#slides;
+  }
+
+  get history(): BrowserEditorHistoryState {
+    return {
+      canUndo: this.#session.canUndo,
+      canRedo: this.#session.canRedo,
+      undoDepth: this.#session.undoDepth,
+      redoDepth: this.#session.redoDepth,
+    };
+  }
+
+  get selection(): BrowserEditorSelectionInfo | undefined {
+    return this.#session.selection;
+  }
+
+  response(): BrowserEditorSlidesResponse {
+    return {
+      slides: this.#slides,
+      history: this.history,
+      ...(this.selection !== undefined ? { selection: this.selection } : {}),
+    };
+  }
+
+  shapes(slideNumber: number): readonly BrowserEditorShapeInfo[] {
+    const slide = this.#session.document.slides[slideNumber - 1];
+    if (slide === undefined) return [];
+    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index));
+  }
+
+  async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
+    const report = await convertPptxToSvg(writePptx(this.#session.document), {
+      textOutput: "text",
+      skipSystemFonts: true,
+      ...this.#renderOptions,
+    });
+    this.#slides = report.slides;
+    return this.#slides;
+  }
+
+  async apply(command: EditorCommand): Promise<BrowserEditorSlidesResponse> {
+    const result = this.#session.apply(command);
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    await this.renderCurrentSlides();
+    return this.response();
+  }
+
+  async applyTextBodyDocJson(
+    handle: SourceHandle,
+    docJson: unknown,
+  ): Promise<BrowserEditorSlidesResponse> {
+    const textBody = this.#requireEditableShapeTextBody(handle);
+    const commands = proseMirrorDocJsonToEditorCommands(textBody, docJson);
+    if (commands.length === 0) return this.response();
+
+    for (const command of commands) {
+      const result = this.#session.apply(command);
+      if (!result.ok) {
+        throw new Error(result.message);
+      }
+    }
+    await this.renderCurrentSlides();
+    return this.response();
+  }
+
+  selectShape(handle: SourceHandle): BrowserEditorSlidesResponse {
+    const result = this.#session.selectShape(handle);
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    return this.response();
+  }
+
+  async undo(): Promise<BrowserEditorSlidesResponse> {
+    const result = this.#session.undo();
+    if (!result.ok) {
+      throw new Error(result.reason);
+    }
+    await this.renderCurrentSlides();
+    return this.response();
+  }
+
+  async redo(): Promise<BrowserEditorSlidesResponse> {
+    const result = this.#session.redo();
+    if (!result.ok) {
+      throw new Error(result.reason);
+    }
+    await this.renderCurrentSlides();
+    return this.response();
+  }
+
+  save(): BrowserEditorSaveResponse {
+    const output = writePptx(this.#session.document);
+    readPptx(output);
+    return { ok: true, pptx: output, history: this.history };
+  }
+
+  #requireEditableShapeTextBody(handle: SourceHandle): SourceTextBody {
+    const shape = findShapeNodeBySourceHandle(this.#session.document, handle);
+    if (shape === undefined) {
+      throw new Error("text body edit: shape handle was not found in PptxSourceModel source");
+    }
+    if (shape.kind !== "shape" || shape.textBody === undefined) {
+      throw new Error("text body edit: shape does not have editable text body");
+    }
+    return shape.textBody;
+  }
+}
+
+export function createBrowserPptxEditorSession(
+  input: Uint8Array,
+  renderOptions?: BrowserEditorRenderOptions,
+): Promise<BrowserPptxEditorSession> {
+  return BrowserPptxEditorSession.create(input, renderOptions);
+}
+
+function shapeInfo(
+  shape: SourceShapeNode,
+  index: number,
+  editableTransform = true,
+): BrowserEditorShapeInfo[] {
+  const base: BrowserEditorShapeInfo = {
+    id: String(shape.nodeId ?? shape.handle?.nodeId ?? `${shape.kind}:${String(index)}`),
+    kind: shape.kind,
+    ...(shapeName(shape) !== undefined ? { name: shapeName(shape) } : {}),
+    ...(shape.handle !== undefined ? { handle: shape.handle } : {}),
+    ...(shape.kind !== "raw" && shape.transform !== undefined
+      ? {
+          bounds: transformBoundsPx(shape.transform),
+          editableTransform: editableTransform && isEditableTransformShape(shape),
+        }
+      : {}),
+    ...("textBody" in shape && shape.textBody !== undefined
+      ? {
+          textRuns: collectTextRuns(
+            shape.textBody.paragraphs.flatMap((paragraph) => paragraph.runs),
+          ),
+        }
+      : {}),
+    ...(shape.kind === "shape" && shape.textBody !== undefined && shape.transform !== undefined
+      ? editableTextBody(shape.textBody)
+      : {}),
+  };
+
+  if (shape.kind !== "group") return [base];
+  return [
+    base,
+    ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex, false)),
+  ];
+}
+
+function shapeName(shape: SourceShapeNode): string | undefined {
+  return "name" in shape ? shape.name : undefined;
+}
+
+function isEditableTransformShape(shape: SourceShapeNode): boolean {
+  if (shape.kind === "raw" || shape.transform === undefined || shape.handle?.nodeId === undefined) {
+    return false;
+  }
+  return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
+}
+
+function collectTextRuns(runs: readonly SourceTextRun[]): BrowserEditorTextRunInfo[] {
+  return runs.flatMap((run) => {
+    if (run.handle === undefined) return [];
+    return [{ text: run.text, handle: run.handle }];
+  });
+}
+
+function editableTextBody(
+  textBody: SourceTextBody,
+): Partial<Pick<BrowserEditorShapeInfo, "editableTextBody">> {
+  try {
+    return { editableTextBody: { docJson: textBodyToProseMirrorDocJson(textBody) } };
+  } catch {
+    return {};
+  }
+}
+
+function transformBoundsPx(transform: {
+  readonly offsetX: number;
+  readonly offsetY: number;
+  readonly width: number;
+  readonly height: number;
+}): BrowserEditorShapeBoundsPx {
+  return {
+    x: emuToPixels(transform.offsetX),
+    y: emuToPixels(transform.offsetY),
+    width: emuToPixels(transform.width),
+    height: emuToPixels(transform.height),
+  };
+}
+
+function emuToPixels(value: number): number {
+  return (value / EMU_PER_INCH) * DEFAULT_DPI;
+}

--- a/packages/core/src/browser-entry.test.ts
+++ b/packages/core/src/browser-entry.test.ts
@@ -71,7 +71,7 @@ describe("browser entry", () => {
     const result = await build({
       stdin: {
         contents:
-          'import { convertPptxToPng, convertPptxToSvg, initResvgWasm } from "pptx-glimpse"; console.log(convertPptxToPng, convertPptxToSvg, initResvgWasm);',
+          'import { convertPptxToPng, convertPptxToSvg, createBrowserPptxEditorSession, initResvgWasm } from "pptx-glimpse"; console.log(convertPptxToPng, convertPptxToSvg, createBrowserPptxEditorSession, initResvgWasm);',
         resolveDir: here,
         sourcefile: "browser-entry-smoke.ts",
         loader: "ts",
@@ -95,6 +95,9 @@ describe("browser entry", () => {
             }));
             build.onResolve({ filter: /^@pptx-glimpse\/document$/ }, () => ({
               path: resolve(packageRoot, "../document/src/index.ts"),
+            }));
+            build.onResolve({ filter: /^@pptx-glimpse\/editor-core$/ }, () => ({
+              path: resolve(packageRoot, "../editor-core/src/index.ts"),
             }));
             build.onResolve({ filter: /^@pptx-glimpse\/renderer$/ }, () => ({
               path: resolve(packageRoot, "../renderer/src/index.ts"),

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -7,6 +7,18 @@ import {
 
 import { type ConvertOptions, convertPptxToSvg as convertPptxToSvgBase } from "./svg-converter.js";
 
+export type {
+  BrowserEditorHistoryState,
+  BrowserEditorRenderOptions,
+  BrowserEditorSaveResponse,
+  BrowserEditorSelectionInfo,
+  BrowserEditorShapeBoundsPx,
+  BrowserEditorShapeInfo,
+  BrowserEditorSlidesResponse,
+  BrowserEditorTextBodyInfo,
+  BrowserEditorTextRunInfo,
+} from "./browser-editor.js";
+export { BrowserPptxEditorSession, createBrowserPptxEditorSession } from "./browser-editor.js";
 export type { PngConversionReport, SlideImage } from "./converter.js";
 export type { UsedFonts } from "./font/font-collector.js";
 export { collectUsedFonts } from "./font/font-collector.js";
@@ -20,6 +32,8 @@ export type {
   SvgConversionReport,
 } from "./svg-converter.js";
 export { convertPptxToSvg } from "./svg-converter.js";
+export type { SourceHandle } from "@pptx-glimpse/document";
+export type { EditorCommand } from "@pptx-glimpse/editor-core";
 export type { FontMapping } from "@pptx-glimpse/renderer";
 export type { FontBuffer, OpentypeSetup } from "@pptx-glimpse/renderer";
 export type { LogLevel, WarningEntry, WarningSummary } from "@pptx-glimpse/renderer";

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -5,11 +5,13 @@ export default defineConfig({
   format: ["cjs", "esm"],
   dts: {
     resolve: [
+      "@pptx-glimpse/document",
+      "@pptx-glimpse/editor-core",
       "@pptx-glimpse/renderer",
       "@pptx-glimpse/renderer/png",
       "@pptx-glimpse/renderer/png/browser",
     ],
   },
   clean: true,
-  noExternal: ["@pptx-glimpse/document", "@pptx-glimpse/renderer"],
+  noExternal: ["@pptx-glimpse/document", "@pptx-glimpse/editor-core", "@pptx-glimpse/renderer"],
 });

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -132,6 +132,40 @@ describe("EditorSession text-run commands", () => {
     expect(session.canRedo).toBe(false);
     expect(session.undo()).toEqual({ ok: false, reason: "empty-undo-stack" });
   });
+
+  it("rejects an invalid command batch without partially applying earlier commands", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const before = session.document;
+    const validHandle = requireHandle(firstRun(source).handle);
+    const invalidHandle = {
+      partPath: asPartPath("ppt/slides/slide1.xml"),
+      nodeId: asSourceNodeId("text:shape:999:p:0:r:0"),
+      orderingSlot: 0,
+    } satisfies SourceHandle;
+
+    const result = session.applyAll([
+      {
+        kind: "replaceTextRunPlainText",
+        handle: validHandle,
+        text: "Should not stay applied",
+      },
+      {
+        kind: "replaceTextRunPlainText",
+        handle: invalidHandle,
+        text: "Should not apply",
+      },
+    ]);
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: "invalid-command",
+    });
+    expect(session.document).toBe(before);
+    expect(firstRun(session.document).text).toBe("Original");
+    expect(session.undoDepth).toBe(0);
+    expect(session.redoDepth).toBe(0);
+  });
 });
 
 describe("ProseMirror text body conversion", () => {
@@ -168,12 +202,11 @@ describe("ProseMirror text body conversion", () => {
     const commands = proseMirrorDocJsonToEditorCommands(textBody, editedJson);
     const session = createEditorSession(source);
 
-    for (const command of commands) {
-      expectApplied(session.apply(command));
-    }
+    expectApplied(session.applyAll(commands));
     const reread = readPptx(writePptx(session.document));
 
     expect(commands).toHaveLength(2);
+    expect(session.undoDepth).toBe(1);
     expect(firstParagraph(session.document).runs.map((run) => run.text)).toEqual(["OrigX", "ep "]);
     expect(firstParagraph(reread).runs.map((run) => run.text)).toEqual(["OrigX", "ep "]);
     expect(firstParagraph(reread).runs[0].properties).toEqual(
@@ -182,6 +215,14 @@ describe("ProseMirror text body conversion", () => {
     expect(firstParagraph(reread).runs[1].properties).toEqual(
       firstParagraph(source).runs[1].properties,
     );
+
+    expectHistory(session.undo());
+    expect(firstParagraph(session.document).runs.map((run) => run.text)).toEqual([
+      "Original",
+      " Keep ",
+    ]);
+    expectHistory(session.redo());
+    expect(firstParagraph(session.document).runs.map((run) => run.text)).toEqual(["OrigX", "ep "]);
   });
 
   it("falls back to paragraph replacement when run mark order changes", async () => {

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -163,11 +163,22 @@ export class EditorSession {
   }
 
   apply(command: EditorCommand): EditorApplyCommandResult {
+    return this.applyAll([command]);
+  }
+
+  applyAll(commands: readonly EditorCommand[]): EditorApplyCommandResult {
     const before = this.#document;
-    let after: PptxSourceModel;
+    if (commands.length === 0) return { ok: true, document: before };
 
     try {
-      after = normalizeEditorEdits(applyCommandToDocument(before, command));
+      const after = normalizeEditorEdits(
+        commands.reduce((document, command) => applyCommandToDocument(document, command), before),
+      );
+      this.#document = after;
+      this.#undoStack.push({ before, after });
+      this.#redoStack.length = 0;
+
+      return { ok: true, document: after };
     } catch (error) {
       return {
         ok: false,
@@ -176,12 +187,6 @@ export class EditorSession {
         cause: error,
       };
     }
-
-    this.#document = after;
-    this.#undoStack.push({ before, after });
-    this.#redoStack.length = 0;
-
-    return { ok: true, document: after };
   }
 
   undo(): EditorHistoryResult {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@pptx-glimpse/document':
         specifier: workspace:*
         version: link:../document
+      '@pptx-glimpse/editor-core':
+        specifier: workspace:*
+        version: link:../editor-core
       '@pptx-glimpse/renderer':
         specifier: workspace:*
         version: link:../renderer


### PR DESCRIPTION
close #593

## 目的

Node バックエンドなしで PPTX の読み込み、shape の move / resize、テキスト編集、undo / redo、編集後 PPTX のダウンロードに使える browser editor session API を追加します。

## 変更内容

- `pptx-glimpse` の browser entry から `createBrowserPptxEditorSession` / `BrowserPptxEditorSession` を公開
- browser editor session 内で `readPptx`、`editor-core` command、`convertPptxToSvg`、`writePptx` を接続
- 複数 text command を 1 undo 履歴として扱う `EditorSession.applyAll()` を追加
- Node API を使わないスタンドアロン browser editor Playwright を追加
- browser editor API の unit smoke と changeset を追加

## 影響範囲

- `packages/core/src/browser-editor.ts`
- `packages/core/src/browser.ts`
- `packages/editor-core/src/index.ts`
- `e2e/browser-standalone-editor.playwright.ts`

## ローカル検証

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint packages/core/src/browser-editor.ts packages/core/src/browser-editor.test.ts packages/core/src/browser.ts packages/core/src/browser-entry.test.ts packages/editor-core/src/index.ts packages/editor-core/src/index.test.ts e2e/browser-standalone-editor.playwright.ts`
- `./node_modules/.bin/vitest run packages/core/src/browser-editor.test.ts packages/core/src/browser-entry.test.ts packages/editor-core/src/index.test.ts`
- `./node_modules/.bin/playwright test e2e/browser-standalone-editor.playwright.ts`

## 補足

- `pnpm exec` はローカルの lockfile supply-chain policy により minimumReleaseAge violation で起動前検査が失敗したため、既存 `node_modules/.bin` を直接使って検証しました。