### PR TITLE
feat(document): publish @pptx-glimpse/document package

### DIFF
--- a/.changeset/document-public-package.md
+++ b/.changeset/document-public-package.md
@@ -1,0 +1,5 @@
+---
+"@pptx-glimpse/document": minor
+---
+
+Publish the document package as an installable public 0.x package with README guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Data flow: **PPTX binary → PptxSourceModel reader → Computed view → Render
 
 Public `convertPptxToSvg` / `convertPptxToPng` use the PptxSourceModel document path. VRT baselines are committed document-path snapshots rather than an in-memory legacy parser oracle.
 
-The source code is split across pnpm workspaces (`packages/*`). The root package is private and only orchestrates the workspace. The public npm package `pptx-glimpse` is published from `packages/core`. The `pptx-glimpse` package references `@pptx-glimpse/document` / `@pptx-glimpse/renderer` as build-time workspace dependencies, and the published tarball contains the bundled output.
+The source code is split across pnpm workspaces (`packages/*`). The root package is private and only orchestrates the workspace. The public npm packages are `pptx-glimpse` from `packages/core` and the 0.x `@pptx-glimpse/document` package from `packages/document`. The `pptx-glimpse` package still references `@pptx-glimpse/document` / `@pptx-glimpse/renderer` as build-time workspace dependencies, and the published core tarball contains the bundled output.
 
 Before working on issues related to `@pptx-glimpse/document`, PptxSourceModel, the writer, editor-core, or pom integration, read the module-level comments in `packages/document/src/source/pptx-source-model.ts`, `packages/document/src/computed/pptx-computed-view.ts`, `packages/document/src/writer/write-pptx.ts`, and `packages/core/src/pptx-computed-view-renderer-adapter.ts` to confirm the current responsibility boundaries and dependency direction. Treat `document` as a lower-level foundation that does not know about `core`, `editor-core`, renderer, or pom.
 
@@ -64,7 +64,7 @@ Before working on issues related to `@pptx-glimpse/document`, PptxSourceModel, t
 
 Entry point: `packages/core/src/index.ts` exports `convertPptxToSvg`, `convertPptxToPng`, warning utilities (`getWarningSummary`, `getWarningEntries`), font utilities (`collectUsedFonts`, `DEFAULT_FONT_MAPPING`, `createFontMapping`, `getMappedFont`), and related types.
 
-`packages/core/tsup.config.ts` bundles `packages/core/src/index.ts`, generates `packages/core/dist/`, and publishes it as the `pptx-glimpse` package (`document` / `renderer` are included in the bundle via `noExternal`). The root `tsup.config.ts` remains for compatible manual builds; the normal publish path uses the `packages/core` config.
+`packages/core/tsup.config.ts` bundles `packages/core/src/index.ts`, generates `packages/core/dist/`, and publishes it as the `pptx-glimpse` package (`document` / `renderer` are included in the bundle via `noExternal`). `packages/document` is also publishable as `@pptx-glimpse/document` for direct document-layer consumers, but core keeps the bundled document configuration until a separate issue changes that packaging strategy. The root `tsup.config.ts` remains for compatible manual builds; the normal publish path uses the package-specific configs.
 
 ## Technical Constraints
 

--- a/packages/document/README.md
+++ b/packages/document/README.md
@@ -58,19 +58,17 @@ await writeFile("round-trip.pptx", output);
 ```ts
 import { readFile, writeFile } from "node:fs/promises";
 import {
-  createComputedView,
   readPptx,
   replaceTextRunPlainText,
   writePptx,
 } from "@pptx-glimpse/document";
 
 const source = readPptx(await readFile("input.pptx"));
-const computed = createComputedView(source);
-const firstTextRun = computed.slides
-  .flatMap((slide) => slide.elements)
-  .flatMap((element) =>
-    element.kind === "shape" && element.textBody !== undefined
-      ? element.textBody.paragraphs.flatMap((paragraph) => paragraph.runs)
+const firstTextRun = source.slides
+  .flatMap((slide) => slide.shapes)
+  .flatMap((shape) =>
+    shape.kind === "shape" && shape.textBody !== undefined
+      ? shape.textBody.paragraphs.flatMap((paragraph) => paragraph.runs)
       : [],
   )
   .find((run) => run.handle !== undefined);

--- a/packages/document/README.md
+++ b/packages/document/README.md
@@ -1,0 +1,90 @@
+# @pptx-glimpse/document
+
+OOXML document foundation for pptx-glimpse.
+
+This package reads PowerPoint `.pptx` files into a `PptxSourceModel`, derives a non-mutating computed view, and writes the source model back to PPTX bytes. It does not render SVG or PNG; use `pptx-glimpse` for rendering.
+
+## Install
+
+```bash
+npm install @pptx-glimpse/document
+```
+
+Node.js 22 or later is required.
+
+## Public API
+
+Import supported APIs from the package root:
+
+```ts
+import {
+  createComputedView,
+  readPptx,
+  replaceTextRunPlainText,
+  writePptx,
+} from "@pptx-glimpse/document";
+```
+
+The stable entry point includes:
+
+- `readPptx(input)` for reading PPTX bytes into a `PptxSourceModel`
+- `createComputedView(source, options?)` for deriving slide/layout/master/theme effective values without mutating the source
+- `writePptx(source)` for structural round-trip writing
+- Text editing helpers such as `replaceTextRunPlainText(source, handle, text)` and related source handle lookup types exported from the root entry point
+- Source model, computed view, and unit types needed to consume those APIs
+
+Parser helpers, raw replacement internals, writer dirty-scope implementation details, and OOXML implementation modules outside the package root are internal and may change without notice.
+
+## Read and Write Round Trip
+
+```ts
+import { readFile, writeFile } from "node:fs/promises";
+import { createComputedView, readPptx, writePptx } from "@pptx-glimpse/document";
+
+const input = await readFile("input.pptx");
+const source = readPptx(input);
+const computed = createComputedView(source);
+
+console.log(`slides: ${computed.slides.length}`);
+
+const output = writePptx(source);
+await writeFile("round-trip.pptx", output);
+```
+
+`writePptx` targets structural round-trip preservation rather than byte-for-byte equality. Unedited package material is preserved where possible, and supported edits mark dirty PPTX parts for serialization.
+
+## Text-Run Edit
+
+```ts
+import { readFile, writeFile } from "node:fs/promises";
+import {
+  createComputedView,
+  readPptx,
+  replaceTextRunPlainText,
+  writePptx,
+} from "@pptx-glimpse/document";
+
+const source = readPptx(await readFile("input.pptx"));
+const computed = createComputedView(source);
+const firstTextRun = computed.slides
+  .flatMap((slide) => slide.elements)
+  .flatMap((element) =>
+    element.kind === "shape" && element.textBody !== undefined
+      ? element.textBody.paragraphs.flatMap((paragraph) => paragraph.runs)
+      : [],
+  )
+  .find((run) => run.handle !== undefined);
+
+if (firstTextRun?.handle === undefined) {
+  throw new Error("No editable text run found");
+}
+
+const edited = replaceTextRunPlainText(source, firstTextRun.handle, "Edited text");
+await writeFile("edited.pptx", writePptx(edited));
+```
+
+## Stability
+
+`@pptx-glimpse/document` starts as a `0.x` package. APIs exported from the package root are the intended public surface, but the document model is still evolving. Minor releases may refine exported types or behavior while the package remains below `1.0.0`.
+
+Do not import from deep internal paths such as `@pptx-glimpse/document/dist/...` or source module paths. Those modules are implementation details.

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -2,6 +2,13 @@
   "name": "@pptx-glimpse/document",
   "version": "0.0.0",
   "description": "PptxSourceModel and OOXML document foundation for pptx-glimpse.",
+  "keywords": [
+    "pptx",
+    "powerpoint",
+    "ooxml",
+    "presentation",
+    "document"
+  ],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -26,5 +33,15 @@
   "engines": {
     "node": ">=22"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hirokisakabe/pptx-glimpse.git",
+    "directory": "packages/document"
+  },
+  "homepage": "https://github.com/hirokisakabe/pptx-glimpse/tree/main/packages/document",
+  "bugs": {
+    "url": "https://github.com/hirokisakabe/pptx-glimpse/issues"
+  },
+  "author": "hirokisakabe",
   "license": "MIT"
 }

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@pptx-glimpse/document",
   "version": "0.0.0",
-  "private": true,
   "description": "PptxSourceModel and OOXML document foundation for pptx-glimpse.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
close #570

## 目的

`@pptx-glimpse/document` を npm 公開可能な 0.x パッケージとして扱えるようにします。core 側の `noExternal` bundle 構成は維持し、`pptx-glimpse` の公開物は従来どおり document を bundle する前提です。

## 変更内容

- `packages/document/package.json` から `private: true` を削除
- document package 向け README を追加し、root entry point の公開 API、read/write round-trip、text-run edit、0.x 安定度ポリシーを記載
- `@pptx-glimpse/document` の minor changeset を追加し、Release PR で `0.1.0` 初期公開へ進むように設定
- 公開 package 向け metadata と AGENTS.md の package 説明を更新

## 影響範囲

- `packages/document`
- `.changeset`
- `AGENTS.md`

## 検証

- `../../node_modules/.bin/tsup` in `packages/document`
- `../../node_modules/.bin/tsup` in `packages/core`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint packages/*/src/ vrt/ scripts/ bench/ e2e/`
- `./node_modules/.bin/prettier --check 'packages/*/src/**/*.ts' 'vrt/**/*.ts' 'scripts/**/*.ts' 'bench/**/*.ts' 'e2e/**/*.ts'`
- `./node_modules/.bin/vitest run packages/document/src`
- `./node_modules/.bin/vitest run`
- `bash scripts/test-package.sh`
- local tarball install of `@pptx-glimpse/document` into a temporary project, then PPTX read → `writePptx` round-trip
- README text-run edit example logic executed against the installed local tarball

## 補足

ローカルの `pnpm` コマンドはユーザー環境の `minimumReleaseAge` policy により既存 lockfile entries (`picomatch@4.0.5`, `postcss@8.5.16`) で停止したため、検証では既存 `node_modules/.bin` のコマンドを直接実行しました。
