### PR TITLE
document: cxnSp connector insertion editing support

### DIFF
--- a/.changeset/native-connectors.md
+++ b/.changeset/native-connectors.md
@@ -1,0 +1,5 @@
+---
+"@pptx-glimpse/document": minor
+---
+
+Add PptxSourceModel editing and writer support for inserting native PowerPoint connector shapes.

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -55,8 +55,12 @@ export { createComputedView } from "./computed/index.js";
 export type { ReadPptxInput } from "./reader/index.js";
 export { readPptx } from "./reader/index.js";
 export type {
+  AddConnectorConnectionEndpointInput,
+  AddConnectorInput,
+  AddConnectorOutlineInput,
   AddEmptySlideFromLayoutInput,
   AddTextBoxInput,
+  ConnectorPresetGeometry,
   ContentTypeDefault,
   ContentTypeOverride,
   ContentTypes,
@@ -74,6 +78,7 @@ export type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelAddConnectorEdit,
   PptxSourceModelAddEmptySlideFromLayoutEdit,
   PptxSourceModelAddTextBoxEdit,
   PptxSourceModelDeleteShapeEdit,
@@ -109,6 +114,8 @@ export type {
   SourceColorMap,
   SourceColorTransform,
   SourceConnector,
+  SourceConnectorConnection,
+  SourceConnectorConnectionEndpoint,
   SourceCustomGeometry,
   SourceCustomGeometryPath,
   SourceDashStyle,
@@ -174,6 +181,7 @@ export type {
   UpdateShapeTransformInput,
 } from "./source/index.js";
 export {
+  addConnector,
   addEmptySlideFromLayout,
   addTextBox,
   clearTextRunProperties,

--- a/packages/document/src/reader/shape-tree.ts
+++ b/packages/document/src/reader/shape-tree.ts
@@ -318,8 +318,10 @@ function parseConnector(
 ): SourceConnector {
   const nvCxnSpPr = getChild(cxnSp, "nvCxnSpPr");
   const cNvPr = getChild(nvCxnSpPr, "cNvPr");
+  const cNvCxnSpPr = getChild(nvCxnSpPr, "cNvCxnSpPr");
   const nodeId = sourceNodeId(cNvPr);
   const name = getAttr(cNvPr, "name");
+  const connection = parseConnectorConnection(cNvCxnSpPr);
   const spPr = getChild(cxnSp, "spPr");
   const transform = parseTransform(spPr);
   const geometry = parseGeometry(spPr, orderedNestedChildChildren(orderedNode, "cxnSp", "spPr"));
@@ -336,6 +338,7 @@ function parseConnector(
     kind: "connector",
     ...(nodeId !== undefined ? { nodeId } : {}),
     ...(name !== undefined ? { name } : {}),
+    ...(connection !== undefined ? { connection } : {}),
     ...(transform !== undefined ? { transform } : {}),
     ...(geometry !== undefined ? { geometry } : {}),
     ...(outline !== undefined ? { outline } : {}),
@@ -343,6 +346,31 @@ function parseConnector(
     ...(style !== undefined ? { style } : {}),
     handle: { partPath, ...(nodeId !== undefined ? { nodeId } : {}), orderingSlot },
     ...(rawSidecars.length > 0 ? { rawSidecars } : {}),
+  };
+}
+
+function parseConnectorConnection(
+  cNvCxnSpPr: XmlNode | undefined,
+): SourceConnector["connection"] | undefined {
+  const start = parseConnectorConnectionEndpoint(getChild(cNvCxnSpPr, "stCxn"));
+  const end = parseConnectorConnectionEndpoint(getChild(cNvCxnSpPr, "endCxn"));
+  return start !== undefined || end !== undefined
+    ? {
+        ...(start !== undefined ? { start } : {}),
+        ...(end !== undefined ? { end } : {}),
+      }
+    : undefined;
+}
+
+function parseConnectorConnectionEndpoint(
+  node: XmlNode | undefined,
+): NonNullable<SourceConnector["connection"]>["start"] | undefined {
+  const shapeId = getAttr(node, "id");
+  const connectionSiteIndex = numericAttr(node, "idx");
+  if (shapeId === undefined || connectionSiteIndex === undefined) return undefined;
+  return {
+    shapeId: asSourceNodeId(shapeId),
+    connectionSiteIndex,
   };
 }
 

--- a/packages/document/src/reader/slide-reader.test.ts
+++ b/packages/document/src/reader/slide-reader.test.ts
@@ -674,7 +674,9 @@ describe("readPptx - typed shape detail (synthetic)", () => {
     const source = readPptx(
       buildSyntheticPptx(
         `<p:cxnSp>` +
-          `<p:nvCxnSpPr><p:cNvPr id="50" name="Connector first"/><p:cNvCxnSpPr/><p:nvPr/></p:nvCxnSpPr>` +
+          `<p:nvCxnSpPr><p:cNvPr id="50" name="Connector first"/><p:cNvCxnSpPr>` +
+          `<a:stCxn id="53" idx="1"/><a:endCxn id="54" idx="3"/>` +
+          `</p:cNvCxnSpPr><p:nvPr/></p:nvCxnSpPr>` +
           `<p:spPr><a:xfrm><a:off x="1" y="2"/><a:ext cx="3" cy="4"/></a:xfrm>` +
           `<a:prstGeom prst="bentConnector3"><a:avLst><a:gd name="adj1" fmla="val 50000"/></a:avLst></a:prstGeom>` +
           `<a:ln w="12700"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:prstDash val="dash"/><a:tailEnd type="triangle" w="med" len="med"/></a:ln>` +
@@ -714,6 +716,10 @@ describe("readPptx - typed shape detail (synthetic)", () => {
     >(source.slides[0].shapes);
     expect(connector).toMatchObject({
       name: "Connector first",
+      connection: {
+        start: { shapeId: "53", connectionSiteIndex: 1 },
+        end: { shapeId: "54", connectionSiteIndex: 3 },
+      },
       geometry: { preset: "bentConnector3", adjustValues: { adj1: 50000 } },
       outline: { width: 12700, dashStyle: "dash", tailEnd: { type: "triangle" } },
     });

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1,15 +1,19 @@
 import { asSourceNodeId } from "./handles.js";
 import type {
+  ConnectorPresetGeometry,
   EditableTextRunProperties,
   EditableTextRunProperty,
   Emu,
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelAddConnectorEdit,
   PptxSourceModelEdit,
   RawPackagePart,
   Relationship,
   RelationshipId,
+  SourceArrowEndpoint,
+  SourceConnector,
   SourceHandle,
   SourceNodeId,
   SourceParagraph,
@@ -60,6 +64,13 @@ const EDITABLE_TEXT_RUN_PROPERTIES = [
   "typeface",
 ] as const satisfies readonly EditableTextRunProperty[];
 const EDITABLE_TEXT_RUN_PROPERTY_SET: ReadonlySet<string> = new Set(EDITABLE_TEXT_RUN_PROPERTIES);
+const CONNECTOR_PRESETS: ReadonlySet<ConnectorPresetGeometry> = new Set([
+  "straightConnector1",
+  "bentConnector3",
+  "curvedConnector3",
+]);
+const ARROW_TYPES = new Set(["triangle", "stealth", "diamond", "oval", "arrow"]);
+const ARROW_SIZES = new Set(["sm", "med", "lg"]);
 
 export function findTextRunBySourceHandle(
   source: PptxSourceModel,
@@ -326,6 +337,24 @@ export interface AddTextBoxInput extends UpdateShapeTransformInput {
   readonly name?: string;
 }
 
+export interface AddConnectorConnectionEndpointInput {
+  readonly shapeHandle: SourceHandle;
+  readonly connectionSiteIndex: number;
+}
+
+export interface AddConnectorOutlineInput {
+  readonly headEnd?: SourceArrowEndpoint;
+  readonly tailEnd?: SourceArrowEndpoint;
+}
+
+export interface AddConnectorInput extends UpdateShapeTransformInput {
+  readonly preset: ConnectorPresetGeometry;
+  readonly start: AddConnectorConnectionEndpointInput;
+  readonly end: AddConnectorConnectionEndpointInput;
+  readonly name?: string;
+  readonly outline?: AddConnectorOutlineInput;
+}
+
 export interface AddEmptySlideFromLayoutInput {
   readonly layoutPartPath: PartPath;
 }
@@ -444,6 +473,69 @@ export function addTextBox(
         height: input.height,
         text: input.text,
       },
+    ],
+  };
+}
+
+export function addConnector(
+  source: PptxSourceModel,
+  slideHandle: SourceHandle,
+  input: AddConnectorInput,
+): PptxSourceModel {
+  assertConnectorInput(input);
+  const slideIndex = source.slides.findIndex((slide) =>
+    sourceHandlesEqual(slide.handle, slideHandle),
+  );
+  if (slideIndex === -1) {
+    throw new Error("addConnector: slide handle was not found in PptxSourceModel source");
+  }
+
+  const slide = source.slides[slideIndex];
+  const startShape = requireConnectorTargetShape(slide, input.start.shapeHandle, "start");
+  const endShape = requireConnectorTargetShape(slide, input.end.shapeHandle, "end");
+  const shapeId = nextShapeId(slide.shapes, source.edits ?? [], slide.partPath);
+  const shapeIdValue = String(shapeId);
+  const name = input.name?.trim() || `Connector ${shapeIdValue}`;
+  const orderingSlot = nextOrderingSlot(slide.shapes);
+  const connector = createConnectorShape(
+    slide.partPath,
+    shapeId,
+    name,
+    orderingSlot,
+    startShape,
+    endShape,
+    input,
+  );
+  const slides = source.slides.map((candidate, index) =>
+    index === slideIndex
+      ? {
+          ...candidate,
+          shapes: [...candidate.shapes, connector],
+        }
+      : candidate,
+  );
+
+  return {
+    ...source,
+    slides,
+    edits: [
+      ...(source.edits ?? []),
+      {
+        kind: "addConnector",
+        slidePartPath: slide.partPath,
+        shapeId: shapeIdValue,
+        name,
+        preset: input.preset,
+        offsetX: input.offsetX,
+        offsetY: input.offsetY,
+        width: input.width,
+        height: input.height,
+        startShapeId: String(startShape.nodeId),
+        startConnectionSiteIndex: input.start.connectionSiteIndex,
+        endShapeId: String(endShape.nodeId),
+        endConnectionSiteIndex: input.end.connectionSiteIndex,
+        ...(input.outline !== undefined ? { outline: input.outline } : {}),
+      } satisfies PptxSourceModelAddConnectorEdit,
     ],
   };
 }
@@ -982,13 +1074,61 @@ function assertTextBoxInput(input: AddTextBoxInput): void {
   }
 }
 
-function assertFiniteEmu(value: Emu, operationName: "addTextBox", fieldName: string): void {
+function assertConnectorInput(input: AddConnectorInput): void {
+  assertFiniteEmu(input.offsetX, "addConnector", "offsetX");
+  assertFiniteEmu(input.offsetY, "addConnector", "offsetY");
+  assertPositiveFiniteEmu(input.width, "addConnector", "width");
+  assertPositiveFiniteEmu(input.height, "addConnector", "height");
+  if (!CONNECTOR_PRESETS.has(input.preset)) {
+    throw new Error(
+      "addConnector: preset must be straightConnector1, bentConnector3, or curvedConnector3",
+    );
+  }
+  assertConnectionSiteIndex(input.start.connectionSiteIndex, "start");
+  assertConnectionSiteIndex(input.end.connectionSiteIndex, "end");
+  if (input.name !== undefined && input.name.trim() === "") {
+    throw new Error("addConnector: name must be a non-empty string when provided");
+  }
+  assertArrowEndpoint(input.outline?.headEnd, "headEnd");
+  assertArrowEndpoint(input.outline?.tailEnd, "tailEnd");
+}
+
+function assertConnectionSiteIndex(value: number, fieldName: "start" | "end"): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `addConnector: ${fieldName}.connectionSiteIndex must be a non-negative integer`,
+    );
+  }
+}
+
+function assertArrowEndpoint(endpoint: SourceArrowEndpoint | undefined, fieldName: string): void {
+  if (endpoint === undefined) return;
+  if (!ARROW_TYPES.has(endpoint.type)) {
+    throw new Error(`addConnector: outline.${fieldName}.type is not supported`);
+  }
+  if (!ARROW_SIZES.has(endpoint.width)) {
+    throw new Error(`addConnector: outline.${fieldName}.width is not supported`);
+  }
+  if (!ARROW_SIZES.has(endpoint.length)) {
+    throw new Error(`addConnector: outline.${fieldName}.length is not supported`);
+  }
+}
+
+function assertFiniteEmu(
+  value: Emu,
+  operationName: "addTextBox" | "addConnector",
+  fieldName: string,
+): void {
   if (!Number.isFinite(value)) {
     throw new Error(`${operationName}: ${fieldName} must be a finite EMU value`);
   }
 }
 
-function assertPositiveFiniteEmu(value: Emu, operationName: "addTextBox", fieldName: string): void {
+function assertPositiveFiniteEmu(
+  value: Emu,
+  operationName: "addTextBox" | "addConnector",
+  fieldName: string,
+): void {
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error(`${operationName}: ${fieldName} must be a finite positive EMU value`);
   }
@@ -1040,6 +1180,61 @@ function createTextBoxShape(
   };
 }
 
+function createConnectorShape(
+  partPath: PartPath,
+  shapeId: SourceNodeId,
+  name: string,
+  orderingSlot: number,
+  startShape: SourceShape & { readonly nodeId: SourceNodeId },
+  endShape: SourceShape & { readonly nodeId: SourceNodeId },
+  input: AddConnectorInput,
+): SourceConnector {
+  const transform: SourceTransform = {
+    offsetX: input.offsetX,
+    offsetY: input.offsetY,
+    width: input.width,
+    height: input.height,
+  };
+  return {
+    kind: "connector",
+    nodeId: shapeId,
+    name,
+    connection: {
+      start: {
+        shapeId: startShape.nodeId,
+        connectionSiteIndex: input.start.connectionSiteIndex,
+      },
+      end: {
+        shapeId: endShape.nodeId,
+        connectionSiteIndex: input.end.connectionSiteIndex,
+      },
+    },
+    transform,
+    geometry: { preset: input.preset },
+    ...(input.outline !== undefined ? { outline: input.outline } : {}),
+    handle: { partPath, nodeId: shapeId, orderingSlot },
+  };
+}
+
+function requireConnectorTargetShape(
+  slide: SourceSlide,
+  handle: SourceHandle,
+  endpointName: "start" | "end",
+): SourceShape & { readonly nodeId: SourceNodeId } {
+  const shape = slide.shapes.find((candidate) => sourceHandlesEqual(candidate.handle, handle));
+  if (shape === undefined) {
+    throw new Error(`addConnector: ${endpointName} shape handle was not found on the target slide`);
+  }
+  if (shape.kind !== "shape") {
+    throw new Error(`addConnector: ${endpointName} target must be a top-level sp shape`);
+  }
+  const nodeId = shape.nodeId;
+  if (nodeId === undefined) {
+    throw new Error(`addConnector: ${endpointName} target shape requires a node id`);
+  }
+  return { ...shape, nodeId };
+}
+
 function nextShapeId(
   shapes: readonly SourceShapeNode[],
   edits: readonly PptxSourceModelEdit[],
@@ -1071,9 +1266,11 @@ function collectNumericShapeEditIds(
     const id =
       edit.kind === "addTextBox" && edit.slidePartPath === slidePartPath
         ? edit.shapeId
-        : edit.kind === "deleteShape" && edit.handle.partPath === slidePartPath
-          ? edit.handle.nodeId
-          : undefined;
+        : edit.kind === "addConnector" && edit.slidePartPath === slidePartPath
+          ? edit.shapeId
+          : edit.kind === "deleteShape" && edit.handle.partPath === slidePartPath
+            ? edit.handle.nodeId
+            : undefined;
     const numericId = Number(id);
     if (Number.isInteger(numericId) && numericId > 0) used.add(numericId);
   }
@@ -1289,6 +1486,7 @@ function topologyEditPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {
     case "deleteSlide":
       return [edit.slidePartPath];
     case "addTextBox":
+    case "addConnector":
       return [edit.slidePartPath];
     case "replaceTextRunPlainText":
     case "updateTextRunProperties":
@@ -1370,6 +1568,7 @@ function hasDirtyEditForPart(edits: readonly PptxSourceModelEdit[], partPath: Pa
       case "deleteShape":
         return edit.handle.partPath === partPath;
       case "addTextBox":
+      case "addConnector":
         return edit.slidePartPath === partPath;
       case "addEmptySlideFromLayout":
       case "duplicateSlide":
@@ -1394,6 +1593,7 @@ function editTargetsShape(edit: PptxSourceModelEdit, handle: SourceHandle): bool
     case "deleteShape":
       return sourceHandlesEqual(edit.handle, handle);
     case "addTextBox":
+    case "addConnector":
       return edit.slidePartPath === handle.partPath && edit.shapeId === String(handle.nodeId);
     case "addEmptySlideFromLayout":
     case "duplicateSlide":
@@ -1421,6 +1621,7 @@ function editIsInvalidatedByDeletedParts(
     case "updateShapeTransform":
       return partPaths.has(edit.handle.partPath);
     case "addTextBox":
+    case "addConnector":
       return partPaths.has(edit.slidePartPath);
     case "addEmptySlideFromLayout":
       return partPaths.has(edit.newSlidePartPath);

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -16,6 +16,7 @@ import type {
   SourceConnector,
   SourceHandle,
   SourceNodeId,
+  SourceOutline,
   SourceParagraph,
   SourceRunProperties,
   SourceShape,
@@ -71,6 +72,9 @@ const CONNECTOR_PRESETS: ReadonlySet<ConnectorPresetGeometry> = new Set([
 ]);
 const ARROW_TYPES = new Set(["triangle", "stealth", "diamond", "oval", "arrow"]);
 const ARROW_SIZES = new Set(["sm", "med", "lg"]);
+const DEFAULT_CONNECTOR_OUTLINE: SourceOutline = {
+  fill: { kind: "solid", color: { kind: "srgb", hex: "000000" } },
+};
 
 export function findTextRunBySourceHandle(
   source: PptxSourceModel,
@@ -673,6 +677,13 @@ export function deleteShape(source: PptxSourceModel, handle: SourceHandle): Pptx
     throw new Error("deleteShape: shape handle was not found in PptxSourceModel source");
   }
 
+  const referencingConnector = findConnectorReferencingShape(source, handle);
+  if (referencingConnector !== undefined) {
+    throw new Error(
+      `deleteShape: shape is referenced by connector '${referencingConnector.name ?? referencingConnector.nodeId ?? "unknown"}'`,
+    );
+  }
+
   const retainedEdits = (source.edits ?? []).filter((edit) => !editTargetsShape(edit, handle));
   const deletedInsertedShape = (source.edits ?? []).some(
     (edit) =>
@@ -1211,8 +1222,16 @@ function createConnectorShape(
     },
     transform,
     geometry: { preset: input.preset },
-    ...(input.outline !== undefined ? { outline: input.outline } : {}),
+    outline: createConnectorOutline(input.outline),
     handle: { partPath, nodeId: shapeId, orderingSlot },
+  };
+}
+
+function createConnectorOutline(input: AddConnectorOutlineInput | undefined): SourceOutline {
+  return {
+    ...DEFAULT_CONNECTOR_OUTLINE,
+    ...(input?.headEnd !== undefined ? { headEnd: input.headEnd } : {}),
+    ...(input?.tailEnd !== undefined ? { tailEnd: input.tailEnd } : {}),
   };
 }
 
@@ -1314,6 +1333,26 @@ function hasNestedShapeNodeWithHandle(
 function hasAlternateContentSidecar(shape: SourceShapeNode): boolean {
   if (shape.kind === "raw") return false;
   return shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent") ?? false;
+}
+
+function findConnectorReferencingShape(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+): SourceConnector | undefined {
+  if (handle.nodeId === undefined) return undefined;
+  for (const slide of source.slides) {
+    if (slide.partPath !== handle.partPath) continue;
+    for (const shape of slide.shapes) {
+      if (shape.kind !== "connector") continue;
+      if (
+        shape.connection?.start?.shapeId === handle.nodeId ||
+        shape.connection?.end?.shapeId === handle.nodeId
+      ) {
+        return shape;
+      }
+    }
+  }
+  return undefined;
 }
 
 function sourceHandlesEqual(left: SourceHandle | undefined, right: SourceHandle): boolean {

--- a/packages/document/src/source/index.ts
+++ b/packages/document/src/source/index.ts
@@ -4,11 +4,15 @@
 
 export type { Diagnostic, DiagnosticSeverity } from "./diagnostics.js";
 export type {
+  AddConnectorConnectionEndpointInput,
+  AddConnectorInput,
+  AddConnectorOutlineInput,
   AddEmptySlideFromLayoutInput,
   AddTextBoxInput,
   UpdateShapeTransformInput,
 } from "./editing.js";
 export {
+  addConnector,
   addEmptySlideFromLayout,
   addTextBox,
   clearTextRunProperties,
@@ -43,9 +47,11 @@ export type {
   RelationshipTargetMode,
 } from "./package-graph.js";
 export type {
+  ConnectorPresetGeometry,
   EditableTextRunProperties,
   EditableTextRunProperty,
   PptxSourceModel,
+  PptxSourceModelAddConnectorEdit,
   PptxSourceModelAddEmptySlideFromLayoutEdit,
   PptxSourceModelAddTextBoxEdit,
   PptxSourceModelDeleteShapeEdit,
@@ -87,6 +93,8 @@ export type {
   SourceColorChangeEffect,
   SourceColorTransform,
   SourceConnector,
+  SourceConnectorConnection,
+  SourceConnectorConnectionEndpoint,
   SourceCustomGeometry,
   SourceCustomGeometryPath,
   SourceDashStyle,

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -32,6 +32,7 @@ import type {
   SourceSlideMaster,
   SourceTheme,
 } from "./presentation.js";
+import type { SourceArrowEndpoint } from "./shapes.js";
 import type { Emu, Pt } from "./units.js";
 
 export interface PptxSourceModel {
@@ -54,6 +55,7 @@ export type PptxSourceModelEdit =
   | PptxSourceModelParagraphTextEdit
   | PptxSourceModelShapeTransformEdit
   | PptxSourceModelAddTextBoxEdit
+  | PptxSourceModelAddConnectorEdit
   | PptxSourceModelDeleteShapeEdit
   | PptxSourceModelAddEmptySlideFromLayoutEdit
   | PptxSourceModelDuplicateSlideEdit
@@ -114,6 +116,28 @@ export interface PptxSourceModelAddTextBoxEdit {
   readonly width: Emu;
   readonly height: Emu;
   readonly text: string;
+}
+
+export type ConnectorPresetGeometry = "straightConnector1" | "bentConnector3" | "curvedConnector3";
+
+export interface PptxSourceModelAddConnectorEdit {
+  readonly kind: "addConnector";
+  readonly slidePartPath: PartPath;
+  readonly shapeId: string;
+  readonly name: string;
+  readonly preset: ConnectorPresetGeometry;
+  readonly offsetX: Emu;
+  readonly offsetY: Emu;
+  readonly width: Emu;
+  readonly height: Emu;
+  readonly startShapeId: string;
+  readonly startConnectionSiteIndex: number;
+  readonly endShapeId: string;
+  readonly endConnectionSiteIndex: number;
+  readonly outline?: {
+    readonly headEnd?: SourceArrowEndpoint;
+    readonly tailEnd?: SourceArrowEndpoint;
+  };
 }
 
 export interface PptxSourceModelDeleteShapeEdit {

--- a/packages/document/src/source/shapes.ts
+++ b/packages/document/src/source/shapes.ts
@@ -376,6 +376,7 @@ export interface SourceConnector {
   readonly kind: "connector";
   readonly nodeId?: SourceNodeId;
   readonly name?: string;
+  readonly connection?: SourceConnectorConnection;
   readonly transform?: SourceTransform;
   readonly geometry?: SourceGeometry;
   readonly outline?: SourceOutline;
@@ -383,6 +384,16 @@ export interface SourceConnector {
   readonly style?: SourceShapeStyle;
   readonly handle?: SourceHandle;
   readonly rawSidecars?: readonly RawSidecar[];
+}
+
+export interface SourceConnectorConnection {
+  readonly start?: SourceConnectorConnectionEndpoint;
+  readonly end?: SourceConnectorConnectionEndpoint;
+}
+
+export interface SourceConnectorConnectionEndpoint {
+  readonly shapeId: SourceNodeId;
+  readonly connectionSiteIndex: number;
 }
 
 export interface SourceGroup {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -878,7 +878,14 @@ describe("writePptx - shape add/delete edits", () => {
         end: { shapeId: "30", connectionSiteIndex: 3 },
       },
       geometry: { preset: "bentConnector3" },
-      outline: { tailEnd: { type: "triangle", width: "med", length: "lg" } },
+      outline: {
+        fill: { kind: "solid", color: { kind: "srgb", hex: "000000" } },
+        tailEnd: { type: "triangle", width: "med", length: "lg" },
+      },
+    });
+    expect(findConnectorByName(edited, "Connector 31").outline).toMatchObject({
+      fill: { kind: "solid", color: { kind: "srgb", hex: "000000" } },
+      tailEnd: { type: "triangle", width: "med", length: "lg" },
     });
     expect(slideXml).toContain(`<p:cxnSp>`);
     expect(slideXml).toContain(`<a:stCxn id="10" idx="1"`);
@@ -886,6 +893,31 @@ describe("writePptx - shape add/delete edits", () => {
     expect(slideXml).toContain(`<a:prstGeom prst="bentConnector3"`);
     expect(slideXml).toContain(`<a:tailEnd type="triangle" w="med" len="lg"`);
     expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toContain("preserve-me");
+  });
+
+  it("rejects deleting a shape referenced by a connector", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const start = findShapeByName(source, "Delete Me");
+    const end = findShapeByName(source, "Keep Shape");
+    const withConnector = addConnector(source, source.slides[0].handle!, {
+      preset: "straightConnector1",
+      offsetX: asEmu(100),
+      offsetY: asEmu(200),
+      width: asEmu(700),
+      height: asEmu(800),
+      start: {
+        shapeHandle: requireHandle(start.handle),
+        connectionSiteIndex: 1,
+      },
+      end: {
+        shapeHandle: requireHandle(end.handle),
+        connectionSiteIndex: 3,
+      },
+    });
+
+    expect(() => deleteShape(withConnector, requireHandle(start.handle))).toThrow(
+      /referenced by connector/,
+    );
   });
 
   it("allows an added text box to be edited before write", () => {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 // Import via the actual public surface (`@pptx-glimpse/document`).
 import { asEmu, asPartPath, asPt, asSourceNodeId, readPptx, writePptx } from "../index.js";
 import {
+  addConnector,
   addEmptySlideFromLayout,
   addTextBox,
   clearTextRunProperties,
@@ -19,6 +20,7 @@ import {
   replaceParagraphPlainText,
   replaceTextRunPlainText,
   setTextRunProperties,
+  type SourceConnector,
   type SourceShape,
   type SourceShapeNode,
   updateShapeTransform,
@@ -841,6 +843,51 @@ describe("writePptx - shape add/delete edits", () => {
     expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toContain("preserve-me");
   });
 
+  it("adds a connector with connection sites, preset geometry, and arrow endpoints", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const start = findShapeByName(source, "Delete Me");
+    const end = findShapeByName(source, "Keep Shape");
+    const edited = addConnector(source, source.slides[0].handle!, {
+      preset: "bentConnector3",
+      offsetX: asEmu(100),
+      offsetY: asEmu(200),
+      width: asEmu(700),
+      height: asEmu(800),
+      start: {
+        shapeHandle: requireHandle(start.handle),
+        connectionSiteIndex: 1,
+      },
+      end: {
+        shapeHandle: requireHandle(end.handle),
+        connectionSiteIndex: 3,
+      },
+      outline: {
+        tailEnd: { type: "triangle", width: "med", length: "lg" },
+      },
+    });
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const added = findConnectorByName(reread, "Connector 31");
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(added).toMatchObject({
+      nodeId: "31",
+      name: "Connector 31",
+      connection: {
+        start: { shapeId: "10", connectionSiteIndex: 1 },
+        end: { shapeId: "30", connectionSiteIndex: 3 },
+      },
+      geometry: { preset: "bentConnector3" },
+      outline: { tailEnd: { type: "triangle", width: "med", length: "lg" } },
+    });
+    expect(slideXml).toContain(`<p:cxnSp>`);
+    expect(slideXml).toContain(`<a:stCxn id="10" idx="1"`);
+    expect(slideXml).toContain(`<a:endCxn id="30" idx="3"`);
+    expect(slideXml).toContain(`<a:prstGeom prst="bentConnector3"`);
+    expect(slideXml).toContain(`<a:tailEnd type="triangle" w="med" len="lg"`);
+    expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toContain("preserve-me");
+  });
+
   it("allows an added text box to be edited before write", () => {
     const source = readPptx(buildShapeDeleteFixture());
     const withTextBox = addTextBox(source, source.slides[0].handle!, {
@@ -1522,6 +1569,14 @@ function findShapeByName(source: ReturnType<typeof readPptx>, name: string): Sou
     .find((node): node is SourceShape => node.kind === "shape" && node.name === name);
   if (shape === undefined) throw new Error(`shape not found: ${name}`);
   return shape;
+}
+
+function findConnectorByName(source: ReturnType<typeof readPptx>, name: string): SourceConnector {
+  const connector = source.slides
+    .flatMap((slide) => slide.shapes)
+    .find((node): node is SourceConnector => node.kind === "connector" && node.name === name);
+  if (connector === undefined) throw new Error(`connector not found: ${name}`);
+  return connector;
 }
 
 function requireShape(shape: SourceShape | undefined): SourceShape {

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -35,6 +35,7 @@ import type {
   PartPath,
   PartRelationships,
   PptxSourceModel,
+  PptxSourceModelAddConnectorEdit,
   PptxSourceModelAddEmptySlideFromLayoutEdit,
   PptxSourceModelAddTextBoxEdit,
   PptxSourceModelDeleteShapeEdit,
@@ -83,6 +84,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   const paragraphTextEdits = source.edits?.filter(isParagraphTextEdit) ?? [];
   const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
   const addTextBoxEdits = source.edits?.filter(isAddTextBoxEdit) ?? [];
+  const addConnectorEdits = source.edits?.filter(isAddConnectorEdit) ?? [];
   const deleteShapeEdits = source.edits?.filter(isDeleteShapeEdit) ?? [];
   const addEmptySlideFromLayoutEdits = source.edits?.filter(isAddEmptySlideFromLayoutEdit) ?? [];
   const duplicateSlideEdits = source.edits?.filter(isDuplicateSlideEdit) ?? [];
@@ -93,6 +95,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
     paragraphTextEdits,
     shapeTransformEdits,
     addTextBoxEdits,
+    addConnectorEdits,
     deleteShapeEdits,
   );
   const dirtyPartPaths = new Set([
@@ -102,6 +105,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
     ...shapeTransformEdits.map((edit) => edit.handle.partPath),
     ...deleteShapeEdits.map((edit) => edit.handle.partPath),
     ...addTextBoxEdits.map((edit) => edit.slidePartPath),
+    ...addConnectorEdits.map((edit) => edit.slidePartPath),
   ]);
   const hasSlideTopologyEdits =
     addEmptySlideFromLayoutEdits.length > 0 ||
@@ -140,6 +144,7 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
       paragraphTextEdits,
       shapeTransformEdits,
       addTextBoxEdits,
+      addConnectorEdits,
       deleteShapeEdits,
     );
     written.add(partPath);
@@ -189,6 +194,10 @@ function isAddTextBoxEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelAdd
   return edit.kind === "addTextBox";
 }
 
+function isAddConnectorEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelAddConnectorEdit {
+  return edit.kind === "addConnector";
+}
+
 function isDeleteShapeEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelDeleteShapeEdit {
   return edit.kind === "deleteShape";
 }
@@ -217,6 +226,7 @@ function serializeDirtyXmlPart(
   paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
   shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
   addTextBoxEdits: readonly PptxSourceModelAddTextBoxEdit[],
+  addConnectorEdits: readonly PptxSourceModelAddConnectorEdit[],
   deleteShapeEdits: readonly PptxSourceModelDeleteShapeEdit[],
 ): Uint8Array {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
@@ -230,6 +240,9 @@ function serializeDirtyXmlPart(
   const root = parseXml(textDecoder.decode(rawPart.bytes));
   for (const edit of addTextBoxEdits.filter((edit) => edit.slidePartPath === partPath)) {
     applyAddTextBoxEdit(root, edit);
+  }
+  for (const edit of addConnectorEdits.filter((edit) => edit.slidePartPath === partPath)) {
+    applyAddConnectorEdit(root, edit);
   }
   for (const edit of paragraphTextEdits.filter((edit) => edit.handle.partPath === partPath)) {
     applyParagraphTextEdit(root, edit);
@@ -533,6 +546,26 @@ function applyAddTextBoxEdit(root: XmlNode, edit: PptxSourceModelAddTextBoxEdit)
   appendChild(spTree, "p:sp", createTextBoxXml(edit));
 }
 
+function applyAddConnectorEdit(root: XmlNode, edit: PptxSourceModelAddConnectorEdit): void {
+  const slide = getChild(root, "sld");
+  const cSld = getChild(slide, "cSld");
+  const spTree = getChild(cSld, "spTree");
+  if (spTree === undefined) {
+    throw new Error(`writePptx: slide '${edit.slidePartPath}' has no spTree`);
+  }
+  if (locateShapeTreeNode(spTree, { nodeId: edit.shapeId }) !== undefined) {
+    throw new Error(`writePptx: shape id '${edit.shapeId}' already exists in source XML`);
+  }
+  if (locateShapeTreeNode(spTree, { nodeId: edit.startShapeId }) === undefined) {
+    throw new Error(`writePptx: connector start shape '${edit.startShapeId}' was not found`);
+  }
+  if (locateShapeTreeNode(spTree, { nodeId: edit.endShapeId }) === undefined) {
+    throw new Error(`writePptx: connector end shape '${edit.endShapeId}' was not found`);
+  }
+
+  appendChild(spTree, "p:cxnSp", createConnectorXml(edit));
+}
+
 function applyDeleteShapeEdit(root: XmlNode, edit: PptxSourceModelDeleteShapeEdit): void {
   const locator = parseShapeLocator(edit.handle);
   const slide = getChild(root, "sld");
@@ -587,6 +620,71 @@ function createTextBoxXml(edit: PptxSourceModelAddTextBoxEdit): XmlNode {
         "a:endParaRPr": {},
       },
     },
+  };
+}
+
+function createConnectorXml(edit: PptxSourceModelAddConnectorEdit): XmlNode {
+  return {
+    "p:nvCxnSpPr": {
+      "p:cNvPr": {
+        "@_id": edit.shapeId,
+        "@_name": edit.name,
+      },
+      "p:cNvCxnSpPr": {
+        "a:stCxn": {
+          "@_id": edit.startShapeId,
+          "@_idx": String(edit.startConnectionSiteIndex),
+        },
+        "a:endCxn": {
+          "@_id": edit.endShapeId,
+          "@_idx": String(edit.endConnectionSiteIndex),
+        },
+      },
+      "p:nvPr": {},
+    },
+    "p:spPr": {
+      "a:xfrm": {
+        "a:off": {
+          "@_x": String(edit.offsetX),
+          "@_y": String(edit.offsetY),
+        },
+        "a:ext": {
+          "@_cx": String(edit.width),
+          "@_cy": String(edit.height),
+        },
+      },
+      "a:prstGeom": {
+        "@_prst": edit.preset,
+        "a:avLst": {},
+      },
+      "a:ln": createConnectorLineXml(edit),
+    },
+  };
+}
+
+function createConnectorLineXml(edit: PptxSourceModelAddConnectorEdit): XmlNode {
+  return {
+    "a:solidFill": {
+      "a:srgbClr": {
+        "@_val": "000000",
+      },
+    },
+    ...(edit.outline?.headEnd !== undefined
+      ? { "a:headEnd": createArrowEndpointXml(edit.outline.headEnd) }
+      : {}),
+    ...(edit.outline?.tailEnd !== undefined
+      ? { "a:tailEnd": createArrowEndpointXml(edit.outline.tailEnd) }
+      : {}),
+  };
+}
+
+function createArrowEndpointXml(
+  endpoint: NonNullable<NonNullable<PptxSourceModelAddConnectorEdit["outline"]>["headEnd"]>,
+): XmlNode {
+  return {
+    "@_type": endpoint.type,
+    "@_w": endpoint.width,
+    "@_len": endpoint.length,
   };
 }
 
@@ -1017,13 +1115,14 @@ function validateEdits(
   paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
   shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
   addTextBoxEdits: readonly PptxSourceModelAddTextBoxEdit[],
+  addConnectorEdits: readonly PptxSourceModelAddConnectorEdit[],
   deleteShapeEdits: readonly PptxSourceModelDeleteShapeEdit[],
 ): void {
   const addedShapeKeys = new Set<string>();
-  for (const edit of addTextBoxEdits) {
+  for (const edit of [...addTextBoxEdits, ...addConnectorEdits]) {
     const key = [edit.slidePartPath, edit.shapeId].join("\u0000");
     if (addedShapeKeys.has(key)) {
-      throw new Error(`writePptx: conflicting text box additions for shape id '${edit.shapeId}'`);
+      throw new Error(`writePptx: conflicting shape additions for shape id '${edit.shapeId}'`);
     }
     addedShapeKeys.add(key);
   }

--- a/packages/editor-core/src/index.test.ts
+++ b/packages/editor-core/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   findShapeNodeBySourceHandle,
   type PptxSourceModel,
   readPptx,
+  type SourceConnector,
   type SourceHandle,
   type SourceShape,
   type SourceShapeNode,
@@ -693,6 +694,45 @@ describe("EditorSession shape add/delete commands", () => {
     });
   });
 
+  it("adds a connector command and persists native connection sites", async () => {
+    const source = readPptx(await buildTextEditFixture());
+    const session = createEditorSession(source);
+    const start = firstShape(source);
+    const end = shapeWithoutTransform(source);
+    const edited = expectApplied(
+      session.apply({
+        kind: "addConnector",
+        slideHandle: requireHandle(source.slides[0].handle),
+        preset: "curvedConnector3",
+        offsetX: asEmu(100),
+        offsetY: asEmu(200),
+        width: asEmu(300),
+        height: asEmu(400),
+        start: {
+          shapeHandle: requireHandle(start.handle),
+          connectionSiteIndex: 0,
+        },
+        end: {
+          shapeHandle: requireHandle(end.handle),
+          connectionSiteIndex: 2,
+        },
+        outline: {
+          tailEnd: { type: "triangle", width: "med", length: "med" },
+        },
+      }),
+    );
+    const connector = findConnectorByName(readPptx(writePptx(edited)), "Connector 12");
+
+    expect(connector).toMatchObject({
+      connection: {
+        start: { shapeId: "10", connectionSiteIndex: 0 },
+        end: { shapeId: "11", connectionSiteIndex: 2 },
+      },
+      geometry: { preset: "curvedConnector3" },
+      outline: { tailEnd: { type: "triangle" } },
+    });
+  });
+
   it("undoes and redoes shape deletion for generated command sequences", async () => {
     const cases = [
       [{ kind: "deleteShape" }],
@@ -1298,6 +1338,14 @@ function shapeWithoutTransform(source: PptxSourceModel): SourceShape {
 
 function findShapeByName(source: PptxSourceModel, name: string): SourceShapeNode | undefined {
   return source.slides.flatMap((slide) => slide.shapes).find((shape) => shape.name === name);
+}
+
+function findConnectorByName(source: PptxSourceModel, name: string): SourceConnector {
+  const connector = source.slides
+    .flatMap((slide) => slide.shapes)
+    .find((shape): shape is SourceConnector => shape.kind === "connector" && shape.name === name);
+  if (connector === undefined) throw new Error(`connector not found: ${name}`);
+  return connector;
 }
 
 function requireShape(shape: SourceShapeNode | undefined): SourceShape & {

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,4 +1,6 @@
 import {
+  addConnector,
+  type AddConnectorInput,
   addEmptySlideFromLayout,
   type AddEmptySlideFromLayoutInput,
   addTextBox,
@@ -90,6 +92,11 @@ export interface AddTextBoxCommand extends AddTextBoxInput {
   readonly slideHandle: SourceHandle;
 }
 
+export interface AddConnectorCommand extends AddConnectorInput {
+  readonly kind: "addConnector";
+  readonly slideHandle: SourceHandle;
+}
+
 export interface DeleteShapeCommand {
   readonly kind: "deleteShape";
   readonly handle: SourceHandle;
@@ -118,6 +125,7 @@ export type EditorCommand =
   | ResizeShapeCommand
   | SetShapeTransformCommand
   | AddTextBoxCommand
+  | AddConnectorCommand
   | DeleteShapeCommand
   | AddEmptySlideFromLayoutCommand
   | DuplicateSlideCommand
@@ -300,6 +308,8 @@ function applyCommandToDocument(
       return setShapeTransform(document, command);
     case "addTextBox":
       return addTextBoxCommand(document, command);
+    case "addConnector":
+      return addConnectorCommand(document, command);
     case "deleteShape":
       return deleteShape(document, command.handle);
     case "addEmptySlideFromLayout":
@@ -323,6 +333,17 @@ function addTextBoxCommand(document: PptxSourceModel, command: AddTextBoxCommand
     throw new Error("addTextBox: name must be a non-empty string when provided");
   }
   return addTextBox(document, command.slideHandle, command);
+}
+
+function addConnectorCommand(
+  document: PptxSourceModel,
+  command: AddConnectorCommand,
+): PptxSourceModel {
+  requireFiniteEmu(command.offsetX, "addConnector", "offsetX");
+  requireFiniteEmu(command.offsetY, "addConnector", "offsetY");
+  requirePositiveFiniteEmu(command.width, "addConnector", "width");
+  requirePositiveFiniteEmu(command.height, "addConnector", "height");
+  return addConnector(document, command.slideHandle, command);
 }
 
 function setTextRunPropertiesCommand(
@@ -470,7 +491,7 @@ function requireEditableShapeTransform(
 
 function requireFiniteEmu(
   value: Emu,
-  commandName: "moveShape" | "resizeShape" | "setShapeTransform" | "addTextBox",
+  commandName: "moveShape" | "resizeShape" | "setShapeTransform" | "addTextBox" | "addConnector",
   fieldName: string,
 ): void {
   if (!Number.isFinite(value)) {
@@ -480,7 +501,7 @@ function requireFiniteEmu(
 
 function requirePositiveFiniteEmu(
   value: Emu,
-  commandName: "moveShape" | "resizeShape" | "setShapeTransform" | "addTextBox",
+  commandName: "moveShape" | "resizeShape" | "setShapeTransform" | "addTextBox" | "addConnector",
   fieldName: string,
 ): void {
   if (!Number.isFinite(value) || value <= 0) {

--- a/vrt/libreoffice/editor-validity.test.ts
+++ b/vrt/libreoffice/editor-validity.test.ts
@@ -5,6 +5,7 @@ import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  addConnector,
   addEmptySlideFromLayout,
   addTextBox,
   asEmu,
@@ -206,6 +207,38 @@ describeOrSkip("LibreOffice shape add/delete validity", { timeout: 120000 }, () 
     renderSingleWithLibreOffice(
       libreOfficeImage,
       "editor-validity-shape-add-edited.pptx",
+      writePptx(edited),
+    );
+  });
+
+  it("opens PPTX after adding a connector", () => {
+    const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
+    const source = readPptx(sourcePptx);
+    const shapes = source.slides[0]?.shapes.filter(
+      (shape): shape is SourceShape => shape.kind === "shape",
+    );
+    const edited = addConnector(source, requireHandle(source.slides[0]?.handle), {
+      preset: "straightConnector1",
+      offsetX: asEmu(914400),
+      offsetY: asEmu(1371600),
+      width: asEmu(3657600),
+      height: asEmu(914400),
+      start: {
+        shapeHandle: requireHandle(shapes?.[0]?.handle),
+        connectionSiteIndex: 1,
+      },
+      end: {
+        shapeHandle: requireHandle(shapes?.[1]?.handle),
+        connectionSiteIndex: 3,
+      },
+      outline: {
+        tailEnd: { type: "triangle", width: "med", length: "med" },
+      },
+    });
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-shape-connector-edited.pptx",
       writePptx(edited),
     );
   });


### PR DESCRIPTION
close #616

## 目的

`@pptx-glimpse/document` の編集 API で、既存の 2 つの shape を connection site index 付きで結ぶネイティブ PowerPoint connector shape（`p:cxnSp`）を挿入できるようにします。

## 変更内容

- `addConnector` / `AddConnectorInput` / `PptxSourceModelAddConnectorEdit` を追加
- `SourceConnector` に `connection`（start/end の shape id と connection site index）を追加し、reader で `a:stCxn` / `a:endCxn` を読み取り
- writer で `p:cxnSp` を生成し、`straightConnector1` / `bentConnector3` / `curvedConnector3` と矢印端点スタイルを保存
- editor-core command と LibreOffice validity test を追加
- connector が参照している shape の削除をこの writer slice では拒否し、dangling connection を防止
- `@pptx-glimpse/document` の minor changeset を追加

## 影響パッケージ / パス

- `packages/document/src/source/*`
- `packages/document/src/reader/shape-tree.ts`
- `packages/document/src/writer/write-pptx.ts`
- `packages/editor-core/src/index.ts`
- `vrt/libreoffice/editor-validity.test.ts`

## 検証

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run knip`
- `npm run test`
- `npm run test -- vrt/libreoffice/editor-validity.test.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npm run build`

補足: 通常の `npm run build` は、現在のローカル pnpm 設定 `minimumReleaseAge: 10080` により既存 lockfile 内の `picomatch@4.0.5` / `postcss@8.5.16` が supply-chain policy に引っかかるため、検証時のみ `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` を付けて実行しています。

## cross-review

- warning 2件（connector endpoint 削除時の dangling connection、SourceModel と writer の既定線表示不一致）を確認
- どちらも追加 commit `fix(document): keep connector edits consistent` で対応済み

## 手動確認事項

PowerPoint 上で接続元/先の図形を動かしたときに線が追従するかは、リリース前手動チェックリストで確認してください。
