### PR TITLE
writer / editor-core: layout 参照の空 slide 新規追加を実装する

### DIFF
--- a/.changeset/empty-slide-layout.md
+++ b/.changeset/empty-slide-layout.md
@@ -1,0 +1,6 @@
+---
+"pptx-glimpse": patch
+"@pptx-glimpse/document": patch
+---
+
+Add headless empty slide creation from a slide layout, including writer package bookkeeping and editor-core command support.

--- a/packages/document/README.md
+++ b/packages/document/README.md
@@ -18,6 +18,7 @@ Import supported APIs from the package root:
 
 ```ts
 import {
+  addEmptySlideFromLayout,
   createComputedView,
   readPptx,
   replaceTextRunPlainText,
@@ -31,6 +32,7 @@ The stable entry point includes:
 - `createComputedView(source, options?)` for deriving slide/layout/master/theme effective values without mutating the source
 - `writePptx(source)` for structural round-trip writing
 - Text editing helpers such as `replaceTextRunPlainText(source, handle, text)` and related source handle lookup types exported from the root entry point
+- Slide topology helpers such as `addEmptySlideFromLayout(source, { layoutPartPath })`; choose `layoutPartPath` from `source.slideLayouts`
 - Source model, computed view, and unit types needed to consume those APIs
 
 Parser helpers, raw replacement internals, writer dirty-scope implementation details, and OOXML implementation modules outside the package root are internal and may change without notice.
@@ -57,11 +59,7 @@ await writeFile("round-trip.pptx", output);
 
 ```ts
 import { readFile, writeFile } from "node:fs/promises";
-import {
-  readPptx,
-  replaceTextRunPlainText,
-  writePptx,
-} from "@pptx-glimpse/document";
+import { readPptx, replaceTextRunPlainText, writePptx } from "@pptx-glimpse/document";
 
 const source = readPptx(await readFile("input.pptx"));
 const firstTextRun = source.slides

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -4,7 +4,7 @@
  * This surface is limited to the PptxSourceModel foundation that current
  * conversion, writer, and minimal editing workflows are allowed to depend on:
  * source model types, the PPTX reader, computed view generation, the writer,
- * and the narrow plain text-run edit operation.
+ * and focused text / shape / slide topology editing operations.
  *
  * Keep parser helpers, raw replacement/editing APIs, writer dirty-scope
  * implementation details, and other OOXML internals behind their owning

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -55,6 +55,7 @@ export { createComputedView } from "./computed/index.js";
 export type { ReadPptxInput } from "./reader/index.js";
 export { readPptx } from "./reader/index.js";
 export type {
+  AddEmptySlideFromLayoutInput,
   AddTextBoxInput,
   ContentTypeDefault,
   ContentTypeOverride,
@@ -73,6 +74,7 @@ export type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelAddEmptySlideFromLayoutEdit,
   PptxSourceModelAddTextBoxEdit,
   PptxSourceModelDeleteShapeEdit,
   PptxSourceModelDeleteSlideEdit,
@@ -172,6 +174,7 @@ export type {
   UpdateShapeTransformInput,
 } from "./source/index.js";
 export {
+  addEmptySlideFromLayout,
   addTextBox,
   clearTextRunProperties,
   deleteShape,

--- a/packages/document/src/reader/read-pptx.ts
+++ b/packages/document/src/reader/read-pptx.ts
@@ -204,6 +204,13 @@ function readSlideHierarchy(
       ),
     );
   }
+  for (const masterPath of resolveAllRels(
+    relationships,
+    presentation.partPath,
+    SLIDE_MASTER_REL_TYPE,
+  )) {
+    masterPaths.add(masterPath);
+  }
 
   const slideMasters: SourceSlideMaster[] = [];
   const themePaths = new OrderedPathSet();

--- a/packages/document/src/reader/read-pptx.ts
+++ b/packages/document/src/reader/read-pptx.ts
@@ -225,6 +225,24 @@ function readSlideHierarchy(
     );
   }
 
+  const readLayoutPaths = new Set(slideLayouts.map((layout) => layout.partPath));
+  for (const layoutPath of slideMasters.flatMap((master) => master.layoutPartPaths)) {
+    if (readLayoutPaths.has(layoutPath)) continue;
+    const part = parsePartRoot(entries, layoutPath, "sldLayout", diagnostics, true);
+    if (part === undefined) continue;
+    const masterPath = resolveSingleRel(relationships, layoutPath, SLIDE_MASTER_REL_TYPE);
+    slideLayouts.push(
+      parseSlideLayout(
+        part.root,
+        layoutPath,
+        masterPath ?? asPartPath(""),
+        createSidecarIdFactory(layoutPath),
+        navigateOrdered(part.orderedRoot, ["cSld", "spTree"]),
+      ),
+    );
+    readLayoutPaths.add(layoutPath);
+  }
+
   const themes: SourceTheme[] = [];
   for (const themePath of themePaths.values()) {
     const part = parsePartRoot(entries, themePath, "theme", diagnostics, true);

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -36,8 +36,20 @@ const SLIDE_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.presen
 const NOTES_SLIDE_CONTENT_TYPE =
   "application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml";
 const SLIDE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide";
+const SLIDE_LAYOUT_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout";
 const NOTES_SLIDE_REL_TYPE =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/notesSlide";
+const EMPTY_SLIDE_XML =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n` +
+  `<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ` +
+  `xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ` +
+  `xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
+  `<p:cSld><p:spTree>` +
+  `<p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>` +
+  `<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/>` +
+  `<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>` +
+  `</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
 
 const EDITABLE_TEXT_RUN_PROPERTIES = [
   "bold",
@@ -314,6 +326,10 @@ export interface AddTextBoxInput extends UpdateShapeTransformInput {
   readonly name?: string;
 }
 
+export interface AddEmptySlideFromLayoutInput {
+  readonly layoutPartPath: PartPath;
+}
+
 export function findShapeNodeBySourceHandle(
   source: PptxSourceModel,
   handle: SourceHandle,
@@ -427,6 +443,104 @@ export function addTextBox(
         width: input.width,
         height: input.height,
         text: input.text,
+      },
+    ],
+  };
+}
+
+export function addEmptySlideFromLayout(
+  source: PptxSourceModel,
+  input: AddEmptySlideFromLayoutInput,
+): PptxSourceModel {
+  const layout = source.slideLayouts.find(
+    (candidate) => candidate.partPath === input.layoutPartPath,
+  );
+  if (layout === undefined) {
+    throw new Error("addEmptySlideFromLayout: slide layout part path was not found");
+  }
+
+  const presentationRels = requirePartRelationships(
+    source,
+    source.presentation.partPath,
+    "addEmptySlideFromLayout",
+  );
+  const newSlidePartPath = nextNumberedPartPath(source, "ppt/slides/slide", ".xml");
+  const newPresentationRelationshipId = nextRelationshipId(presentationRels.relationships);
+  const newSlideRelationshipsPartPath = asPartPath(relationshipsPartPath(newSlidePartPath));
+  const newSlide: SourceSlide = {
+    partPath: newSlidePartPath,
+    layoutPartPath: layout.partPath,
+    shapes: [],
+    handle: { partPath: newSlidePartPath },
+  };
+  const newSlideRelationships: PartRelationships = {
+    sourcePartPath: newSlidePartPath,
+    relationships: [
+      {
+        id: asRelationshipId("rId1"),
+        type: SLIDE_LAYOUT_REL_TYPE,
+        target: relativeTarget(newSlidePartPath, layout.partPath),
+      },
+    ],
+  };
+
+  return {
+    ...source,
+    presentation: {
+      ...source.presentation,
+      slidePartPaths: [...source.presentation.slidePartPaths, newSlidePartPath],
+    },
+    slides: [...source.slides, newSlide],
+    packageGraph: {
+      ...source.packageGraph,
+      parts: [
+        ...source.packageGraph.parts,
+        { partPath: newSlidePartPath, contentType: SLIDE_CONTENT_TYPE },
+        { partPath: newSlideRelationshipsPartPath, contentType: RELS_CONTENT_TYPE },
+      ],
+      contentTypes: {
+        ...source.packageGraph.contentTypes,
+        overrides: [
+          ...source.packageGraph.contentTypes.overrides,
+          { partName: newSlidePartPath, contentType: SLIDE_CONTENT_TYPE },
+          ...relationshipPartOverrides(source, [newSlideRelationshipsPartPath]),
+        ],
+      },
+      relationships: [
+        ...source.packageGraph.relationships.map((relationships) =>
+          relationships.sourcePartPath !== source.presentation.partPath
+            ? relationships
+            : {
+                ...relationships,
+                relationships: [
+                  ...relationships.relationships,
+                  {
+                    id: newPresentationRelationshipId,
+                    type: SLIDE_REL_TYPE,
+                    target: relativeTarget(source.presentation.partPath, newSlidePartPath),
+                  },
+                ],
+              },
+        ),
+        newSlideRelationships,
+      ],
+      rawParts: [
+        ...(source.packageGraph.rawParts ?? []),
+        {
+          kind: "binary",
+          partPath: newSlidePartPath,
+          contentType: SLIDE_CONTENT_TYPE,
+          bytes: new TextEncoder().encode(EMPTY_SLIDE_XML),
+        },
+      ],
+    },
+    edits: [
+      ...(source.edits ?? []),
+      {
+        kind: "addEmptySlideFromLayout",
+        layoutPartPath: layout.partPath,
+        newSlidePartPath,
+        newRelationshipId: newPresentationRelationshipId,
       },
     ],
   };
@@ -699,7 +813,9 @@ export function deleteSlide(source: PptxSourceModel, slideHandle: SourceHandle):
     (edit) => !editIsInvalidatedByDeletedParts(edit, removedPartPaths),
   );
   const deletedInsertedSlide = (source.edits ?? []).some(
-    (edit) => edit.kind === "duplicateSlide" && edit.newSlidePartPath === slide.partPath,
+    (edit) =>
+      (edit.kind === "addEmptySlideFromLayout" || edit.kind === "duplicateSlide") &&
+      edit.newSlidePartPath === slide.partPath,
   );
 
   return {
@@ -1068,7 +1184,7 @@ function createNotesSlideCopy(
 function requirePartRelationships(
   source: PptxSourceModel,
   partPath: PartPath,
-  operationName: "duplicateSlide" | "deleteSlide",
+  operationName: "addEmptySlideFromLayout" | "duplicateSlide" | "deleteSlide",
 ): PartRelationships {
   const relationships = source.packageGraph.relationships.find(
     (candidate) => candidate.sourcePartPath === partPath,
@@ -1083,7 +1199,7 @@ function requireSlideRelationship(
   source: PptxSourceModel,
   relationships: PartRelationships,
   slidePartPath: PartPath,
-  operationName: "duplicateSlide" | "deleteSlide",
+  operationName: "addEmptySlideFromLayout" | "duplicateSlide" | "deleteSlide",
 ): Relationship {
   const relationship = relationships.relationships.find(
     (candidate) =>
@@ -1166,6 +1282,8 @@ function relationshipPartOverrides(
 
 function topologyEditPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {
   switch (edit.kind) {
+    case "addEmptySlideFromLayout":
+      return [edit.layoutPartPath, edit.newSlidePartPath];
     case "duplicateSlide":
       return [edit.sourceSlidePartPath, edit.newSlidePartPath];
     case "deleteSlide":
@@ -1253,6 +1371,7 @@ function hasDirtyEditForPart(edits: readonly PptxSourceModelEdit[], partPath: Pa
         return edit.handle.partPath === partPath;
       case "addTextBox":
         return edit.slidePartPath === partPath;
+      case "addEmptySlideFromLayout":
       case "duplicateSlide":
       case "deleteSlide":
         return false;
@@ -1276,6 +1395,7 @@ function editTargetsShape(edit: PptxSourceModelEdit, handle: SourceHandle): bool
       return sourceHandlesEqual(edit.handle, handle);
     case "addTextBox":
       return edit.slidePartPath === handle.partPath && edit.shapeId === String(handle.nodeId);
+    case "addEmptySlideFromLayout":
     case "duplicateSlide":
     case "deleteSlide":
       return false;
@@ -1302,6 +1422,8 @@ function editIsInvalidatedByDeletedParts(
       return partPaths.has(edit.handle.partPath);
     case "addTextBox":
       return partPaths.has(edit.slidePartPath);
+    case "addEmptySlideFromLayout":
+      return partPaths.has(edit.newSlidePartPath);
     case "deleteShape":
       return partPaths.has(edit.handle.partPath);
     case "duplicateSlide":

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -3,8 +3,13 @@
  */
 
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
-export type { AddTextBoxInput, UpdateShapeTransformInput } from "./editing.js";
+export type {
+  AddEmptySlideFromLayoutInput,
+  AddTextBoxInput,
+  UpdateShapeTransformInput,
+} from "./editing.js";
 export {
+  addEmptySlideFromLayout,
   addTextBox,
   clearTextRunProperties,
   deleteShape,
@@ -41,6 +46,7 @@ export type {
   EditableTextRunProperties,
   EditableTextRunProperty,
   PptxSourceModel,
+  PptxSourceModelAddEmptySlideFromLayoutEdit,
   PptxSourceModelAddTextBoxEdit,
   PptxSourceModelDeleteShapeEdit,
   PptxSourceModelDeleteSlideEdit,

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -55,6 +55,7 @@ export type PptxSourceModelEdit =
   | PptxSourceModelShapeTransformEdit
   | PptxSourceModelAddTextBoxEdit
   | PptxSourceModelDeleteShapeEdit
+  | PptxSourceModelAddEmptySlideFromLayoutEdit
   | PptxSourceModelDuplicateSlideEdit
   | PptxSourceModelDeleteSlideEdit;
 
@@ -118,6 +119,13 @@ export interface PptxSourceModelAddTextBoxEdit {
 export interface PptxSourceModelDeleteShapeEdit {
   readonly kind: "deleteShape";
   readonly handle: SourceHandle;
+}
+
+export interface PptxSourceModelAddEmptySlideFromLayoutEdit {
+  readonly kind: "addEmptySlideFromLayout";
+  readonly layoutPartPath: PartPath;
+  readonly newSlidePartPath: PartPath;
+  readonly newRelationshipId: RelationshipId;
 }
 
 export interface PptxSourceModelDuplicateSlideEdit {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -185,7 +185,9 @@ function buildUnreferencedLayoutFixture(): Uint8Array {
         `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
         `<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
         `<Override PartName="/ppt/slideLayouts/slideLayout2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
+        `<Override PartName="/ppt/slideLayouts/slideLayout3.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
         `<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>` +
+        `<Override PartName="/ppt/slideMasters/slideMaster2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>` +
         `</Types>`,
     ),
     "_rels/.rels": xml(
@@ -195,6 +197,7 @@ function buildUnreferencedLayoutFixture(): Uint8Array {
     ),
     "ppt/presentation.xml": xml(
       `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rIdMaster1"/><p:sldMasterId id="2147483649" r:id="rIdMaster2"/></p:sldMasterIdLst>` +
         `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
         `<p:sldSz cx="9144000" cy="5143500"/>` +
         `</p:presentation>`,
@@ -202,6 +205,8 @@ function buildUnreferencedLayoutFixture(): Uint8Array {
     "ppt/_rels/presentation.xml.rels": xml(
       `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
         `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `<Relationship Id="rIdMaster1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>` +
+        `<Relationship Id="rIdMaster2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster2.xml"/>` +
         `</Relationships>`,
     ),
     "ppt/slides/slide1.xml": xml(
@@ -234,6 +239,16 @@ function buildUnreferencedLayoutFixture(): Uint8Array {
         `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>` +
         `</Relationships>`,
     ),
+    "ppt/slideLayouts/slideLayout3.xml": xml(
+      `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="picTx">` +
+        `<p:cSld name="Unused Master Layout"><p:spTree/></p:cSld>` +
+        `</p:sldLayout>`,
+    ),
+    "ppt/slideLayouts/_rels/slideLayout3.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster2.xml"/>` +
+        `</Relationships>`,
+    ),
     "ppt/slideMasters/slideMaster1.xml": xml(
       `<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
         `<p:cSld><p:spTree/></p:cSld>` +
@@ -247,6 +262,17 @@ function buildUnreferencedLayoutFixture(): Uint8Array {
       `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
         `<Relationship Id="rIdLayout1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
         `<Relationship Id="rIdLayout2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideMasters/slideMaster2.xml": xml(
+      `<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `<p:sldLayoutIdLst><p:sldLayoutId id="2147483651" r:id="rIdLayout3"/></p:sldLayoutIdLst>` +
+        `</p:sldMaster>`,
+    ),
+    "ppt/slideMasters/_rels/slideMaster2.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdLayout3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout3.xml"/>` +
         `</Relationships>`,
     ),
   });
@@ -601,10 +627,10 @@ describe("writePptx - slide topology edits", () => {
   it("adds an empty slide that references a layout unused by existing slides", () => {
     const source = readPptx(buildUnreferencedLayoutFixture());
     const targetLayout = source.slideLayouts.find(
-      (layout) => layout.partPath === "ppt/slideLayouts/slideLayout2.xml",
+      (layout) => layout.partPath === "ppt/slideLayouts/slideLayout3.xml",
     );
     const edited = addEmptySlideFromLayout(source, {
-      layoutPartPath: asPartPath("ppt/slideLayouts/slideLayout2.xml"),
+      layoutPartPath: asPartPath("ppt/slideLayouts/slideLayout3.xml"),
     });
     const output = writePptx(edited);
     const entries = unzipSync(output);
@@ -619,13 +645,13 @@ describe("writePptx - slide topology edits", () => {
       "ppt/slides/slide1.xml",
       "ppt/slides/slide2.xml",
     ]);
-    expect(reread.slides[1]?.layoutPartPath).toBe("ppt/slideLayouts/slideLayout2.xml");
-    expect(presentationXml).toContain(`<p:sldId id="257" r:id="rId2"/>`);
+    expect(reread.slides[1]?.layoutPartPath).toBe("ppt/slideLayouts/slideLayout3.xml");
+    expect(presentationXml).toContain(`<p:sldId id="257" r:id="rId3"/>`);
     expect(presentationRels).toContain(
-      `<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>`,
+      `<Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>`,
     );
     expect(newSlideRels).toContain(
-      `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>`,
+      `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout3.xml"/>`,
     );
     expect(newSlideXml).toContain("<p:cSld><p:spTree>");
     expect(newSlideXml).not.toContain("<p:sp>");

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -5,8 +5,9 @@ import { unzipSync, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 
 // Import via the actual public surface (`@pptx-glimpse/document`).
-import { asEmu, asPt, asSourceNodeId, readPptx, writePptx } from "../index.js";
+import { asEmu, asPartPath, asPt, asSourceNodeId, readPptx, writePptx } from "../index.js";
 import {
+  addEmptySlideFromLayout,
   addTextBox,
   clearTextRunProperties,
   deleteShape,
@@ -171,6 +172,83 @@ function buildSlideTopologyFixtureWithRelationshipOverrides(): Uint8Array {
   return zipSync({
     ...entries,
     "[Content_Types].xml": encoder.encode(contentTypes),
+  });
+}
+
+function buildUnreferencedLayoutFixture(): Uint8Array {
+  return zipSync({
+    "[Content_Types].xml": xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
+        `<Override PartName="/ppt/slideLayouts/slideLayout2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
+        `<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>` +
+        `</Types>`,
+    ),
+    "_rels/.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/presentation.xml": xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+    "ppt/_rels/presentation.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slides/slide1.xml": xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sld>`,
+    ),
+    "ppt/slides/_rels/slide1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideLayouts/slideLayout1.xml": xml(
+      `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="blank">` +
+        `<p:cSld name="Referenced"><p:spTree/></p:cSld>` +
+        `</p:sldLayout>`,
+    ),
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideLayouts/slideLayout2.xml": xml(
+      `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="title">` +
+        `<p:cSld name="Unreferenced"><p:spTree/></p:cSld>` +
+        `</p:sldLayout>`,
+    ),
+    "ppt/slideLayouts/_rels/slideLayout2.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>` +
+        `</Relationships>`,
+    ),
+    "ppt/slideMasters/slideMaster1.xml": xml(
+      `<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `<p:sldLayoutIdLst>` +
+        `<p:sldLayoutId id="2147483649" r:id="rIdLayout1"/>` +
+        `<p:sldLayoutId id="2147483650" r:id="rIdLayout2"/>` +
+        `</p:sldLayoutIdLst>` +
+        `</p:sldMaster>`,
+    ),
+    "ppt/slideMasters/_rels/slideMaster1.xml.rels": xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdLayout1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+        `<Relationship Id="rIdLayout2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>` +
+        `</Relationships>`,
+    ),
   });
 }
 
@@ -520,6 +598,49 @@ describe("writePptx - no-edit round-trip", () => {
 });
 
 describe("writePptx - slide topology edits", () => {
+  it("adds an empty slide that references a layout unused by existing slides", () => {
+    const source = readPptx(buildUnreferencedLayoutFixture());
+    const targetLayout = source.slideLayouts.find(
+      (layout) => layout.partPath === "ppt/slideLayouts/slideLayout2.xml",
+    );
+    const edited = addEmptySlideFromLayout(source, {
+      layoutPartPath: asPartPath("ppt/slideLayouts/slideLayout2.xml"),
+    });
+    const output = writePptx(edited);
+    const entries = unzipSync(output);
+    const reread = readPptx(output);
+    const presentationXml = decoder.decode(getEntry(output, "ppt/presentation.xml"));
+    const presentationRels = decoder.decode(getEntry(output, "ppt/_rels/presentation.xml.rels"));
+    const newSlideXml = decoder.decode(getEntry(output, "ppt/slides/slide2.xml"));
+    const newSlideRels = decoder.decode(getEntry(output, "ppt/slides/_rels/slide2.xml.rels"));
+
+    expect(targetLayout).toBeDefined();
+    expect(edited.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(reread.slides[1]?.layoutPartPath).toBe("ppt/slideLayouts/slideLayout2.xml");
+    expect(presentationXml).toContain(`<p:sldId id="257" r:id="rId2"/>`);
+    expect(presentationRels).toContain(
+      `<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>`,
+    );
+    expect(newSlideRels).toContain(
+      `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>`,
+    );
+    expect(newSlideXml).toContain("<p:cSld><p:spTree>");
+    expect(newSlideXml).not.toContain("<p:sp>");
+    expect(entries["ppt/slides/slide2.xml"]).toBeDefined();
+    expect(entries["ppt/slides/_rels/slide2.xml.rels"]).toBeDefined();
+    expect(reread.packageGraph.contentTypes.overrides).toEqual(
+      expect.arrayContaining([
+        {
+          partName: "ppt/slides/slide2.xml",
+          contentType: "application/vnd.openxmlformats-officedocument.presentationml.slide+xml",
+        },
+      ]),
+    );
+  });
+
   it("duplicates a slide immediately after the source and preserves raw invisible slide material", () => {
     const source = readPptx(buildSlideTopologyFixture());
     const edited = duplicateSlide(source, source.slides[0].handle!);

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -35,6 +35,7 @@ import type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelAddEmptySlideFromLayoutEdit,
   PptxSourceModelAddTextBoxEdit,
   PptxSourceModelDeleteShapeEdit,
   PptxSourceModelDeleteSlideEdit,
@@ -83,6 +84,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
   const addTextBoxEdits = source.edits?.filter(isAddTextBoxEdit) ?? [];
   const deleteShapeEdits = source.edits?.filter(isDeleteShapeEdit) ?? [];
+  const addEmptySlideFromLayoutEdits = source.edits?.filter(isAddEmptySlideFromLayoutEdit) ?? [];
   const duplicateSlideEdits = source.edits?.filter(isDuplicateSlideEdit) ?? [];
   const deleteSlideEdits = source.edits?.filter(isDeleteSlideEdit) ?? [];
   validateEdits(
@@ -101,7 +103,10 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
     ...deleteShapeEdits.map((edit) => edit.handle.partPath),
     ...addTextBoxEdits.map((edit) => edit.slidePartPath),
   ]);
-  const hasSlideTopologyEdits = duplicateSlideEdits.length > 0 || deleteSlideEdits.length > 0;
+  const hasSlideTopologyEdits =
+    addEmptySlideFromLayoutEdits.length > 0 ||
+    duplicateSlideEdits.length > 0 ||
+    deleteSlideEdits.length > 0;
   const files: Record<string, Uint8Array> = {
     [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
   };
@@ -188,6 +193,12 @@ function isDeleteShapeEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelDe
   return edit.kind === "deleteShape";
 }
 
+function isAddEmptySlideFromLayoutEdit(
+  edit: PptxSourceModelEdit,
+): edit is PptxSourceModelAddEmptySlideFromLayoutEdit {
+  return edit.kind === "addEmptySlideFromLayout";
+}
+
 function isDuplicateSlideEdit(
   edit: PptxSourceModelEdit,
 ): edit is PptxSourceModelDuplicateSlideEdit {
@@ -238,14 +249,19 @@ function serializeDirtyXmlPart(
   return encodeXml(XML_DECLARATION + xmlBuilder.build(stripXmlProcessingInstruction(root)));
 }
 
-type SlideTopologyEdit = PptxSourceModelDuplicateSlideEdit | PptxSourceModelDeleteSlideEdit;
+type SlideTopologyEdit =
+  | PptxSourceModelAddEmptySlideFromLayoutEdit
+  | PptxSourceModelDuplicateSlideEdit
+  | PptxSourceModelDeleteSlideEdit;
 
 function mergeSlideTopologyEdits(
   edits: readonly PptxSourceModelEdit[],
 ): readonly SlideTopologyEdit[] {
   return edits.filter(
     (edit): edit is SlideTopologyEdit =>
-      edit.kind === "duplicateSlide" || edit.kind === "deleteSlide",
+      edit.kind === "addEmptySlideFromLayout" ||
+      edit.kind === "duplicateSlide" ||
+      edit.kind === "deleteSlide",
   );
 }
 
@@ -273,7 +289,9 @@ function serializePresentationWithSlideTopologyEdits(
   const sldIdLst = ensureSlideIdList(presentation);
 
   for (const edit of edits) {
-    if (edit.kind === "duplicateSlide") {
+    if (edit.kind === "addEmptySlideFromLayout") {
+      appendSlideId(sldIdLst, edit.newRelationshipId);
+    } else if (edit.kind === "duplicateSlide") {
       insertSlideIdAfter(sldIdLst, edit.sourceRelationshipId, edit.newRelationshipId);
     } else {
       removeSlideId(sldIdLst, edit.relationshipId);
@@ -290,6 +308,18 @@ function ensureSlideIdList(presentation: XmlNode): XmlNode {
   const created: XmlNode = {};
   presentation[key] = created;
   return created;
+}
+
+function appendSlideId(sldIdLst: XmlNode, newRelationshipId: RelationshipId): void {
+  const { key, items } = slideIdEntries(sldIdLst);
+  if (items.some((item) => getRelationshipAttr(item) === newRelationshipId)) return;
+  const relationshipAttrKey =
+    items[0] === undefined ? "@_r:id" : namespacedAttributeKey(items[0], "r:id", "id");
+  const newNode: XmlNode = {
+    "@_id": String(nextSlideNumericId(items)),
+    [relationshipAttrKey]: newRelationshipId,
+  };
+  sldIdLst[key] = [...items, newNode];
 }
 
 function insertSlideIdAfter(

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -943,6 +943,31 @@ describe("EditorSession xfrm commands", () => {
 });
 
 describe("EditorSession slide topology commands", () => {
+  it("adds an empty slide from a layout as one undoable command and persists it", async () => {
+    const source = readPptx(await buildUnreferencedLayoutFixture());
+    const session = createEditorSession(source);
+    const added = expectApplied(
+      session.apply({
+        kind: "addEmptySlideFromLayout",
+        layoutPartPath: asPartPath("ppt/slideLayouts/slideLayout2.xml"),
+      }),
+    );
+
+    expect(added.presentation.slidePartPaths).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(readPptx(writePptx(added)).slides[1]?.layoutPartPath).toBe(
+      "ppt/slideLayouts/slideLayout2.xml",
+    );
+    expect(session.undoDepth).toBe(1);
+
+    const undone = expectHistory(session.undo());
+    expect(undone.presentation.slidePartPaths).toEqual(source.presentation.slidePartPaths);
+    const redone = expectHistory(session.redo());
+    expect(redone.presentation.slidePartPaths).toEqual(added.presentation.slidePartPaths);
+  });
+
   it("duplicates a slide as one undoable command and persists it", async () => {
     const source = readPptx(await buildTwoSlideFixture());
     const session = createEditorSession(source);
@@ -1115,6 +1140,120 @@ async function buildTwoSlideFixture(): Promise<Uint8Array> {
       `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
         `<p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="20" name="Second"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr><a:prstGeom prst="rect"/></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Second</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>` +
         `</p:sld>`,
+    ),
+  );
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+async function buildUnreferencedLayoutFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
+        `<Override PartName="/ppt/slideLayouts/slideLayout2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>` +
+        `<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/_rels/slide1.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slideLayouts/slideLayout1.xml",
+    xml(
+      `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="blank">` +
+        `<p:cSld name="Referenced"><p:spTree/></p:cSld>` +
+        `</p:sldLayout>`,
+    ),
+  );
+  zip.file(
+    "ppt/slideLayouts/_rels/slideLayout1.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slideLayouts/slideLayout2.xml",
+    xml(
+      `<p:sldLayout xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" type="title">` +
+        `<p:cSld name="Unreferenced"><p:spTree/></p:cSld>` +
+        `</p:sldLayout>`,
+    ),
+  );
+  zip.file(
+    "ppt/slideLayouts/_rels/slideLayout2.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdMaster" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="../slideMasters/slideMaster1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slideMasters/slideMaster1.xml",
+    xml(
+      `<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree/></p:cSld>` +
+        `<p:sldLayoutIdLst>` +
+        `<p:sldLayoutId id="2147483649" r:id="rIdLayout1"/>` +
+        `<p:sldLayoutId id="2147483650" r:id="rIdLayout2"/>` +
+        `</p:sldLayoutIdLst>` +
+        `</p:sldMaster>`,
+    ),
+  );
+  zip.file(
+    "ppt/slideMasters/_rels/slideMaster1.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdLayout1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout1.xml"/>` +
+        `<Relationship Id="rIdLayout2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout2.xml"/>` +
+        `</Relationships>`,
     ),
   );
 

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,4 +1,6 @@
 import {
+  addEmptySlideFromLayout,
+  type AddEmptySlideFromLayoutInput,
   addTextBox,
   type AddTextBoxInput,
   clearTextRunProperties,
@@ -93,6 +95,10 @@ export interface DeleteShapeCommand {
   readonly handle: SourceHandle;
 }
 
+export interface AddEmptySlideFromLayoutCommand extends AddEmptySlideFromLayoutInput {
+  readonly kind: "addEmptySlideFromLayout";
+}
+
 export interface DuplicateSlideCommand {
   readonly kind: "duplicateSlide";
   readonly handle: SourceHandle;
@@ -113,6 +119,7 @@ export type EditorCommand =
   | SetShapeTransformCommand
   | AddTextBoxCommand
   | DeleteShapeCommand
+  | AddEmptySlideFromLayoutCommand
   | DuplicateSlideCommand
   | DeleteSlideCommand;
 
@@ -295,6 +302,8 @@ function applyCommandToDocument(
       return addTextBoxCommand(document, command);
     case "deleteShape":
       return deleteShape(document, command.handle);
+    case "addEmptySlideFromLayout":
+      return addEmptySlideFromLayout(document, command);
     case "duplicateSlide":
       return duplicateSlide(document, command.handle);
     case "deleteSlide":

--- a/vrt/libreoffice/editor-validity.test.ts
+++ b/vrt/libreoffice/editor-validity.test.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  addEmptySlideFromLayout,
   addTextBox,
   asEmu,
   asPt,
@@ -162,6 +163,20 @@ describeOrSkip("LibreOffice edited PPTX validity", { timeout: 120000 }, () => {
 });
 
 describeOrSkip("LibreOffice slide topology validity", { timeout: 120000 }, () => {
+  it("opens PPTX after adding an empty slide from a layout", () => {
+    const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
+    const source = readPptx(sourcePptx);
+    const layout = source.slideLayouts[0];
+    if (layout === undefined) throw new Error("basic-shapes fixture has no slide layout");
+    const edited = addEmptySlideFromLayout(source, { layoutPartPath: layout.partPath });
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-empty-slide-from-layout-edited.pptx",
+      writePptx(edited),
+    );
+  });
+
   it("opens PPTX after slide duplicate and delete edits", () => {
     const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
     const source = readPptx(sourcePptx);


### PR DESCRIPTION
close #614

## 目的

指定した slideLayout を参照する空 slide を PptxSourceModel writer / editor-core から追加できるようにします。

## 変更内容

- `@pptx-glimpse/document` に `addEmptySlideFromLayout(source, { layoutPartPath })` と edit journal 種別を追加
- 新規 slide part / slide `.rels` / presentation relationship / content type / `sldIdLst` の整合を writer で保存
- 既存 slide が参照していない master/layout も `source.slideLayouts` に載るよう reader の layout discovery を拡張
- editor-core command として `addEmptySlideFromLayout` を追加し、undo / redo に組み込み
- writer / editor-core / LibreOffice validity のテストと changeset を追加
- `@pptx-glimpse/document` README と entrypoint コメントを更新

## 影響パッケージ / パス

- `packages/document/src/source/*`
- `packages/document/src/reader/read-pptx.ts`
- `packages/document/src/writer/write-pptx.ts`
- `packages/editor-core/src/index.ts`
- `vrt/libreoffice/editor-validity.test.ts`

## ローカル検証

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test`
- `npm run test -- vrt/libreoffice/editor-validity.test.ts`
- `npx tsup --config tsup.config.ts` in `packages/document`
- `npx tsup --config tsup.config.ts` in `packages/editor-core`
- `npx tsup --config tsup.config.ts` in `packages/core`

補足: root の `npm run build` は pnpm minimum release age policy により、lockfile 内の `picomatch@4.0.5` / `postcss@8.5.16` が cutoff 内として install 段階で停止しました。package build 自体は上記 tsup 直呼びで確認済みです。
