### PR TITLE
文字 run property 編集を追加

### DIFF
--- a/.changeset/fresh-trees-format.md
+++ b/.changeset/fresh-trees-format.md
@@ -1,0 +1,6 @@
+---
+"@pptx-glimpse/document": minor
+"pptx-glimpse": minor
+---
+
+Add headless text run formatting edits for bold, italic, underline, font size, direct sRGB color, and latin typeface.

--- a/e2e/edit-equivalence.test.ts
+++ b/e2e/edit-equivalence.test.ts
@@ -6,7 +6,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import type { ConvertOptions } from "../packages/core/src/converter.js";
-import { replaceTextRunPlainText } from "../packages/document/src/index.js";
+import { asPt, replaceTextRunPlainText } from "../packages/document/src/index.js";
+import { createEditorSession } from "../packages/editor-core/src/index.js";
 import {
   assertEditEquivalence,
   defineEditEquivalenceTests,
@@ -22,16 +23,32 @@ import {
 } from "../vrt/snapshot/create-fixtures.js";
 import { unsafeVrtInteropAssertion } from "../vrt/unsafe-type-assertion.js";
 
+const TEST_FONT_FAMILY = "Pptx Glimpse Edit Equivalence";
+const TEST_FONT_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-font-v2");
+const TEST_FONT_PATH = join(TEST_FONT_DIR, "PptxGlimpseEditEquivalence-Regular.ttf");
+
 const originalTextRunFixture = textRunFixture("source text-run fixture", "Original text");
 const editedTextRunFixture = textRunFixture("expected edited text-run fixture", "Edited text");
+const originalDecoratedRunFixture = textRunFixture(
+  "source text-run decoration fixture",
+  "Edited text",
+);
+const expectedDecoratedRunFixture = textRunFixture(
+  "expected decorated text-run fixture",
+  "Edited text",
+  {
+    bold: true,
+    italic: true,
+    underline: true,
+    fontSize: 32,
+    color: "9C0000",
+    typeface: TEST_FONT_FAMILY,
+  },
+);
 const mismatchedTextRunFixture = textRunFixture(
   "mismatched expected text-run fixture",
   "Alterd text",
 );
-
-const TEST_FONT_FAMILY = "Pptx Glimpse Edit Equivalence";
-const TEST_FONT_DIR = join(tmpdir(), "pptx-glimpse-edit-equivalence-font-v2");
-const TEST_FONT_PATH = join(TEST_FONT_DIR, "PptxGlimpseEditEquivalence-Regular.ttf");
 
 const replaceFirstRunWithEditedText = {
   name: "replace first text run with edited text",
@@ -45,12 +62,46 @@ const replaceFirstRunWithEditedText = {
   },
 } as const satisfies EditEquivalenceOperation;
 
+const decorateFirstRun = {
+  name: "set first text run decoration",
+  apply: (source) => {
+    const run =
+      source.slides[0]?.shapes[0]?.kind === "shape"
+        ? source.slides[0].shapes[0].textBody?.paragraphs[0]?.runs[0]
+        : undefined;
+    if (run?.handle === undefined) throw new Error("editable text run not found");
+    const session = createEditorSession(source);
+    const result = session.apply({
+      kind: "setTextRunProperties",
+      handle: run.handle,
+      properties: {
+        bold: true,
+        italic: true,
+        underline: true,
+        fontSize: asPt(32),
+        color: { kind: "srgb", hex: "9C0000" },
+        typeface: TEST_FONT_FAMILY,
+      },
+    });
+    if (!result.ok) throw new Error(result.message);
+    return result.document;
+  },
+} as const satisfies EditEquivalenceOperation;
+
 defineEditEquivalenceTests([
   {
     name: "text-run replacement",
     sourceFixture: originalTextRunFixture,
     operations: [replaceFirstRunWithEditedText],
     expectedFixture: editedTextRunFixture,
+    renderOptionsProvider: getTinyTestFontRenderOptions,
+    renderOptions: { width: 480 },
+  },
+  {
+    name: "text-run decoration",
+    sourceFixture: originalDecoratedRunFixture,
+    operations: [decorateFirstRun],
+    expectedFixture: expectedDecoratedRunFixture,
     renderOptionsProvider: getTinyTestFontRenderOptions,
     renderOptions: { width: 480 },
   },
@@ -71,14 +122,18 @@ describe("edit equivalence rendering oracle", { timeout: 60000 }, () => {
   });
 });
 
-function textRunFixture(name: string, text: string): EditEquivalenceFixture {
+function textRunFixture(
+  name: string,
+  text: string,
+  opts?: Parameters<typeof textBodyXmlHelper>[1],
+): EditEquivalenceFixture {
   return {
     name,
     create: async () =>
       await buildPptx({
         slides: [
           {
-            xml: wrapSlideXml(textRunShapeXml(text)),
+            xml: wrapSlideXml(textRunShapeXml(text, opts)),
             rels: slideRelsXml(),
           },
         ],
@@ -86,7 +141,20 @@ function textRunFixture(name: string, text: string): EditEquivalenceFixture {
   };
 }
 
-function textRunShapeXml(text: string): string {
+function textRunShapeXml(text: string, opts?: Parameters<typeof textBodyXmlHelper>[1]): string {
+  return decoratedTextRunShapeXml(text, {
+    fontSize: 28,
+    color: "FFFFFF",
+    typeface: TEST_FONT_FAMILY,
+    align: "ctr",
+    ...opts,
+  });
+}
+
+function decoratedTextRunShapeXml(
+  text: string,
+  opts: Parameters<typeof textBodyXmlHelper>[1],
+): string {
   return shapeXml(2, "Editable Text", {
     preset: "rect",
     x: 914400,
@@ -95,12 +163,7 @@ function textRunShapeXml(text: string): string {
     cy: 1371600,
     fillXml: `<a:solidFill><a:srgbClr val="4472C4"/></a:solidFill>`,
     outlineXml: `<a:ln w="12700"><a:solidFill><a:srgbClr val="2F528F"/></a:solidFill></a:ln>`,
-    textBodyXml: textBodyXmlHelper(text, {
-      fontSize: 28,
-      color: "FFFFFF",
-      typeface: TEST_FONT_FAMILY,
-      align: "ctr",
-    }),
+    textBodyXml: textBodyXmlHelper(text, opts),
   });
 }
 

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -60,6 +60,8 @@ export type {
   ContentTypes,
   Diagnostic,
   DiagnosticSeverity,
+  EditableTextRunProperties,
+  EditableTextRunProperty,
   Emu,
   HundredthPt,
   MediaPart,
@@ -74,6 +76,7 @@ export type {
   PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
+  PptxSourceModelTextRunPropertiesEdit,
   Pt,
   RawOoxmlNode,
   RawPackagePart,
@@ -164,11 +167,13 @@ export type {
   UpdateShapeTransformInput,
 } from "./source/index.js";
 export {
+  clearTextRunProperties,
   findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
   replaceParagraphPlainText,
   replaceTextRunPlainText,
+  setTextRunProperties,
   updateShapeTransform,
 } from "./source/index.js";
 export {

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -16,6 +16,19 @@ type TransformableShapeNode = Exclude<SourceShapeNode, { readonly kind: "raw" }>
 type MutableRunProperties = {
   -readonly [K in keyof SourceRunProperties]?: SourceRunProperties[K];
 };
+type MutableEditableTextRunProperties = {
+  -readonly [K in keyof EditableTextRunProperties]?: EditableTextRunProperties[K];
+};
+
+const EDITABLE_TEXT_RUN_PROPERTIES = [
+  "bold",
+  "italic",
+  "underline",
+  "fontSize",
+  "color",
+  "typeface",
+] as const satisfies readonly EditableTextRunProperty[];
+const EDITABLE_TEXT_RUN_PROPERTY_SET: ReadonlySet<string> = new Set(EDITABLE_TEXT_RUN_PROPERTIES);
 
 export function findTextRunBySourceHandle(
   source: PptxSourceModel,
@@ -184,11 +197,14 @@ function updateTextRunProperties(
   patch: UpdateTextRunPropertiesPatch,
 ): PptxSourceModel {
   assertEditableTextRunProperties(patch.set);
-  if (Object.values(patch.set).every((value) => value === undefined) && patch.clear.length === 0) {
+  assertEditableTextRunPropertyNames(patch.clear);
+  const set = definedEditableTextRunProperties(patch.set);
+  if (Object.values(set).every((value) => value === undefined) && patch.clear.length === 0) {
     throw new Error("updateTextRunProperties: patch must set or clear at least one property");
   }
 
-  let updated = false;
+  let found = false;
+  let changed = false;
 
   const slides = source.slides.map((slide) => ({
     ...slide,
@@ -200,10 +216,12 @@ function updateTextRunProperties(
         let paragraphChanged = false;
         const runs = paragraph.runs.map((run) => {
           if (!sourceHandlesEqual(run.handle, handle)) return run;
-          updated = true;
+          found = true;
+          const properties = patchTextRunProperties(run.properties, { set, clear: patch.clear });
+          if (textRunPropertiesEqual(run.properties, properties)) return run;
+          changed = true;
           paragraphChanged = true;
           shapeChanged = true;
-          const properties = patchTextRunProperties(run.properties, patch);
           return {
             kind: run.kind,
             text: run.text,
@@ -226,11 +244,12 @@ function updateTextRunProperties(
     }),
   }));
 
-  if (!updated) {
+  if (!found) {
     throw new Error(
       "updateTextRunProperties: text run handle was not found in PptxSourceModel source",
     );
   }
+  if (!changed) return source;
 
   return {
     ...source,
@@ -240,7 +259,7 @@ function updateTextRunProperties(
       {
         kind: "updateTextRunProperties",
         handle,
-        ...(Object.keys(patch.set).length > 0 ? { set: patch.set } : {}),
+        ...(Object.keys(set).length > 0 ? { set } : {}),
         ...(patch.clear.length > 0 ? { clear: patch.clear } : {}),
       },
     ],
@@ -360,6 +379,23 @@ function findParagraphInShape(
 }
 
 function assertEditableTextRunProperties(properties: EditableTextRunProperties): void {
+  for (const property of Object.keys(properties)) {
+    if (!EDITABLE_TEXT_RUN_PROPERTY_SET.has(property)) {
+      throw new Error(`updateTextRunProperties: unsupported text run property '${property}'`);
+    }
+  }
+  requireBooleanOrUndefined(properties.bold, "bold");
+  requireBooleanOrUndefined(properties.italic, "italic");
+  requireBooleanOrUndefined(properties.underline, "underline");
+  if (
+    properties.fontSize !== undefined &&
+    (!Number.isFinite(properties.fontSize) || properties.fontSize <= 0)
+  ) {
+    throw new Error("updateTextRunProperties: fontSize must be a finite positive pt value");
+  }
+  if (properties.typeface !== undefined && properties.typeface.trim() === "") {
+    throw new Error("updateTextRunProperties: typeface must be a non-empty string");
+  }
   if (properties.color !== undefined) {
     if (properties.color.kind !== "srgb") {
       throw new Error("updateTextRunProperties: only srgb text run color is supported");
@@ -368,6 +404,43 @@ function assertEditableTextRunProperties(properties: EditableTextRunProperties):
       throw new Error("updateTextRunProperties: srgb text run color must be a 6-digit hex value");
     }
   }
+}
+
+function requireBooleanOrUndefined(
+  value: boolean | undefined,
+  fieldName: "bold" | "italic" | "underline",
+): void {
+  if (value !== undefined && typeof value !== "boolean") {
+    throw new Error(`updateTextRunProperties: ${fieldName} must be a boolean value`);
+  }
+}
+
+function assertEditableTextRunPropertyNames(properties: readonly EditableTextRunProperty[]): void {
+  for (const property of properties) {
+    if (!EDITABLE_TEXT_RUN_PROPERTY_SET.has(property)) {
+      throw new Error(`updateTextRunProperties: unsupported text run property '${property}'`);
+    }
+  }
+}
+
+function definedEditableTextRunProperties(
+  properties: EditableTextRunProperties,
+): EditableTextRunProperties {
+  const defined: MutableEditableTextRunProperties = {};
+  if (properties.bold !== undefined) defined.bold = properties.bold;
+  if (properties.italic !== undefined) defined.italic = properties.italic;
+  if (properties.underline !== undefined) defined.underline = properties.underline;
+  if (properties.fontSize !== undefined) defined.fontSize = properties.fontSize;
+  if (properties.color !== undefined) defined.color = properties.color;
+  if (properties.typeface !== undefined) defined.typeface = properties.typeface;
+  return defined;
+}
+
+function textRunPropertiesEqual(
+  left: SourceRunProperties | undefined,
+  right: SourceRunProperties | undefined,
+): boolean {
+  return JSON.stringify(left ?? {}) === JSON.stringify(right ?? {});
 }
 
 function createReplacementRunHandle(paragraph: SourceParagraph): SourceHandle | undefined {

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1,15 +1,21 @@
 import { asSourceNodeId } from "./handles.js";
 import type {
+  EditableTextRunProperties,
+  EditableTextRunProperty,
   Emu,
   PptxSourceModel,
   SourceHandle,
   SourceParagraph,
+  SourceRunProperties,
   SourceShape,
   SourceShapeNode,
   SourceTextRun,
 } from "./index.js";
 
 type TransformableShapeNode = Exclude<SourceShapeNode, { readonly kind: "raw" }>;
+type MutableRunProperties = {
+  -readonly [K in keyof SourceRunProperties]?: SourceRunProperties[K];
+};
 
 export function findTextRunBySourceHandle(
   source: PptxSourceModel,
@@ -88,6 +94,28 @@ export function replaceTextRunPlainText(
   };
 }
 
+export function setTextRunProperties(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+  properties: EditableTextRunProperties,
+): PptxSourceModel {
+  return updateTextRunProperties(source, handle, {
+    set: properties,
+    clear: [],
+  });
+}
+
+export function clearTextRunProperties(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+  properties: readonly EditableTextRunProperty[],
+): PptxSourceModel {
+  return updateTextRunProperties(source, handle, {
+    set: {},
+    clear: properties,
+  });
+}
+
 export function replaceParagraphPlainText(
   source: PptxSourceModel,
   handle: SourceHandle,
@@ -143,6 +171,97 @@ export function replaceParagraphPlainText(
     slides,
     edits: [...(source.edits ?? []), { kind: "replaceParagraphPlainText", handle, text }],
   };
+}
+
+interface UpdateTextRunPropertiesPatch {
+  readonly set: EditableTextRunProperties;
+  readonly clear: readonly EditableTextRunProperty[];
+}
+
+function updateTextRunProperties(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+  patch: UpdateTextRunPropertiesPatch,
+): PptxSourceModel {
+  assertEditableTextRunProperties(patch.set);
+  if (Object.values(patch.set).every((value) => value === undefined) && patch.clear.length === 0) {
+    throw new Error("updateTextRunProperties: patch must set or clear at least one property");
+  }
+
+  let updated = false;
+
+  const slides = source.slides.map((slide) => ({
+    ...slide,
+    shapes: slide.shapes.map((shape) => {
+      if (shape.kind !== "shape" || shape.textBody === undefined) return shape;
+
+      let shapeChanged = false;
+      const paragraphs = shape.textBody.paragraphs.map((paragraph) => {
+        let paragraphChanged = false;
+        const runs = paragraph.runs.map((run) => {
+          if (!sourceHandlesEqual(run.handle, handle)) return run;
+          updated = true;
+          paragraphChanged = true;
+          shapeChanged = true;
+          const properties = patchTextRunProperties(run.properties, patch);
+          return {
+            kind: run.kind,
+            text: run.text,
+            ...(run.handle !== undefined ? { handle: run.handle } : {}),
+            ...(run.rawSidecars !== undefined ? { rawSidecars: run.rawSidecars } : {}),
+            ...(properties !== undefined ? { properties } : {}),
+          } satisfies SourceTextRun;
+        });
+        return !paragraphChanged ? paragraph : ({ ...paragraph, runs } satisfies SourceParagraph);
+      });
+
+      if (!shapeChanged) return shape;
+      return {
+        ...shape,
+        textBody: {
+          ...shape.textBody,
+          paragraphs,
+        },
+      } satisfies SourceShape;
+    }),
+  }));
+
+  if (!updated) {
+    throw new Error(
+      "updateTextRunProperties: text run handle was not found in PptxSourceModel source",
+    );
+  }
+
+  return {
+    ...source,
+    slides,
+    edits: [
+      ...(source.edits ?? []),
+      {
+        kind: "updateTextRunProperties",
+        handle,
+        ...(Object.keys(patch.set).length > 0 ? { set: patch.set } : {}),
+        ...(patch.clear.length > 0 ? { clear: patch.clear } : {}),
+      },
+    ],
+  };
+}
+
+function patchTextRunProperties(
+  current: SourceRunProperties | undefined,
+  patch: UpdateTextRunPropertiesPatch,
+): SourceRunProperties | undefined {
+  const next: MutableRunProperties = { ...(current ?? {}) };
+  for (const property of patch.clear) {
+    delete next[property];
+  }
+  if (patch.set.bold !== undefined) next.bold = patch.set.bold;
+  if (patch.set.italic !== undefined) next.italic = patch.set.italic;
+  if (patch.set.underline !== undefined) next.underline = patch.set.underline;
+  if (patch.set.fontSize !== undefined) next.fontSize = patch.set.fontSize;
+  if (patch.set.color !== undefined) next.color = patch.set.color;
+  if (patch.set.typeface !== undefined) next.typeface = patch.set.typeface;
+  return Object.keys(next).length > 0 ? next : undefined;
 }
 
 export interface UpdateShapeTransformInput {
@@ -238,6 +357,17 @@ function findParagraphInShape(
   return shape.textBody?.paragraphs.find((paragraph) =>
     sourceHandlesEqual(paragraph.handle, handle),
   );
+}
+
+function assertEditableTextRunProperties(properties: EditableTextRunProperties): void {
+  if (properties.color !== undefined) {
+    if (properties.color.kind !== "srgb") {
+      throw new Error("updateTextRunProperties: only srgb text run color is supported");
+    }
+    if (!/^[0-9A-Fa-f]{6}$/.test(properties.color.hex)) {
+      throw new Error("updateTextRunProperties: srgb text run color must be a 6-digit hex value");
+    }
+  }
 }
 
 function createReplacementRunHandle(paragraph: SourceParagraph): SourceHandle | undefined {

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -5,11 +5,13 @@
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
 export type { UpdateShapeTransformInput } from "./editing.js";
 export {
+  clearTextRunProperties,
   findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
   replaceParagraphPlainText,
   replaceTextRunPlainText,
+  setTextRunProperties,
   updateShapeTransform,
 } from "./editing.js";
 export type {
@@ -32,11 +34,14 @@ export type {
   RelationshipTargetMode,
 } from "./package-graph.js";
 export type {
+  EditableTextRunProperties,
+  EditableTextRunProperty,
   PptxSourceModel,
   PptxSourceModelEdit,
   PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
+  PptxSourceModelTextRunPropertiesEdit,
 } from "./pptx-source-model.js";
 export type {
   SlideSize,

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -32,7 +32,7 @@ import type {
   SourceSlideMaster,
   SourceTheme,
 } from "./presentation.js";
-import type { Emu } from "./units.js";
+import type { Emu, Pt } from "./units.js";
 
 export interface PptxSourceModel {
   /** Structure of package part / relationship / content type / media. */
@@ -50,6 +50,7 @@ export interface PptxSourceModel {
 
 export type PptxSourceModelEdit =
   | PptxSourceModelTextRunEdit
+  | PptxSourceModelTextRunPropertiesEdit
   | PptxSourceModelParagraphTextEdit
   | PptxSourceModelShapeTransformEdit;
 
@@ -57,6 +58,30 @@ export interface PptxSourceModelTextRunEdit {
   readonly kind: "replaceTextRunPlainText";
   readonly handle: SourceHandle;
   readonly text: string;
+}
+
+export type EditableTextRunProperty =
+  | "bold"
+  | "italic"
+  | "underline"
+  | "fontSize"
+  | "color"
+  | "typeface";
+
+export interface EditableTextRunProperties {
+  readonly bold?: boolean;
+  readonly italic?: boolean;
+  readonly underline?: boolean;
+  readonly fontSize?: Pt;
+  readonly color?: { readonly kind: "srgb"; readonly hex: string };
+  readonly typeface?: string;
+}
+
+export interface PptxSourceModelTextRunPropertiesEdit {
+  readonly kind: "updateTextRunProperties";
+  readonly handle: SourceHandle;
+  readonly set?: EditableTextRunProperties;
+  readonly clear?: readonly EditableTextRunProperty[];
 }
 
 export interface PptxSourceModelParagraphTextEdit {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -519,6 +519,68 @@ describe("writePptx - text run property edits", () => {
     });
   });
 
+  it("Does not dirty a run when clearing properties that are already absent", () => {
+    const source = readPptx(buildSlotHandleTextEditFixture());
+    const edited = clearTextRunProperties(source, firstRun(source).handle!, ["bold"]);
+    const output = writePptx(edited);
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(edited).toBe(source);
+    expect(slideXml).not.toContain("<a:rPr");
+    expect(firstRun(readPptx(output)).properties).toBeUndefined();
+  });
+
+  it("Removes an empty latin run property element when clearing typeface", () => {
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<p:sp><p:nvSpPr><p:cNvPr id="71" name="Typeface"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+          `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+          `<a:p><a:r><a:rPr><a:latin typeface="Aptos"/></a:rPr><a:t>Original</a:t></a:r></a:p>` +
+          `</p:txBody></p:sp>`,
+      ),
+    );
+    const edited = clearTextRunProperties(source, firstRun(source).handle!, ["typeface"]);
+    const output = writePptx(edited);
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(slideXml).not.toContain("<a:latin");
+    expect(slideXml).not.toContain("<a:rPr");
+    expect(firstRun(readPptx(output)).properties).toBeUndefined();
+  });
+
+  it("Rejects invalid direct text run property helper input", () => {
+    const source = readPptx(buildTextEditFixture());
+    const handle = firstRun(source).handle!;
+
+    expect(() => setTextRunProperties(source, handle, { fontSize: asPt(0) })).toThrow(
+      /fontSize must be a finite positive pt value/,
+    );
+    expect(() =>
+      // @ts-expect-error exercises runtime validation for JS callers.
+      setTextRunProperties(source, handle, { strikethrough: true }),
+    ).toThrow(/unsupported text run property 'strikethrough'/);
+    expect(() =>
+      // @ts-expect-error exercises runtime validation for JS callers.
+      clearTextRunProperties(source, handle, ["strikethrough"]),
+    ).toThrow(/unsupported text run property 'strikethrough'/);
+  });
+
+  it("Rejects no-op text run property edits constructed directly in an edit journal", () => {
+    const source = readPptx(buildTextEditFixture());
+    const edited = {
+      ...source,
+      edits: [
+        {
+          kind: "updateTextRunProperties",
+          handle: firstRun(source).handle!,
+        },
+      ],
+    } satisfies typeof source;
+
+    expect(() => writePptx(edited)).toThrow(/must set or clear at least one property/);
+  });
+
   it("Applies text and property edits to the same run in one write", () => {
     const source = readPptx(buildTextEditFixture());
     const handle = firstRun(source).handle!;

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -5,13 +5,15 @@ import { unzipSync, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 
 // Import via the actual public surface (`@pptx-glimpse/document`).
-import { asEmu, asSourceNodeId, readPptx, writePptx } from "../index.js";
+import { asEmu, asPt, asSourceNodeId, readPptx, writePptx } from "../index.js";
 import {
+  clearTextRunProperties,
   findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
   replaceParagraphPlainText,
   replaceTextRunPlainText,
+  setTextRunProperties,
   type SourceShape,
   updateShapeTransform,
 } from "../index.js";
@@ -415,6 +417,135 @@ describe("writePptx - multiple text edits", () => {
     );
 
     expect(() => writePptx(edited)).toThrow(/conflicting text run and paragraph edits/);
+  });
+});
+
+describe("writePptx - text run property edits", () => {
+  it("Sets all supported text run properties and persists them after write/read", () => {
+    const source = readPptx(buildTextEditFixture());
+    const run = firstRun(source);
+
+    const edited = setTextRunProperties(source, run.handle!, {
+      bold: false,
+      italic: false,
+      underline: true,
+      fontSize: asPt(32),
+      color: { kind: "srgb", hex: "00aa44" },
+      typeface: "Liberation Sans",
+    });
+    const reread = readPptx(writePptx(edited));
+    const editedRun = firstRun(reread);
+
+    expect(firstRun(edited).properties).toMatchObject({
+      bold: false,
+      italic: false,
+      underline: true,
+      fontSize: 32,
+      color: { kind: "srgb", hex: "00aa44" },
+      typeface: "Liberation Sans",
+    });
+    expect(editedRun.properties).toMatchObject({
+      bold: false,
+      italic: false,
+      underline: true,
+      fontSize: 32,
+      color: { kind: "srgb", hex: "00AA44" },
+      typeface: "Liberation Sans",
+      typefaceEa: "Noto Sans JP",
+    });
+  });
+
+  it("Clears supported text run properties without removing unrelated rPr attributes or children", () => {
+    const source = readPptx(
+      buildTextEditFixtureFromSlide(
+        `<p:sp><p:nvSpPr><p:cNvPr id="70" name="Decorated"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+          `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+          `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+          `<a:p><a:r><a:rPr lang="en-US" b="1" i="1" u="sng" sz="2400" spc="120">` +
+          `<a:solidFill><a:schemeClr val="accent1"><a:lumMod val="65000"/></a:schemeClr></a:solidFill>` +
+          `<a:latin typeface="Aptos"/><a:effectLst/><a:ea typeface="Noto Sans JP"/>` +
+          `</a:rPr><a:t>Original</a:t></a:r>` +
+          `<a:r><a:rPr b="1"><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:rPr><a:t>Untouched</a:t></a:r>` +
+          `</a:p>` +
+          `</p:txBody></p:sp>`,
+      ),
+    );
+
+    const edited = clearTextRunProperties(source, firstRun(source).handle!, [
+      "bold",
+      "italic",
+      "underline",
+      "fontSize",
+      "color",
+      "typeface",
+    ]);
+    const output = writePptx(edited);
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+    const reread = readPptx(output);
+
+    const properties = firstRun(reread).properties;
+    expect(properties).toMatchObject({ typefaceEa: "Noto Sans JP" });
+    expect(properties?.bold).toBeUndefined();
+    expect(properties?.italic).toBeUndefined();
+    expect(properties?.underline).toBeUndefined();
+    expect(properties?.fontSize).toBeUndefined();
+    expect(properties?.color).toBeUndefined();
+    expect(properties?.typeface).toBeUndefined();
+    expect(slideXml).toContain('lang="en-US"');
+    expect(slideXml).toContain('spc="120"');
+    expect(slideXml).toContain("<a:effectLst");
+    expect(slideXml).toContain('<a:ea typeface="Noto Sans JP"');
+    expect(firstParagraph(reread).runs[1].properties).toMatchObject({
+      bold: true,
+      color: { kind: "srgb", hex: "00FF00" },
+    });
+  });
+
+  it("Creates rPr when setting properties on a run without existing properties", () => {
+    const source = readPptx(buildSlotHandleTextEditFixture());
+    const edited = setTextRunProperties(source, firstRun(source).handle!, {
+      bold: true,
+      fontSize: asPt(18),
+      color: { kind: "srgb", hex: "112233" },
+    });
+    const output = writePptx(edited);
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(slideXml.indexOf("<a:rPr")).toBeLessThan(slideXml.indexOf("<a:t>Original</a:t>"));
+    expect(firstRun(readPptx(output)).properties).toMatchObject({
+      bold: true,
+      fontSize: 18,
+      color: { kind: "srgb", hex: "112233" },
+    });
+  });
+
+  it("Applies text and property edits to the same run in one write", () => {
+    const source = readPptx(buildTextEditFixture());
+    const handle = firstRun(source).handle!;
+    const edited = setTextRunProperties(
+      replaceTextRunPlainText(source, handle, "Edited property text"),
+      handle,
+      { underline: true, color: { kind: "srgb", hex: "336699" } },
+    );
+    const reread = readPptx(writePptx(edited));
+
+    expect(firstRun(reread).text).toBe("Edited property text");
+    expect(firstRun(reread).properties).toMatchObject({
+      underline: true,
+      color: { kind: "srgb", hex: "336699" },
+    });
+  });
+
+  it("Rejects conflicting text run property and paragraph replacements for the same paragraph", () => {
+    const source = readPptx(buildTextEditFixture());
+    const paragraph = firstParagraph(source);
+    const edited = replaceParagraphPlainText(
+      setTextRunProperties(source, paragraph.runs[0].handle!, { bold: false }),
+      paragraph.handle!,
+      "Paragraph edit",
+    );
+
+    expect(() => writePptx(edited)).toThrow(/conflicting text run properties and paragraph edits/);
   });
 });
 

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -28,6 +28,7 @@ import {
   type XmlNode,
 } from "../reader/xml.js";
 import type {
+  EditableTextRunProperties,
   PartPath,
   PartRelationships,
   PptxSourceModel,
@@ -206,6 +207,7 @@ function applyTextRunPropertiesEdit(
   root: XmlNode,
   edit: PptxSourceModelTextRunPropertiesEdit,
 ): void {
+  assertTextRunPropertiesEdit(edit);
   const run = locateTextRun(root, edit.handle.nodeId);
 
   if (run === undefined) {
@@ -214,11 +216,16 @@ function applyTextRunPropertiesEdit(
     );
   }
 
-  const rPr = ensureRunProperties(run);
-  for (const property of edit.clear ?? []) {
-    clearRunProperty(rPr, property);
-  }
   const set = edit.set ?? {};
+  const hasSet = hasTextRunPropertiesSetValues(set);
+  const existingRunProperties = getChild(run, "rPr");
+  if (existingRunProperties === undefined && !hasSet) return;
+
+  const rPr = existingRunProperties ?? ensureRunProperties(run);
+  let cleared = false;
+  for (const property of edit.clear ?? []) {
+    cleared = clearRunProperty(rPr, property) || cleared;
+  }
   if (set.bold !== undefined) rPr["@_b"] = booleanOoxmlValue(set.bold);
   if (set.italic !== undefined) rPr["@_i"] = booleanOoxmlValue(set.italic);
   if (set.underline !== undefined) rPr["@_u"] = set.underline ? "sng" : "none";
@@ -231,6 +238,7 @@ function applyTextRunPropertiesEdit(
       },
     });
   }
+  if (!hasSet && cleared && xmlNodeIsEmpty(rPr)) deleteChild(run, "rPr");
 }
 
 function applyParagraphTextEdit(root: XmlNode, edit: PptxSourceModelParagraphTextEdit): void {
@@ -473,28 +481,33 @@ function ensureRunProperties(run: XmlNode): XmlNode {
 function clearRunProperty(
   rPr: XmlNode,
   property: NonNullable<PptxSourceModelTextRunPropertiesEdit["clear"]>[number],
-): void {
+): boolean {
   switch (property) {
     case "bold":
+      if (rPr["@_b"] === undefined) return false;
       delete rPr["@_b"];
-      break;
+      return true;
     case "italic":
+      if (rPr["@_i"] === undefined) return false;
       delete rPr["@_i"];
-      break;
+      return true;
     case "underline":
+      if (rPr["@_u"] === undefined) return false;
       delete rPr["@_u"];
-      break;
+      return true;
     case "fontSize":
+      if (rPr["@_sz"] === undefined) return false;
       delete rPr["@_sz"];
-      break;
+      return true;
     case "typeface": {
       const latin = getChild(rPr, "latin");
-      if (latin !== undefined) delete latin["@_typeface"];
-      break;
+      if (latin?.["@_typeface"] === undefined) return false;
+      delete latin["@_typeface"];
+      if (xmlNodeIsEmpty(latin)) deleteChild(rPr, "latin");
+      return true;
     }
     case "color":
-      deleteChild(rPr, "solidFill");
-      break;
+      return deleteChild(rPr, "solidFill");
   }
 }
 
@@ -520,15 +533,43 @@ function replaceChild(node: XmlNode, name: string, value: XmlNode): void {
   replaceNodeEntries(node, entries);
 }
 
-function deleteChild(node: XmlNode, name: string): void {
+function deleteChild(node: XmlNode, name: string): boolean {
+  let deleted = false;
   replaceNodeEntries(
     node,
-    Object.entries(node).filter(([key]) => key.startsWith("@_") || localName(key) !== name),
+    Object.entries(node).filter(([key]) => {
+      const keep = key.startsWith("@_") || localName(key) !== name;
+      if (!keep) deleted = true;
+      return keep;
+    }),
   );
+  return deleted;
 }
 
 function booleanOoxmlValue(value: boolean): string {
   return value ? "1" : "0";
+}
+
+function hasTextRunPropertiesSetValues(properties: EditableTextRunProperties): boolean {
+  return (
+    properties.bold !== undefined ||
+    properties.italic !== undefined ||
+    properties.underline !== undefined ||
+    properties.fontSize !== undefined ||
+    properties.color !== undefined ||
+    properties.typeface !== undefined
+  );
+}
+
+function assertTextRunPropertiesEdit(edit: PptxSourceModelTextRunPropertiesEdit): void {
+  const clear = edit.clear ?? [];
+  if (!hasTextRunPropertiesSetValues(edit.set ?? {}) && clear.length === 0) {
+    throw new Error("writePptx: text run properties edit must set or clear at least one property");
+  }
+}
+
+function xmlNodeIsEmpty(node: XmlNode): boolean {
+  return Object.keys(node).length === 0;
 }
 
 function replaceParagraphRunsWithSingleTextRun(paragraph: XmlNode, text: string): void {

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -35,6 +35,7 @@ import type {
   PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
   PptxSourceModelTextRunEdit,
+  PptxSourceModelTextRunPropertiesEdit,
   RawOoxmlNode,
   RawPackagePart,
 } from "../source/index.js";
@@ -68,11 +69,12 @@ const xmlBuilder = new XMLBuilder({
  */
 export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const textRunEdits = source.edits?.filter(isTextRunEdit) ?? [];
+  const textRunPropertiesEdits = source.edits?.filter(isTextRunPropertiesEdit) ?? [];
   const paragraphTextEdits = source.edits?.filter(isParagraphTextEdit) ?? [];
   const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
-  validateEdits(textRunEdits, paragraphTextEdits, shapeTransformEdits);
+  validateEdits(textRunEdits, textRunPropertiesEdits, paragraphTextEdits, shapeTransformEdits);
   const dirtyPartPaths = new Set(
-    [...textRunEdits, ...paragraphTextEdits, ...shapeTransformEdits].map(
+    [...textRunEdits, ...textRunPropertiesEdits, ...paragraphTextEdits, ...shapeTransformEdits].map(
       (edit) => edit.handle.partPath,
     ),
   );
@@ -104,6 +106,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
       source,
       partPath,
       textRunEdits,
+      textRunPropertiesEdits,
       paragraphTextEdits,
       shapeTransformEdits,
     );
@@ -126,6 +129,12 @@ function isTextRunEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelTextRu
   return edit.kind === "replaceTextRunPlainText";
 }
 
+function isTextRunPropertiesEdit(
+  edit: PptxSourceModelEdit,
+): edit is PptxSourceModelTextRunPropertiesEdit {
+  return edit.kind === "updateTextRunProperties";
+}
+
 function isParagraphTextEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelParagraphTextEdit {
   return edit.kind === "replaceParagraphPlainText";
 }
@@ -140,6 +149,7 @@ function serializeDirtyXmlPart(
   source: PptxSourceModel,
   partPath: PartPath,
   textRunEdits: readonly PptxSourceModelTextRunEdit[],
+  textRunPropertiesEdits: readonly PptxSourceModelTextRunPropertiesEdit[],
   paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
   shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
 ): Uint8Array {
@@ -157,6 +167,9 @@ function serializeDirtyXmlPart(
   }
   for (const edit of textRunEdits.filter((edit) => edit.handle.partPath === partPath)) {
     applyTextRunEdit(root, edit);
+  }
+  for (const edit of textRunPropertiesEdits.filter((edit) => edit.handle.partPath === partPath)) {
+    applyTextRunPropertiesEdit(root, edit);
   }
   for (const edit of shapeTransformEdits.filter((edit) => edit.handle.partPath === partPath)) {
     applyShapeTransformEdit(root, edit);
@@ -189,6 +202,37 @@ function applyTextRunEdit(root: XmlNode, edit: PptxSourceModelTextRunEdit): void
   setChildText(run, "t", edit.text);
 }
 
+function applyTextRunPropertiesEdit(
+  root: XmlNode,
+  edit: PptxSourceModelTextRunPropertiesEdit,
+): void {
+  const run = locateTextRun(root, edit.handle.nodeId);
+
+  if (run === undefined) {
+    throw new Error(
+      `writePptx: text run properties handle '${edit.handle.nodeId}' no longer matches source XML`,
+    );
+  }
+
+  const rPr = ensureRunProperties(run);
+  for (const property of edit.clear ?? []) {
+    clearRunProperty(rPr, property);
+  }
+  const set = edit.set ?? {};
+  if (set.bold !== undefined) rPr["@_b"] = booleanOoxmlValue(set.bold);
+  if (set.italic !== undefined) rPr["@_i"] = booleanOoxmlValue(set.italic);
+  if (set.underline !== undefined) rPr["@_u"] = set.underline ? "sng" : "none";
+  if (set.fontSize !== undefined) rPr["@_sz"] = String(Math.round(set.fontSize * 100));
+  if (set.typeface !== undefined) ensureChild(rPr, "latin")["@_typeface"] = set.typeface;
+  if (set.color !== undefined) {
+    replaceChild(rPr, "solidFill", {
+      "a:srgbClr": {
+        "@_val": set.color.hex.toUpperCase(),
+      },
+    });
+  }
+}
+
 function applyParagraphTextEdit(root: XmlNode, edit: PptxSourceModelParagraphTextEdit): void {
   const locator = parseParagraphLocator(edit.handle.nodeId);
   const slide = getChild(root, "sld");
@@ -205,6 +249,20 @@ function applyParagraphTextEdit(root: XmlNode, edit: PptxSourceModelParagraphTex
   }
 
   replaceParagraphRunsWithSingleTextRun(paragraph, edit.text);
+}
+
+function locateTextRun(
+  root: XmlNode,
+  nodeId: PptxSourceModelTextRunEdit["handle"]["nodeId"],
+): XmlNode | undefined {
+  const locator = parseTextRunLocator(nodeId);
+  const slide = getChild(root, "sld");
+  const cSld = getChild(slide, "cSld");
+  const spTree = getChild(cSld, "spTree");
+  const shape = locateShape(spTree, locator);
+  const paragraphs = getChildArray(getChild(shape, "txBody"), "p");
+  const paragraph = paragraphs[locator.paragraphIndex];
+  return getChildArray(paragraph, "r")[locator.runIndex];
 }
 
 function applyShapeTransformEdit(root: XmlNode, edit: PptxSourceModelShapeTransformEdit): void {
@@ -394,6 +452,85 @@ function setChildText(node: XmlNode, name: string, text: string): void {
     : text;
 }
 
+function ensureRunProperties(run: XmlNode): XmlNode {
+  const existing = getChild(run, "rPr");
+  if (existing !== undefined) return existing;
+
+  const entries: [string, unknown][] = [];
+  let inserted = false;
+  for (const [key, value] of Object.entries(run)) {
+    if (!inserted && !key.startsWith("@_")) {
+      entries.push(["a:rPr", {}]);
+      inserted = true;
+    }
+    entries.push([key, value]);
+  }
+  if (!inserted) entries.push(["a:rPr", {}]);
+  replaceNodeEntries(run, entries);
+  return getChild(run, "rPr") ?? {};
+}
+
+function clearRunProperty(
+  rPr: XmlNode,
+  property: NonNullable<PptxSourceModelTextRunPropertiesEdit["clear"]>[number],
+): void {
+  switch (property) {
+    case "bold":
+      delete rPr["@_b"];
+      break;
+    case "italic":
+      delete rPr["@_i"];
+      break;
+    case "underline":
+      delete rPr["@_u"];
+      break;
+    case "fontSize":
+      delete rPr["@_sz"];
+      break;
+    case "typeface": {
+      const latin = getChild(rPr, "latin");
+      if (latin !== undefined) delete latin["@_typeface"];
+      break;
+    }
+    case "color":
+      deleteChild(rPr, "solidFill");
+      break;
+  }
+}
+
+function ensureChild(node: XmlNode, name: string): XmlNode {
+  const existing = getChild(node, name);
+  if (existing !== undefined) return existing;
+  node[`a:${name}`] = {};
+  return unsafeOoxmlBoundaryAssertion<XmlNode>(node[`a:${name}`]);
+}
+
+function replaceChild(node: XmlNode, name: string, value: XmlNode): void {
+  const entries: [string, unknown][] = [];
+  let replaced = false;
+  for (const [key, entryValue] of Object.entries(node)) {
+    if (!key.startsWith("@_") && localName(key) === name) {
+      if (!replaced) entries.push([key, value]);
+      replaced = true;
+      continue;
+    }
+    entries.push([key, entryValue]);
+  }
+  if (!replaced) entries.push([`a:${name}`, value]);
+  replaceNodeEntries(node, entries);
+}
+
+function deleteChild(node: XmlNode, name: string): void {
+  replaceNodeEntries(
+    node,
+    Object.entries(node).filter(([key]) => key.startsWith("@_") || localName(key) !== name),
+  );
+}
+
+function booleanOoxmlValue(value: boolean): string {
+  return value ? "1" : "0";
+}
+
 function replaceParagraphRunsWithSingleTextRun(paragraph: XmlNode, text: string): void {
   const firstRunProperties = getChild(getFirstRunLikeNode(paragraph), "rPr");
   const replacementRun: XmlNode = {
@@ -511,6 +648,7 @@ function textRequiresPreserve(text: string): boolean {
 
 function validateEdits(
   textRunEdits: readonly PptxSourceModelTextRunEdit[],
+  textRunPropertiesEdits: readonly PptxSourceModelTextRunPropertiesEdit[],
   paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
   shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
 ): void {
@@ -542,6 +680,14 @@ function validateEdits(
       );
     }
   }
+  for (const runPropertiesEdit of textRunPropertiesEdits) {
+    const paragraphKey = textRunParagraphEditKey(runPropertiesEdit);
+    if (paragraphKey !== undefined && paragraphKeys.has(paragraphKey)) {
+      throw new Error(
+        `writePptx: conflicting text run properties and paragraph edits for handle '${runPropertiesEdit.handle.nodeId}'`,
+      );
+    }
+  }
 
   const shapeKeys = new Set<string>();
   for (const edit of shapeTransformEdits) {
@@ -563,7 +709,9 @@ function editHandleNodeKey(edit: {
   );
 }
 
-function textRunParagraphEditKey(edit: PptxSourceModelTextRunEdit): string | undefined {
+function textRunParagraphEditKey(
+  edit: PptxSourceModelTextRunEdit | PptxSourceModelTextRunPropertiesEdit,
+): string | undefined {
   const nodeId = String(edit.handle.nodeId ?? "");
   const byShapeId = /^(text:shape:.+:p:\d+):r:\d+$/.exec(nodeId);
   const byShapeSlot = /^(text:shapeSlot:\d+:p:\d+):r:\d+$/.exec(nodeId);

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -270,6 +270,12 @@ describe("EditorSession text run property commands", () => {
       handle,
       properties: { fontSize: asPt(0) },
     });
+    const unsupportedSetProperty = session.apply({
+      kind: "setTextRunProperties",
+      handle,
+      // @ts-expect-error exercises runtime validation for JS callers.
+      properties: { strikethrough: true },
+    });
     const emptyClearProperties = session.apply({
       kind: "clearTextRunProperties",
       handle,
@@ -281,7 +287,13 @@ describe("EditorSession text run property commands", () => {
       properties: { bold: true },
     });
 
-    for (const result of [invalidHex, invalidFontSize, emptyClearProperties, missingHandle]) {
+    for (const result of [
+      invalidHex,
+      invalidFontSize,
+      unsupportedSetProperty,
+      emptyClearProperties,
+      missingHandle,
+    ]) {
       expect(result).toMatchObject({ ok: false, code: "invalid-command" });
     }
     expect(session.document).toBe(before);
@@ -322,6 +334,44 @@ describe("EditorSession text run property commands", () => {
       italic: false,
       fontSize: 20,
       color: { kind: "srgb", hex: "445566" },
+    });
+  });
+
+  it("preserves mixed clear and set edits from an existing edit journal during normalization", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const handle = requireHandle(firstRun(source).handle);
+    const sourceWithMixedEdit: PptxSourceModel = {
+      ...source,
+      edits: [
+        {
+          kind: "updateTextRunProperties",
+          handle,
+          clear: ["color"],
+          set: { color: { kind: "srgb", hex: "112233" } },
+        },
+      ],
+    };
+    const session = createEditorSession(sourceWithMixedEdit);
+    const edited = expectApplied(
+      session.apply({
+        kind: "setTextRunProperties",
+        handle,
+        properties: { bold: false },
+      }),
+    );
+    const propertyEdits =
+      edited.edits?.filter((edit) => edit.kind === "updateTextRunProperties") ?? [];
+    const reread = readPptx(writePptx(edited));
+
+    expect(propertyEdits).toHaveLength(2);
+    expect(propertyEdits[0]).toMatchObject({
+      set: { color: { kind: "srgb", hex: "112233" } },
+    });
+    expect(propertyEdits[0]?.clear).toBeUndefined();
+    expect(propertyEdits[1]).toMatchObject({ set: { bold: false } });
+    expect(firstRun(reread).properties).toMatchObject({
+      bold: false,
+      color: { kind: "srgb", hex: "112233" },
     });
   });
 

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -1,6 +1,7 @@
 import {
   asEmu,
   asPartPath,
+  asPt,
   asSourceNodeId,
   findShapeNodeBySourceHandle,
   type PptxSourceModel,
@@ -165,6 +166,206 @@ describe("EditorSession text-run commands", () => {
     expect(firstRun(session.document).text).toBe("Original");
     expect(session.undoDepth).toBe(0);
     expect(session.redoDepth).toBe(0);
+  });
+});
+
+describe("EditorSession text run property commands", () => {
+  it("sets and clears supported run properties and persists them through write/read", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstRun(source).handle);
+
+    const setDocument = expectApplied(
+      session.apply({
+        kind: "setTextRunProperties",
+        handle,
+        properties: {
+          bold: false,
+          italic: false,
+          underline: true,
+          fontSize: asPt(30),
+          color: { kind: "srgb", hex: "336699" },
+          typeface: "Liberation Sans",
+        },
+      }),
+    );
+    const clearedDocument = expectApplied(
+      session.apply({
+        kind: "clearTextRunProperties",
+        handle,
+        properties: ["italic", "fontSize", "color"],
+      }),
+    );
+    const reread = readPptx(writePptx(clearedDocument));
+
+    expect(firstRun(setDocument).properties).toMatchObject({
+      bold: false,
+      italic: false,
+      underline: true,
+      fontSize: 30,
+      color: { kind: "srgb", hex: "336699" },
+      typeface: "Liberation Sans",
+    });
+    expect(firstRun(reread).properties).toMatchObject({
+      bold: false,
+      underline: true,
+      typeface: "Liberation Sans",
+    });
+    expect(firstRun(reread).properties?.italic).toBeUndefined();
+    expect(firstRun(reread).properties?.fontSize).toBeUndefined();
+    expect(firstRun(reread).properties?.color).toBeUndefined();
+    expect(firstParagraph(reread).runs[1].properties).toMatchObject({
+      italic: true,
+      fontSize: 18,
+      typeface: "Arial",
+    });
+  });
+
+  it("undoes and redoes run property edits", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstRun(source).handle);
+
+    expectApplied(
+      session.apply({
+        kind: "setTextRunProperties",
+        handle,
+        properties: { underline: true, color: { kind: "srgb", hex: "0088CC" } },
+      }),
+    );
+
+    const undone = expectHistory(session.undo());
+    const redone = expectHistory(session.redo());
+
+    expect(firstRun(undone).properties?.underline).toBeUndefined();
+    expect(firstRun(readPptx(writePptx(undone))).properties?.underline).toBeUndefined();
+    expect(firstRun(redone).properties).toMatchObject({
+      underline: true,
+      color: { kind: "srgb", hex: "0088CC" },
+    });
+    expect(firstRun(readPptx(writePptx(redone))).properties).toMatchObject({
+      underline: true,
+      color: { kind: "srgb", hex: "0088CC" },
+    });
+  });
+
+  it("rejects invalid run property commands without changing document state or undo history", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const before = session.document;
+    const handle = requireHandle(firstRun(source).handle);
+    const invalidHandle = {
+      partPath: asPartPath("ppt/slides/slide1.xml"),
+      nodeId: asSourceNodeId("text:shape:999:p:0:r:0"),
+      orderingSlot: 0,
+    } satisfies SourceHandle;
+
+    const invalidHex = session.apply({
+      kind: "setTextRunProperties",
+      handle,
+      properties: { color: { kind: "srgb", hex: "bad" } },
+    });
+    const invalidFontSize = session.apply({
+      kind: "setTextRunProperties",
+      handle,
+      properties: { fontSize: asPt(0) },
+    });
+    const emptyClearProperties = session.apply({
+      kind: "clearTextRunProperties",
+      handle,
+      properties: [],
+    });
+    const missingHandle = session.apply({
+      kind: "setTextRunProperties",
+      handle: invalidHandle,
+      properties: { bold: true },
+    });
+
+    for (const result of [invalidHex, invalidFontSize, emptyClearProperties, missingHandle]) {
+      expect(result).toMatchObject({ ok: false, code: "invalid-command" });
+    }
+    expect(session.document).toBe(before);
+    expect(firstRun(session.document).properties).toEqual(firstRun(source).properties);
+    expect(session.undoDepth).toBe(0);
+    expect(session.redoDepth).toBe(0);
+  });
+
+  it("keeps only the latest generated edit per run property while preserving independent properties", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstRun(source).handle);
+
+    expectApplied(
+      session.apply({
+        kind: "setTextRunProperties",
+        handle,
+        properties: { bold: false, italic: false, fontSize: asPt(20) },
+      }),
+    );
+    const edited = expectApplied(
+      session.apply({
+        kind: "setTextRunProperties",
+        handle,
+        properties: { bold: true, color: { kind: "srgb", hex: "445566" } },
+      }),
+    );
+    const propertyEdits =
+      edited.edits?.filter((edit) => edit.kind === "updateTextRunProperties") ?? [];
+
+    expect(propertyEdits).toHaveLength(2);
+    expect(propertyEdits[0]).toMatchObject({ set: { italic: false, fontSize: 20 } });
+    expect(propertyEdits[1]).toMatchObject({
+      set: { bold: true, color: { kind: "srgb", hex: "445566" } },
+    });
+    expect(firstRun(readPptx(writePptx(edited))).properties).toMatchObject({
+      bold: true,
+      italic: false,
+      fontSize: 20,
+      color: { kind: "srgb", hex: "445566" },
+    });
+  });
+
+  it("passes property-style undo and redo checks for generated decoration command sequences", async () => {
+    const cases = [
+      [
+        { kind: "setTextRunProperties", properties: { bold: false } },
+        { kind: "setTextRunProperties", properties: { italic: true } },
+      ],
+      [
+        { kind: "setTextRunProperties", properties: { underline: true } },
+        { kind: "clearTextRunProperties", properties: ["underline"] },
+      ],
+      [
+        { kind: "clearTextRunProperties", properties: ["fontSize", "typeface"] },
+        { kind: "setTextRunProperties", properties: { fontSize: asPt(22), typeface: "Arial" } },
+      ],
+      [
+        { kind: "setTextRunProperties", properties: { color: { kind: "srgb", hex: "123ABC" } } },
+        { kind: "clearTextRunProperties", properties: ["color"] },
+      ],
+    ] as const;
+
+    for (const commands of cases) {
+      const source = readPptx(await buildTextEditFixture());
+      const session = createEditorSession(source);
+      const handle = requireHandle(firstRun(source).handle);
+      for (const command of commands) {
+        expectApplied(session.apply({ ...command, handle }));
+      }
+      const edited = session.document;
+
+      for (let i = 0; i < commands.length; i += 1) expectHistory(session.undo());
+      expect(firstRun(session.document).properties).toEqual(firstRun(source).properties);
+      expect(firstRun(readPptx(writePptx(session.document))).properties).toEqual(
+        firstRun(source).properties,
+      );
+
+      for (let i = 0; i < commands.length; i += 1) expectHistory(session.redo());
+      expect(firstRun(session.document).properties).toEqual(firstRun(edited).properties);
+      expect(firstRun(readPptx(writePptx(session.document))).properties).toEqual(
+        firstRun(readPptx(writePptx(edited))).properties,
+      );
+    }
   });
 });
 

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -346,6 +346,11 @@ function validateTextRunPropertySet(
   properties: EditableTextRunProperties,
   commandName: "setTextRunProperties",
 ): void {
+  for (const property of Object.keys(properties)) {
+    if (!EDITABLE_TEXT_RUN_PROPERTY_SET.has(property)) {
+      throw new Error(`${commandName}: unsupported text run property '${property}'`);
+    }
+  }
   requireBooleanOrUndefined(properties.bold, commandName, "bold");
   requireBooleanOrUndefined(properties.italic, commandName, "italic");
   requireBooleanOrUndefined(properties.underline, commandName, "underline");
@@ -428,42 +433,66 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
   const seenParagraphs = new Set<string>();
   const seenShapeTransforms = new Set<string>();
   const normalizedReversed: PptxSourceModelEdit[] = [];
+  let changed = false;
 
   for (let index = edits.length - 1; index >= 0; index -= 1) {
     const edit = edits[index];
     if (edit.kind === "replaceTextRunPlainText") {
       const key = editHandleNodeKey(edit);
       const paragraphKey = textRunParagraphEditKey(edit);
-      if (paragraphKey !== undefined && seenParagraphs.has(paragraphKey)) continue;
-      if (seenTextRuns.has(key)) continue;
+      if (paragraphKey !== undefined && seenParagraphs.has(paragraphKey)) {
+        changed = true;
+        continue;
+      }
+      if (seenTextRuns.has(key)) {
+        changed = true;
+        continue;
+      }
       seenTextRuns.add(key);
     }
     if (edit.kind === "updateTextRunProperties") {
       const paragraphKey = textRunParagraphEditKey(edit);
-      if (paragraphKey !== undefined && seenParagraphs.has(paragraphKey)) continue;
+      if (paragraphKey !== undefined && seenParagraphs.has(paragraphKey)) {
+        changed = true;
+        continue;
+      }
       const normalized = normalizeTextRunPropertiesEdit(edit, seenTextRunProperties);
-      if (normalized === undefined) continue;
+      if (normalized === undefined) {
+        changed = true;
+        continue;
+      }
+      if (!editorEditsEqual(normalized, edit)) changed = true;
       normalizedReversed.push(normalized);
       continue;
     }
     if (edit.kind === "replaceParagraphPlainText") {
       const key = editHandleNodeKey(edit);
-      if (seenParagraphs.has(key)) continue;
+      if (seenParagraphs.has(key)) {
+        changed = true;
+        continue;
+      }
       seenParagraphs.add(key);
     }
     if (edit.kind === "updateShapeTransform") {
       const key = editHandleNodeKey(edit);
-      if (seenShapeTransforms.has(key)) continue;
+      if (seenShapeTransforms.has(key)) {
+        changed = true;
+        continue;
+      }
       seenShapeTransforms.add(key);
     }
     normalizedReversed.push(edit);
   }
 
-  if (normalizedReversed.length === edits.length) return document;
+  if (!changed && normalizedReversed.length === edits.length) return document;
   return {
     ...document,
     edits: normalizedReversed.reverse(),
   };
+}
+
+function editorEditsEqual(left: PptxSourceModelEdit, right: PptxSourceModelEdit): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function editHandleNodeKey(
@@ -509,9 +538,6 @@ function normalizeTextRunPropertiesEdit(
     seenTextRunProperties.set(key, seenProperties);
   }
 
-  const clear = (edit.clear ?? []).filter((property) => !seenProperties.has(property));
-  for (const property of clear) seenProperties.add(property);
-
   const set: MutableEditableTextRunProperties = {};
   if (edit.set?.bold !== undefined && !seenProperties.has("bold")) {
     seenProperties.add("bold");
@@ -537,6 +563,9 @@ function normalizeTextRunPropertiesEdit(
     seenProperties.add("typeface");
     set.typeface = edit.set.typeface;
   }
+
+  const clear = (edit.clear ?? []).filter((property) => !seenProperties.has(property));
+  for (const property of clear) seenProperties.add(property);
 
   if (clear.length === 0 && Object.keys(set).length === 0) return undefined;
   const normalized: PptxSourceModelTextRunPropertiesEdit = {

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,4 +1,7 @@
 import {
+  clearTextRunProperties,
+  type EditableTextRunProperties,
+  type EditableTextRunProperty,
   type Emu,
   findShapeNodeBySourceHandle,
   type PptxSourceModel,
@@ -6,8 +9,10 @@ import {
   type PptxSourceModelParagraphTextEdit,
   type PptxSourceModelShapeTransformEdit,
   type PptxSourceModelTextRunEdit,
+  type PptxSourceModelTextRunPropertiesEdit,
   replaceParagraphPlainText,
   replaceTextRunPlainText,
+  setTextRunProperties,
   type SourceHandle,
   type SourceShapeNode,
   type SourceTransform,
@@ -38,6 +43,18 @@ export interface ReplaceParagraphPlainTextCommand {
   readonly text: string;
 }
 
+export interface SetTextRunPropertiesCommand {
+  readonly kind: "setTextRunProperties";
+  readonly handle: SourceHandle;
+  readonly properties: EditableTextRunProperties;
+}
+
+export interface ClearTextRunPropertiesCommand {
+  readonly kind: "clearTextRunProperties";
+  readonly handle: SourceHandle;
+  readonly properties: readonly EditableTextRunProperty[];
+}
+
 export interface MoveShapeCommand {
   readonly kind: "moveShape";
   readonly handle: SourceHandle;
@@ -64,6 +81,8 @@ export interface SetShapeTransformCommand {
 export type EditorCommand =
   | ReplaceTextRunPlainTextCommand
   | ReplaceParagraphPlainTextCommand
+  | SetTextRunPropertiesCommand
+  | ClearTextRunPropertiesCommand
   | MoveShapeCommand
   | ResizeShapeCommand
   | SetShapeTransformCommand;
@@ -223,6 +242,10 @@ function applyCommandToDocument(
       return replaceTextRunPlainText(document, command.handle, command.text);
     case "replaceParagraphPlainText":
       return replaceParagraphPlainText(document, command.handle, command.text);
+    case "setTextRunProperties":
+      return setTextRunPropertiesCommand(document, command);
+    case "clearTextRunProperties":
+      return clearTextRunPropertiesCommand(document, command);
     case "moveShape":
       return moveShape(document, command);
     case "resizeShape":
@@ -230,6 +253,30 @@ function applyCommandToDocument(
     case "setShapeTransform":
       return setShapeTransform(document, command);
   }
+}
+
+function setTextRunPropertiesCommand(
+  document: PptxSourceModel,
+  command: SetTextRunPropertiesCommand,
+): PptxSourceModel {
+  requireNonEmptyPropertySet(command.properties, "setTextRunProperties");
+  validateTextRunPropertySet(command.properties, "setTextRunProperties");
+  return setTextRunProperties(document, command.handle, command.properties);
+}
+
+function clearTextRunPropertiesCommand(
+  document: PptxSourceModel,
+  command: ClearTextRunPropertiesCommand,
+): PptxSourceModel {
+  if (command.properties.length === 0) {
+    throw new Error("clearTextRunProperties: properties must contain at least one property name");
+  }
+  for (const property of command.properties) {
+    if (!EDITABLE_TEXT_RUN_PROPERTY_SET.has(property)) {
+      throw new Error(`clearTextRunProperties: unsupported text run property '${property}'`);
+    }
+  }
+  return clearTextRunProperties(document, command.handle, command.properties);
 }
 
 function moveShape(document: PptxSourceModel, command: MoveShapeCommand): PptxSourceModel {
@@ -274,6 +321,61 @@ function setShapeTransform(
     width: command.width,
     height: command.height,
   });
+}
+
+const EDITABLE_TEXT_RUN_PROPERTIES = [
+  "bold",
+  "italic",
+  "underline",
+  "fontSize",
+  "color",
+  "typeface",
+] as const satisfies readonly EditableTextRunProperty[];
+const EDITABLE_TEXT_RUN_PROPERTY_SET: ReadonlySet<string> = new Set(EDITABLE_TEXT_RUN_PROPERTIES);
+
+function requireNonEmptyPropertySet(
+  properties: EditableTextRunProperties,
+  commandName: "setTextRunProperties",
+): void {
+  if (Object.values(properties).every((value) => value === undefined)) {
+    throw new Error(`${commandName}: properties must contain at least one defined property`);
+  }
+}
+
+function validateTextRunPropertySet(
+  properties: EditableTextRunProperties,
+  commandName: "setTextRunProperties",
+): void {
+  requireBooleanOrUndefined(properties.bold, commandName, "bold");
+  requireBooleanOrUndefined(properties.italic, commandName, "italic");
+  requireBooleanOrUndefined(properties.underline, commandName, "underline");
+  if (
+    properties.fontSize !== undefined &&
+    (!Number.isFinite(properties.fontSize) || properties.fontSize <= 0)
+  ) {
+    throw new Error(`${commandName}: fontSize must be a finite positive pt value`);
+  }
+  if (properties.typeface !== undefined && properties.typeface.trim() === "") {
+    throw new Error(`${commandName}: typeface must be a non-empty string`);
+  }
+  if (properties.color !== undefined) {
+    if (properties.color.kind !== "srgb") {
+      throw new Error(`${commandName}: only srgb text run color is supported`);
+    }
+    if (!/^[0-9A-Fa-f]{6}$/.test(properties.color.hex)) {
+      throw new Error(`${commandName}: color.hex must be a 6-digit hex value`);
+    }
+  }
+}
+
+function requireBooleanOrUndefined(
+  value: boolean | undefined,
+  commandName: "setTextRunProperties",
+  fieldName: "bold" | "italic" | "underline",
+): void {
+  if (value !== undefined && typeof value !== "boolean") {
+    throw new Error(`${commandName}: ${fieldName} must be a boolean value`);
+  }
 }
 
 function requireEditableShapeTransform(
@@ -322,6 +424,7 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
   if (edits === undefined) return document;
 
   const seenTextRuns = new Set<string>();
+  const seenTextRunProperties = new Map<string, Set<EditableTextRunProperty>>();
   const seenParagraphs = new Set<string>();
   const seenShapeTransforms = new Set<string>();
   const normalizedReversed: PptxSourceModelEdit[] = [];
@@ -334,6 +437,14 @@ function normalizeEditorEdits(document: PptxSourceModel): PptxSourceModel {
       if (paragraphKey !== undefined && seenParagraphs.has(paragraphKey)) continue;
       if (seenTextRuns.has(key)) continue;
       seenTextRuns.add(key);
+    }
+    if (edit.kind === "updateTextRunProperties") {
+      const paragraphKey = textRunParagraphEditKey(edit);
+      if (paragraphKey !== undefined && seenParagraphs.has(paragraphKey)) continue;
+      const normalized = normalizeTextRunPropertiesEdit(edit, seenTextRunProperties);
+      if (normalized === undefined) continue;
+      normalizedReversed.push(normalized);
+      continue;
     }
     if (edit.kind === "replaceParagraphPlainText") {
       const key = editHandleNodeKey(edit);
@@ -359,6 +470,7 @@ function editHandleNodeKey(
   edit:
     | PptxSourceModelTextRunEdit
     | PptxSourceModelParagraphTextEdit
+    | PptxSourceModelTextRunPropertiesEdit
     | PptxSourceModelShapeTransformEdit,
 ): string {
   return [
@@ -369,7 +481,9 @@ function editHandleNodeKey(
   ].join("\u0000");
 }
 
-function textRunParagraphEditKey(edit: PptxSourceModelTextRunEdit): string | undefined {
+function textRunParagraphEditKey(
+  edit: PptxSourceModelTextRunEdit | PptxSourceModelTextRunPropertiesEdit,
+): string | undefined {
   const nodeId = String(edit.handle.nodeId ?? "");
   const byShapeId = /^(text:shape:.+:p:(\d+)):r:\d+$/.exec(nodeId);
   const byShapeSlot = /^(text:shapeSlot:\d+:p:(\d+)):r:\d+$/.exec(nodeId);
@@ -383,3 +497,57 @@ function textRunParagraphEditKey(edit: PptxSourceModelTextRunEdit): string | und
     paragraphOrderingSlot,
   ].join("\u0000");
 }
+
+function normalizeTextRunPropertiesEdit(
+  edit: PptxSourceModelTextRunPropertiesEdit,
+  seenTextRunProperties: Map<string, Set<EditableTextRunProperty>>,
+): PptxSourceModelTextRunPropertiesEdit | undefined {
+  const key = editHandleNodeKey(edit);
+  let seenProperties = seenTextRunProperties.get(key);
+  if (seenProperties === undefined) {
+    seenProperties = new Set();
+    seenTextRunProperties.set(key, seenProperties);
+  }
+
+  const clear = (edit.clear ?? []).filter((property) => !seenProperties.has(property));
+  for (const property of clear) seenProperties.add(property);
+
+  const set: MutableEditableTextRunProperties = {};
+  if (edit.set?.bold !== undefined && !seenProperties.has("bold")) {
+    seenProperties.add("bold");
+    set.bold = edit.set.bold;
+  }
+  if (edit.set?.italic !== undefined && !seenProperties.has("italic")) {
+    seenProperties.add("italic");
+    set.italic = edit.set.italic;
+  }
+  if (edit.set?.underline !== undefined && !seenProperties.has("underline")) {
+    seenProperties.add("underline");
+    set.underline = edit.set.underline;
+  }
+  if (edit.set?.fontSize !== undefined && !seenProperties.has("fontSize")) {
+    seenProperties.add("fontSize");
+    set.fontSize = edit.set.fontSize;
+  }
+  if (edit.set?.color !== undefined && !seenProperties.has("color")) {
+    seenProperties.add("color");
+    set.color = edit.set.color;
+  }
+  if (edit.set?.typeface !== undefined && !seenProperties.has("typeface")) {
+    seenProperties.add("typeface");
+    set.typeface = edit.set.typeface;
+  }
+
+  if (clear.length === 0 && Object.keys(set).length === 0) return undefined;
+  const normalized: PptxSourceModelTextRunPropertiesEdit = {
+    kind: "updateTextRunProperties",
+    handle: edit.handle,
+    ...(Object.keys(set).length > 0 ? { set } : {}),
+    ...(clear.length > 0 ? { clear } : {}),
+  };
+  return normalized;
+}
+
+type MutableEditableTextRunProperties = {
+  -readonly [K in keyof EditableTextRunProperties]?: EditableTextRunProperties[K];
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,11 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    include: ["packages/*/src/**/*.test.ts", "e2e/**/*.test.ts"],
+    include: [
+      "packages/*/src/**/*.test.ts",
+      "e2e/**/*.test.ts",
+      "vrt/libreoffice/editor-validity.test.ts",
+    ],
     testTimeout: 30000,
     coverage: {
       provider: "v8",

--- a/vrt/libreoffice/create_fixtures.py
+++ b/vrt/libreoffice/create_fixtures.py
@@ -201,6 +201,50 @@ def create_editor_validity_transform_fixture(filename, left, top, width, height)
     print(f"  Created: {filename}")
 
 
+def create_editor_validity_formatting_fixture(filename, *, expected):
+    """Fixture pair for editor-core run property validity checks."""
+    prs = new_presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    title = slide.shapes.add_textbox(Inches(0.4), Inches(0.25), Inches(9.2), Inches(0.5))
+    title.text_frame.text = "LibreOffice editor validity: formatting"
+    title.text_frame.paragraphs[0].runs[0].font.size = Pt(18)
+
+    shape = slide.shapes.add_shape(
+        MSO_SHAPE.ROUNDED_RECTANGLE, Inches(0.8), Inches(1.4), Inches(8.2), Inches(2.0)
+    )
+    shape.name = "Editable Formatting Target"
+    shape.fill.solid()
+    shape.fill.fore_color.rgb = RGBColor(0xFF, 0xF2, 0xCC)
+    shape.line.color.rgb = RGBColor(0xBF, 0x90, 0x00)
+    shape.line.width = Pt(1.5)
+
+    tf = shape.text_frame
+    tf.word_wrap = True
+    paragraph = tf.paragraphs[0]
+    paragraph.text = "Editable formatting target"
+    paragraph.alignment = PP_ALIGN.CENTER
+    run = paragraph.runs[0]
+
+    if expected:
+        run.font.name = "Liberation Serif"
+        run.font.size = Pt(30)
+        run.font.bold = False
+        run.font.italic = False
+        run.font.underline = False
+        run.font.color.rgb = RGBColor(0x9C, 0x00, 0x00)
+    else:
+        run.font.name = "Liberation Sans"
+        run.font.size = Pt(18)
+        run.font.bold = True
+        run.font.italic = True
+        run.font.underline = True
+        run.font.color.rgb = RGBColor(0x1F, 0x4E, 0x79)
+
+    prs.save(os.path.join(OUTPUT_DIR, filename))
+    print(f"  Created: {filename}")
+
+
 def create_editor_validity_fixtures():
     """PPTX source / expected pairs consumed by editor-validity.test.ts."""
     create_editor_validity_text_fixture(
@@ -224,6 +268,14 @@ def create_editor_validity_fixtures():
         Inches(2.1),
         Inches(3.2),
         Inches(1.6),
+    )
+    create_editor_validity_formatting_fixture(
+        "editor-validity-formatting-source.pptx",
+        expected=False,
+    )
+    create_editor_validity_formatting_fixture(
+        "editor-validity-formatting-expected.pptx",
+        expected=True,
     )
 
 

--- a/vrt/libreoffice/editor-validity.test.ts
+++ b/vrt/libreoffice/editor-validity.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   asEmu,
+  asPt,
   readPptx,
   type SourceHandle,
   type SourceShape,
@@ -32,6 +33,7 @@ const TRANSFORM_EDIT = {
   width: asEmu(2926080),
   height: asEmu(1463040),
 } as const;
+const FORMATTING_EDITED_VALUE = "Editable formatting target";
 
 const LO_EDITOR_VALIDITY_CASES = [
   {
@@ -79,6 +81,37 @@ const LO_EDITOR_VALIDITY_CASES = [
 
       if (!resizeResult.ok) throw new Error(resizeResult.message);
       return writePptx(resizeResult.document);
+    },
+  },
+  {
+    name: "text run formatting",
+    sourceFixture: "editor-validity-formatting-source.pptx",
+    expectedFixture: "editor-validity-formatting-expected.pptx",
+    createEditedPptx: (input: Uint8Array) => {
+      const source = readPptx(input);
+      const session = createEditorSession(source);
+      const handle = requireHandle(findTextRun(source, FORMATTING_EDITED_VALUE).handle);
+      const setResult = session.apply({
+        kind: "setTextRunProperties",
+        handle,
+        properties: {
+          bold: false,
+          fontSize: asPt(30),
+          color: { kind: "srgb", hex: "9C0000" },
+          typeface: "Liberation Serif",
+        },
+      });
+
+      if (!setResult.ok) throw new Error(setResult.message);
+
+      const clearResult = session.apply({
+        kind: "clearTextRunProperties",
+        handle,
+        properties: ["italic", "underline"],
+      });
+
+      if (!clearResult.ok) throw new Error(clearResult.message);
+      return writePptx(clearResult.document);
     },
   },
 ] as const;


### PR DESCRIPTION
close #604

## 概要
- document 層に text run property の set / clear API と edit journal を追加
- writer で bold / italic / underline / fontSize / color / typeface の XML 更新を保存
- editor-core に setTextRunProperties / clearTextRunProperties command と undo / redo 対応を追加
- edit equivalence と LibreOffice validity の検証ケースを追加

## 受け入れ条件
- 6 種類の text run property を editor-core 経由で set / clear し、保存後 PPTX に反映
- unrelated rPr、未編集 run / paragraph の保持を writer test で確認
- #571 の edit equivalence harness に text run decoration ケースを追加
- LibreOffice validity test に text run formatting ケースを追加
- property-style の undo / redo シーケンスを editor-core test で確認

## 検証
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npm run build
