### PR TITLE
writer / editor-core: shape の追加・削除を追加する

### DIFF
--- a/.changeset/shape-textbox-add-delete.md
+++ b/.changeset/shape-textbox-add-delete.md
@@ -1,0 +1,5 @@
+---
+"@pptx-glimpse/document": patch
+---
+
+Add PptxSourceModel writer operations for adding text boxes and deleting top-level shapes.

--- a/e2e/edit-equivalence.test.ts
+++ b/e2e/edit-equivalence.test.ts
@@ -6,7 +6,12 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import type { ConvertOptions } from "../packages/core/src/converter.js";
-import { asPt, replaceTextRunPlainText } from "../packages/document/src/index.js";
+import {
+  addTextBox,
+  asEmu,
+  asPt,
+  replaceTextRunPlainText,
+} from "../packages/document/src/index.js";
 import { createEditorSession } from "../packages/editor-core/src/index.js";
 import {
   assertEditEquivalence,
@@ -49,6 +54,38 @@ const mismatchedTextRunFixture = textRunFixture(
   "mismatched expected text-run fixture",
   "Alterd text",
 );
+const emptySlideFixture = {
+  name: "source empty slide fixture",
+  create: async () =>
+    await buildPptx({
+      slides: [
+        {
+          xml: wrapSlideXml(""),
+          rels: slideRelsXml(),
+        },
+      ],
+    }),
+} as const satisfies EditEquivalenceFixture;
+const expectedAddedTextBoxFixture = {
+  name: "expected added text box fixture",
+  create: async () =>
+    await buildPptx({
+      slides: [
+        {
+          xml: wrapSlideXml(
+            textBoxShapeXml(1, "TextBox 1", {
+              x: 914400,
+              y: 914400,
+              cx: 3657600,
+              cy: 914400,
+              text: "Edited added box",
+            }),
+          ),
+          rels: slideRelsXml(),
+        },
+      ],
+    }),
+} as const satisfies EditEquivalenceFixture;
 
 const replaceFirstRunWithEditedText = {
   name: "replace first text run with edited text",
@@ -88,6 +125,44 @@ const decorateFirstRun = {
   },
 } as const satisfies EditEquivalenceOperation;
 
+const addThenEditTextBox = {
+  name: "add then edit text box",
+  apply: (source) => {
+    const withTextBox = addTextBox(source, source.slides[0].handle!, {
+      offsetX: asEmu(457200),
+      offsetY: asEmu(457200),
+      width: asEmu(2743200),
+      height: asEmu(685800),
+      text: "Initial added box",
+    });
+    const shape = withTextBox.slides[0]?.shapes.find(
+      (candidate) => candidate.kind === "shape" && candidate.name === "TextBox 1",
+    );
+    const runHandle =
+      shape?.kind === "shape" ? shape.textBody?.paragraphs[0]?.runs[0]?.handle : undefined;
+    if (shape?.handle === undefined || runHandle === undefined) {
+      throw new Error("added text box handles not found");
+    }
+    const session = createEditorSession(withTextBox);
+    const textResult = session.apply({
+      kind: "replaceTextRunPlainText",
+      handle: runHandle,
+      text: "Edited added box",
+    });
+    if (!textResult.ok) throw new Error(textResult.message);
+    const xfrmResult = session.apply({
+      kind: "setShapeTransform",
+      handle: shape.handle,
+      offsetX: asEmu(914400),
+      offsetY: asEmu(914400),
+      width: asEmu(3657600),
+      height: asEmu(914400),
+    });
+    if (!xfrmResult.ok) throw new Error(xfrmResult.message);
+    return xfrmResult.document;
+  },
+} as const satisfies EditEquivalenceOperation;
+
 defineEditEquivalenceTests([
   {
     name: "text-run replacement",
@@ -102,6 +177,14 @@ defineEditEquivalenceTests([
     sourceFixture: originalDecoratedRunFixture,
     operations: [decorateFirstRun],
     expectedFixture: expectedDecoratedRunFixture,
+    renderOptionsProvider: getTinyTestFontRenderOptions,
+    renderOptions: { width: 480 },
+  },
+  {
+    name: "add edit text box",
+    sourceFixture: emptySlideFixture,
+    operations: [addThenEditTextBox],
+    expectedFixture: expectedAddedTextBoxFixture,
     renderOptionsProvider: getTinyTestFontRenderOptions,
     renderOptions: { width: 480 },
   },
@@ -167,6 +250,23 @@ function decoratedTextRunShapeXml(
   });
 }
 
+function textBoxShapeXml(
+  id: number,
+  name: string,
+  opts: { x: number; y: number; cx: number; cy: number; text: string },
+): string {
+  return `<p:sp>
+  <p:nvSpPr><p:cNvPr id="${id}" name="${name}"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>
+  <p:spPr>
+    <a:xfrm><a:off x="${opts.x}" y="${opts.y}"/><a:ext cx="${opts.cx}" cy="${opts.cy}"/></a:xfrm>
+    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+    <a:noFill/>
+    <a:ln><a:noFill/></a:ln>
+  </p:spPr>
+  <p:txBody><a:bodyPr wrap="square"/><a:lstStyle/><a:p><a:r><a:t>${opts.text}</a:t></a:r><a:endParaRPr/></a:p></p:txBody>
+</p:sp>`;
+}
+
 let tinyTestFontDirPromise: Promise<string> | null = null;
 
 async function getTinyTestFontRenderOptions(): Promise<ConvertOptions> {
@@ -192,7 +292,7 @@ async function createTinyTestFontDir(): Promise<string> {
       advanceWidth: 600,
       path: createGlyphPath(opentype),
     }),
-    ...Array.from(new Set("EditedOriginalAlterd text")).map(
+    ...Array.from(new Set("EditedOriginalAlterd added box text")).map(
       (char) =>
         new opentype.Glyph({
           name: char === " " ? "space" : char,

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -55,6 +55,7 @@ export { createComputedView } from "./computed/index.js";
 export type { ReadPptxInput } from "./reader/index.js";
 export { readPptx } from "./reader/index.js";
 export type {
+  AddTextBoxInput,
   ContentTypeDefault,
   ContentTypeOverride,
   ContentTypes,
@@ -72,6 +73,8 @@ export type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelAddTextBoxEdit,
+  PptxSourceModelDeleteShapeEdit,
   PptxSourceModelDeleteSlideEdit,
   PptxSourceModelDuplicateSlideEdit,
   PptxSourceModelEdit,
@@ -169,7 +172,9 @@ export type {
   UpdateShapeTransformInput,
 } from "./source/index.js";
 export {
+  addTextBox,
   clearTextRunProperties,
+  deleteShape,
   deleteSlide,
   duplicateSlide,
   findParagraphBySourceHandle,

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -398,7 +398,7 @@ export function addTextBox(
   }
 
   const slide = source.slides[slideIndex];
-  const shapeId = nextShapeId(slide.shapes);
+  const shapeId = nextShapeId(slide.shapes, source.edits ?? [], slide.partPath);
   const shapeIdValue = String(shapeId);
   const name = input.name?.trim() || `TextBox ${shapeIdValue}`;
   const orderingSlot = nextOrderingSlot(slide.shapes);
@@ -440,6 +440,7 @@ export function deleteShape(source: PptxSourceModel, handle: SourceHandle): Pptx
   let found: SourceShapeNode | undefined;
   let deleted = false;
   const slides = source.slides.map((slide) => {
+    let slideChanged = false;
     const nextShapes = slide.shapes.filter((shape) => {
       if (!sourceHandlesEqual(shape.handle, handle)) return true;
       found = shape;
@@ -450,9 +451,10 @@ export function deleteShape(source: PptxSourceModel, handle: SourceHandle): Pptx
         throw new Error("deleteShape: shapes inside AlternateContent are not supported");
       }
       deleted = true;
+      slideChanged = true;
       return false;
     });
-    return nextShapes === slide.shapes ? slide : { ...slide, shapes: nextShapes };
+    return slideChanged ? { ...slide, shapes: nextShapes } : slide;
   });
 
   if (!deleted) {
@@ -922,9 +924,14 @@ function createTextBoxShape(
   };
 }
 
-function nextShapeId(shapes: readonly SourceShapeNode[]): SourceNodeId {
+function nextShapeId(
+  shapes: readonly SourceShapeNode[],
+  edits: readonly PptxSourceModelEdit[],
+  slidePartPath: PartPath,
+): SourceNodeId {
   const used = new Set<number>();
   collectNumericShapeIds(shapes, used);
+  collectNumericShapeEditIds(edits, slidePartPath, used);
   const max = Math.max(0, ...used);
   for (let candidate = max + 1; ; candidate += 1) {
     if (!used.has(candidate)) return asSourceNodeId(String(candidate));
@@ -936,6 +943,23 @@ function collectNumericShapeIds(shapes: readonly SourceShapeNode[], used: Set<nu
     const numericId = Number(shape.nodeId);
     if (Number.isInteger(numericId) && numericId > 0) used.add(numericId);
     if (shape.kind === "group") collectNumericShapeIds(shape.children, used);
+  }
+}
+
+function collectNumericShapeEditIds(
+  edits: readonly PptxSourceModelEdit[],
+  slidePartPath: PartPath,
+  used: Set<number>,
+): void {
+  for (const edit of edits) {
+    const id =
+      edit.kind === "addTextBox" && edit.slidePartPath === slidePartPath
+        ? edit.shapeId
+        : edit.kind === "deleteShape" && edit.handle.partPath === slidePartPath
+          ? edit.handle.nodeId
+          : undefined;
+    const numericId = Number(id);
+    if (Number.isInteger(numericId) && numericId > 0) used.add(numericId);
   }
 }
 

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -11,12 +11,14 @@ import type {
   Relationship,
   RelationshipId,
   SourceHandle,
+  SourceNodeId,
   SourceParagraph,
   SourceRunProperties,
   SourceShape,
   SourceShapeNode,
   SourceSlide,
   SourceTextRun,
+  SourceTransform,
 } from "./index.js";
 import { asPartPath, asRelationshipId } from "./index.js";
 import { relationshipsPartPath, resolveInternalRelationshipTarget } from "./package-paths.js";
@@ -307,6 +309,11 @@ export interface UpdateShapeTransformInput {
   readonly height: Emu;
 }
 
+export interface AddTextBoxInput extends UpdateShapeTransformInput {
+  readonly text: string;
+  readonly name?: string;
+}
+
 export function findShapeNodeBySourceHandle(
   source: PptxSourceModel,
   handle: SourceHandle,
@@ -374,6 +381,110 @@ export function updateShapeTransform(
         height: transform.height,
       },
     ],
+  };
+}
+
+export function addTextBox(
+  source: PptxSourceModel,
+  slideHandle: SourceHandle,
+  input: AddTextBoxInput,
+): PptxSourceModel {
+  assertTextBoxInput(input);
+  const slideIndex = source.slides.findIndex((slide) =>
+    sourceHandlesEqual(slide.handle, slideHandle),
+  );
+  if (slideIndex === -1) {
+    throw new Error("addTextBox: slide handle was not found in PptxSourceModel source");
+  }
+
+  const slide = source.slides[slideIndex];
+  const shapeId = nextShapeId(slide.shapes);
+  const shapeIdValue = String(shapeId);
+  const name = input.name?.trim() || `TextBox ${shapeIdValue}`;
+  const orderingSlot = nextOrderingSlot(slide.shapes);
+  const shape = createTextBoxShape(slide.partPath, shapeId, name, orderingSlot, input);
+  const slides = source.slides.map((candidate, index) =>
+    index === slideIndex
+      ? {
+          ...candidate,
+          shapes: [...candidate.shapes, shape],
+        }
+      : candidate,
+  );
+
+  return {
+    ...source,
+    slides,
+    edits: [
+      ...(source.edits ?? []),
+      {
+        kind: "addTextBox",
+        slidePartPath: slide.partPath,
+        shapeId: shapeIdValue,
+        name,
+        offsetX: input.offsetX,
+        offsetY: input.offsetY,
+        width: input.width,
+        height: input.height,
+        text: input.text,
+      },
+    ],
+  };
+}
+
+export function deleteShape(source: PptxSourceModel, handle: SourceHandle): PptxSourceModel {
+  if (handle.nodeId === undefined) {
+    throw new Error("deleteShape: shape delete requires a node id");
+  }
+
+  let found: SourceShapeNode | undefined;
+  let deleted = false;
+  const slides = source.slides.map((slide) => {
+    const nextShapes = slide.shapes.filter((shape) => {
+      if (!sourceHandlesEqual(shape.handle, handle)) return true;
+      found = shape;
+      if (shape.kind !== "shape") {
+        throw new Error("deleteShape: only top-level sp shapes can be deleted");
+      }
+      if (hasAlternateContentSidecar(shape)) {
+        throw new Error("deleteShape: shapes inside AlternateContent are not supported");
+      }
+      deleted = true;
+      return false;
+    });
+    return nextShapes === slide.shapes ? slide : { ...slide, shapes: nextShapes };
+  });
+
+  if (!deleted) {
+    if (
+      found === undefined &&
+      source.slides.some((slide) => hasNestedShapeNodeWithHandle(slide.shapes, handle))
+    ) {
+      throw new Error("deleteShape: nested group shape deletion is not supported");
+    }
+    throw new Error("deleteShape: shape handle was not found in PptxSourceModel source");
+  }
+
+  const retainedEdits = (source.edits ?? []).filter((edit) => !editTargetsShape(edit, handle));
+  const deletedInsertedShape = (source.edits ?? []).some(
+    (edit) =>
+      edit.kind === "addTextBox" &&
+      edit.slidePartPath === handle.partPath &&
+      edit.shapeId === String(handle.nodeId),
+  );
+
+  return {
+    ...source,
+    slides,
+    edits: deletedInsertedShape
+      ? retainedEdits
+      : [
+          ...retainedEdits,
+          {
+            kind: "deleteShape",
+            handle,
+          },
+        ],
   };
 }
 
@@ -740,6 +851,103 @@ function hasEditableTransform(shape: SourceShapeNode): shape is TransformableSha
   return shape.kind !== "raw" && shape.transform !== undefined;
 }
 
+function assertTextBoxInput(input: AddTextBoxInput): void {
+  assertFiniteEmu(input.offsetX, "addTextBox", "offsetX");
+  assertFiniteEmu(input.offsetY, "addTextBox", "offsetY");
+  assertPositiveFiniteEmu(input.width, "addTextBox", "width");
+  assertPositiveFiniteEmu(input.height, "addTextBox", "height");
+  if (typeof input.text !== "string") {
+    throw new Error("addTextBox: text must be a string");
+  }
+  if (input.name !== undefined && input.name.trim() === "") {
+    throw new Error("addTextBox: name must be a non-empty string when provided");
+  }
+}
+
+function assertFiniteEmu(value: Emu, operationName: "addTextBox", fieldName: string): void {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${operationName}: ${fieldName} must be a finite EMU value`);
+  }
+}
+
+function assertPositiveFiniteEmu(value: Emu, operationName: "addTextBox", fieldName: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${operationName}: ${fieldName} must be a finite positive EMU value`);
+  }
+}
+
+function createTextBoxShape(
+  partPath: PartPath,
+  shapeId: SourceNodeId,
+  name: string,
+  orderingSlot: number,
+  input: AddTextBoxInput,
+): SourceShape {
+  const transform: SourceTransform = {
+    offsetX: input.offsetX,
+    offsetY: input.offsetY,
+    width: input.width,
+    height: input.height,
+  };
+  return {
+    kind: "shape",
+    nodeId: shapeId,
+    name,
+    transform,
+    geometry: { preset: "rect" },
+    textBody: {
+      handle: { partPath, nodeId: asSourceNodeId(`text:shape:${shapeId}`), orderingSlot },
+      paragraphs: [
+        {
+          handle: {
+            partPath,
+            nodeId: asSourceNodeId(`text:shape:${shapeId}:p:0`),
+            orderingSlot: 0,
+          },
+          runs: [
+            {
+              kind: "textRun",
+              text: input.text,
+              handle: {
+                partPath,
+                nodeId: asSourceNodeId(`text:shape:${shapeId}:p:0:r:0`),
+                orderingSlot: 0,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    handle: { partPath, nodeId: shapeId, orderingSlot },
+  };
+}
+
+function nextShapeId(shapes: readonly SourceShapeNode[]): SourceNodeId {
+  const used = new Set<number>();
+  collectNumericShapeIds(shapes, used);
+  const max = Math.max(0, ...used);
+  for (let candidate = max + 1; ; candidate += 1) {
+    if (!used.has(candidate)) return asSourceNodeId(String(candidate));
+  }
+}
+
+function collectNumericShapeIds(shapes: readonly SourceShapeNode[], used: Set<number>): void {
+  for (const shape of shapes) {
+    const numericId = Number(shape.nodeId);
+    if (Number.isInteger(numericId) && numericId > 0) used.add(numericId);
+    if (shape.kind === "group") collectNumericShapeIds(shape.children, used);
+  }
+}
+
+function nextOrderingSlot(shapes: readonly SourceShapeNode[]): number {
+  return (
+    shapes.reduce((current, shape) => {
+      const slot = shape.handle?.orderingSlot ?? -1;
+      return Math.max(current, slot);
+    }, -1) + 1
+  );
+}
+
 function findShapeNodeInTree(
   shapes: readonly SourceShapeNode[],
   handle: SourceHandle,
@@ -938,10 +1146,13 @@ function topologyEditPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {
       return [edit.sourceSlidePartPath, edit.newSlidePartPath];
     case "deleteSlide":
       return [edit.slidePartPath];
+    case "addTextBox":
+      return [edit.slidePartPath];
     case "replaceTextRunPlainText":
     case "updateTextRunProperties":
     case "replaceParagraphPlainText":
     case "updateShapeTransform":
+    case "deleteShape":
       return [];
   }
 }
@@ -1014,12 +1225,45 @@ function hasDirtyEditForPart(edits: readonly PptxSourceModelEdit[], partPath: Pa
       case "updateTextRunProperties":
       case "replaceParagraphPlainText":
       case "updateShapeTransform":
+      case "deleteShape":
         return edit.handle.partPath === partPath;
+      case "addTextBox":
+        return edit.slidePartPath === partPath;
       case "duplicateSlide":
       case "deleteSlide":
         return false;
     }
   });
+}
+
+function editTargetsShape(edit: PptxSourceModelEdit, handle: SourceHandle): boolean {
+  switch (edit.kind) {
+    case "replaceTextRunPlainText":
+    case "updateTextRunProperties":
+      return (
+        edit.handle.partPath === handle.partPath && textRunShapeId(edit.handle) === handle.nodeId
+      );
+    case "replaceParagraphPlainText":
+      return (
+        edit.handle.partPath === handle.partPath && paragraphShapeId(edit.handle) === handle.nodeId
+      );
+    case "updateShapeTransform":
+    case "deleteShape":
+      return sourceHandlesEqual(edit.handle, handle);
+    case "addTextBox":
+      return edit.slidePartPath === handle.partPath && edit.shapeId === String(handle.nodeId);
+    case "duplicateSlide":
+    case "deleteSlide":
+      return false;
+  }
+}
+
+function textRunShapeId(handle: SourceHandle): string | undefined {
+  return /^text:shape:([^:]+):p:\d+:r:\d+$/.exec(String(handle.nodeId ?? ""))?.[1];
+}
+
+function paragraphShapeId(handle: SourceHandle): string | undefined {
+  return /^text:shape:([^:]+):p:\d+$/.exec(String(handle.nodeId ?? ""))?.[1];
 }
 
 function editIsInvalidatedByDeletedParts(
@@ -1031,6 +1275,10 @@ function editIsInvalidatedByDeletedParts(
     case "updateTextRunProperties":
     case "replaceParagraphPlainText":
     case "updateShapeTransform":
+      return partPaths.has(edit.handle.partPath);
+    case "addTextBox":
+      return partPaths.has(edit.slidePartPath);
+    case "deleteShape":
       return partPaths.has(edit.handle.partPath);
     case "duplicateSlide":
       return partPaths.has(edit.newSlidePartPath);

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -3,9 +3,11 @@
  */
 
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
-export type { UpdateShapeTransformInput } from "./editing.js";
+export type { AddTextBoxInput, UpdateShapeTransformInput } from "./editing.js";
 export {
+  addTextBox,
   clearTextRunProperties,
+  deleteShape,
   deleteSlide,
   duplicateSlide,
   findParagraphBySourceHandle,
@@ -39,6 +41,8 @@ export type {
   EditableTextRunProperties,
   EditableTextRunProperty,
   PptxSourceModel,
+  PptxSourceModelAddTextBoxEdit,
+  PptxSourceModelDeleteShapeEdit,
   PptxSourceModelDeleteSlideEdit,
   PptxSourceModelDuplicateSlideEdit,
   PptxSourceModelEdit,

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -53,6 +53,8 @@ export type PptxSourceModelEdit =
   | PptxSourceModelTextRunPropertiesEdit
   | PptxSourceModelParagraphTextEdit
   | PptxSourceModelShapeTransformEdit
+  | PptxSourceModelAddTextBoxEdit
+  | PptxSourceModelDeleteShapeEdit
   | PptxSourceModelDuplicateSlideEdit
   | PptxSourceModelDeleteSlideEdit;
 
@@ -99,6 +101,23 @@ export interface PptxSourceModelShapeTransformEdit {
   readonly offsetY: Emu;
   readonly width: Emu;
   readonly height: Emu;
+}
+
+export interface PptxSourceModelAddTextBoxEdit {
+  readonly kind: "addTextBox";
+  readonly slidePartPath: PartPath;
+  readonly shapeId: string;
+  readonly name: string;
+  readonly offsetX: Emu;
+  readonly offsetY: Emu;
+  readonly width: Emu;
+  readonly height: Emu;
+  readonly text: string;
+}
+
+export interface PptxSourceModelDeleteShapeEdit {
+  readonly kind: "deleteShape";
+  readonly handle: SourceHandle;
 }
 
 export interface PptxSourceModelDuplicateSlideEdit {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -733,6 +733,50 @@ describe("writePptx - shape add/delete edits", () => {
     });
   });
 
+  it("does not reuse a pending-deleted shape id when adding a text box", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const deletedMaxIdShape = deleteShape(
+      source,
+      requireHandle(findShapeByName(source, "Keep Shape").handle),
+    );
+    const edited = addTextBox(deletedMaxIdShape, deletedMaxIdShape.slides[0].handle!, {
+      offsetX: asEmu(900),
+      offsetY: asEmu(1000),
+      width: asEmu(1100),
+      height: asEmu(1200),
+      text: "Added after delete",
+    });
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+
+    expect(findShapeByName(reread, "TextBox 31").textBody?.paragraphs[0]?.runs[0]?.text).toBe(
+      "Added after delete",
+    );
+    expect(() => findShapeByName(reread, "Keep Shape")).toThrow(/shape not found/);
+  });
+
+  it("cancels the add edit when a newly-added text box is deleted before write", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const withTextBox = addTextBox(source, source.slides[0].handle!, {
+      offsetX: asEmu(100),
+      offsetY: asEmu(200),
+      width: asEmu(300),
+      height: asEmu(400),
+      text: "Temporary",
+      name: "Temporary TextBox",
+    });
+    const added = findShapeByName(withTextBox, "Temporary TextBox");
+    const edited = deleteShape(withTextBox, requireHandle(added.handle));
+    const output = writePptx(edited);
+
+    expect(
+      edited.edits?.filter((edit) => edit.kind === "addTextBox" || edit.kind === "deleteShape"),
+    ).toEqual([]);
+    expect(decoder.decode(getEntry(output, "ppt/slides/slide1.xml"))).not.toContain(
+      "Temporary TextBox",
+    );
+  });
+
   it("deletes only the targeted sp shape while preserving other shapes and invisible slide material", () => {
     const source = readPptx(buildShapeDeleteFixture());
     const deleted = deleteShape(source, requireHandle(source.slides[0].shapes[0]?.handle));

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it } from "vitest";
 // Import via the actual public surface (`@pptx-glimpse/document`).
 import { asEmu, asPt, asSourceNodeId, readPptx, writePptx } from "../index.js";
 import {
+  addTextBox,
   clearTextRunProperties,
+  deleteShape,
   deleteSlide,
   duplicateSlide,
   findParagraphBySourceHandle,
@@ -17,6 +19,7 @@ import {
   replaceTextRunPlainText,
   setTextRunProperties,
   type SourceShape,
+  type SourceShapeNode,
   updateShapeTransform,
 } from "../index.js";
 
@@ -295,6 +298,52 @@ function buildTextEditFixtureFromSlide(slideSpTree: string): Uint8Array {
     ),
     "docProps/custom.xml": xml(`<Properties><custom value="preserve-me"/></Properties>`),
     "ppt/media/image1.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47, 9, 8, 7]),
+  });
+}
+
+function buildShapeDeleteFixture(): Uint8Array {
+  return zipSync({
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+        `<p:cSld><p:spTree>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Delete Me"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="100" y="200"/><a:ext cx="300" cy="400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Remove</a:t></a:r></a:p></p:txBody>` +
+        `</p:sp>` +
+        `<p:pic><p:nvPicPr><p:cNvPr id="20" name="Keep Picture"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill/><p:spPr/></p:pic>` +
+        `<p:sp><p:nvSpPr><p:cNvPr id="30" name="Keep Shape"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+        `<p:spPr><a:xfrm><a:off x="500" y="600"/><a:ext cx="700" cy="800"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+        `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Keep</a:t></a:r></a:p></p:txBody>` +
+        `</p:sp>` +
+        `</p:spTree></p:cSld>` +
+        `<p:timing><p:tnLst><p:par/></p:tnLst></p:timing>` +
+        `</p:sld>`,
+    ),
+    "docProps/custom.xml": xml(`<Properties><custom value="preserve-me"/></Properties>`),
   });
 }
 
@@ -611,6 +660,105 @@ describe("writePptx - slide topology edits", () => {
     expect(reread.presentation.slidePartPaths).toEqual(["ppt/slides/slide1.xml"]);
     expect(presentationXml).not.toContain(`r:id="rIdSlide2"`);
     expect(presentationXml).not.toContain(`r:id="rId3"`);
+  });
+});
+
+describe("writePptx - shape add/delete edits", () => {
+  it("adds a text box with a collision-free shape id and persists it", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const edited = addTextBox(source, source.slides[0].handle!, {
+      offsetX: asEmu(914400),
+      offsetY: asEmu(457200),
+      width: asEmu(2743200),
+      height: asEmu(914400),
+      text: "Added text box",
+    });
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const added = requireShape(findShapeByName(reread, "TextBox 31"));
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(added).toMatchObject({
+      nodeId: "31",
+      name: "TextBox 31",
+      transform: {
+        offsetX: 914400,
+        offsetY: 457200,
+        width: 2743200,
+        height: 914400,
+      },
+    });
+    expect(added.textBody?.paragraphs[0]?.runs[0]?.text).toBe("Added text box");
+    expect(slideXml).toContain(`<p:cNvPr id="31" name="TextBox 31"`);
+    expect(slideXml).toContain(`<p:cNvSpPr txBox="1"`);
+    expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toContain("preserve-me");
+  });
+
+  it("allows an added text box to be edited before write", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const withTextBox = addTextBox(source, source.slides[0].handle!, {
+      offsetX: asEmu(1000),
+      offsetY: asEmu(2000),
+      width: asEmu(3000),
+      height: asEmu(4000),
+      text: "Initial",
+      name: "Editable Added",
+    });
+    const added = requireShape(findShapeByName(withTextBox, "Editable Added"));
+    const runHandle = added.textBody?.paragraphs[0]?.runs[0]?.handle;
+    if (runHandle === undefined || added.handle === undefined) {
+      throw new Error("added text box handles not found");
+    }
+
+    const edited = updateShapeTransform(
+      replaceTextRunPlainText(withTextBox, runHandle, "Edited Added"),
+      added.handle,
+      {
+        offsetX: asEmu(5000),
+        offsetY: asEmu(6000),
+        width: asEmu(7000),
+        height: asEmu(8000),
+      },
+    );
+    const rereadAdded = requireShape(
+      findShapeByName(readPptx(writePptx(edited)), "Editable Added"),
+    );
+
+    expect(rereadAdded.textBody?.paragraphs[0]?.runs[0]?.text).toBe("Edited Added");
+    expect(rereadAdded.transform).toMatchObject({
+      offsetX: 5000,
+      offsetY: 6000,
+      width: 7000,
+      height: 8000,
+    });
+  });
+
+  it("deletes only the targeted sp shape while preserving other shapes and invisible slide material", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const deleted = deleteShape(source, requireHandle(source.slides[0].shapes[0]?.handle));
+    const output = writePptx(deleted);
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+    const reread = readPptx(output);
+    const rereadShapeNames: (string | undefined)[] = [];
+    for (const shape of reread.slides[0].shapes) {
+      rereadShapeNames.push(shape.kind === "raw" ? undefined : shape.name);
+    }
+
+    expect(rereadShapeNames).toEqual(expect.arrayContaining(["Keep Picture", "Keep Shape"]));
+    expect(reread.slides[0].shapes).toHaveLength(2);
+    expect(slideXml).not.toContain("Delete Me");
+    expect(slideXml).toContain("Keep Picture");
+    expect(slideXml).toContain("Keep Shape");
+    expect(slideXml).toContain("<p:timing>");
+    expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toContain("preserve-me");
+  });
+
+  it("rejects deleting pic and graphicFrame nodes through the sp-only delete API", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+
+    expect(() => deleteShape(source, requireHandle(source.slides[0].shapes[1]?.handle))).toThrow(
+      /only top-level sp shapes/,
+    );
   });
 });
 
@@ -1175,6 +1323,24 @@ function shapeAt(source: ReturnType<typeof readPptx>, index: number): SourceShap
   )[index];
   if (shape === undefined) throw new Error("shape not found");
   return shape;
+}
+
+function findShapeByName(source: ReturnType<typeof readPptx>, name: string): SourceShape {
+  const shape = source.slides
+    .flatMap((slide) => slide.shapes)
+    .find((node): node is SourceShape => node.kind === "shape" && node.name === name);
+  if (shape === undefined) throw new Error(`shape not found: ${name}`);
+  return shape;
+}
+
+function requireShape(shape: SourceShape | undefined): SourceShape {
+  if (shape === undefined) throw new Error("shape not found");
+  return shape;
+}
+
+function requireHandle(handle: SourceShapeNode["handle"]): NonNullable<SourceShapeNode["handle"]> {
+  if (handle === undefined) throw new Error("handle not found");
+  return handle;
 }
 
 function firstParagraph(source: ReturnType<typeof readPptx>) {

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -35,6 +35,8 @@ import type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelAddTextBoxEdit,
+  PptxSourceModelDeleteShapeEdit,
   PptxSourceModelDeleteSlideEdit,
   PptxSourceModelDuplicateSlideEdit,
   PptxSourceModelEdit,
@@ -79,14 +81,26 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const textRunPropertiesEdits = source.edits?.filter(isTextRunPropertiesEdit) ?? [];
   const paragraphTextEdits = source.edits?.filter(isParagraphTextEdit) ?? [];
   const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
+  const addTextBoxEdits = source.edits?.filter(isAddTextBoxEdit) ?? [];
+  const deleteShapeEdits = source.edits?.filter(isDeleteShapeEdit) ?? [];
   const duplicateSlideEdits = source.edits?.filter(isDuplicateSlideEdit) ?? [];
   const deleteSlideEdits = source.edits?.filter(isDeleteSlideEdit) ?? [];
-  validateEdits(textRunEdits, textRunPropertiesEdits, paragraphTextEdits, shapeTransformEdits);
-  const dirtyPartPaths = new Set(
-    [...textRunEdits, ...textRunPropertiesEdits, ...paragraphTextEdits, ...shapeTransformEdits].map(
-      (edit) => edit.handle.partPath,
-    ),
+  validateEdits(
+    textRunEdits,
+    textRunPropertiesEdits,
+    paragraphTextEdits,
+    shapeTransformEdits,
+    addTextBoxEdits,
+    deleteShapeEdits,
   );
+  const dirtyPartPaths = new Set([
+    ...textRunEdits.map((edit) => edit.handle.partPath),
+    ...textRunPropertiesEdits.map((edit) => edit.handle.partPath),
+    ...paragraphTextEdits.map((edit) => edit.handle.partPath),
+    ...shapeTransformEdits.map((edit) => edit.handle.partPath),
+    ...deleteShapeEdits.map((edit) => edit.handle.partPath),
+    ...addTextBoxEdits.map((edit) => edit.slidePartPath),
+  ]);
   const hasSlideTopologyEdits = duplicateSlideEdits.length > 0 || deleteSlideEdits.length > 0;
   const files: Record<string, Uint8Array> = {
     [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
@@ -120,6 +134,8 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
       textRunPropertiesEdits,
       paragraphTextEdits,
       shapeTransformEdits,
+      addTextBoxEdits,
+      deleteShapeEdits,
     );
     written.add(partPath);
   }
@@ -164,6 +180,14 @@ function isShapeTransformEdit(
   return edit.kind === "updateShapeTransform";
 }
 
+function isAddTextBoxEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelAddTextBoxEdit {
+  return edit.kind === "addTextBox";
+}
+
+function isDeleteShapeEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelDeleteShapeEdit {
+  return edit.kind === "deleteShape";
+}
+
 function isDuplicateSlideEdit(
   edit: PptxSourceModelEdit,
 ): edit is PptxSourceModelDuplicateSlideEdit {
@@ -181,6 +205,8 @@ function serializeDirtyXmlPart(
   textRunPropertiesEdits: readonly PptxSourceModelTextRunPropertiesEdit[],
   paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
   shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
+  addTextBoxEdits: readonly PptxSourceModelAddTextBoxEdit[],
+  deleteShapeEdits: readonly PptxSourceModelDeleteShapeEdit[],
 ): Uint8Array {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
   if (rawPart === undefined) {
@@ -191,6 +217,9 @@ function serializeDirtyXmlPart(
   }
 
   const root = parseXml(textDecoder.decode(rawPart.bytes));
+  for (const edit of addTextBoxEdits.filter((edit) => edit.slidePartPath === partPath)) {
+    applyAddTextBoxEdit(root, edit);
+  }
   for (const edit of paragraphTextEdits.filter((edit) => edit.handle.partPath === partPath)) {
     applyParagraphTextEdit(root, edit);
   }
@@ -202,6 +231,9 @@ function serializeDirtyXmlPart(
   }
   for (const edit of shapeTransformEdits.filter((edit) => edit.handle.partPath === partPath)) {
     applyShapeTransformEdit(root, edit);
+  }
+  for (const edit of deleteShapeEdits.filter((edit) => edit.handle.partPath === partPath)) {
+    applyDeleteShapeEdit(root, edit);
   }
   return encodeXml(XML_DECLARATION + xmlBuilder.build(stripXmlProcessingInstruction(root)));
 }
@@ -457,6 +489,77 @@ function applyShapeTransformEdit(root: XmlNode, edit: PptxSourceModelShapeTransf
   ext["@_cy"] = String(edit.height);
 }
 
+function applyAddTextBoxEdit(root: XmlNode, edit: PptxSourceModelAddTextBoxEdit): void {
+  const slide = getChild(root, "sld");
+  const cSld = getChild(slide, "cSld");
+  const spTree = getChild(cSld, "spTree");
+  if (spTree === undefined) {
+    throw new Error(`writePptx: slide '${edit.slidePartPath}' has no spTree`);
+  }
+  if (locateShapeTreeNode(spTree, { nodeId: edit.shapeId }) !== undefined) {
+    throw new Error(`writePptx: shape id '${edit.shapeId}' already exists in source XML`);
+  }
+
+  appendChild(spTree, "p:sp", createTextBoxXml(edit));
+}
+
+function applyDeleteShapeEdit(root: XmlNode, edit: PptxSourceModelDeleteShapeEdit): void {
+  const locator = parseShapeLocator(edit.handle);
+  const slide = getChild(root, "sld");
+  const cSld = getChild(slide, "cSld");
+  const spTree = getChild(cSld, "spTree");
+  if (!deleteShapeXml(spTree, locator.nodeId)) {
+    throw new Error(`writePptx: shape delete handle '${locator.nodeId}' no longer matches p:sp`);
+  }
+}
+
+function createTextBoxXml(edit: PptxSourceModelAddTextBoxEdit): XmlNode {
+  return {
+    "p:nvSpPr": {
+      "p:cNvPr": {
+        "@_id": edit.shapeId,
+        "@_name": edit.name,
+      },
+      "p:cNvSpPr": {
+        "@_txBox": "1",
+      },
+      "p:nvPr": {},
+    },
+    "p:spPr": {
+      "a:xfrm": {
+        "a:off": {
+          "@_x": String(edit.offsetX),
+          "@_y": String(edit.offsetY),
+        },
+        "a:ext": {
+          "@_cx": String(edit.width),
+          "@_cy": String(edit.height),
+        },
+      },
+      "a:prstGeom": {
+        "@_prst": "rect",
+        "a:avLst": {},
+      },
+      "a:noFill": {},
+      "a:ln": {
+        "a:noFill": {},
+      },
+    },
+    "p:txBody": {
+      "a:bodyPr": {
+        "@_wrap": "square",
+      },
+      "a:lstStyle": {},
+      "a:p": {
+        "a:r": {
+          "a:t": textElementValue(undefined, edit.text),
+        },
+        "a:endParaRPr": {},
+      },
+    },
+  };
+}
+
 interface TextRunLocator {
   readonly shapeNodeId?: string;
   readonly shapeOrderingSlot?: number;
@@ -556,6 +659,24 @@ function locateShapeTreeNode(
   return undefined;
 }
 
+function deleteShapeXml(spTree: XmlNode | undefined, nodeId: string): boolean {
+  if (spTree === undefined) return false;
+  const entry = Object.entries(spTree).find(
+    ([key]) => !key.startsWith("@_") && localName(key) === "sp",
+  );
+  if (entry === undefined) return false;
+
+  const [key, value] = entry;
+  const shapes = Array.isArray(value) ? unsafeOoxmlBoundaryAssertion<unknown[]>(value) : [value];
+  const nextShapes = shapes.filter(
+    (shape) => getShapeTreeNodeId(unsafeOoxmlBoundaryAssertion<XmlNode>(shape)) !== nodeId,
+  );
+  if (nextShapes.length === shapes.length) return false;
+  if (nextShapes.length === 0) delete spTree[key];
+  else spTree[key] = Array.isArray(value) ? nextShapes : nextShapes[0];
+  return true;
+}
+
 function getShapeByOrderingSlot(
   spTree: XmlNode | undefined,
   orderingSlot: number,
@@ -614,6 +735,23 @@ function setChildText(node: XmlNode, name: string, text: string): void {
   node[`a:${name}`] = textRequiresPreserve(text)
     ? { "@_xml:space": "preserve", "#text": text }
     : text;
+}
+
+function appendChild(node: XmlNode, preferredKey: string, value: XmlNode): void {
+  const local = localName(preferredKey);
+  const existingKey = Object.keys(node).find(
+    (key) => !key.startsWith("@_") && localName(key) === local,
+  );
+  if (existingKey === undefined) {
+    node[preferredKey] = [value];
+    return;
+  }
+
+  const current = node[existingKey];
+  const currentItems = Array.isArray(current)
+    ? unsafeOoxmlBoundaryAssertion<unknown[]>(current)
+    : [current];
+  node[existingKey] = [...currentItems, value];
 }
 
 function ensureRunProperties(run: XmlNode): XmlNode {
@@ -848,7 +986,18 @@ function validateEdits(
   textRunPropertiesEdits: readonly PptxSourceModelTextRunPropertiesEdit[],
   paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
   shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
+  addTextBoxEdits: readonly PptxSourceModelAddTextBoxEdit[],
+  deleteShapeEdits: readonly PptxSourceModelDeleteShapeEdit[],
 ): void {
+  const addedShapeKeys = new Set<string>();
+  for (const edit of addTextBoxEdits) {
+    const key = [edit.slidePartPath, edit.shapeId].join("\u0000");
+    if (addedShapeKeys.has(key)) {
+      throw new Error(`writePptx: conflicting text box additions for shape id '${edit.shapeId}'`);
+    }
+    addedShapeKeys.add(key);
+  }
+
   const runKeys = new Set<string>();
   for (const edit of textRunEdits) {
     const key = editHandleNodeKey(edit);
@@ -895,6 +1044,17 @@ function validateEdits(
       );
     }
     shapeKeys.add(key);
+  }
+
+  const deletedShapeKeys = new Set<string>();
+  for (const edit of deleteShapeEdits) {
+    const key = editHandleNodeKey(edit);
+    if (deletedShapeKeys.has(key)) {
+      throw new Error(
+        `writePptx: conflicting shape delete edits for handle '${String(edit.handle.nodeId)}'`,
+      );
+    }
+    deletedShapeKeys.add(key);
   }
 }
 

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -623,6 +623,130 @@ describe("EditorSession selection", () => {
     expect(session.selection).toEqual({ shapeHandle: handle });
     expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
   });
+
+  it("clears selection when the selected shape is deleted", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const handle = requireHandle(firstShape(source).handle);
+
+    expect(session.selectShape(handle)).toMatchObject({ ok: true });
+    expectApplied(session.apply({ kind: "deleteShape", handle }));
+
+    expect(session.selection).toBeUndefined();
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeUndefined();
+    expectHistory(session.undo());
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
+    expect(session.selection).toBeUndefined();
+    expectHistory(session.redo());
+    expect(findShapeNodeBySourceHandle(session.document, handle)).toBeUndefined();
+    expect(session.selection).toBeUndefined();
+  });
+});
+
+describe("EditorSession shape add/delete commands", () => {
+  it("adds a text box and lets existing text/xfrm commands edit it before save", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const withTextBox = expectApplied(
+      session.apply({
+        kind: "addTextBox",
+        slideHandle: requireHandle(source.slides[0].handle),
+        offsetX: asEmu(914400),
+        offsetY: asEmu(457200),
+        width: asEmu(2743200),
+        height: asEmu(914400),
+        text: "Initial textbox",
+        name: "Added Textbox",
+      }),
+    );
+    const addedShape = requireShape(findShapeByName(withTextBox, "Added Textbox"));
+    const runHandle = addedShape.textBody?.paragraphs[0]?.runs[0]?.handle;
+    if (runHandle === undefined || addedShape.handle === undefined) {
+      throw new Error("added text box handles not found");
+    }
+
+    expectApplied(
+      session.apply({
+        kind: "replaceTextRunPlainText",
+        handle: runHandle,
+        text: "Edited textbox",
+      }),
+    );
+    const edited = expectApplied(
+      session.apply({
+        kind: "setShapeTransform",
+        handle: addedShape.handle,
+        offsetX: asEmu(1000),
+        offsetY: asEmu(2000),
+        width: asEmu(3000),
+        height: asEmu(4000),
+      }),
+    );
+    const rereadAdded = requireShape(findShapeByName(readPptx(writePptx(edited)), "Added Textbox"));
+
+    expect(rereadAdded.textBody?.paragraphs[0]?.runs[0]?.text).toBe("Edited textbox");
+    expect(rereadAdded.transform).toMatchObject({
+      offsetX: 1000,
+      offsetY: 2000,
+      width: 3000,
+      height: 4000,
+    });
+  });
+
+  it("undoes and redoes shape deletion for generated command sequences", async () => {
+    const cases = [
+      [{ kind: "deleteShape" }],
+      [{ kind: "moveShape", offsetX: asEmu(1000), offsetY: asEmu(2000) }, { kind: "deleteShape" }],
+      [{ kind: "resizeShape", width: asEmu(3000), height: asEmu(4000) }, { kind: "deleteShape" }],
+    ] as const;
+
+    for (const commands of cases) {
+      const source = readPptx(await buildTextEditFixture());
+      const session = createEditorSession(source);
+      const handle = requireHandle(firstShape(source).handle);
+
+      for (const command of commands) {
+        expectApplied(session.apply({ ...command, handle }));
+      }
+      expect(findShapeNodeBySourceHandle(session.document, handle)).toBeUndefined();
+      expect(firstRun(readPptx(writePptx(session.document))).text).toBe("No xfrm");
+
+      for (let i = 0; i < commands.length; i += 1) expectHistory(session.undo());
+      expect(findShapeNodeBySourceHandle(session.document, handle)).toBeDefined();
+      expect(firstRun(readPptx(writePptx(session.document))).text).toBe("Original");
+
+      for (let i = 0; i < commands.length; i += 1) expectHistory(session.redo());
+      expect(findShapeNodeBySourceHandle(session.document, handle)).toBeUndefined();
+      expect(firstRun(readPptx(writePptx(session.document))).text).toBe("No xfrm");
+    }
+  });
+
+  it("rejects invalid add/delete shape commands without changing document state", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const before = session.document;
+    const missingHandle = {
+      partPath: asPartPath("ppt/slides/slide1.xml"),
+      nodeId: asSourceNodeId("999"),
+      orderingSlot: 99,
+    } satisfies SourceHandle;
+
+    const invalidAdd = session.apply({
+      kind: "addTextBox",
+      slideHandle: requireHandle(source.slides[0].handle),
+      offsetX: asEmu(0),
+      offsetY: asEmu(0),
+      width: asEmu(0),
+      height: asEmu(100),
+      text: "Invalid",
+    });
+    const missingDelete = session.apply({ kind: "deleteShape", handle: missingHandle });
+
+    expect(invalidAdd).toMatchObject({ ok: false, code: "invalid-command" });
+    expect(missingDelete).toMatchObject({ ok: false, code: "invalid-command" });
+    expect(session.document).toBe(before);
+    expect(session.undoDepth).toBe(0);
+  });
 });
 
 describe("EditorSession xfrm commands", () => {
@@ -1033,10 +1157,14 @@ function shapeWithoutTransform(source: PptxSourceModel): SourceShape {
   return shape;
 }
 
-function requireShape(shape: SourceShapeNode | undefined): SourceShapeNode & {
-  readonly transform: NonNullable<SourceShapeNode["transform"]>;
+function findShapeByName(source: PptxSourceModel, name: string): SourceShapeNode | undefined {
+  return source.slides.flatMap((slide) => slide.shapes).find((shape) => shape.name === name);
+}
+
+function requireShape(shape: SourceShapeNode | undefined): SourceShape & {
+  readonly transform: NonNullable<SourceShape["transform"]>;
 } {
-  if (shape === undefined || shape.kind === "raw" || shape.transform === undefined) {
+  if (shape === undefined || shape.kind !== "shape" || shape.transform === undefined) {
     throw new Error("transform shape not found");
   }
   return shape;

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,5 +1,8 @@
 import {
+  addTextBox,
+  type AddTextBoxInput,
   clearTextRunProperties,
+  deleteShape,
   deleteSlide,
   duplicateSlide,
   type EditableTextRunProperties,
@@ -80,6 +83,16 @@ export interface SetShapeTransformCommand {
   readonly height: Emu;
 }
 
+export interface AddTextBoxCommand extends AddTextBoxInput {
+  readonly kind: "addTextBox";
+  readonly slideHandle: SourceHandle;
+}
+
+export interface DeleteShapeCommand {
+  readonly kind: "deleteShape";
+  readonly handle: SourceHandle;
+}
+
 export interface DuplicateSlideCommand {
   readonly kind: "duplicateSlide";
   readonly handle: SourceHandle;
@@ -98,6 +111,8 @@ export type EditorCommand =
   | MoveShapeCommand
   | ResizeShapeCommand
   | SetShapeTransformCommand
+  | AddTextBoxCommand
+  | DeleteShapeCommand
   | DuplicateSlideCommand
   | DeleteSlideCommand;
 
@@ -208,6 +223,7 @@ export class EditorSession {
         commands.reduce((document, command) => applyCommandToDocument(document, command), before),
       );
       this.#document = after;
+      this.reconcileSelectionAfterDocumentChange();
       this.#undoStack.push({ before, after });
       this.#redoStack.length = 0;
 
@@ -227,6 +243,7 @@ export class EditorSession {
     if (entry === undefined) return { ok: false, reason: "empty-undo-stack" };
 
     this.#document = entry.before;
+    this.reconcileSelectionAfterDocumentChange();
     this.#redoStack.push(entry);
 
     return { ok: true, document: entry.before };
@@ -237,9 +254,17 @@ export class EditorSession {
     if (entry === undefined) return { ok: false, reason: "empty-redo-stack" };
 
     this.#document = entry.after;
+    this.reconcileSelectionAfterDocumentChange();
     this.#undoStack.push(entry);
 
     return { ok: true, document: entry.after };
+  }
+
+  private reconcileSelectionAfterDocumentChange(): void {
+    if (this.#selection === undefined) return;
+    if (findShapeNodeBySourceHandle(this.#document, this.#selection.shapeHandle) === undefined) {
+      this.#selection = undefined;
+    }
   }
 }
 
@@ -266,11 +291,29 @@ function applyCommandToDocument(
       return resizeShape(document, command);
     case "setShapeTransform":
       return setShapeTransform(document, command);
+    case "addTextBox":
+      return addTextBoxCommand(document, command);
+    case "deleteShape":
+      return deleteShape(document, command.handle);
     case "duplicateSlide":
       return duplicateSlide(document, command.handle);
     case "deleteSlide":
       return deleteSlide(document, command.handle);
   }
+}
+
+function addTextBoxCommand(document: PptxSourceModel, command: AddTextBoxCommand): PptxSourceModel {
+  requireFiniteEmu(command.offsetX, "addTextBox", "offsetX");
+  requireFiniteEmu(command.offsetY, "addTextBox", "offsetY");
+  requirePositiveFiniteEmu(command.width, "addTextBox", "width");
+  requirePositiveFiniteEmu(command.height, "addTextBox", "height");
+  if (typeof command.text !== "string") {
+    throw new Error("addTextBox: text must be a string");
+  }
+  if (command.name !== undefined && command.name.trim() === "") {
+    throw new Error("addTextBox: name must be a non-empty string when provided");
+  }
+  return addTextBox(document, command.slideHandle, command);
 }
 
 function setTextRunPropertiesCommand(
@@ -418,7 +461,7 @@ function requireEditableShapeTransform(
 
 function requireFiniteEmu(
   value: Emu,
-  commandName: "moveShape" | "resizeShape" | "setShapeTransform",
+  commandName: "moveShape" | "resizeShape" | "setShapeTransform" | "addTextBox",
   fieldName: string,
 ): void {
   if (!Number.isFinite(value)) {
@@ -428,7 +471,7 @@ function requireFiniteEmu(
 
 function requirePositiveFiniteEmu(
   value: Emu,
-  commandName: "moveShape" | "resizeShape" | "setShapeTransform",
+  commandName: "moveShape" | "resizeShape" | "setShapeTransform" | "addTextBox",
   fieldName: string,
 ): void {
   if (!Number.isFinite(value) || value <= 0) {

--- a/vrt/libreoffice/editor-validity.test.ts
+++ b/vrt/libreoffice/editor-validity.test.ts
@@ -5,8 +5,10 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  addTextBox,
   asEmu,
   asPt,
+  deleteShape,
   deleteSlide,
   duplicateSlide,
   readPptx,
@@ -170,6 +172,39 @@ describeOrSkip("LibreOffice slide topology validity", { timeout: 120000 }, () =>
       libreOfficeImage,
       "editor-validity-slide-topology-edited.pptx",
       writePptx(deleted),
+    );
+  });
+});
+
+describeOrSkip("LibreOffice shape add/delete validity", { timeout: 120000 }, () => {
+  it("opens PPTX after adding a text box", () => {
+    const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
+    const source = readPptx(sourcePptx);
+    const edited = addTextBox(source, requireHandle(source.slides[0]?.handle), {
+      offsetX: asEmu(914400),
+      offsetY: asEmu(914400),
+      width: asEmu(3657600),
+      height: asEmu(914400),
+      text: "LibreOffice added text box",
+    });
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-shape-add-edited.pptx",
+      writePptx(edited),
+    );
+  });
+
+  it("opens PPTX after deleting a shape", () => {
+    const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
+    const source = readPptx(sourcePptx);
+    const shape = source.slides[0]?.shapes.find((candidate) => candidate.kind === "shape");
+    const edited = deleteShape(source, requireHandle(shape?.handle));
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-shape-delete-edited.pptx",
+      writePptx(edited),
     );
   });
 });


### PR DESCRIPTION
close #605

## 目的

テキストボックス MVP として、slide の shape tree に top-level p:sp を追加する writer slice と、top-level p:sp を削除する writer / editor-core command を追加します。

## 変更内容

- @pptx-glimpse/document に addTextBox / deleteShape と対応する PptxSourceModel edit を追加
- writePptx で addTextBox / deleteShape を dirty slide XML に反映
- editor-core に addTextBox / deleteShape command を追加し、削除時の selection 解除と undo / redo に対応
- 追加後編集、削除後 preservation、LibreOffice validity、編集等価性レンダリングのテストを追加
- @pptx-glimpse/document の patch Changeset を追加

## 影響パス

- packages/document/src/source/
- packages/document/src/writer/
- packages/editor-core/src/
- e2e/edit-equivalence.test.ts
- vrt/libreoffice/editor-validity.test.ts

## ローカル検証

- npm run test
- npm run lint
- npm run typecheck
- npm run knip
- npm run format:check
- npm run test -- packages/document/src/writer/write-pptx.test.ts
- npm run test -- packages/editor-core/src/index.test.ts
- npm run test -- e2e/edit-equivalence.test.ts
- npm run test -- vrt/libreoffice/editor-validity.test.ts

補足: npm run build は pnpm の lockfile supply-chain policy で、既存 lockfile 内の picomatch@4.0.5 / postcss@8.5.16 が minimumReleaseAge に抵触して停止しました。document と core は tsup 直接実行で build 成功、editor-core の直接 tsup は workspace package 解決を再現できず DTS build のみ失敗しました。