### PR TITLE
writer / editor-core: slide の複製・削除を追加する

### DIFF
--- a/.changeset/curly-slides-duplicate.md
+++ b/.changeset/curly-slides-duplicate.md
@@ -1,0 +1,6 @@
+---
+"pptx-glimpse": patch
+"@pptx-glimpse/document": patch
+---
+
+Add headless slide duplicate/delete editing support with package relationship, content type, and ID management.

--- a/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
+++ b/packages/core/src/pptx-source-model-round-trip.e2e.test.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 import {
   asEmu,
   createComputedView,
+  deleteSlide,
+  duplicateSlide,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
   type MediaPart,
@@ -187,6 +189,40 @@ describe("PptxSourceModel PoC end-to-end round-trip", () => {
     expect(slides).toHaveLength(1);
     expect(slides[0].svg).toContain('transform="translate(96, 192)"');
     expect(slides[0].svg).toContain('width="288" height="96"');
+  });
+
+  it("duplicates and deletes slides through writer output while keeping render order stable", async () => {
+    const input = readFixture("real-basic-theme.pptx");
+    const source = readPptx(input);
+    const duplicatedOutput = writePptx(duplicateSlide(source, source.slides[0].handle!));
+    const duplicated = readPptx(duplicatedOutput);
+    const { slides: duplicatedSvgs } = await convertPptxToSvg(duplicatedOutput, {
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+
+    expect(duplicated.presentation.slidePartPaths).toEqual([
+      source.slides[0].partPath,
+      "ppt/slides/slide3.xml",
+      source.slides[1].partPath,
+    ]);
+    expect(duplicatedSvgs).toHaveLength(3);
+    expect(duplicatedSvgs[1].svg).toEqual(duplicatedSvgs[0].svg);
+
+    const deletedOutput = writePptx(deleteSlide(duplicated, duplicated.slides[0].handle!));
+    const deleted = readPptx(deletedOutput);
+    const { slides: deletedSvgs } = await convertPptxToSvg(deletedOutput, {
+      textOutput: "text",
+      skipSystemFonts: true,
+    });
+
+    expect(deleted.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide3.xml",
+      source.slides[1].partPath,
+    ]);
+    expect(deletedSvgs).toHaveLength(2);
+    expect(deletedSvgs[0].svg).toEqual(duplicatedSvgs[0].svg);
+    expect(deletedSvgs[1].svg).toEqual(duplicatedSvgs[2].svg);
   });
 });
 

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -72,6 +72,8 @@ export type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelDeleteSlideEdit,
+  PptxSourceModelDuplicateSlideEdit,
   PptxSourceModelEdit,
   PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
@@ -168,6 +170,8 @@ export type {
 } from "./source/index.js";
 export {
   clearTextRunProperties,
+  deleteSlide,
+  duplicateSlide,
   findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -429,6 +429,14 @@ export function duplicateSlide(
               : relationship,
           ),
         };
+  const newRelationshipPartPaths = [
+    ...(newSlideRelationships === undefined
+      ? []
+      : [asPartPath(relationshipsPartPath(newSlidePartPath))]),
+    ...(notesCopy?.relationships === undefined
+      ? []
+      : [asPartPath(relationshipsPartPath(notesCopy.newPartPath))]),
+  ];
 
   const slideContentType =
     source.packageGraph.parts.find((part) => part.partPath === sourceSlide.partPath)?.contentType ??
@@ -482,6 +490,7 @@ export function duplicateSlide(
           ...(notesCopy === undefined
             ? []
             : [{ partName: notesCopy.newPartPath, contentType: notesCopy.contentType }]),
+          ...relationshipPartOverrides(source, newRelationshipPartPaths),
         ],
       },
       relationships: [
@@ -598,7 +607,9 @@ export function deleteSlide(source: PptxSourceModel, slideHandle: SourceHandle):
       contentTypes: {
         ...source.packageGraph.contentTypes,
         overrides: source.packageGraph.contentTypes.overrides.filter(
-          (override) => !removedPartPaths.has(override.partName),
+          (override) =>
+            !removedPartPaths.has(override.partName) &&
+            !removedRelationshipPartPaths.has(override.partName),
         ),
       },
       relationships: source.packageGraph.relationships
@@ -899,6 +910,26 @@ function nextNumberedPartPath(source: PptxSourceModel, prefix: string, suffix: s
     const candidate = asPartPath(`${prefix}${index}${suffix}`);
     if (!used.has(candidate)) return candidate;
   }
+}
+
+function relationshipPartOverrides(
+  source: PptxSourceModel,
+  partPaths: readonly PartPath[],
+): readonly { readonly partName: PartPath; readonly contentType: string }[] {
+  if (
+    source.packageGraph.contentTypes.defaults.some(
+      (entry) => entry.extension === "rels" && entry.contentType === RELS_CONTENT_TYPE,
+    )
+  ) {
+    return [];
+  }
+
+  const existingOverrides = new Set(
+    source.packageGraph.contentTypes.overrides.map((override) => override.partName),
+  );
+  return partPaths
+    .filter((partPath) => !existingOverrides.has(partPath))
+    .map((partName) => ({ partName, contentType: RELS_CONTENT_TYPE }));
 }
 
 function topologyEditPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -412,7 +412,12 @@ export function duplicateSlide(
   );
   const newSlidePartPath = nextNumberedPartPath(source, "ppt/slides/slide", ".xml");
   const newPresentationRelationshipId = nextRelationshipId(presentationRels.relationships);
-  const notesCopy = createNotesSlideCopy(source, sourceSlide, sourceSlideRelationships);
+  const notesCopy = createNotesSlideCopy(
+    source,
+    sourceSlide,
+    sourceSlideRelationships,
+    newSlidePartPath,
+  );
   const newSlideRelationships =
     sourceSlideRelationships === undefined
       ? undefined
@@ -777,6 +782,7 @@ function createNotesSlideCopy(
   source: PptxSourceModel,
   sourceSlide: SourceSlide,
   slideRelationships: PartRelationships | undefined,
+  newSlidePartPath: PartPath,
 ): NotesSlideCopy | undefined {
   const notesRelationship = slideRelationships?.relationships.find(
     (relationship) => relationship.type === NOTES_SLIDE_REL_TYPE,
@@ -794,6 +800,8 @@ function createNotesSlideCopy(
     (relationships) => relationships.sourcePartPath === notesPartPath,
   );
 
+  // Notes slides are 1:1 with a slide, so their slide back-reference must move
+  // to the duplicated slide. Other notes relationships remain shared.
   return {
     slideRelationshipId: notesRelationship.id,
     newPartPath,
@@ -804,7 +812,11 @@ function createNotesSlideCopy(
       : {
           relationships: {
             sourcePartPath: newPartPath,
-            relationships: notesRelationships.relationships,
+            relationships: notesRelationships.relationships.map((relationship) =>
+              relationship.type === SLIDE_REL_TYPE && relationship.targetMode !== "External"
+                ? { ...relationship, target: relativeTarget(newPartPath, newSlidePartPath) }
+                : relationship,
+            ),
           },
         }),
   };
@@ -876,6 +888,7 @@ function nextNumberedPartPath(source: PptxSourceModel, prefix: string, suffix: s
     ...source.packageGraph.parts.map((part) => part.partPath),
     ...source.packageGraph.contentTypes.overrides.map((override) => override.partName),
     ...(source.packageGraph.rawParts ?? []).map((part) => part.partPath),
+    ...(source.edits?.flatMap((edit) => topologyEditPartPaths(edit)) ?? []),
   ]);
   const pattern = new RegExp(`^${escapeRegExp(prefix)}(\\d+)${escapeRegExp(suffix)}$`);
   const max = [...used].reduce((current, path) => {
@@ -885,6 +898,20 @@ function nextNumberedPartPath(source: PptxSourceModel, prefix: string, suffix: s
   for (let index = max + 1; ; index += 1) {
     const candidate = asPartPath(`${prefix}${index}${suffix}`);
     if (!used.has(candidate)) return candidate;
+  }
+}
+
+function topologyEditPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {
+  switch (edit.kind) {
+    case "duplicateSlide":
+      return [edit.sourceSlidePartPath, edit.newSlidePartPath];
+    case "deleteSlide":
+      return [edit.slidePartPath];
+    case "replaceTextRunPlainText":
+    case "updateTextRunProperties":
+    case "replaceParagraphPlainText":
+    case "updateShapeTransform":
+      return [];
   }
 }
 

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -3,14 +3,23 @@ import type {
   EditableTextRunProperties,
   EditableTextRunProperty,
   Emu,
+  PartPath,
+  PartRelationships,
   PptxSourceModel,
+  PptxSourceModelEdit,
+  RawPackagePart,
+  Relationship,
+  RelationshipId,
   SourceHandle,
   SourceParagraph,
   SourceRunProperties,
   SourceShape,
   SourceShapeNode,
+  SourceSlide,
   SourceTextRun,
 } from "./index.js";
+import { asPartPath, asRelationshipId } from "./index.js";
+import { relationshipsPartPath, resolveInternalRelationshipTarget } from "./package-paths.js";
 
 type TransformableShapeNode = Exclude<SourceShapeNode, { readonly kind: "raw" }>;
 type MutableRunProperties = {
@@ -19,6 +28,14 @@ type MutableRunProperties = {
 type MutableEditableTextRunProperties = {
   -readonly [K in keyof EditableTextRunProperties]?: EditableTextRunProperties[K];
 };
+
+const RELS_CONTENT_TYPE = "application/vnd.openxmlformats-package.relationships+xml";
+const SLIDE_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.slide+xml";
+const NOTES_SLIDE_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml";
+const SLIDE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide";
+const NOTES_SLIDE_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide";
 
 const EDITABLE_TEXT_RUN_PROPERTIES = [
   "bold",
@@ -360,6 +377,254 @@ export function updateShapeTransform(
   };
 }
 
+export function duplicateSlide(
+  source: PptxSourceModel,
+  slideHandle: SourceHandle,
+): PptxSourceModel {
+  const slideIndex = source.slides.findIndex((slide) =>
+    sourceHandlesEqual(slide.handle, slideHandle),
+  );
+  if (slideIndex === -1) {
+    throw new Error("duplicateSlide: slide handle was not found in PptxSourceModel source");
+  }
+
+  const sourceSlide = source.slides[slideIndex];
+  if (hasDirtyEditForPart(source.edits ?? [], sourceSlide.partPath)) {
+    throw new Error(
+      "duplicateSlide: duplicating a slide with pending dirty part edits is unsupported",
+    );
+  }
+
+  const presentationRels = requirePartRelationships(
+    source,
+    source.presentation.partPath,
+    "duplicateSlide",
+  );
+  const sourcePresentationRelationship = requireSlideRelationship(
+    source,
+    presentationRels,
+    sourceSlide.partPath,
+    "duplicateSlide",
+  );
+  const sourceRawSlide = requireRawBinaryPart(source, sourceSlide.partPath, "duplicateSlide");
+  const sourceSlideRelationships = source.packageGraph.relationships.find(
+    (relationships) => relationships.sourcePartPath === sourceSlide.partPath,
+  );
+  const newSlidePartPath = nextNumberedPartPath(source, "ppt/slides/slide", ".xml");
+  const newPresentationRelationshipId = nextRelationshipId(presentationRels.relationships);
+  const notesCopy = createNotesSlideCopy(source, sourceSlide, sourceSlideRelationships);
+  const newSlideRelationships =
+    sourceSlideRelationships === undefined
+      ? undefined
+      : {
+          sourcePartPath: newSlidePartPath,
+          relationships: sourceSlideRelationships.relationships.map((relationship) =>
+            notesCopy !== undefined && relationship.id === notesCopy.slideRelationshipId
+              ? { ...relationship, target: relativeTarget(newSlidePartPath, notesCopy.newPartPath) }
+              : relationship,
+          ),
+        };
+
+  const slideContentType =
+    source.packageGraph.parts.find((part) => part.partPath === sourceSlide.partPath)?.contentType ??
+    SLIDE_CONTENT_TYPE;
+  const insertAt = slideIndex + 1;
+  const newSlide = withPartPath(cloneJson(sourceSlide), newSlidePartPath);
+
+  return {
+    ...source,
+    presentation: {
+      ...source.presentation,
+      slidePartPaths: insertAtReadonly(
+        source.presentation.slidePartPaths,
+        insertAt,
+        newSlidePartPath,
+      ),
+    },
+    slides: insertAtReadonly(source.slides, insertAt, newSlide),
+    packageGraph: {
+      ...source.packageGraph,
+      parts: [
+        ...source.packageGraph.parts,
+        { partPath: newSlidePartPath, contentType: slideContentType },
+        ...(newSlideRelationships === undefined
+          ? []
+          : [
+              {
+                partPath: asPartPath(relationshipsPartPath(newSlidePartPath)),
+                contentType: RELS_CONTENT_TYPE,
+              },
+            ]),
+        ...(notesCopy === undefined
+          ? []
+          : [
+              { partPath: notesCopy.newPartPath, contentType: notesCopy.contentType },
+              ...(notesCopy.relationships === undefined
+                ? []
+                : [
+                    {
+                      partPath: asPartPath(relationshipsPartPath(notesCopy.newPartPath)),
+                      contentType: RELS_CONTENT_TYPE,
+                    },
+                  ]),
+            ]),
+      ],
+      contentTypes: {
+        ...source.packageGraph.contentTypes,
+        overrides: [
+          ...source.packageGraph.contentTypes.overrides,
+          { partName: newSlidePartPath, contentType: slideContentType },
+          ...(notesCopy === undefined
+            ? []
+            : [{ partName: notesCopy.newPartPath, contentType: notesCopy.contentType }]),
+        ],
+      },
+      relationships: [
+        ...source.packageGraph.relationships.map((relationships) =>
+          relationships.sourcePartPath !== source.presentation.partPath
+            ? relationships
+            : {
+                ...relationships,
+                relationships: [
+                  ...relationships.relationships,
+                  {
+                    id: newPresentationRelationshipId,
+                    type: SLIDE_REL_TYPE,
+                    target: relativeTarget(source.presentation.partPath, newSlidePartPath),
+                  },
+                ],
+              },
+        ),
+        ...(newSlideRelationships === undefined ? [] : [newSlideRelationships]),
+        ...(notesCopy?.relationships === undefined ? [] : [notesCopy.relationships]),
+      ],
+      rawParts: [
+        ...(source.packageGraph.rawParts ?? []),
+        {
+          kind: "binary",
+          partPath: newSlidePartPath,
+          contentType: slideContentType,
+          bytes: copyBytes(sourceRawSlide.bytes),
+        },
+        ...(notesCopy === undefined
+          ? []
+          : [
+              {
+                kind: "binary" as const,
+                partPath: notesCopy.newPartPath,
+                contentType: notesCopy.contentType,
+                bytes: copyBytes(notesCopy.raw.bytes),
+              },
+            ]),
+      ],
+    },
+    edits: [
+      ...(source.edits ?? []),
+      {
+        kind: "duplicateSlide",
+        sourceSlidePartPath: sourceSlide.partPath,
+        sourceRelationshipId: sourcePresentationRelationship.id,
+        newSlidePartPath,
+        newRelationshipId: newPresentationRelationshipId,
+      },
+    ],
+  };
+}
+
+export function deleteSlide(source: PptxSourceModel, slideHandle: SourceHandle): PptxSourceModel {
+  if (source.slides.length <= 1) {
+    throw new Error("deleteSlide: cannot delete the last slide");
+  }
+
+  const slideIndex = source.slides.findIndex((slide) =>
+    sourceHandlesEqual(slide.handle, slideHandle),
+  );
+  if (slideIndex === -1) {
+    throw new Error("deleteSlide: slide handle was not found in PptxSourceModel source");
+  }
+
+  const slide = source.slides[slideIndex];
+  const presentationRels = requirePartRelationships(
+    source,
+    source.presentation.partPath,
+    "deleteSlide",
+  );
+  const presentationRelationship = requireSlideRelationship(
+    source,
+    presentationRels,
+    slide.partPath,
+    "deleteSlide",
+  );
+  const slideRelationships = source.packageGraph.relationships.find(
+    (relationships) => relationships.sourcePartPath === slide.partPath,
+  );
+  const notesPartPaths =
+    slideRelationships?.relationships.flatMap((relationship) => {
+      if (relationship.type !== NOTES_SLIDE_REL_TYPE) return [];
+      const target = resolveInternalRelationshipTarget(slide.partPath, relationship);
+      return target === undefined ? [] : [target];
+    }) ?? [];
+  const removedPartPaths = new Set<string>([slide.partPath, ...notesPartPaths]);
+  const removedRelationshipPartPaths = new Set<string>(
+    [slide.partPath, ...notesPartPaths].map((partPath) => relationshipsPartPath(partPath)),
+  );
+  const retainedEdits = (source.edits ?? []).filter(
+    (edit) => !editIsInvalidatedByDeletedParts(edit, removedPartPaths),
+  );
+  const deletedInsertedSlide = (source.edits ?? []).some(
+    (edit) => edit.kind === "duplicateSlide" && edit.newSlidePartPath === slide.partPath,
+  );
+
+  return {
+    ...source,
+    presentation: {
+      ...source.presentation,
+      slidePartPaths: source.presentation.slidePartPaths.filter(
+        (partPath) => partPath !== slide.partPath,
+      ),
+    },
+    slides: source.slides.filter((candidate) => candidate.partPath !== slide.partPath),
+    packageGraph: {
+      ...source.packageGraph,
+      parts: source.packageGraph.parts.filter(
+        (part) =>
+          !removedPartPaths.has(part.partPath) && !removedRelationshipPartPaths.has(part.partPath),
+      ),
+      contentTypes: {
+        ...source.packageGraph.contentTypes,
+        overrides: source.packageGraph.contentTypes.overrides.filter(
+          (override) => !removedPartPaths.has(override.partName),
+        ),
+      },
+      relationships: source.packageGraph.relationships
+        .filter((relationships) => !removedPartPaths.has(relationships.sourcePartPath))
+        .map((relationships) =>
+          relationships.sourcePartPath !== source.presentation.partPath
+            ? relationships
+            : {
+                ...relationships,
+                relationships: relationships.relationships.filter(
+                  (relationship) => relationship.id !== presentationRelationship.id,
+                ),
+              },
+        ),
+      rawParts: source.packageGraph.rawParts?.filter(
+        (part) => !removedPartPaths.has(part.partPath),
+      ),
+    },
+    edits: deletedInsertedSlide
+      ? retainedEdits
+      : [
+          ...retainedEdits,
+          {
+            kind: "deleteSlide",
+            slidePartPath: slide.partPath,
+            relationshipId: presentationRelationship.id,
+          },
+        ],
+  };
+}
+
 function findTextRunInShape(shape: SourceShape, handle: SourceHandle): SourceTextRun | undefined {
   for (const paragraph of shape.textBody?.paragraphs ?? []) {
     for (const run of paragraph.runs) {
@@ -498,4 +763,224 @@ function sourceHandlesEqual(left: SourceHandle | undefined, right: SourceHandle)
     left.relationshipId === right.relationshipId &&
     left.orderingSlot === right.orderingSlot
   );
+}
+
+interface NotesSlideCopy {
+  readonly slideRelationshipId: RelationshipId;
+  readonly newPartPath: PartPath;
+  readonly contentType: string;
+  readonly raw: Extract<RawPackagePart, { readonly kind: "binary" }>;
+  readonly relationships?: PartRelationships;
+}
+
+function createNotesSlideCopy(
+  source: PptxSourceModel,
+  sourceSlide: SourceSlide,
+  slideRelationships: PartRelationships | undefined,
+): NotesSlideCopy | undefined {
+  const notesRelationship = slideRelationships?.relationships.find(
+    (relationship) => relationship.type === NOTES_SLIDE_REL_TYPE,
+  );
+  if (notesRelationship === undefined) return undefined;
+  const notesPartPath = resolveInternalRelationshipTarget(sourceSlide.partPath, notesRelationship);
+  if (notesPartPath === undefined) return undefined;
+
+  const raw = requireRawBinaryPart(source, notesPartPath, "duplicateSlide");
+  const contentType =
+    source.packageGraph.parts.find((part) => part.partPath === notesPartPath)?.contentType ??
+    NOTES_SLIDE_CONTENT_TYPE;
+  const newPartPath = nextNumberedPartPath(source, "ppt/notesSlides/notesSlide", ".xml");
+  const notesRelationships = source.packageGraph.relationships.find(
+    (relationships) => relationships.sourcePartPath === notesPartPath,
+  );
+
+  return {
+    slideRelationshipId: notesRelationship.id,
+    newPartPath,
+    contentType,
+    raw,
+    ...(notesRelationships === undefined
+      ? {}
+      : {
+          relationships: {
+            sourcePartPath: newPartPath,
+            relationships: notesRelationships.relationships,
+          },
+        }),
+  };
+}
+
+function requirePartRelationships(
+  source: PptxSourceModel,
+  partPath: PartPath,
+  operationName: "duplicateSlide" | "deleteSlide",
+): PartRelationships {
+  const relationships = source.packageGraph.relationships.find(
+    (candidate) => candidate.sourcePartPath === partPath,
+  );
+  if (relationships === undefined) {
+    throw new Error(`${operationName}: presentation relationships were not found`);
+  }
+  return relationships;
+}
+
+function requireSlideRelationship(
+  source: PptxSourceModel,
+  relationships: PartRelationships,
+  slidePartPath: PartPath,
+  operationName: "duplicateSlide" | "deleteSlide",
+): Relationship {
+  const relationship = relationships.relationships.find(
+    (candidate) =>
+      candidate.type === SLIDE_REL_TYPE &&
+      candidate.targetMode !== "External" &&
+      resolveInternalRelationshipTarget(source.presentation.partPath, candidate) === slidePartPath,
+  );
+  if (relationship === undefined) {
+    throw new Error(`${operationName}: slide relationship was not found in presentation.xml.rels`);
+  }
+  return relationship;
+}
+
+function requireRawBinaryPart(
+  source: PptxSourceModel,
+  partPath: PartPath,
+  operationName: "duplicateSlide",
+): Extract<RawPackagePart, { readonly kind: "binary" }> {
+  const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
+  if (rawPart === undefined) {
+    throw new Error(`${operationName}: part '${partPath}' has no preserved raw package material`);
+  }
+  if (rawPart.kind !== "binary") {
+    throw new Error(
+      `${operationName}: part '${partPath}' is not backed by binary package material`,
+    );
+  }
+  return rawPart;
+}
+
+function nextRelationshipId(relationships: readonly Relationship[]): RelationshipId {
+  const used = new Set(relationships.map((relationship) => relationship.id));
+  const max = relationships.reduce((current, relationship) => {
+    const match = /(\d+)$/.exec(relationship.id);
+    return match === null ? current : Math.max(current, Number(match[1]));
+  }, 0);
+  for (let index = max + 1; ; index += 1) {
+    const candidate = asRelationshipId(`rId${index}`);
+    if (!used.has(candidate)) return candidate;
+  }
+}
+
+function nextNumberedPartPath(source: PptxSourceModel, prefix: string, suffix: string): PartPath {
+  const used = new Set<string>([
+    ...source.packageGraph.parts.map((part) => part.partPath),
+    ...source.packageGraph.contentTypes.overrides.map((override) => override.partName),
+    ...(source.packageGraph.rawParts ?? []).map((part) => part.partPath),
+  ]);
+  const pattern = new RegExp(`^${escapeRegExp(prefix)}(\\d+)${escapeRegExp(suffix)}$`);
+  const max = [...used].reduce((current, path) => {
+    const match = pattern.exec(path);
+    return match === null ? current : Math.max(current, Number(match[1]));
+  }, 0);
+  for (let index = max + 1; ; index += 1) {
+    const candidate = asPartPath(`${prefix}${index}${suffix}`);
+    if (!used.has(candidate)) return candidate;
+  }
+}
+
+function relativeTarget(sourcePartPath: PartPath, targetPartPath: PartPath): string {
+  const sourceDir = sourcePartPath.split("/").slice(0, -1);
+  const targetSegments = targetPartPath.split("/");
+  while (sourceDir.length > 0 && targetSegments.length > 0 && sourceDir[0] === targetSegments[0]) {
+    sourceDir.shift();
+    targetSegments.shift();
+  }
+  return [...sourceDir.map(() => ".."), ...targetSegments].join("/");
+}
+
+function withPartPath(slide: SourceSlide, partPath: PartPath): SourceSlide {
+  return {
+    ...slide,
+    partPath,
+    handle: { partPath },
+    shapes: slide.shapes.map((shape) => withShapePartPath(shape, partPath)),
+  };
+}
+
+function withShapePartPath(shape: SourceShapeNode, partPath: PartPath): SourceShapeNode {
+  if (shape.kind === "raw") return shape;
+  const handle = shape.handle === undefined ? undefined : { ...shape.handle, partPath };
+  if (shape.kind === "group") {
+    return {
+      ...shape,
+      ...(handle !== undefined ? { handle } : {}),
+      children: shape.children.map((child) => withShapePartPath(child, partPath)),
+    };
+  }
+  if (shape.kind !== "shape" || shape.textBody === undefined) {
+    return { ...shape, ...(handle !== undefined ? { handle } : {}) };
+  }
+  return {
+    ...shape,
+    ...(handle !== undefined ? { handle } : {}),
+    textBody: {
+      ...shape.textBody,
+      paragraphs: shape.textBody.paragraphs.map((paragraph) => ({
+        ...paragraph,
+        ...(paragraph.handle !== undefined ? { handle: { ...paragraph.handle, partPath } } : {}),
+        runs: paragraph.runs.map((run) => ({
+          ...run,
+          ...(run.handle !== undefined ? { handle: { ...run.handle, partPath } } : {}),
+        })),
+      })),
+    },
+  };
+}
+
+function cloneJson<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function copyBytes(bytes: Uint8Array): Uint8Array {
+  return new Uint8Array(bytes);
+}
+
+function insertAtReadonly<T>(items: readonly T[], index: number, item: T): readonly T[] {
+  return [...items.slice(0, index), item, ...items.slice(index)];
+}
+
+function hasDirtyEditForPart(edits: readonly PptxSourceModelEdit[], partPath: PartPath): boolean {
+  return edits.some((edit) => {
+    switch (edit.kind) {
+      case "replaceTextRunPlainText":
+      case "updateTextRunProperties":
+      case "replaceParagraphPlainText":
+      case "updateShapeTransform":
+        return edit.handle.partPath === partPath;
+      case "duplicateSlide":
+      case "deleteSlide":
+        return false;
+    }
+  });
+}
+
+function editIsInvalidatedByDeletedParts(
+  edit: PptxSourceModelEdit,
+  partPaths: ReadonlySet<string>,
+): boolean {
+  switch (edit.kind) {
+    case "replaceTextRunPlainText":
+    case "updateTextRunProperties":
+    case "replaceParagraphPlainText":
+    case "updateShapeTransform":
+      return partPaths.has(edit.handle.partPath);
+    case "duplicateSlide":
+      return partPaths.has(edit.newSlidePartPath);
+    case "deleteSlide":
+      return partPaths.has(edit.slidePartPath);
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -6,6 +6,8 @@ export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
 export type { UpdateShapeTransformInput } from "./editing.js";
 export {
   clearTextRunProperties,
+  deleteSlide,
+  duplicateSlide,
   findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
@@ -37,6 +39,8 @@ export type {
   EditableTextRunProperties,
   EditableTextRunProperty,
   PptxSourceModel,
+  PptxSourceModelDeleteSlideEdit,
+  PptxSourceModelDuplicateSlideEdit,
   PptxSourceModelEdit,
   PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -23,7 +23,7 @@
  */
 
 import type { Diagnostic } from "./diagnostics.js";
-import type { SourceHandle } from "./handles.js";
+import type { PartPath, RelationshipId, SourceHandle } from "./handles.js";
 import type { PackageGraph } from "./package-graph.js";
 import type {
   SourcePresentation,
@@ -52,7 +52,9 @@ export type PptxSourceModelEdit =
   | PptxSourceModelTextRunEdit
   | PptxSourceModelTextRunPropertiesEdit
   | PptxSourceModelParagraphTextEdit
-  | PptxSourceModelShapeTransformEdit;
+  | PptxSourceModelShapeTransformEdit
+  | PptxSourceModelDuplicateSlideEdit
+  | PptxSourceModelDeleteSlideEdit;
 
 export interface PptxSourceModelTextRunEdit {
   readonly kind: "replaceTextRunPlainText";
@@ -97,4 +99,18 @@ export interface PptxSourceModelShapeTransformEdit {
   readonly offsetY: Emu;
   readonly width: Emu;
   readonly height: Emu;
+}
+
+export interface PptxSourceModelDuplicateSlideEdit {
+  readonly kind: "duplicateSlide";
+  readonly sourceSlidePartPath: PartPath;
+  readonly sourceRelationshipId: RelationshipId;
+  readonly newSlidePartPath: PartPath;
+  readonly newRelationshipId: RelationshipId;
+}
+
+export interface PptxSourceModelDeleteSlideEdit {
+  readonly kind: "deleteSlide";
+  readonly slidePartPath: PartPath;
+  readonly relationshipId: RelationshipId;
 }

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -150,6 +150,27 @@ function buildSlideTopologyFixture(): Uint8Array {
   });
 }
 
+function buildSlideTopologyFixtureWithRelationshipOverrides(): Uint8Array {
+  const entries = unzipSync(buildSlideTopologyFixture());
+  const relationshipContentType = "application/vnd.openxmlformats-package.relationships+xml";
+  const contentTypes = decoder
+    .decode(entries["[Content_Types].xml"])
+    .replace(`<Default Extension="rels" ContentType="${relationshipContentType}"/>`, "")
+    .replace(
+      `</Types>`,
+      `<Override PartName="/_rels/.rels" ContentType="${relationshipContentType}"/>` +
+        `<Override PartName="/ppt/_rels/presentation.xml.rels" ContentType="${relationshipContentType}"/>` +
+        `<Override PartName="/ppt/slides/_rels/slide1.xml.rels" ContentType="${relationshipContentType}"/>` +
+        `<Override PartName="/ppt/notesSlides/_rels/notesSlide1.xml.rels" ContentType="${relationshipContentType}"/>` +
+        `</Types>`,
+    );
+
+  return zipSync({
+    ...entries,
+    "[Content_Types].xml": encoder.encode(contentTypes),
+  });
+}
+
 function buildLayoutShowRoundTripFixture(): Uint8Array {
   return zipSync({
     "[Content_Types].xml": xml(
@@ -532,6 +553,36 @@ describe("writePptx - slide topology edits", () => {
         (override) => override.partName === "ppt/notesSlides/notesSlide1.xml",
       ),
     ).toBe(false);
+  });
+
+  it("keeps relationship content type overrides consistent when no rels default exists", () => {
+    const source = readPptx(buildSlideTopologyFixtureWithRelationshipOverrides());
+    const duplicated = readPptx(writePptx(duplicateSlide(source, source.slides[0].handle!)));
+    const deleted = readPptx(writePptx(deleteSlide(source, source.slides[0].handle!)));
+    const duplicatedOverrides = duplicated.packageGraph.contentTypes.overrides;
+    const deletedOverridePartNames = new Set(
+      deleted.packageGraph.contentTypes.overrides.map((override) => override.partName),
+    );
+
+    expect(
+      duplicated.packageGraph.contentTypes.defaults.some((entry) => entry.extension === "rels"),
+    ).toBe(false);
+    expect(duplicatedOverrides).toEqual(
+      expect.arrayContaining([
+        {
+          partName: "ppt/slides/_rels/slide3.xml.rels",
+          contentType: "application/vnd.openxmlformats-package.relationships+xml",
+        },
+        {
+          partName: "ppt/notesSlides/_rels/notesSlide2.xml.rels",
+          contentType: "application/vnd.openxmlformats-package.relationships+xml",
+        },
+      ]),
+    );
+    expect(deletedOverridePartNames.has("ppt/slides/slide1.xml")).toBe(false);
+    expect(deletedOverridePartNames.has("ppt/slides/_rels/slide1.xml.rels")).toBe(false);
+    expect(deletedOverridePartNames.has("ppt/notesSlides/notesSlide1.xml")).toBe(false);
+    expect(deletedOverridePartNames.has("ppt/notesSlides/_rels/notesSlide1.xml.rels")).toBe(false);
   });
 
   it("rejects deleting the last slide and duplicating a dirty slide", () => {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from "vitest";
 import { asEmu, asPt, asSourceNodeId, readPptx, writePptx } from "../index.js";
 import {
   clearTextRunProperties,
+  deleteSlide,
+  duplicateSlide,
   findParagraphBySourceHandle,
   findShapeNodeBySourceHandle,
   findTextRunBySourceHandle,
@@ -67,6 +69,83 @@ function buildRoundTripFixture(): Uint8Array {
     ),
     "ppt/media/image1.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
     "docProps/custom.xml": xml(`<Properties><custom value="preserve-me"/></Properties>`),
+  });
+}
+
+function buildSlideTopologyFixture(): Uint8Array {
+  return zipSync({
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/notesSlides/notesSlide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml"/>` +
+        `<Override PartName="/ppt/comments/comment1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.comments+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst>` +
+        `<p:sldId id="256" r:id="rIdSlide1"/>` +
+        `<p:sldId id="300" r:id="rIdSlide2"/>` +
+        `</p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `<Relationship Id="rIdSlide2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>` +
+        `<Relationship Id="rId9" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProps" Target="viewProps.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Invisible Source"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Slide One</a:t></a:r></a:p></p:txBody>` +
+        `</p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `<p:timing><p:tnLst><p:par/></p:tnLst></p:timing>` +
+        `</p:sld>`,
+    ),
+    "ppt/slides/slide2.xml": xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="20" name="Second"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Slide Two</a:t></a:r></a:p></p:txBody>` +
+        `</p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+    "ppt/slides/_rels/slide1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdNotes" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide" Target="../notesSlides/notesSlide1.xml"/>` +
+        `<Relationship Id="rIdComments" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments/comment1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/notesSlides/notesSlide1.xml": xml(
+      `<p:notes xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:notes>`,
+    ),
+    "ppt/notesSlides/_rels/notesSlide1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdNotesMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster" Target="../notesMasters/notesMaster1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/comments/comment1.xml": xml(
+      `<p:cmLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"/>`,
+    ),
   });
 }
 
@@ -366,6 +445,99 @@ describe("writePptx - no-edit round-trip", () => {
     };
 
     expect(() => writePptx(withoutRawSlide)).toThrow(/no preserved package material/);
+  });
+});
+
+describe("writePptx - slide topology edits", () => {
+  it("duplicates a slide immediately after the source and preserves raw invisible slide material", () => {
+    const source = readPptx(buildSlideTopologyFixture());
+    const edited = duplicateSlide(source, source.slides[0].handle!);
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const presentationXml = decoder.decode(getEntry(output, "ppt/presentation.xml"));
+    const presentationRels = decoder.decode(getEntry(output, "ppt/_rels/presentation.xml.rels"));
+    const duplicateSlideXml = decoder.decode(getEntry(output, "ppt/slides/slide3.xml"));
+    const duplicateSlideRels = decoder.decode(getEntry(output, "ppt/slides/_rels/slide3.xml.rels"));
+
+    expect(reread.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide3.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(
+      reread.slides.map((slide) => slide.shapes[0]?.kind === "shape" && slide.shapes[0].name),
+    ).toEqual(["Invisible Source", "Invisible Source", "Second"]);
+    expect(presentationXml).toContain(`<p:sldId id="301" r:id="rId10"/>`);
+    expect(presentationXml.indexOf(`r:id="rIdSlide1"`)).toBeLessThan(
+      presentationXml.indexOf(`r:id="rId10"`),
+    );
+    expect(presentationXml.indexOf(`r:id="rId10"`)).toBeLessThan(
+      presentationXml.indexOf(`r:id="rIdSlide2"`),
+    );
+    expect(presentationRels).toContain(
+      `<Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide3.xml"/>`,
+    );
+    expect(duplicateSlideXml).toContain("<p:timing>");
+    expect(duplicateSlideRels).toContain(`Id="rIdComments"`);
+    expect(duplicateSlideRels).toContain(`Target="../comments/comment1.xml"`);
+    expect(duplicateSlideRels).toContain(`Id="rIdNotes"`);
+    expect(duplicateSlideRels).toContain(`Target="../notesSlides/notesSlide2.xml"`);
+    expect(decoder.decode(getEntry(output, "ppt/notesSlides/notesSlide2.xml"))).toContain(
+      "<p:notes",
+    );
+    expect(
+      decoder.decode(getEntry(output, "ppt/notesSlides/_rels/notesSlide2.xml.rels")),
+    ).toContain(`notesMaster`);
+    expect(reread.packageGraph.contentTypes.overrides).toEqual(
+      expect.arrayContaining([
+        {
+          partName: "ppt/slides/slide3.xml",
+          contentType: "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+        },
+        {
+          partName: "ppt/notesSlides/notesSlide2.xml",
+          contentType:
+            "application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml",
+        },
+      ]),
+    );
+  });
+
+  it("deletes a slide and its notes part while keeping remaining slide order and orphan cleanup out of scope", () => {
+    const source = readPptx(buildSlideTopologyFixture());
+    const edited = deleteSlide(source, source.slides[0].handle!);
+    const output = writePptx(edited);
+    const entries = unzipSync(output);
+    const reread = readPptx(output);
+    const presentationXml = decoder.decode(getEntry(output, "ppt/presentation.xml"));
+    const presentationRels = decoder.decode(getEntry(output, "ppt/_rels/presentation.xml.rels"));
+
+    expect(reread.presentation.slidePartPaths).toEqual(["ppt/slides/slide2.xml"]);
+    expect(reread.slides[0]?.shapes[0]?.kind === "shape" && reread.slides[0].shapes[0].name).toBe(
+      "Second",
+    );
+    expect(presentationXml).not.toContain(`r:id="rIdSlide1"`);
+    expect(presentationRels).not.toContain(`Id="rIdSlide1"`);
+    expect(entries["ppt/slides/slide1.xml"]).toBeUndefined();
+    expect(entries["ppt/slides/_rels/slide1.xml.rels"]).toBeUndefined();
+    expect(entries["ppt/notesSlides/notesSlide1.xml"]).toBeUndefined();
+    expect(entries["ppt/notesSlides/_rels/notesSlide1.xml.rels"]).toBeUndefined();
+    expect(entries["ppt/comments/comment1.xml"]).toBeDefined();
+    expect(
+      reread.packageGraph.contentTypes.overrides.some(
+        (override) => override.partName === "ppt/notesSlides/notesSlide1.xml",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects deleting the last slide and duplicating a dirty slide", () => {
+    const singleSlide = readPptx(buildTextEditFixture());
+    expect(() => deleteSlide(singleSlide, singleSlide.slides[0].handle!)).toThrow(/last slide/);
+
+    const dirty = replaceTextRunPlainText(singleSlide, firstRun(singleSlide).handle!, "Dirty");
+    expect(() => duplicateSlide(dirty, dirty.slides[0].handle!)).toThrow(
+      /pending dirty part edits/,
+    );
   });
 });
 

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -140,6 +140,7 @@ function buildSlideTopologyFixture(): Uint8Array {
     ),
     "ppt/notesSlides/_rels/notesSlide1.xml.rels": xml(
       `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="../slides/slide1.xml"/>` +
         `<Relationship Id="rIdNotesMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesMaster" Target="../notesMasters/notesMaster1.xml"/>` +
         `</Relationships>`,
     ),
@@ -488,6 +489,9 @@ describe("writePptx - slide topology edits", () => {
     expect(
       decoder.decode(getEntry(output, "ppt/notesSlides/_rels/notesSlide2.xml.rels")),
     ).toContain(`notesMaster`);
+    expect(
+      decoder.decode(getEntry(output, "ppt/notesSlides/_rels/notesSlide2.xml.rels")),
+    ).toContain(`Target="../slides/slide3.xml"`);
     expect(reread.packageGraph.contentTypes.overrides).toEqual(
       expect.arrayContaining([
         {
@@ -538,6 +542,24 @@ describe("writePptx - slide topology edits", () => {
     expect(() => duplicateSlide(dirty, dirty.slides[0].handle!)).toThrow(
       /pending dirty part edits/,
     );
+  });
+
+  it("does not reuse a deleted slide part name within the same edit journal", () => {
+    const source = readPptx(buildRoundTripFixture());
+    const deletedSecond = deleteSlide(source, source.slides[1].handle!);
+    const duplicatedFirst = duplicateSlide(deletedSecond, deletedSecond.slides[0].handle!);
+    const deletedDuplicate = deleteSlide(duplicatedFirst, duplicatedFirst.slides[1].handle!);
+    const output = writePptx(deletedDuplicate);
+    const reread = readPptx(output);
+    const presentationXml = decoder.decode(getEntry(output, "ppt/presentation.xml"));
+
+    expect(duplicatedFirst.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide3.xml",
+    ]);
+    expect(reread.presentation.slidePartPaths).toEqual(["ppt/slides/slide1.xml"]);
+    expect(presentationXml).not.toContain(`r:id="rIdSlide2"`);
+    expect(presentationXml).not.toContain(`r:id="rId3"`);
   });
 });
 

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -23,6 +23,7 @@ import {
   getAttr,
   getChild,
   getChildArray,
+  getNamespacedAttr,
   localName,
   parseXml,
   type XmlNode,
@@ -32,6 +33,8 @@ import type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelDeleteSlideEdit,
+  PptxSourceModelDuplicateSlideEdit,
   PptxSourceModelEdit,
   PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
@@ -39,6 +42,7 @@ import type {
   PptxSourceModelTextRunPropertiesEdit,
   RawOoxmlNode,
   RawPackagePart,
+  RelationshipId,
 } from "../source/index.js";
 import { isRelationshipPart, relationshipsPartPath } from "../source/package-paths.js";
 import { unsafeOoxmlBoundaryAssertion } from "../unsafe-type-assertion.js";
@@ -73,12 +77,15 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const textRunPropertiesEdits = source.edits?.filter(isTextRunPropertiesEdit) ?? [];
   const paragraphTextEdits = source.edits?.filter(isParagraphTextEdit) ?? [];
   const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
+  const duplicateSlideEdits = source.edits?.filter(isDuplicateSlideEdit) ?? [];
+  const deleteSlideEdits = source.edits?.filter(isDeleteSlideEdit) ?? [];
   validateEdits(textRunEdits, textRunPropertiesEdits, paragraphTextEdits, shapeTransformEdits);
   const dirtyPartPaths = new Set(
     [...textRunEdits, ...textRunPropertiesEdits, ...paragraphTextEdits, ...shapeTransformEdits].map(
       (edit) => edit.handle.partPath,
     ),
   );
+  const hasSlideTopologyEdits = duplicateSlideEdits.length > 0 || deleteSlideEdits.length > 0;
   const files: Record<string, Uint8Array> = {
     [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
   };
@@ -97,6 +104,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   }
 
   for (const rawPart of source.packageGraph.rawParts ?? []) {
+    if (hasSlideTopologyEdits && rawPart.partPath === source.presentation.partPath) continue;
     if (dirtyPartPaths.has(rawPart.partPath)) continue;
     files[rawPart.partPath] = serializeRawPackagePart(rawPart);
     written.add(rawPart.partPath);
@@ -112,6 +120,14 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
       shapeTransformEdits,
     );
     written.add(partPath);
+  }
+
+  if (hasSlideTopologyEdits) {
+    files[source.presentation.partPath] = serializePresentationWithSlideTopologyEdits(
+      source,
+      mergeSlideTopologyEdits(source.edits ?? []),
+    );
+    written.add(source.presentation.partPath);
   }
 
   for (const part of source.packageGraph.parts) {
@@ -146,6 +162,16 @@ function isShapeTransformEdit(
   return edit.kind === "updateShapeTransform";
 }
 
+function isDuplicateSlideEdit(
+  edit: PptxSourceModelEdit,
+): edit is PptxSourceModelDuplicateSlideEdit {
+  return edit.kind === "duplicateSlide";
+}
+
+function isDeleteSlideEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelDeleteSlideEdit {
+  return edit.kind === "deleteSlide";
+}
+
 function serializeDirtyXmlPart(
   source: PptxSourceModel,
   partPath: PartPath,
@@ -176,6 +202,134 @@ function serializeDirtyXmlPart(
     applyShapeTransformEdit(root, edit);
   }
   return encodeXml(XML_DECLARATION + xmlBuilder.build(stripXmlProcessingInstruction(root)));
+}
+
+type SlideTopologyEdit = PptxSourceModelDuplicateSlideEdit | PptxSourceModelDeleteSlideEdit;
+
+function mergeSlideTopologyEdits(
+  edits: readonly PptxSourceModelEdit[],
+): readonly SlideTopologyEdit[] {
+  return edits.filter(
+    (edit): edit is SlideTopologyEdit =>
+      edit.kind === "duplicateSlide" || edit.kind === "deleteSlide",
+  );
+}
+
+function serializePresentationWithSlideTopologyEdits(
+  source: PptxSourceModel,
+  edits: readonly SlideTopologyEdit[],
+): Uint8Array {
+  const rawPart = source.packageGraph.rawParts?.find(
+    (part) => part.partPath === source.presentation.partPath,
+  );
+  if (rawPart === undefined) {
+    throw new Error(
+      `writePptx: presentation part '${source.presentation.partPath}' has no preserved raw package material`,
+    );
+  }
+  if (rawPart.kind !== "binary") {
+    throw new Error("writePptx: presentation XML tree part patching is not implemented");
+  }
+
+  const root = parseXml(textDecoder.decode(rawPart.bytes));
+  const presentation = getChild(root, "presentation");
+  if (presentation === undefined) {
+    throw new Error("writePptx: presentation part does not contain p:presentation root");
+  }
+  const sldIdLst = ensureSlideIdList(presentation);
+
+  for (const edit of edits) {
+    if (edit.kind === "duplicateSlide") {
+      insertSlideIdAfter(sldIdLst, edit.sourceRelationshipId, edit.newRelationshipId);
+    } else {
+      removeSlideId(sldIdLst, edit.relationshipId);
+    }
+  }
+
+  return encodeXml(XML_DECLARATION + xmlBuilder.build(stripXmlProcessingInstruction(root)));
+}
+
+function ensureSlideIdList(presentation: XmlNode): XmlNode {
+  const existing = getChild(presentation, "sldIdLst");
+  if (existing !== undefined) return existing;
+  const key = namespacedChildKey(presentation, "p:sldIdLst", "sldIdLst");
+  const created: XmlNode = {};
+  presentation[key] = created;
+  return created;
+}
+
+function insertSlideIdAfter(
+  sldIdLst: XmlNode,
+  sourceRelationshipId: RelationshipId,
+  newRelationshipId: RelationshipId,
+): void {
+  const { key, items } = slideIdEntries(sldIdLst);
+  const sourceIndex = items.findIndex((item) => getRelationshipAttr(item) === sourceRelationshipId);
+  if (sourceIndex === -1) {
+    throw new Error(
+      `writePptx: slide relationship '${sourceRelationshipId}' was not found in p:sldIdLst`,
+    );
+  }
+  if (items.some((item) => getRelationshipAttr(item) === newRelationshipId)) return;
+  const newSlideId = String(nextSlideNumericId(items));
+  const relationshipAttrKey = namespacedAttributeKey(items[sourceIndex], "r:id", "id");
+  const newNode: XmlNode = {
+    "@_id": newSlideId,
+    [relationshipAttrKey]: newRelationshipId,
+  };
+  sldIdLst[key] = [...items.slice(0, sourceIndex + 1), newNode, ...items.slice(sourceIndex + 1)];
+}
+
+function removeSlideId(sldIdLst: XmlNode, relationshipId: RelationshipId): void {
+  const { key, items } = slideIdEntries(sldIdLst);
+  sldIdLst[key] = items.filter((item) => getRelationshipAttr(item) !== relationshipId);
+}
+
+function slideIdEntries(sldIdLst: XmlNode): { readonly key: string; readonly items: XmlNode[] } {
+  const key = namespacedChildKey(sldIdLst, "p:sldId", "sldId");
+  const value = sldIdLst[key];
+  if (value === undefined || value === null) return { key, items: [] };
+  return {
+    key,
+    items: Array.isArray(value)
+      ? unsafeOoxmlBoundaryAssertion<XmlNode[]>(value)
+      : [unsafeOoxmlBoundaryAssertion<XmlNode>(value)],
+  };
+}
+
+function nextSlideNumericId(items: readonly XmlNode[]): number {
+  const used = new Set(
+    items.flatMap((item) => {
+      const id = Number(getAttr(item, "id"));
+      return Number.isFinite(id) ? [id] : [];
+    }),
+  );
+  const max = Math.max(255, ...used);
+  for (let candidate = max + 1; ; candidate += 1) {
+    if (!used.has(candidate)) return candidate;
+  }
+}
+
+function getRelationshipAttr(node: XmlNode): string | undefined {
+  return getNamespacedAttr(node, "id");
+}
+
+function namespacedChildKey(node: XmlNode, fallback: string, local: string): string {
+  for (const key of Object.keys(node)) {
+    if (key.startsWith("@_")) continue;
+    if (localName(key) === local) return key;
+  }
+  return fallback;
+}
+
+function namespacedAttributeKey(node: XmlNode, fallback: string, local: string): string {
+  for (const key of Object.keys(node)) {
+    if (!key.startsWith("@_")) continue;
+    const name = key.slice(2);
+    const colon = name.indexOf(":");
+    if (colon !== -1 && name.slice(colon + 1) === local) return key;
+  }
+  return `@_${fallback}`;
 }
 
 function stripXmlProcessingInstruction(root: XmlNode): XmlNode {

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -8,12 +8,14 @@
  * non-bookkeeping raw parts prefer the raw package material preserved by the reader.
  * Only dirty scopes are updated according to supported PptxSourceModel operations.
  *
- * The current slice supports plain text-run replacement and top-level shape transform
- * offset/extent edits, reserializing dirty slide XML parts and replacing only the
- * targeted values via stable source handles.
- * Node-level XML splicing, precise unsupported raw-sidecar invalidation, and package
- * topology rewrites belong to later writer slices, but the API and dirty-scope tracking
- * remain shaped for that extension path.
+ * The current slice supports plain text-run replacement, paragraph replacement,
+ * top-level shape transform offset/extent edits, and slide duplicate/delete topology
+ * edits. Dirty slide XML parts are reserialized by replacing only targeted values via
+ * stable source handles; slide duplicate/delete patches presentation bookkeeping while
+ * preserving unrelated raw package material.
+ * Node-level XML splicing and precise unsupported raw-sidecar invalidation belong to
+ * later writer slices, but the API and dirty-scope tracking remain shaped for that
+ * extension path.
  */
 
 import { XMLBuilder } from "fast-xml-parser";

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -818,6 +818,63 @@ describe("EditorSession xfrm commands", () => {
   });
 });
 
+describe("EditorSession slide topology commands", () => {
+  it("duplicates a slide as one undoable command and persists it", async () => {
+    const source = readPptx(await buildTwoSlideFixture());
+    const session = createEditorSession(source);
+    const duplicated = expectApplied(
+      session.apply({ kind: "duplicateSlide", handle: requireHandle(source.slides[0].handle) }),
+    );
+
+    expect(duplicated.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide3.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(readPptx(writePptx(duplicated)).presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide3.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(session.undoDepth).toBe(1);
+
+    const undone = expectHistory(session.undo());
+    expect(undone.presentation.slidePartPaths).toEqual(source.presentation.slidePartPaths);
+    const redone = expectHistory(session.redo());
+    expect(redone.presentation.slidePartPaths).toEqual(duplicated.presentation.slidePartPaths);
+  });
+
+  it("deletes a slide as one undoable command and rejects invalid slide deletes", async () => {
+    const source = readPptx(await buildTwoSlideFixture());
+    const session = createEditorSession(source);
+    const deleted = expectApplied(
+      session.apply({ kind: "deleteSlide", handle: requireHandle(source.slides[0].handle) }),
+    );
+
+    expect(deleted.presentation.slidePartPaths).toEqual(["ppt/slides/slide2.xml"]);
+    expect(readPptx(writePptx(deleted)).presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide2.xml",
+    ]);
+
+    const undone = expectHistory(session.undo());
+    expect(undone.presentation.slidePartPaths).toEqual(source.presentation.slidePartPaths);
+    expectHistory(session.redo());
+
+    const lastSlideReject = session.apply({
+      kind: "deleteSlide",
+      handle: requireHandle(session.document.slides[0].handle),
+    });
+    expect(lastSlideReject).toMatchObject({ ok: false, code: "invalid-command" });
+    expect(session.undoDepth).toBe(1);
+
+    const missingHandleReject = createEditorSession(source).apply({
+      kind: "duplicateSlide",
+      handle: { partPath: asPartPath("ppt/slides/missing.xml") },
+    });
+    expect(missingHandleReject).toMatchObject({ ok: false, code: "invalid-command" });
+  });
+});
+
 async function buildTextEditFixture(): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file(
@@ -873,6 +930,66 @@ async function buildTextEditFixture(): Promise<Uint8Array> {
         `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
         `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>No xfrm</a:t></a:r></a:p></p:txBody></p:sp>` +
         `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+async function buildTwoSlideFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/><p:sldId id="257" r:id="rIdSlide2"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `<Relationship Id="rIdSlide2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="10" name="First"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr><a:prstGeom prst="rect"/></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>First</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide2.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="20" name="Second"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr><a:prstGeom prst="rect"/></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Second</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>` +
         `</p:sld>`,
     ),
   );

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,5 +1,7 @@
 import {
   clearTextRunProperties,
+  deleteSlide,
+  duplicateSlide,
   type EditableTextRunProperties,
   type EditableTextRunProperty,
   type Emu,
@@ -78,6 +80,16 @@ export interface SetShapeTransformCommand {
   readonly height: Emu;
 }
 
+export interface DuplicateSlideCommand {
+  readonly kind: "duplicateSlide";
+  readonly handle: SourceHandle;
+}
+
+export interface DeleteSlideCommand {
+  readonly kind: "deleteSlide";
+  readonly handle: SourceHandle;
+}
+
 export type EditorCommand =
   | ReplaceTextRunPlainTextCommand
   | ReplaceParagraphPlainTextCommand
@@ -85,7 +97,9 @@ export type EditorCommand =
   | ClearTextRunPropertiesCommand
   | MoveShapeCommand
   | ResizeShapeCommand
-  | SetShapeTransformCommand;
+  | SetShapeTransformCommand
+  | DuplicateSlideCommand
+  | DeleteSlideCommand;
 
 export type EditorApplyCommandResult =
   | {
@@ -252,6 +266,10 @@ function applyCommandToDocument(
       return resizeShape(document, command);
     case "setShapeTransform":
       return setShapeTransform(document, command);
+    case "duplicateSlide":
+      return duplicateSlide(document, command.handle);
+    case "deleteSlide":
+      return deleteSlide(document, command.handle);
   }
 }
 

--- a/vrt/libreoffice/editor-validity.test.ts
+++ b/vrt/libreoffice/editor-validity.test.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 import {
   asEmu,
   asPt,
+  deleteSlide,
+  duplicateSlide,
   readPptx,
   type SourceHandle,
   type SourceShape,
@@ -157,6 +159,21 @@ describeOrSkip("LibreOffice edited PPTX validity", { timeout: 120000 }, () => {
   }
 });
 
+describeOrSkip("LibreOffice slide topology validity", { timeout: 120000 }, () => {
+  it("opens PPTX after slide duplicate and delete edits", () => {
+    const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
+    const source = readPptx(sourcePptx);
+    const duplicated = duplicateSlide(source, requireHandle(source.slides[0]?.handle));
+    const deleted = deleteSlide(duplicated, requireHandle(duplicated.slides[1]?.handle));
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-slide-topology-edited.pptx",
+      writePptx(deleted),
+    );
+  });
+});
+
 function findLibreOfficeDockerImage(): string | undefined {
   for (const image of LIBREOFFICE_IMAGE_CANDIDATES) {
     const result = spawnSync("docker", ["image", "inspect", image], { encoding: "utf8" });
@@ -212,6 +229,46 @@ function renderWithLibreOffice(
   }
 
   return { editedPngPath, expectedPngPath };
+}
+
+function renderSingleWithLibreOffice(
+  image: string,
+  editedFilename: string,
+  editedPptx: Uint8Array,
+): string {
+  const workDir = mkdtempSync(join(tmpdir(), "pptx-glimpse-lo-editor-validity-"));
+  const outputDir = join(workDir, "out");
+  const editedPath = join(workDir, editedFilename);
+
+  writeFileSync(editedPath, editedPptx);
+
+  const result = spawnSync(
+    "docker",
+    [
+      "run",
+      "--rm",
+      "-v",
+      `${workDir}:/work`,
+      image,
+      "bash",
+      "-lc",
+      `mkdir -p /work/out && libreoffice --headless --convert-to png --outdir /work/out /work/${editedFilename}`,
+    ],
+    { encoding: "utf8" },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `LibreOffice conversion failed for '${editedFilename}'.\n` +
+        `stdout:\n${result.stdout}\n\nstderr:\n${result.stderr}`,
+    );
+  }
+
+  const editedPngPath = join(outputDir, `${basename(editedFilename, ".pptx")}.png`);
+  if (!existsSync(editedPngPath)) {
+    throw new Error(`LibreOffice conversion did not produce expected PNG for '${editedFilename}'.`);
+  }
+  return editedPngPath;
 }
 
 function findTextRun(source: ReturnType<typeof readPptx>, text: string): SourceTextRun {


### PR DESCRIPTION
close #607

## 目的

slide の複製・削除を writer / editor-core に追加し、relationship / content type / ID 管理を含む slide topology 編集を扱えるようにします。

## 変更内容

- `@pptx-glimpse/document` に `duplicateSlide` / `deleteSlide` と topology edit journal を追加
- writer で `presentation.xml` の `sldIdLst`、presentation rels、slide / notes parts、content types を整合
- editor-core command と undo / redo / reject を追加
- rendering order、invisible material、LibreOffice validity、ID collision 回避のテストを追加
- published package 影響分の changeset を追加

## 検証

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- direct tsup build: document / editor-core / renderer / core

補足: `npm run build` はローカルの pnpm `minimumReleaseAge` policy により、既存 lockfile entries の `picomatch@4.0.5` / `postcss@8.5.16` が拒否され停止しました。実装差分起因ではないため、各 package の tsup build を直接実行して確認しています。