### PR TITLE
demo: Open sample の本番 404 を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,10 @@ jobs:
       - name: Verify package (CJS/ESM/TypeScript)
         run: bash scripts/test-package.sh
 
+      - name: Verify demo production samples
+        if: matrix.node-version == 22
+        run: cd demo && npm install && npm run verify:samples
+
   vrt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Verify demo production samples
         if: matrix.node-version == 22
-        run: cd demo && npm install && npm run verify:samples
+        run: cd demo && npm ci && npx playwright install chromium && npm run verify:samples
 
   vrt:
     runs-on: ubuntu-latest

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,3 +1,4 @@
 .next/
 node_modules/
 next-env.d.ts
+public/samples/*.pptx

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -14,6 +14,7 @@
         "sharp": "^0.34.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -22,7 +23,7 @@
     },
     "../packages/core": {
       "name": "pptx-glimpse",
-      "version": "1.1.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-wasm": "^2.6.2",
@@ -32,6 +33,7 @@
       },
       "devDependencies": {
         "@pptx-glimpse/document": "workspace:*",
+        "@pptx-glimpse/editor-core": "workspace:*",
         "@pptx-glimpse/renderer": "workspace:*"
       },
       "engines": {
@@ -647,6 +649,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -766,6 +784,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -841,6 +874,38 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",

--- a/demo/package.json
+++ b/demo/package.json
@@ -20,6 +20,7 @@
     "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -3,9 +3,13 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "sync:samples": "node scripts/sync-samples.mjs",
+    "predev": "npm run sync:samples",
     "dev": "next dev",
+    "prebuild": "npm run sync:samples",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "verify:samples": "node scripts/verify-production-samples.mjs"
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",

--- a/demo/public/samples/real-basic-theme.pptx
+++ b/demo/public/samples/real-basic-theme.pptx
@@ -1,1 +1,0 @@
-../../../shared-fixtures/real-basic-theme.pptx

--- a/demo/public/samples/real-product-page.pptx
+++ b/demo/public/samples/real-product-page.pptx
@@ -1,1 +1,0 @@
-../../../shared-fixtures/real-product-page.pptx

--- a/demo/scripts/sync-samples.mjs
+++ b/demo/scripts/sync-samples.mjs
@@ -1,0 +1,19 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const demoRoot = resolve(here, "..");
+const repoRoot = resolve(demoRoot, "..");
+const sampleNames = ["real-basic-theme.pptx", "real-product-page.pptx"];
+const sampleDir = resolve(demoRoot, "public/samples");
+
+await mkdir(sampleDir, { recursive: true });
+
+await Promise.all(
+  sampleNames.map((name) =>
+    copyFile(resolve(repoRoot, "shared-fixtures", name), resolve(sampleDir, name)),
+  ),
+);
+
+console.log(`Synced ${sampleNames.length.toString()} sample PPTX files from shared-fixtures.`);

--- a/demo/scripts/verify-production-samples.mjs
+++ b/demo/scripts/verify-production-samples.mjs
@@ -40,7 +40,24 @@ try {
     serverOutput += chunk.toString();
   });
 
-  await waitForHttpOk(baseUrl, () => serverOutput);
+  let serverReady = false;
+  const serverExitBeforeReady = new Promise((_, reject) => {
+    server.once("exit", (code, signal) => {
+      if (serverReady) return;
+      reject(
+        new Error(
+          `next start exited before becoming ready (code ${String(code)}, signal ${String(signal)})\n${serverOutput}`,
+        ),
+      );
+    });
+  });
+
+  await Promise.race([
+    waitForHttpOk(baseUrl, () => serverOutput).then(() => {
+      serverReady = true;
+    }),
+    serverExitBeforeReady,
+  ]);
 
   for (const sample of samples) {
     await assertSampleServed(baseUrl, sample.filename);

--- a/demo/scripts/verify-production-samples.mjs
+++ b/demo/scripts/verify-production-samples.mjs
@@ -1,0 +1,113 @@
+import { execFile, spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { chromium, expect } from "@playwright/test";
+
+const execFileAsync = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
+const demoRoot = resolve(here, "..");
+const repoRoot = resolve(demoRoot, "..");
+const sampleNames = ["real-basic-theme.pptx", "real-product-page.pptx"];
+
+const port = await getFreePort();
+const baseUrl = `http://127.0.0.1:${port.toString()}`;
+let server;
+let browser;
+
+try {
+  await execFileAsync("npm", ["run", "build"], {
+    cwd: demoRoot,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+
+  server = spawn("npm", ["run", "start", "--", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: demoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let serverOutput = "";
+  server.stdout.on("data", (chunk) => {
+    serverOutput += chunk.toString();
+  });
+  server.stderr.on("data", (chunk) => {
+    serverOutput += chunk.toString();
+  });
+
+  await waitForHttpOk(baseUrl, () => serverOutput);
+
+  for (const sampleName of sampleNames) {
+    await assertSampleServed(baseUrl, sampleName);
+  }
+
+  browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto(baseUrl);
+  await page.getByTestId("sample-basic-theme").click();
+  await expect(page.getByTestId("viewer-status")).toContainText("slides rendered", {
+    timeout: 30_000,
+  });
+  await expect(page.locator("svg").first()).toBeVisible();
+} finally {
+  await browser?.close();
+  if (server !== undefined) {
+    server.kill("SIGTERM");
+    await new Promise((resolve) => {
+      server.once("exit", resolve);
+      setTimeout(resolve, 5_000);
+    });
+  }
+}
+
+async function assertSampleServed(baseUrl, sampleName) {
+  const response = await fetch(`${baseUrl}/samples/${sampleName}`);
+  if (!response.ok) {
+    throw new Error(`/samples/${sampleName} returned ${response.status.toString()}`);
+  }
+
+  const actual = Buffer.from(await response.arrayBuffer());
+  const expected = await readFile(resolve(repoRoot, "shared-fixtures", sampleName));
+
+  if (!actual.equals(expected)) {
+    throw new Error(`/samples/${sampleName} did not match shared-fixtures/${sampleName}`);
+  }
+}
+
+async function waitForHttpOk(url, getOutput) {
+  const deadline = Date.now() + 60_000;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status.toString()}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`next start did not become ready: ${String(lastError)}\n${getOutput()}`);
+}
+
+async function getFreePort() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+
+  if (address === null || typeof address === "string") {
+    throw new Error("failed to allocate a local port");
+  }
+
+  return address.port;
+}

--- a/demo/scripts/verify-production-samples.mjs
+++ b/demo/scripts/verify-production-samples.mjs
@@ -11,6 +11,7 @@ const execFileAsync = promisify(execFile);
 const here = dirname(fileURLToPath(import.meta.url));
 const demoRoot = resolve(here, "..");
 const repoRoot = resolve(demoRoot, "..");
+const nextCli = resolve(demoRoot, "node_modules/next/dist/bin/next");
 const samples = [
   { id: "basic-theme", filename: "real-basic-theme.pptx" },
   { id: "product-page", filename: "real-product-page.pptx" },
@@ -27,10 +28,14 @@ try {
     maxBuffer: 20 * 1024 * 1024,
   });
 
-  server = spawn("npm", ["run", "start", "--", "--hostname", "127.0.0.1", "--port", String(port)], {
-    cwd: demoRoot,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  server = spawn(
+    process.execPath,
+    [nextCli, "start", "--hostname", "127.0.0.1", "--port", String(port)],
+    {
+      cwd: demoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
 
   let serverOutput = "";
   server.stdout.on("data", (chunk) => {

--- a/demo/scripts/verify-production-samples.mjs
+++ b/demo/scripts/verify-production-samples.mjs
@@ -11,7 +11,10 @@ const execFileAsync = promisify(execFile);
 const here = dirname(fileURLToPath(import.meta.url));
 const demoRoot = resolve(here, "..");
 const repoRoot = resolve(demoRoot, "..");
-const sampleNames = ["real-basic-theme.pptx", "real-product-page.pptx"];
+const samples = [
+  { id: "basic-theme", filename: "real-basic-theme.pptx" },
+  { id: "product-page", filename: "real-product-page.pptx" },
+];
 
 const port = await getFreePort();
 const baseUrl = `http://127.0.0.1:${port.toString()}`;
@@ -39,18 +42,20 @@ try {
 
   await waitForHttpOk(baseUrl, () => serverOutput);
 
-  for (const sampleName of sampleNames) {
-    await assertSampleServed(baseUrl, sampleName);
+  for (const sample of samples) {
+    await assertSampleServed(baseUrl, sample.filename);
   }
 
   browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(baseUrl);
-  await page.getByTestId("sample-basic-theme").click();
-  await expect(page.getByTestId("viewer-status")).toContainText("slides rendered", {
-    timeout: 30_000,
-  });
-  await expect(page.locator("svg").first()).toBeVisible();
+  for (const sample of samples) {
+    await page.goto(baseUrl);
+    await page.getByTestId(`sample-${sample.id}`).click();
+    await expect(page.getByTestId("viewer-status")).toContainText("slides rendered", {
+      timeout: 30_000,
+    });
+    await expect(page.locator("svg").first()).toBeVisible();
+  }
 } finally {
   await browser?.close();
   if (server !== undefined) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "changeset": "changeset",
     "demo:dev": "cd demo && npm run dev",
     "demo:build": "pnpm run build && cd demo && npm install && npm run build",
-    "demo:verify-samples": "pnpm run build && pnpm exec playwright install chromium && cd demo && npm install && npm run verify:samples"
+    "demo:verify-samples": "pnpm run build && cd demo && npm ci && npx playwright install chromium && npm run verify:samples"
   },
   "packageManager": "pnpm@11.5.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:package": "pnpm run build && bash scripts/test-package.sh",
     "changeset": "changeset",
     "demo:dev": "cd demo && npm run dev",
-    "demo:build": "pnpm run build && cd demo && npm install && npm run build"
+    "demo:build": "pnpm run build && cd demo && npm install && npm run build",
+    "demo:verify-samples": "pnpm run build && cd demo && npm install && npm run verify:samples"
   },
   "packageManager": "pnpm@11.5.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "changeset": "changeset",
     "demo:dev": "cd demo && npm run dev",
     "demo:build": "pnpm run build && cd demo && npm install && npm run build",
-    "demo:verify-samples": "pnpm run build && cd demo && npm install && npm run verify:samples"
+    "demo:verify-samples": "pnpm run build && pnpm exec playwright install chromium && cd demo && npm install && npm run verify:samples"
   },
   "packageManager": "pnpm@11.5.0",
   "engines": {


### PR DESCRIPTION
close #611

## 目的

Vercel 上で demo の `/samples/*.pptx` が 404 になり、「Open sample」が失敗する問題を修正します。

## 変更内容

- `demo/public/samples/*.pptx` の tracked symlink を削除
- `shared-fixtures/` から demo public samples へビルド前コピーする `sync:samples` を追加
- コピー先 PPTX を `.gitignore` 対象化し、供給元を `shared-fixtures/` に一元化
- `next build` + `next start` で `/samples/*.pptx` の配信と 2 つの sample ボタンの描画を検証する `verify:samples` を追加
- CI の Node 22 test job に demo production samples 検証を追加

## 検証

- `npm ci` (demo)
- `npx playwright install chromium` (demo)
- `npm run verify:samples` (demo)
- `npm run lint`
- `npm run typecheck`
- `npx prettier --check .github/workflows/ci.yml package.json demo/package.json demo/package-lock.json demo/scripts/sync-samples.mjs demo/scripts/verify-production-samples.mjs`
- `node --check demo/scripts/sync-samples.mjs`
- `node --check demo/scripts/verify-production-samples.mjs`

補足: ローカルの `npm run build` はユーザー環境の pnpm `minimumReleaseAge=10080` 設定により既存 lockfile の `picomatch@4.0.5` / `postcss@8.5.16` で停止したため、各 package の `tsup` 直接ビルドで確認しています。