### PR TITLE
document: SourceSlideLayout に show 属性を追加

### DIFF
--- a/.changeset/slide-layout-show.md
+++ b/.changeset/slide-layout-show.md
@@ -1,0 +1,5 @@
+---
+"@pptx-glimpse/document": minor
+---
+
+Expose `p:sldLayout@show` as `SourceSlideLayout.show` for detecting hidden slide layouts.

--- a/packages/document/src/reader/slide-parts.ts
+++ b/packages/document/src/reader/slide-parts.ts
@@ -108,6 +108,7 @@ export function parseSlideLayout(
 ): SourceSlideLayout {
   const cSld = getChild(root, "cSld");
   const type = getAttr(root, "type");
+  const show = booleanAttr(root, "show");
   const background = parseBackground(getChild(cSld, "bg"), nextId);
   const colorMapOverride = parseColorMapOverride(getChild(root, "clrMapOvr"));
   const showMasterShapes = booleanAttr(root, "showMasterSp");
@@ -116,6 +117,7 @@ export function parseSlideLayout(
     partPath,
     masterPartPath,
     ...(type !== undefined ? { type } : {}),
+    ...(show !== undefined ? { show } : {}),
     ...(background !== undefined ? { background } : {}),
     ...(colorMapOverride !== undefined ? { colorMapOverride } : {}),
     ...(showMasterShapes !== undefined ? { showMasterShapes } : {}),

--- a/packages/document/src/reader/slide-reader.test.ts
+++ b/packages/document/src/reader/slide-reader.test.ts
@@ -208,7 +208,75 @@ function buildSyntheticPptx(slideSpTree: string): Uint8Array {
   return zipSync(files);
 }
 
+function buildSyntheticPptxWithLayout(slideLayoutAttrs: string): Uint8Array {
+  const files: Record<string, Uint8Array> = {
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
+        `<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sld>`,
+    ),
+    "ppt/slides/_rels/slide1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdLayout" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideLayouts/slideLayout1.xml": xml(
+      `<p:sldLayout${slideLayoutAttrs} xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sldLayout>`,
+    ),
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideMasters/slideMaster1.xml": xml(
+      `<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sldMaster>`,
+    ),
+  };
+  return zipSync(files);
+}
+
 describe("readPptx - typed shape detail (synthetic)", () => {
+  it.each([
+    ['show="0"', ` show="0"`, false, false],
+    ['show="false"', ` show="false"`, false, false],
+    ["missing show", "", undefined, true],
+  ])("Read p:sldLayout@show for %s", (_label, slideLayoutAttrs, authored, effective) => {
+    const source = readPptx(buildSyntheticPptxWithLayout(slideLayoutAttrs));
+    const layout = source.slideLayouts[0];
+
+    expect(layout?.show).toBe(authored);
+    expect(layout?.show ?? true).toBe(effective);
+  });
+
   it("Read scheme color + lumMod transform / outline width+color / rotation+flip", () => {
     const source = readPptx(
       buildSyntheticPptx(

--- a/packages/document/src/source/presentation.ts
+++ b/packages/document/src/source/presentation.ts
@@ -113,6 +113,8 @@ export interface SourceSlideLayout {
   readonly background?: SourceBackground;
   /** Layout `p:clrMapOvr` (when overridden). */
   readonly colorMapOverride?: SourceColorMap;
+  /** `p:sldLayout@show` (layout visibility). When omitted, the effective value is visible (`show ?? true`). */
+  readonly show?: boolean;
   /** `p:sldLayout@showMasterSp` (master shape visibility). */
   readonly showMasterShapes?: boolean;
   readonly shapes: readonly SourceShapeNode[];

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -70,6 +70,61 @@ function buildRoundTripFixture(): Uint8Array {
   });
 }
 
+function buildLayoutShowRoundTripFixture(): Uint8Array {
+  return zipSync({
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
+        `<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sld>`,
+    ),
+    "ppt/slides/_rels/slide1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdLayout" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideLayouts/slideLayout1.xml": xml(
+      `<p:sldLayout show="0" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sldLayout>`,
+    ),
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideMasters/slideMaster1.xml": xml(
+      `<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sldMaster>`,
+    ),
+  });
+}
+
 function buildTextEditFixture(): Uint8Array {
   return buildTextEditFixtureFromSlide(
     `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
@@ -169,6 +224,19 @@ describe("writePptx - no-edit round-trip", () => {
 
     expect(reread.packageGraph.contentTypes).toEqual(original.packageGraph.contentTypes);
     expect(reread.packageGraph.relationships).toEqual(original.packageGraph.relationships);
+  });
+
+  it("Preserves p:sldLayout@show structurally in no-edit round-trip", () => {
+    const input = buildLayoutShowRoundTripFixture();
+    const source = readPptx(input);
+    const output = writePptx(source);
+    const reread = readPptx(output);
+
+    expect(source.slideLayouts[0]?.show).toBe(false);
+    expect(decoder.decode(getEntry(output, "ppt/slideLayouts/slideLayout1.xml"))).toContain(
+      `show="0"`,
+    );
+    expect(reread.slideLayouts[0]?.show).toBe(false);
   });
 
   it("Preserving media bytes and unsupported raw package material", () => {


### PR DESCRIPTION
close #613

## 目的

`p:sldLayout@show` を `SourceSlideLayout.show` として typed model から参照できるようにし、hidden slide layout 判定で raw XML parse を不要にします。

## 変更内容

- `packages/document/src/source/presentation.ts` に `SourceSlideLayout.show?: boolean` を追加
- `packages/document/src/reader/slide-parts.ts` で `p:sldLayout@show` を boolean 属性として読み取り
- `show="0"` / `show="false"` / 属性なしの reader テストを追加
- `writePptx` の no-edit round-trip で `p:sldLayout@show` が保持される structural preservation テストを追加
- `@pptx-glimpse/document` の minor changeset を追加

## ローカル検証

- `npm run test -- packages/document/src/reader/slide-reader.test.ts`
- `npm run test -- packages/document/src/writer/write-pptx.test.ts`
- `npm run test -- packages/document/src/reader/slide-reader.test.ts packages/document/src/writer/write-pptx.test.ts`
- `npm run format`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npm run knip`
- `cd packages/document && npx tsup`

補足: `npm run build` は `pnpm` の supply-chain policy により、既存 lockfile 内の `picomatch@4.0.5` / `postcss@8.5.16` が minimumReleaseAge cutoff にかかって停止しました。コード単体の document package build は `cd packages/document && npx tsup` で成功しています。
