### PR TITLE
PptxSourceModel から SVG を直接レンダリングする API を追加

### DIFF
--- a/.changeset/quick-slides-render.md
+++ b/.changeset/quick-slides-render.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+Add `renderPptxSourceModelToSvg` for rendering SVG slides directly from a parsed `PptxSourceModel` without re-reading PPTX bytes.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ When rendering slides repeatedly, keep the parsed `PptxSourceModel` from
 `@pptx-glimpse/document` and call `renderPptxSourceModelToSvg`. This avoids
 unzipping and parsing the PPTX bytes again on each render.
 
+```bash
+npm install pptx-glimpse @pptx-glimpse/document
+```
+
 ```typescript
 import { readPptx } from "@pptx-glimpse/document";
 import { renderPptxSourceModelToSvg } from "pptx-glimpse";

--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ Note: embedded fonts and `<text>` may not render as expected when the SVG is ref
 
 ### Advanced Usage
 
+#### Rendering from a parsed source model
+
+When rendering slides repeatedly, keep the parsed `PptxSourceModel` from
+`@pptx-glimpse/document` and call `renderPptxSourceModelToSvg`. This avoids
+unzipping and parsing the PPTX bytes again on each render.
+
+```typescript
+import { readPptx } from "@pptx-glimpse/document";
+import { renderPptxSourceModelToSvg } from "pptx-glimpse";
+
+const source = readPptx(pptx);
+
+const first = await renderPptxSourceModelToSvg(source, { slides: [1] });
+const second = await renderPptxSourceModelToSvg(source, { slides: [2] });
+```
+
 <details>
 <summary>Font Utilities</summary>
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,13 +46,13 @@
   "author": "hirokisakabe",
   "license": "MIT",
   "dependencies": {
+    "@pptx-glimpse/document": "^0.1.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "fast-xml-parser": "^5.7.3",
     "fflate": "^0.8.2",
     "opentype.js": "1.3.4"
   },
   "devDependencies": {
-    "@pptx-glimpse/document": "workspace:*",
     "@pptx-glimpse/editor-core": "workspace:*",
     "@pptx-glimpse/renderer": "workspace:*"
   }

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -17,7 +17,7 @@ import {
   textBodyToProseMirrorDocJson,
 } from "@pptx-glimpse/editor-core";
 
-import { type ConvertOptions, convertPptxToSvg, type SlideSvg } from "./svg-converter.js";
+import { type ConvertOptions, renderPptxSourceModelToSvg, type SlideSvg } from "./svg-converter.js";
 
 const EMU_PER_INCH = 914400;
 const DEFAULT_DPI = 96;
@@ -131,7 +131,7 @@ export class BrowserPptxEditorSession {
   }
 
   async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
-    const report = await convertPptxToSvg(writePptx(this.#session.document), {
+    const report = await renderPptxSourceModelToSvg(this.#session.document, {
       textOutput: "text",
       skipSystemFonts: true,
       ...this.#renderOptions,

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -25,13 +25,14 @@ export { collectUsedFonts } from "./font/font-collector.js";
 export type {
   ConversionDiagnostic,
   ConvertOptions,
+  PptxSourceModel,
   SlideSupportCoverage,
   SlideSvg,
   SupportCoverage,
   SupportCoverageCounts,
   SvgConversionReport,
 } from "./svg-converter.js";
-export { convertPptxToSvg } from "./svg-converter.js";
+export { convertPptxToSvg, renderPptxSourceModelToSvg } from "./svg-converter.js";
 export type { SourceHandle } from "@pptx-glimpse/document";
 export type { EditorCommand, EditorCommandWarning } from "@pptx-glimpse/editor-core";
 export type { FontMapping } from "@pptx-glimpse/renderer";

--- a/packages/core/src/converter.test.ts
+++ b/packages/core/src/converter.test.ts
@@ -2,7 +2,13 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import * as document from "@pptx-glimpse/document";
-import { clearFontCache, getWarningEntries, warn } from "@pptx-glimpse/renderer";
+import {
+  clearFontCache,
+  getWarningEntries,
+  OpentypeTextMeasurer,
+  type TextPathFontResolver,
+  warn,
+} from "@pptx-glimpse/renderer";
 import JSZip from "jszip";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +18,7 @@ import {
   renderPptxSourceModelToSvg as renderPptxSourceModelToSvgBase,
 } from "./converter.js";
 import * as adapterModule from "./pptx-computed-view-renderer-adapter.js";
+import { renderPptxSourceModelToSvg as renderPptxSourceModelToSvgInternal } from "./svg-converter.js";
 
 const convertPptxToSvg: typeof convertPptxToSvgBase = (input, options) =>
   convertPptxToSvgBase(input, { skipSystemFonts: true, ...options });
@@ -401,6 +408,29 @@ describe("public conversion orchestration", () => {
     expect(alpha.slides[0]?.svg).not.toContain("MappedBeta");
     expect(beta.slides[0]?.svg).toContain("MappedBeta");
     expect(beta.slides[0]?.svg).not.toContain("MappedAlpha");
+  });
+
+  it('collects text measurement font warnings in diagnostics when logLevel is "off"', async () => {
+    const source = document.readPptx(testPptx);
+    const fontResolver: TextPathFontResolver = { resolveFont: () => null };
+
+    const report = await renderPptxSourceModelToSvgInternal(
+      source,
+      { textOutput: "text", logLevel: "off" },
+      () =>
+        Promise.resolve({
+          measurer: new OpentypeTextMeasurer(new Map()),
+          fontResolver,
+        }),
+    );
+
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        source: "renderer",
+        code: "renderer.font.notFound",
+      }),
+    );
+    expect(getWarningEntries()).toHaveLength(0);
   });
 
   it("uses the source model reader and renderer adapter for PNG conversion", async () => {

--- a/packages/core/src/converter.test.ts
+++ b/packages/core/src/converter.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   convertPptxToPng as convertPptxToPngBase,
   convertPptxToSvg as convertPptxToSvgBase,
+  renderPptxSourceModelToSvg as renderPptxSourceModelToSvgBase,
 } from "./converter.js";
 import * as adapterModule from "./pptx-computed-view-renderer-adapter.js";
 
@@ -17,6 +18,9 @@ const convertPptxToSvg: typeof convertPptxToSvgBase = (input, options) =>
 
 const convertPptxToPng: typeof convertPptxToPngBase = (input, options) =>
   convertPptxToPngBase(input, { skipSystemFonts: true, ...options });
+
+const renderPptxSourceModelToSvg: typeof renderPptxSourceModelToSvgBase = (source, options) =>
+  renderPptxSourceModelToSvgBase(source, { skipSystemFonts: true, ...options });
 
 const SELECTED_SHARED_FIXTURES = ["real-basic-theme.pptx", "real-product-page.pptx"] as const;
 
@@ -363,6 +367,40 @@ describe("public conversion orchestration", () => {
     expect(publicDefault[0]?.svg).toContain("<svg");
     expect(readPptxSpy).toHaveBeenCalledOnce();
     expect(adapterSpy).toHaveBeenCalledOnce();
+  });
+
+  it("renders from a PptxSourceModel repeatedly without re-reading PPTX bytes", async () => {
+    const readPptxSpy = vi.spyOn(document, "readPptx");
+    const adapterSpy = vi.spyOn(adapterModule, "adaptComputedViewToRendererModel");
+    const source = document.readPptx(readSharedFixture("real-basic-theme.pptx"));
+
+    const first = await renderPptxSourceModelToSvg(source, { slides: [1] });
+    const second = await renderPptxSourceModelToSvg(source, { slides: [1] });
+
+    expect(first.slides[0]?.svg).toContain("<svg");
+    expect(second.slides[0]?.svg).toContain("<svg");
+    expect(readPptxSpy).toHaveBeenCalledOnce();
+    expect(adapterSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps concurrent source-model renders isolated by font options", async () => {
+    const source = document.readPptx(testPptx);
+
+    const [alpha, beta] = await Promise.all([
+      renderPptxSourceModelToSvg(source, {
+        textOutput: "text",
+        fontMapping: { Arial: "MappedAlpha" },
+      }),
+      renderPptxSourceModelToSvg(source, {
+        textOutput: "text",
+        fontMapping: { Arial: "MappedBeta" },
+      }),
+    ]);
+
+    expect(alpha.slides[0]?.svg).toContain("MappedAlpha");
+    expect(alpha.slides[0]?.svg).not.toContain("MappedBeta");
+    expect(beta.slides[0]?.svg).toContain("MappedBeta");
+    expect(beta.slides[0]?.svg).not.toContain("MappedAlpha");
   });
 
   it("uses the source model reader and renderer adapter for PNG conversion", async () => {

--- a/packages/core/src/converter.ts
+++ b/packages/core/src/converter.ts
@@ -1,8 +1,10 @@
+import type { PptxSourceModel } from "@pptx-glimpse/document";
 import { DEFAULT_OUTPUT_WIDTH } from "@pptx-glimpse/renderer";
 
 import {
   type ConvertOptions,
   convertPptxToSvg as convertPptxToSvgBase,
+  renderPptxSourceModelToSvg as renderPptxSourceModelToSvgBase,
   type SupportCoverage,
   type SvgConversionReport,
   type SystemFontSetupLoader,
@@ -17,6 +19,7 @@ export type {
   SupportCoverageCounts,
   SvgConversionReport,
 } from "./svg-converter.js";
+export type { PptxSourceModel } from "@pptx-glimpse/document";
 
 /**
  * PNG conversion result for one slide.
@@ -64,6 +67,19 @@ export async function convertPptxToSvg(
   options?: ConvertOptions,
 ): Promise<SvgConversionReport> {
   return convertPptxToSvgBase(input, options, loadSystemFontSetup);
+}
+
+/**
+ * Render SVG documents from an already parsed PptxSourceModel.
+ *
+ * Use this with `readPptx()` from `@pptx-glimpse/document` to repeatedly render
+ * slides without unzipping and parsing the PPTX bytes again.
+ */
+export async function renderPptxSourceModelToSvg(
+  source: PptxSourceModel,
+  options?: ConvertOptions,
+): Promise<SvgConversionReport> {
+  return renderPptxSourceModelToSvgBase(source, options, loadSystemFontSetup);
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export type {
   ConversionDiagnostic,
   ConvertOptions,
   PngConversionReport,
+  PptxSourceModel,
   SlideImage,
   SlideSupportCoverage,
   SlideSvg,
@@ -9,7 +10,7 @@ export type {
   SupportCoverageCounts,
   SvgConversionReport,
 } from "./converter.js";
-export { convertPptxToPng, convertPptxToSvg } from "./converter.js";
+export { convertPptxToPng, convertPptxToSvg, renderPptxSourceModelToSvg } from "./converter.js";
 export type { UsedFonts } from "./font/font-collector.js";
 export { collectUsedFonts } from "./font/font-collector.js";
 export type { FontMapping } from "@pptx-glimpse/renderer";

--- a/packages/core/src/svg-converter.ts
+++ b/packages/core/src/svg-converter.ts
@@ -3,6 +3,7 @@ import type {
   ComputedSlide,
   Diagnostic,
   PptxComputedView,
+  PptxSourceModel,
   SourceHandle,
 } from "@pptx-glimpse/document";
 import { createComputedView, readPptx } from "@pptx-glimpse/document";
@@ -19,22 +20,10 @@ import {
   buildFontFaceStyle,
   createFontMapping,
   createOpentypeSetupFromBuffers,
-  flushWarnings,
+  createRendererContext,
+  createWarningLogger,
   FontUsageCollector,
-  getWarningEntries,
-  initWarningLogger,
   renderSlideToSvg,
-  resetFontMapping,
-  resetFontUsageCollector,
-  resetScriptFonts,
-  resetTextMeasurer,
-  resetTextPathFontResolver,
-  setFontMapping,
-  setFontUsageCollector,
-  setScriptFonts,
-  setTextMeasurer,
-  setTextPathFontResolver,
-  warn,
 } from "@pptx-glimpse/renderer";
 
 import {
@@ -201,6 +190,8 @@ export type SystemFontSetupLoader = (
   options: ConvertOptions | undefined,
 ) => Promise<OpentypeSetup | null>;
 
+export type { PptxSourceModel } from "@pptx-glimpse/document";
+
 /**
  * Convert a PPTX file to SVG documents.
  *
@@ -219,85 +210,86 @@ export async function convertPptxToSvg(
   options?: ConvertOptions,
   loadSystemFontSetup?: SystemFontSetupLoader,
 ): Promise<SvgConversionReport> {
+  const source = readPptx(input);
+  return renderPptxSourceModelToSvg(source, options, loadSystemFontSetup);
+}
+
+/**
+ * Render SVG documents from an already parsed PptxSourceModel.
+ *
+ * This avoids re-reading PPTX bytes when callers keep the result of `readPptx()`
+ * and need to render one or more slides repeatedly.
+ */
+export async function renderPptxSourceModelToSvg(
+  source: PptxSourceModel,
+  options?: ConvertOptions,
+  loadSystemFontSetup?: SystemFontSetupLoader,
+): Promise<SvgConversionReport> {
   const textOutput = options?.textOutput ?? "path";
   const logLevel = options?.logLevel ?? "off";
   const setup = await createOpentypeSetup(options, loadSystemFontSetup);
-  if (setup) {
-    setTextMeasurer(setup.measurer);
-    if (textOutput !== "text") {
-      setTextPathFontResolver(setup.fontResolver);
-    }
-  }
 
   const fontUsageCollector = textOutput === "text" ? new FontUsageCollector() : null;
-  if (fontUsageCollector) {
-    setFontUsageCollector(fontUsageCollector);
+  const scriptFontScheme = findScriptFontScheme(source);
+  const warningLogger = createWarningLogger(logLevel === "off" ? "warn" : logLevel);
+  const context = createRendererContext({
+    ...(setup !== null ? { textMeasurer: setup.measurer } : {}),
+    textPathFontResolver: setup !== null && textOutput !== "text" ? setup.fontResolver : null,
+    fontUsageCollector,
+    fontMapping: createFontMapping(options?.fontMapping),
+    scriptFonts: {
+      majorJpan: scriptFontScheme?.majorJapanese ?? null,
+      minorJpan: scriptFontScheme?.minorJapanese ?? null,
+    },
+    warningLogger,
+  });
+
+  if (source.presentation.slidePartPaths.length === 0) {
+    context.warningLogger.warn("presentation.noSlides", "No slides found in the PPTX file");
   }
-  setFontMapping(createFontMapping(options?.fontMapping));
 
-  try {
-    initWarningLogger(logLevel === "off" ? "warn" : logLevel);
+  const computed = createComputedView(source, { slides: options?.slides });
+  const adapted = adaptComputedViewToRendererModel(computed);
+  const slideSize = adapted.slideSize;
+  if (slideSize === undefined && adapted.slides.length > 0) {
+    throw new Error("Converter requires a computed slide size");
+  }
 
-    const source = readPptx(input);
-    const scriptFontScheme = findScriptFontScheme(source);
-    setScriptFonts(
-      scriptFontScheme?.majorJapanese ?? null,
-      scriptFontScheme?.minorJapanese ?? null,
-    );
-    if (source.presentation.slidePartPaths.length === 0) {
-      warn("presentation.noSlides", "No slides found in the PPTX file");
-    }
-
-    const computed = createComputedView(source, { slides: options?.slides });
-    const adapted = adaptComputedViewToRendererModel(computed);
-    const slideSize = adapted.slideSize;
-    if (slideSize === undefined && adapted.slides.length > 0) {
-      throw new Error("Converter requires a computed slide size");
-    }
-
-    const slides: SlideSvg[] = [];
-    for (const slide of adapted.slides) {
-      if (slideSize === undefined) continue;
-      fontUsageCollector?.reset();
-      let svg = renderSlideToSvg(slide, slideSize);
-      if (fontUsageCollector && setup) {
-        const style = await buildFontFaceStyle(fontUsageCollector.getUsages(), setup.fontResolver);
-        if (style) {
-          svg = injectIntoSvgDefs(svg, style);
-        }
+  const slides: SlideSvg[] = [];
+  for (const slide of adapted.slides) {
+    if (slideSize === undefined) continue;
+    fontUsageCollector?.reset();
+    let svg = renderSlideToSvg(slide, slideSize, context);
+    if (fontUsageCollector && setup) {
+      const style = await buildFontFaceStyle(
+        fontUsageCollector.getUsages(),
+        setup.fontResolver,
+        context,
+      );
+      if (style) {
+        svg = injectIntoSvgDefs(svg, style);
       }
-      slides.push({ slideNumber: slide.slideNumber, svg });
     }
-
-    const rendererWarningEntries = [...getWarningEntries()];
-    if (logLevel === "off") {
-      initWarningLogger("off");
-    } else {
-      flushWarnings();
-    }
-
-    const diagnostics: ConversionDiagnostic[] = [
-      ...normalizeDocumentDiagnostics(source.diagnostics),
-      ...collectSmartArtComputedViewDiagnostics(computed),
-      ...normalizeRendererAdapterDiagnostics(adapted.diagnostics),
-      ...normalizeRendererWarningDiagnostics(rendererWarningEntries),
-    ];
-    const supportCoverage = buildSupportCoverage(computed, adapted.slides, diagnostics);
-
-    return { slides, diagnostics, supportCoverage };
-  } finally {
-    if (logLevel === "off") {
-      initWarningLogger("off");
-    }
-    resetTextMeasurer();
-    resetTextPathFontResolver();
-    resetFontUsageCollector();
-    resetFontMapping();
-    resetScriptFonts();
+    slides.push({ slideNumber: slide.slideNumber, svg });
   }
+
+  const rendererWarningEntries = [...context.warningLogger.getWarningEntries()];
+  if (logLevel !== "off") {
+    context.warningLogger.flushWarnings();
+  }
+
+  const diagnostics: ConversionDiagnostic[] = [
+    ...normalizeDocumentDiagnostics(source.diagnostics),
+    ...collectSmartArtComputedViewDiagnostics(computed),
+    ...normalizeRendererAdapterDiagnostics(adapted.diagnostics),
+    ...normalizeRendererWarningDiagnostics(rendererWarningEntries),
+  ];
+  const supportCoverage = buildSupportCoverage(computed, adapted.slides, diagnostics);
+
+  return { slides, diagnostics, supportCoverage };
 }
 
-function findScriptFontScheme(source: ReturnType<typeof readPptx>) {
+function findScriptFontScheme(source: PptxSourceModel) {
   const firstThemePartPath = source.slideMasters.find(
     (master) => master.themePartPath !== undefined,
   )?.themePartPath;

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   format: ["cjs", "esm"],
   dts: {
     resolve: [
-      "@pptx-glimpse/document",
       "@pptx-glimpse/editor-core",
       "@pptx-glimpse/renderer",
       "@pptx-glimpse/renderer/png",

--- a/packages/renderer/src/font/font-embedder.ts
+++ b/packages/renderer/src/font/font-embedder.ts
@@ -3,6 +3,8 @@
  * Used to embed subsetted fonts in SVG in native <text> output mode.
  */
 
+import type { RendererContext } from "../renderer/render-context.js";
+import { getJpanFallbackFontFromContext } from "../renderer/render-context.js";
 import { uint8ArrayToBase64 } from "../utils/base64.js";
 import { subsetFont } from "./font-subsetter.js";
 import type { FontUsage } from "./font-usage-collector.js";
@@ -26,19 +28,22 @@ function escapeCssFamilyName(name: string): string {
 export async function buildFontFaceStyle(
   usages: Map<string, FontUsage>,
   fontResolver: TextPathFontResolver,
+  context?: RendererContext,
 ): Promise<string> {
   const faces: string[] = [];
-  const jpanFallback = getJpanFallbackFont();
+  const jpanFallback =
+    context !== undefined ? getJpanFallbackFontFromContext(context) : getJpanFallbackFont();
 
   for (const [familyName, usage] of usages) {
     const font = fontResolver.resolveFont(
       usage.fonts[0],
       usage.fonts[1] ?? null,
       usage.fonts[2] ?? jpanFallback,
+      context,
     );
     if (!font) continue;
 
-    const buffer = await subsetFont(font, usage.chars, familyName);
+    const buffer = await subsetFont(font, usage.chars, familyName, context?.warningLogger);
     if (!buffer) continue;
 
     const base64 = uint8ArrayToBase64(buffer);

--- a/packages/renderer/src/font/font-mapping-context.ts
+++ b/packages/renderer/src/font/font-mapping-context.ts
@@ -15,6 +15,10 @@ export function resetFontMapping(): void {
   currentMapping = { ...DEFAULT_FONT_MAPPING };
 }
 
+export function getFontMapping(): FontMapping {
+  return currentMapping;
+}
+
 /**
  * Shortcut for getting an OSS replacement font name from the current mapping table.
  */

--- a/packages/renderer/src/font/font-subsetter.ts
+++ b/packages/renderer/src/font/font-subsetter.ts
@@ -4,6 +4,7 @@
  */
 
 import { unsafeExternalInteropAssertion } from "../unsafe-type-assertion.js";
+import type { WarningLogger } from "../warning-logger.js";
 import { warn } from "../warning-logger.js";
 import type { OpentypeFullFont } from "./text-path-context.js";
 
@@ -58,6 +59,7 @@ export async function subsetFont(
   font: OpentypeFullFont,
   chars: Set<string>,
   familyName: string,
+  warningLogger?: WarningLogger,
 ): Promise<Uint8Array | null> {
   const opentype = await tryLoadOpentypeCtors();
   if (!opentype) return null;
@@ -124,10 +126,14 @@ export async function subsetFont(
 
     return new Uint8Array(subset.toArrayBuffer());
   } catch (e) {
-    warn(
-      "font.subsetFailed",
-      `Failed to subset font "${familyName}": ${e instanceof Error ? e.message : String(e)}`,
-    );
+    const message = `Failed to subset font "${familyName}": ${
+      e instanceof Error ? e.message : String(e)
+    }`;
+    if (warningLogger) {
+      warningLogger.warn("font.subsetFailed", message);
+    } else {
+      warn("font.subsetFailed", message);
+    }
     return null;
   }
 }

--- a/packages/renderer/src/font/opentype-buffer-helpers.ts
+++ b/packages/renderer/src/font/opentype-buffer-helpers.ts
@@ -203,12 +203,16 @@ export interface OpentypeSetup {
   fontResolver: TextPathFontResolver;
 }
 
-export function buildOpentypeSetupFromState(state: OpentypeSetupState): OpentypeSetup | null {
+export function buildOpentypeSetupFromState(
+  state: OpentypeSetupState,
+  fontMapping?: FontMapping,
+): OpentypeSetup | null {
   if (state.measurerFonts.size === 0 && !state.firstMeasurerFont) return null;
 
   const measurer = new OpentypeTextMeasurer(
     state.measurerFonts,
     state.firstMeasurerFont ?? undefined,
+    fontMapping,
   );
   const fontResolver = new DefaultTextPathFontResolver(
     state.resolverFonts,
@@ -274,7 +278,7 @@ export async function createOpentypeSetupFromBuffers(
     }
   }
 
-  return buildOpentypeSetupFromState(state);
+  return buildOpentypeSetupFromState(state, mapping);
 }
 
 interface SystemFontCacheStore {

--- a/packages/renderer/src/font/opentype-system-helpers.ts
+++ b/packages/renderer/src/font/opentype-system-helpers.ts
@@ -61,7 +61,8 @@ export async function createOpentypeSetupFromSystem(
   const fontFilePaths = collectFontFilePaths(additionalFontDirs, skipSystemFonts);
   if (fontFilePaths.length === 0) return null;
 
-  const reverseMap = buildReverseMapping(createFontMapping(fontMapping));
+  const mapping = createFontMapping(fontMapping);
+  const reverseMap = buildReverseMapping(mapping);
   const state = createOpentypeSetupState();
 
   for (const filePath of fontFilePaths) {
@@ -78,7 +79,7 @@ export async function createOpentypeSetupFromSystem(
     }
   }
 
-  const setup = buildOpentypeSetupFromState(state);
+  const setup = buildOpentypeSetupFromState(state, mapping);
   if (setup === null) return null;
 
   setCachedSystemOpentypeSetup(key, setup);

--- a/packages/renderer/src/font/opentype-text-measurer.test.ts
+++ b/packages/renderer/src/font/opentype-text-measurer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getWarningEntries, initWarningLogger } from "../warning-logger.js";
+import { createWarningLogger, getWarningEntries, initWarningLogger } from "../warning-logger.js";
 import { resetFontMapping, setFontMapping } from "./font-mapping-context.js";
 import { type OpentypeFont, OpentypeTextMeasurer } from "./opentype-text-measurer.js";
 
@@ -321,6 +321,37 @@ describe("OpentypeTextMeasurer font warnings", () => {
     const entries = getWarningEntries();
     expect(entries.some((e) => e.feature === "font.notFound")).toBe(true);
     expect(entries.some((e) => e.message.includes("UnknownFont"))).toBe(true);
+  });
+
+  it("records font.notFound warnings into the provided measurement context", () => {
+    initWarningLogger("warn");
+    const logger = createWarningLogger("warn");
+    const measurer = new OpentypeTextMeasurer(new Map());
+
+    const fontWarningCache = new Set<string>();
+    const context = {
+      warningLogger: logger,
+      fontWarningCache,
+    };
+
+    measurer.measureTextWidth("A", 18, false, "UnknownFont", null, context);
+    measurer.measureTextWidth("A", 18, false, "UnknownFont", null, context);
+
+    expect(
+      logger
+        .getWarningEntries()
+        .some(
+          (entry) => entry.feature === "font.notFound" && entry.message.includes("UnknownFont"),
+        ),
+    ).toBe(true);
+    expect(
+      logger
+        .getWarningEntries()
+        .filter(
+          (entry) => entry.feature === "font.notFound" && entry.message.includes("UnknownFont"),
+        ),
+    ).toHaveLength(1);
+    expect(getWarningEntries()).toHaveLength(0);
   });
 
   it("Warnings with the same font name are not duplicated", () => {

--- a/packages/renderer/src/font/opentype-text-measurer.ts
+++ b/packages/renderer/src/font/opentype-text-measurer.ts
@@ -4,6 +4,8 @@ import {
 } from "../utils/text-measure.js";
 import { warn } from "../warning-logger.js";
 import { getCjkFallbackFonts } from "./cjk-font-fallback.js";
+import type { FontMapping } from "./font-mapping.js";
+import { getMappedFont } from "./font-mapping.js";
 import { getCurrentMappedFont } from "./font-mapping-context.js";
 import type { TextMeasurer } from "./text-measurer.js";
 
@@ -30,7 +32,11 @@ export class OpentypeTextMeasurer implements TextMeasurer {
    * @param fonts - font name -> opentype.js Map of Font objects
    * @param defaultFont - fallback font (optional)
    */
-  constructor(fonts: Map<string, OpentypeFont>, defaultFont?: OpentypeFont) {
+  constructor(
+    fonts: Map<string, OpentypeFont>,
+    defaultFont?: OpentypeFont,
+    private readonly fontMapping?: FontMapping,
+  ) {
     this.fonts = fonts;
     this.defaultFont = defaultFont ?? null;
   }
@@ -108,13 +114,13 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     if (!name) return null;
     // Look for Bold variants by both the original name and the OSS alternate name after font mapping
     const bases = [name];
-    const mappedBase = getCurrentMappedFont(name);
+    const mappedBase = this.getMappedFont(name);
     if (mappedBase && mappedBase !== name) bases.push(mappedBase);
     for (const base of bases) {
       for (const boldName of [`${base} Bold`, `${base}-Bold`]) {
         const direct = this.fonts.get(boldName);
         if (direct) return direct;
-        const mapped = getCurrentMappedFont(boldName);
+        const mapped = this.getMappedFont(boldName);
         if (mapped) {
           const mappedFont = this.fonts.get(mapped);
           if (mappedFont) return mappedFont;
@@ -130,7 +136,7 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     if (direct) return direct;
 
     // Try OSS replacement names from font mapping
-    const mapped = getCurrentMappedFont(name);
+    const mapped = this.getMappedFont(name);
     if (mapped) {
       const mappedFont = this.fonts.get(mapped);
       if (mappedFont) return mappedFont;
@@ -149,5 +155,11 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     }
 
     return null;
+  }
+
+  private getMappedFont(name: string | null | undefined): string | null {
+    return this.fontMapping !== undefined
+      ? getMappedFont(name, this.fontMapping)
+      : getCurrentMappedFont(name);
   }
 }

--- a/packages/renderer/src/font/opentype-text-measurer.ts
+++ b/packages/renderer/src/font/opentype-text-measurer.ts
@@ -7,7 +7,7 @@ import { getCjkFallbackFonts } from "./cjk-font-fallback.js";
 import type { FontMapping } from "./font-mapping.js";
 import { getMappedFont } from "./font-mapping.js";
 import { getCurrentMappedFont } from "./font-mapping-context.js";
-import type { TextMeasurer } from "./text-measurer.js";
+import type { TextMeasurementContext, TextMeasurer } from "./text-measurer.js";
 
 const PX_PER_PT = 96 / 72;
 const BOLD_FACTOR = 1.05;
@@ -47,9 +47,10 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     bold: boolean,
     fontFamily?: string | null,
     fontFamilyEa?: string | null,
+    context?: TextMeasurementContext,
   ): number {
-    const latinFont = this.resolveFont(fontFamily);
-    const eaFont = this.resolveFont(fontFamilyEa);
+    const latinFont = this.resolveFont(fontFamily, context);
+    const eaFont = this.resolveFont(fontFamilyEa, context);
     const fallbackFont = latinFont ?? eaFont ?? this.defaultFont;
     if (!fallbackFont) {
       return defaultMeasureTextWidth(text, fontSizePt, bold, fontFamily, fontFamilyEa);
@@ -58,7 +59,7 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     // CJK characters prefer East Asian fonts, Latin characters prefer Latin fonts.
     const latinFontResolved = latinFont ?? fallbackFont;
     const eaFontResolved = eaFont ?? fallbackFont;
-    const boldLatinFont = bold ? this.resolveBoldFont(fontFamily) : null;
+    const boldLatinFont = bold ? this.resolveBoldFont(fontFamily, context) : null;
 
     // Cache each unique character to reduce stringToGlyphs calls
     // Full-text bulk calls cannot be used because the number of glyphs changes with the GSUB ligature.
@@ -98,29 +99,46 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     return totalWidth;
   }
 
-  getLineHeightRatio(fontFamily?: string | null, fontFamilyEa?: string | null): number {
-    const font = this.resolveFont(fontFamily) ?? this.resolveFont(fontFamilyEa) ?? this.defaultFont;
+  getLineHeightRatio(
+    fontFamily?: string | null,
+    fontFamilyEa?: string | null,
+    context?: TextMeasurementContext,
+  ): number {
+    const font =
+      this.resolveFont(fontFamily, context) ??
+      this.resolveFont(fontFamilyEa, context) ??
+      this.defaultFont;
     if (!font) return 1.2;
     return (font.ascender + Math.abs(font.descender)) / font.unitsPerEm;
   }
 
-  getAscenderRatio(fontFamily?: string | null, fontFamilyEa?: string | null): number {
-    const font = this.resolveFont(fontFamily) ?? this.resolveFont(fontFamilyEa) ?? this.defaultFont;
+  getAscenderRatio(
+    fontFamily?: string | null,
+    fontFamilyEa?: string | null,
+    context?: TextMeasurementContext,
+  ): number {
+    const font =
+      this.resolveFont(fontFamily, context) ??
+      this.resolveFont(fontFamilyEa, context) ??
+      this.defaultFont;
     if (!font) return 1.0;
     return font.ascender / font.unitsPerEm;
   }
 
-  private resolveBoldFont(name: string | null | undefined): OpentypeFont | null {
+  private resolveBoldFont(
+    name: string | null | undefined,
+    context?: TextMeasurementContext,
+  ): OpentypeFont | null {
     if (!name) return null;
     // Look for Bold variants by both the original name and the OSS alternate name after font mapping
     const bases = [name];
-    const mappedBase = this.getMappedFont(name);
+    const mappedBase = this.getMappedFont(name, context);
     if (mappedBase && mappedBase !== name) bases.push(mappedBase);
     for (const base of bases) {
       for (const boldName of [`${base} Bold`, `${base}-Bold`]) {
         const direct = this.fonts.get(boldName);
         if (direct) return direct;
-        const mapped = this.getMappedFont(boldName);
+        const mapped = this.getMappedFont(boldName, context);
         if (mapped) {
           const mappedFont = this.fonts.get(mapped);
           if (mappedFont) return mappedFont;
@@ -130,13 +148,16 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     return null;
   }
 
-  private resolveFont(name: string | null | undefined): OpentypeFont | null {
+  private resolveFont(
+    name: string | null | undefined,
+    context?: TextMeasurementContext,
+  ): OpentypeFont | null {
     if (!name) return null;
     const direct = this.fonts.get(name);
     if (direct) return direct;
 
     // Try OSS replacement names from font mapping
-    const mapped = this.getMappedFont(name);
+    const mapped = this.getMappedFont(name, context);
     if (mapped) {
       const mappedFont = this.fonts.get(mapped);
       if (mappedFont) return mappedFont;
@@ -149,7 +170,11 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     }
 
     // Font-not-found warning
-    if (!this.warnedFonts.has(name)) {
+    if (context?.warningLogger) {
+      if (context.fontWarningCache?.has(name)) return null;
+      context.fontWarningCache?.add(name);
+      context.warningLogger.warn("font.notFound", `Font not found: "${name}"`);
+    } else if (!this.warnedFonts.has(name)) {
       this.warnedFonts.add(name);
       warn("font.notFound", `Font not found: "${name}"`);
     }
@@ -157,9 +182,14 @@ export class OpentypeTextMeasurer implements TextMeasurer {
     return null;
   }
 
-  private getMappedFont(name: string | null | undefined): string | null {
-    return this.fontMapping !== undefined
-      ? getMappedFont(name, this.fontMapping)
-      : getCurrentMappedFont(name);
+  private getMappedFont(
+    name: string | null | undefined,
+    context?: TextMeasurementContext,
+  ): string | null {
+    return context?.fontMapping !== undefined
+      ? getMappedFont(name, context.fontMapping)
+      : this.fontMapping !== undefined
+        ? getMappedFont(name, this.fontMapping)
+        : getCurrentMappedFont(name);
   }
 }

--- a/packages/renderer/src/font/script-font-context.ts
+++ b/packages/renderer/src/font/script-font-context.ts
@@ -16,6 +16,10 @@ export function resetScriptFonts(): void {
   jpanMinorFont = null;
 }
 
+export function getScriptFonts(): { majorJpan: string | null; minorJpan: string | null } {
+  return { majorJpan: jpanMajorFont, minorJpan: jpanMinorFont };
+}
+
 /**
  * Returns the Japan font for fallback for CJK text.
  * If major/minor distinction is not necessary, major takes precedence.

--- a/packages/renderer/src/font/text-measurer.ts
+++ b/packages/renderer/src/font/text-measurer.ts
@@ -3,6 +3,14 @@ import {
   getLineHeightRatio as defaultGetLineHeightRatio,
   measureTextWidth as defaultMeasureTextWidth,
 } from "../utils/text-measure.js";
+import type { WarningLogger } from "../warning-logger.js";
+import type { FontMapping } from "./font-mapping.js";
+
+export interface TextMeasurementContext {
+  readonly fontMapping?: FontMapping;
+  readonly warningLogger?: WarningLogger;
+  readonly fontWarningCache?: Set<string>;
+}
 
 /**
  * Interface for measuring text width and line height.
@@ -25,6 +33,7 @@ export interface TextMeasurer {
     bold: boolean,
     fontFamily?: string | null,
     fontFamilyEa?: string | null,
+    context?: TextMeasurementContext,
   ): number;
 
   /**
@@ -33,7 +42,11 @@ export interface TextMeasurer {
    * @param fontFamily - font family name for Latin text
    * @param fontFamilyEa - font family name for East Asian text
    */
-  getLineHeightRatio(fontFamily?: string | null, fontFamilyEa?: string | null): number;
+  getLineHeightRatio(
+    fontFamily?: string | null,
+    fontFamilyEa?: string | null,
+    context?: TextMeasurementContext,
+  ): number;
 
   /**
    * Font ascender ratio (ascender / unitsPerEm) .
@@ -42,7 +55,11 @@ export interface TextMeasurer {
    * @param fontFamily - font family name for Latin text
    * @param fontFamilyEa - font family name for East Asian text
    */
-  getAscenderRatio(fontFamily?: string | null, fontFamilyEa?: string | null): number;
+  getAscenderRatio(
+    fontFamily?: string | null,
+    fontFamilyEa?: string | null,
+    context?: TextMeasurementContext,
+  ): number;
 }
 
 export class DefaultTextMeasurer implements TextMeasurer {
@@ -52,15 +69,24 @@ export class DefaultTextMeasurer implements TextMeasurer {
     bold: boolean,
     fontFamily?: string | null,
     fontFamilyEa?: string | null,
+    _context?: TextMeasurementContext,
   ): number {
     return defaultMeasureTextWidth(text, fontSizePt, bold, fontFamily, fontFamilyEa);
   }
 
-  getLineHeightRatio(fontFamily?: string | null, fontFamilyEa?: string | null): number {
+  getLineHeightRatio(
+    fontFamily?: string | null,
+    fontFamilyEa?: string | null,
+    _context?: TextMeasurementContext,
+  ): number {
     return defaultGetLineHeightRatio(fontFamily, fontFamilyEa);
   }
 
-  getAscenderRatio(fontFamily?: string | null, fontFamilyEa?: string | null): number {
+  getAscenderRatio(
+    fontFamily?: string | null,
+    fontFamilyEa?: string | null,
+    _context?: TextMeasurementContext,
+  ): number {
     return defaultGetAscenderRatio(fontFamily, fontFamilyEa);
   }
 }

--- a/packages/renderer/src/font/text-path-context.ts
+++ b/packages/renderer/src/font/text-path-context.ts
@@ -34,6 +34,7 @@ export interface TextPathFontResolver {
 export interface TextPathFontResolverContext {
   readonly fontMapping?: FontMapping;
   readonly warningLogger?: WarningLogger;
+  readonly fontWarningCache?: Set<string>;
 }
 
 export class DefaultTextPathFontResolver implements TextPathFontResolver {
@@ -70,6 +71,8 @@ export class DefaultTextPathFontResolver implements TextPathFontResolver {
       if (name) {
         const logger = context?.warningLogger;
         if (logger) {
+          if (context.fontWarningCache?.has(name)) continue;
+          context.fontWarningCache?.add(name);
           logger.warn("font.notFound", `Font not found: "${name}"`);
           continue;
         }

--- a/packages/renderer/src/font/text-path-context.ts
+++ b/packages/renderer/src/font/text-path-context.ts
@@ -3,8 +3,11 @@
  * Provides access to a Font object with the opentype.js getPath() method.
  */
 
+import type { WarningLogger } from "../warning-logger.js";
 import { warn } from "../warning-logger.js";
 import { getCjkFallbackFonts } from "./cjk-font-fallback.js";
+import type { FontMapping } from "./font-mapping.js";
+import { getMappedFont } from "./font-mapping.js";
 import { getCurrentMappedFont } from "./font-mapping-context.js";
 
 export interface OpentypePath {
@@ -24,7 +27,13 @@ export interface TextPathFontResolver {
     fontFamily: string | null | undefined,
     fontFamilyEa: string | null | undefined,
     jpanFallback?: string | null,
+    context?: TextPathFontResolverContext,
   ): OpentypeFullFont | null;
+}
+
+export interface TextPathFontResolverContext {
+  readonly fontMapping?: FontMapping;
+  readonly warningLogger?: WarningLogger;
 }
 
 export class DefaultTextPathFontResolver implements TextPathFontResolver {
@@ -41,37 +50,48 @@ export class DefaultTextPathFontResolver implements TextPathFontResolver {
     fontFamily: string | null | undefined,
     fontFamilyEa: string | null | undefined,
     jpanFallback?: string | null,
+    context?: TextPathFontResolverContext,
   ): OpentypeFullFont | null {
     if (fontFamily) {
-      const font = this.findFont(fontFamily);
+      const font = this.findFont(fontFamily, context);
       if (font) return font;
     }
     if (fontFamilyEa) {
-      const font = this.findFont(fontFamilyEa);
+      const font = this.findFont(fontFamilyEa, context);
       if (font) return font;
     }
     if (jpanFallback) {
-      const font = this.findFont(jpanFallback);
+      const font = this.findFont(jpanFallback, context);
       if (font) return font;
     }
 
     // Font-not-found warning
     for (const name of [fontFamily, fontFamilyEa, jpanFallback]) {
-      if (name && !this.warnedFonts.has(name)) {
-        this.warnedFonts.add(name);
-        warn("font.notFound", `Font not found: "${name}"`);
+      if (name) {
+        const logger = context?.warningLogger;
+        if (logger) {
+          logger.warn("font.notFound", `Font not found: "${name}"`);
+          continue;
+        }
+        if (!this.warnedFonts.has(name)) {
+          this.warnedFonts.add(name);
+          warn("font.notFound", `Font not found: "${name}"`);
+        }
       }
     }
 
     return this.defaultFont;
   }
 
-  private findFont(name: string): OpentypeFullFont | null {
+  private findFont(name: string, context?: TextPathFontResolverContext): OpentypeFullFont | null {
     const direct = this.fonts.get(name);
     if (direct) return direct;
 
     // Try OSS replacement names from font mapping
-    const mapped = getCurrentMappedFont(name);
+    const mapped =
+      context?.fontMapping !== undefined
+        ? getMappedFont(name, context.fontMapping)
+        : getCurrentMappedFont(name);
     if (mapped) {
       const mappedFont = this.fonts.get(mapped);
       if (mappedFont) return mappedFont;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -33,6 +33,7 @@ export * from "./renderer/chart-renderer.js";
 export * from "./renderer/effect-renderer.js";
 export * from "./renderer/fill-renderer.js";
 export * from "./renderer/image-renderer.js";
+export * from "./renderer/render-context.js";
 export * from "./renderer/render-result.js";
 export * from "./renderer/shape-renderer.js";
 export * from "./renderer/svg-renderer.js";

--- a/packages/renderer/src/renderer/chart-renderer.ts
+++ b/packages/renderer/src/renderer/chart-renderer.ts
@@ -1,7 +1,8 @@
 import type { ChartData, ChartElement, ChartSeries } from "../model/chart.js";
 import type { ResolvedColor } from "../model/fill.js";
 import { emuToPixels } from "../utils/emu.js";
-import { debug } from "../warning-logger.js";
+import type { RendererContext } from "./render-context.js";
+import { createLegacyRendererContext } from "./render-context.js";
 import type { RenderResult } from "./render-result.js";
 import { buildTransformAttr } from "./transform.js";
 
@@ -16,7 +17,10 @@ const DEFAULT_SERIES_COLORS: ResolvedColor[] = [
 
 const LEGEND_SIDE_WIDTH = 100;
 
-export function renderChart(element: ChartElement): RenderResult {
+export function renderChart(
+  element: ChartElement,
+  context: RendererContext = createLegacyRendererContext(),
+): RenderResult {
   const { transform, chart } = element;
   const w = emuToPixels(transform.extentWidth);
   const h = emuToPixels(transform.extentHeight);
@@ -50,37 +54,37 @@ export function renderChart(element: ChartElement): RenderResult {
   if (plotW > 0 && plotH > 0) {
     switch (chart.chartType) {
       case "bar":
-        parts.push(renderBarChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderBarChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "line":
-        parts.push(renderLineChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderLineChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "pie":
-        parts.push(renderPieChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderPieChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "doughnut":
-        parts.push(renderDoughnutChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderDoughnutChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "scatter":
-        parts.push(renderScatterChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderScatterChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "bubble":
-        parts.push(renderBubbleChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderBubbleChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "area":
-        parts.push(renderAreaChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderAreaChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "radar":
-        parts.push(renderRadarChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderRadarChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "stock":
-        parts.push(renderStockChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderStockChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "surface":
-        parts.push(renderSurfaceChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderSurfaceChart(chart, plotX, plotY, plotW, plotH, context));
         break;
       case "ofPie":
-        parts.push(renderOfPieChart(chart, plotX, plotY, plotW, plotH));
+        parts.push(renderOfPieChart(chart, plotX, plotY, plotW, plotH, context));
         break;
     }
   }
@@ -97,23 +101,34 @@ function renderChartTitle(title: string, chartWidth: number): string {
   return `<text x="${round(chartWidth / 2)}" y="20" text-anchor="middle" font-size="14" font-weight="bold" fill="#404040">${escapeXml(title)}</text>`;
 }
 
-function renderBarChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function debugChart(context: RendererContext, feature: string, message: string): void {
+  context.warningLogger.debug(feature, message);
+}
+
+function renderBarChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series, categories } = chart;
   if (series.length === 0) {
-    debug("chart.bar", "series is empty");
+    debugChart(context, "chart.bar", "series is empty");
     return "";
   }
 
   const maxVal = getMaxValue(series);
   if (maxVal === 0) {
-    debug("chart.bar", "max value is 0");
+    debugChart(context, "chart.bar", "max value is 0");
     return "";
   }
 
   const catCount = categories.length || Math.max(...series.map((s) => s.values.length));
   if (catCount === 0) {
-    debug("chart.bar", "category count is 0");
+    debugChart(context, "chart.bar", "category count is 0");
     return "";
   }
 
@@ -199,23 +214,30 @@ function renderBarChart(chart: ChartData, x: number, y: number, w: number, h: nu
   return parts.join("");
 }
 
-function renderLineChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderLineChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series, categories } = chart;
   if (series.length === 0) {
-    debug("chart.line", "series is empty");
+    debugChart(context, "chart.line", "series is empty");
     return "";
   }
 
   const maxVal = getMaxValue(series);
   if (maxVal === 0) {
-    debug("chart.line", "max value is 0");
+    debugChart(context, "chart.line", "max value is 0");
     return "";
   }
 
   const catCount = categories.length || Math.max(...series.map((s) => s.values.length));
   if (catCount === 0) {
-    debug("chart.line", "category count is 0");
+    debugChart(context, "chart.line", "category count is 0");
     return "";
   }
 
@@ -267,23 +289,30 @@ function renderLineChart(chart: ChartData, x: number, y: number, w: number, h: n
   return parts.join("");
 }
 
-function renderAreaChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderAreaChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series, categories } = chart;
   if (series.length === 0) {
-    debug("chart.area", "series is empty");
+    debugChart(context, "chart.area", "series is empty");
     return "";
   }
 
   const maxVal = getMaxValue(series);
   if (maxVal === 0) {
-    debug("chart.area", "max value is 0");
+    debugChart(context, "chart.area", "max value is 0");
     return "";
   }
 
   const catCount = categories.length || Math.max(...series.map((s) => s.values.length));
   if (catCount === 0) {
-    debug("chart.area", "category count is 0");
+    debugChart(context, "chart.area", "category count is 0");
     return "";
   }
 
@@ -336,17 +365,24 @@ function renderAreaChart(chart: ChartData, x: number, y: number, w: number, h: n
   return parts.join("");
 }
 
-function renderPieChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderPieChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const series = chart.series[0];
   if (!series || series.values.length === 0) {
-    debug("chart.pie", "series is empty or has no values");
+    debugChart(context, "chart.pie", "series is empty or has no values");
     return "";
   }
 
   const total = series.values.reduce((sum, v) => sum + v, 0);
   if (total === 0) {
-    debug("chart.pie", "total value is 0");
+    debugChart(context, "chart.pie", "total value is 0");
     return "";
   }
 
@@ -383,17 +419,24 @@ function renderPieChart(chart: ChartData, x: number, y: number, w: number, h: nu
   return parts.join("");
 }
 
-function renderDoughnutChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderDoughnutChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const series = chart.series[0];
   if (!series || series.values.length === 0) {
-    debug("chart.doughnut", "series is empty or has no values");
+    debugChart(context, "chart.doughnut", "series is empty or has no values");
     return "";
   }
 
   const total = series.values.reduce((sum, v) => sum + v, 0);
   if (total === 0) {
-    debug("chart.doughnut", "total value is 0");
+    debugChart(context, "chart.doughnut", "total value is 0");
     return "";
   }
 
@@ -439,11 +482,18 @@ function renderDoughnutChart(chart: ChartData, x: number, y: number, w: number, 
   return parts.join("");
 }
 
-function renderScatterChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderScatterChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series } = chart;
   if (series.length === 0) {
-    debug("chart.scatter", "series is empty");
+    debugChart(context, "chart.scatter", "series is empty");
     return "";
   }
 
@@ -487,11 +537,18 @@ function renderScatterChart(chart: ChartData, x: number, y: number, w: number, h
   return parts.join("");
 }
 
-function renderBubbleChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderBubbleChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series } = chart;
   if (series.length === 0) {
-    debug("chart.bubble", "series is empty");
+    debugChart(context, "chart.bubble", "series is empty");
     return "";
   }
 
@@ -546,23 +603,30 @@ function renderBubbleChart(chart: ChartData, x: number, y: number, w: number, h:
   return parts.join("");
 }
 
-function renderRadarChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderRadarChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series, categories } = chart;
   if (series.length === 0) {
-    debug("chart.radar", "series is empty");
+    debugChart(context, "chart.radar", "series is empty");
     return "";
   }
 
   const maxVal = getMaxValue(series);
   if (maxVal === 0) {
-    debug("chart.radar", "max value is 0");
+    debugChart(context, "chart.radar", "max value is 0");
     return "";
   }
 
   const catCount = categories.length || Math.max(...series.map((s) => s.values.length));
   if (catCount === 0) {
-    debug("chart.radar", "category count is 0");
+    debugChart(context, "chart.radar", "category count is 0");
     return "";
   }
 
@@ -639,13 +703,24 @@ function renderRadarChart(chart: ChartData, x: number, y: number, w: number, h: 
   return parts.join("");
 }
 
-function renderStockChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderStockChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series, categories } = chart;
 
   // Stock chart expects series in order: High (0), Low (1), Close (2)
   if (series.length < 3) {
-    debug("chart.stock", `insufficient series count: ${series.length} (need at least 3)`);
+    debugChart(
+      context,
+      "chart.stock",
+      `insufficient series count: ${series.length} (need at least 3)`,
+    );
     return "";
   }
 
@@ -654,7 +729,7 @@ function renderStockChart(chart: ChartData, x: number, y: number, w: number, h: 
   const closeSeries = series[2];
   const catCount = categories.length || highSeries.values.length;
   if (catCount === 0) {
-    debug("chart.stock", "category count is 0");
+    debugChart(context, "chart.stock", "category count is 0");
     return "";
   }
 
@@ -667,7 +742,7 @@ function renderStockChart(chart: ChartData, x: number, y: number, w: number, h: 
     }
   }
   if (maxVal === minVal) {
-    debug("chart.stock", "max equals min value");
+    debugChart(context, "chart.stock", "max equals min value");
     return "";
   }
 
@@ -723,18 +798,25 @@ function renderStockChart(chart: ChartData, x: number, y: number, w: number, h: 
   return parts.join("");
 }
 
-function renderSurfaceChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderSurfaceChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const { series, categories } = chart;
   if (series.length === 0) {
-    debug("chart.surface", "series is empty");
+    debugChart(context, "chart.surface", "series is empty");
     return "";
   }
 
   const rows = series.length;
   const cols = categories.length || Math.max(...series.map((s) => s.values.length));
   if (cols === 0) {
-    debug("chart.surface", "column count is 0");
+    debugChart(context, "chart.surface", "column count is 0");
     return "";
   }
 
@@ -819,17 +901,24 @@ function heatmapColor(t: number): string {
   return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
 }
 
-function renderOfPieChart(chart: ChartData, x: number, y: number, w: number, h: number): string {
+function renderOfPieChart(
+  chart: ChartData,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  context: RendererContext,
+): string {
   const parts: string[] = [];
   const series = chart.series[0];
   if (!series || series.values.length === 0) {
-    debug("chart.ofPie", "series is empty or has no values");
+    debugChart(context, "chart.ofPie", "series is empty or has no values");
     return "";
   }
 
   const total = series.values.reduce((sum, v) => sum + v, 0);
   if (total === 0) {
-    debug("chart.ofPie", "total value is 0");
+    debugChart(context, "chart.ofPie", "total value is 0");
     return "";
   }
 

--- a/packages/renderer/src/renderer/render-context.ts
+++ b/packages/renderer/src/renderer/render-context.ts
@@ -24,6 +24,7 @@ export interface RendererContext {
   readonly fontUsageCollector: FontUsageCollector | null;
   readonly scriptFonts: RendererScriptFonts;
   readonly warningLogger: WarningLogger;
+  readonly fontWarningCache: Set<string>;
 }
 
 export function createRendererContext(overrides: Partial<RendererContext> = {}): RendererContext {
@@ -34,6 +35,7 @@ export function createRendererContext(overrides: Partial<RendererContext> = {}):
     fontUsageCollector: overrides.fontUsageCollector ?? null,
     scriptFonts: overrides.scriptFonts ?? { majorJpan: null, minorJpan: null },
     warningLogger: overrides.warningLogger ?? createWarningLogger("off"),
+    fontWarningCache: overrides.fontWarningCache ?? new Set<string>(),
   };
 }
 
@@ -45,6 +47,7 @@ export function createLegacyRendererContext(): RendererContext {
     fontUsageCollector: getFontUsageCollector(),
     scriptFonts: getScriptFonts(),
     warningLogger: getActiveWarningLogger(),
+    fontWarningCache: new Set<string>(),
   };
 }
 

--- a/packages/renderer/src/renderer/render-context.ts
+++ b/packages/renderer/src/renderer/render-context.ts
@@ -1,0 +1,60 @@
+import { DEFAULT_FONT_MAPPING, type FontMapping, getMappedFont } from "../font/font-mapping.js";
+import { getFontMapping } from "../font/font-mapping-context.js";
+import type { FontUsageCollector } from "../font/font-usage-collector.js";
+import { getFontUsageCollector } from "../font/font-usage-collector.js";
+import { getScriptFonts } from "../font/script-font-context.js";
+import { DefaultTextMeasurer, getTextMeasurer, type TextMeasurer } from "../font/text-measurer.js";
+import type { TextPathFontResolver } from "../font/text-path-context.js";
+import { getTextPathFontResolver } from "../font/text-path-context.js";
+import {
+  createWarningLogger,
+  getActiveWarningLogger,
+  type WarningLogger,
+} from "../warning-logger.js";
+
+export interface RendererScriptFonts {
+  readonly majorJpan: string | null;
+  readonly minorJpan: string | null;
+}
+
+export interface RendererContext {
+  readonly textMeasurer: TextMeasurer;
+  readonly textPathFontResolver: TextPathFontResolver | null;
+  readonly fontMapping: FontMapping;
+  readonly fontUsageCollector: FontUsageCollector | null;
+  readonly scriptFonts: RendererScriptFonts;
+  readonly warningLogger: WarningLogger;
+}
+
+export function createRendererContext(overrides: Partial<RendererContext> = {}): RendererContext {
+  return {
+    textMeasurer: overrides.textMeasurer ?? new DefaultTextMeasurer(),
+    textPathFontResolver: overrides.textPathFontResolver ?? null,
+    fontMapping: overrides.fontMapping ?? { ...DEFAULT_FONT_MAPPING },
+    fontUsageCollector: overrides.fontUsageCollector ?? null,
+    scriptFonts: overrides.scriptFonts ?? { majorJpan: null, minorJpan: null },
+    warningLogger: overrides.warningLogger ?? createWarningLogger("off"),
+  };
+}
+
+export function createLegacyRendererContext(): RendererContext {
+  return {
+    textMeasurer: getTextMeasurer(),
+    textPathFontResolver: getTextPathFontResolver(),
+    fontMapping: getFontMapping(),
+    fontUsageCollector: getFontUsageCollector(),
+    scriptFonts: getScriptFonts(),
+    warningLogger: getActiveWarningLogger(),
+  };
+}
+
+export function getJpanFallbackFontFromContext(context: RendererContext): string | null {
+  return context.scriptFonts.majorJpan ?? context.scriptFonts.minorJpan;
+}
+
+export function getMappedFontFromContext(
+  fontFamily: string | null | undefined,
+  context: RendererContext,
+): string | null {
+  return getMappedFont(fontFamily, context.fontMapping);
+}

--- a/packages/renderer/src/renderer/shape-renderer.ts
+++ b/packages/renderer/src/renderer/shape-renderer.ts
@@ -3,17 +3,22 @@ import { emuToPixels } from "../utils/emu.js";
 import { renderEffects } from "./effect-renderer.js";
 import { renderFillAttrs, renderMarkers, renderOutlineAttrs } from "./fill-renderer.js";
 import { renderGeometry } from "./geometry/index.js";
+import type { RendererContext } from "./render-context.js";
+import { createLegacyRendererContext } from "./render-context.js";
 import type { RenderResult } from "./render-result.js";
 import { computeSpAutofitHeight, renderTextBody } from "./text-renderer.js";
 import { buildTransformAttr } from "./transform.js";
 
-export function renderShape(shape: ShapeElement): RenderResult {
+export function renderShape(
+  shape: ShapeElement,
+  context: RendererContext = createLegacyRendererContext(),
+): RenderResult {
   const { transform, geometry, fill, outline, textBody, effects } = shape;
 
   // spAutofit: expand shape height according to text amount
   let effectiveTransform = transform;
   if (textBody?.bodyProperties.autoFit === "spAutofit") {
-    const requiredHeightEmu = computeSpAutofitHeight(textBody, transform);
+    const requiredHeightEmu = computeSpAutofitHeight(textBody, transform, context);
     if (requiredHeightEmu !== null) {
       effectiveTransform = { ...transform, extentHeight: requiredHeightEmu };
     }
@@ -48,7 +53,7 @@ export function renderShape(shape: ShapeElement): RenderResult {
   }
 
   if (textBody) {
-    const textSvg = renderTextBody(textBody, effectiveTransform);
+    const textSvg = renderTextBody(textBody, effectiveTransform, context);
     if (textSvg) {
       parts.push(textSvg);
     }

--- a/packages/renderer/src/renderer/svg-renderer.ts
+++ b/packages/renderer/src/renderer/svg-renderer.ts
@@ -5,6 +5,8 @@ import { emuToPixels } from "../utils/emu.js";
 import { renderChart } from "./chart-renderer.js";
 import { renderFillAttrs } from "./fill-renderer.js";
 import { renderImage } from "./image-renderer.js";
+import type { RendererContext } from "./render-context.js";
+import { createLegacyRendererContext } from "./render-context.js";
 import type { RenderResult } from "./render-result.js";
 import { renderConnector, renderShape } from "./shape-renderer.js";
 import { renderTable } from "./table-renderer.js";
@@ -12,7 +14,11 @@ import { renderTable } from "./table-renderer.js";
 // Outputs SVG 1.1 (W3C). Uses only inline attributes and no CSS classes.
 // Reason: sharp (which uses librsvg internally) does not interpret CSS selectors correctly.
 
-export function renderSlideToSvg(slide: Slide, slideSize: SlideSize): string {
+export function renderSlideToSvg(
+  slide: Slide,
+  slideSize: SlideSize,
+  context: RendererContext = createLegacyRendererContext(),
+): string {
   const width = emuToPixels(slideSize.width);
   const height = emuToPixels(slideSize.height);
 
@@ -39,7 +45,7 @@ export function renderSlideToSvg(slide: Slide, slideSize: SlideSize): string {
 
   // Elements
   for (const element of slide.elements) {
-    const result = renderElement(element);
+    const result = renderElement(element, context);
     if (result) {
       parts.push(result.content);
       defs.push(...result.defs);
@@ -55,11 +61,11 @@ export function renderSlideToSvg(slide: Slide, slideSize: SlideSize): string {
   return parts.join("");
 }
 
-function renderElement(element: SlideElement): RenderResult | null {
+function renderElement(element: SlideElement, context: RendererContext): RenderResult | null {
   let result: RenderResult | null = null;
   switch (element.type) {
     case "shape":
-      result = renderShape(element);
+      result = renderShape(element, context);
       break;
     case "image":
       result = renderImage(element);
@@ -68,13 +74,13 @@ function renderElement(element: SlideElement): RenderResult | null {
       result = renderConnector(element);
       break;
     case "group":
-      result = renderGroup(element);
+      result = renderGroup(element, context);
       break;
     case "chart":
-      result = renderChart(element);
+      result = renderChart(element, context);
       break;
     case "table":
-      result = renderTable(element);
+      result = renderTable(element, context);
       break;
   }
 
@@ -99,7 +105,7 @@ function addAriaLabel(svgFragment: string, altText: string): string {
   return svgFragment.replace(/^<(g|image|path)\b/, `<$1 role="img" aria-label="${escaped}"`);
 }
 
-function renderGroup(group: GroupElement): RenderResult {
+function renderGroup(group: GroupElement, context: RendererContext): RenderResult {
   const x = emuToPixels(group.transform.offsetX);
   const y = emuToPixels(group.transform.offsetY);
   const w = emuToPixels(group.transform.extentWidth);
@@ -136,7 +142,7 @@ function renderGroup(group: GroupElement): RenderResult {
   parts.push(`<g transform="${transformParts.join(" ")}">`);
 
   for (const child of group.children) {
-    const childResult = renderElement(child);
+    const childResult = renderElement(child, context);
     if (childResult) {
       parts.push(childResult.content);
       defs.push(...childResult.defs);

--- a/packages/renderer/src/renderer/table-renderer.ts
+++ b/packages/renderer/src/renderer/table-renderer.ts
@@ -4,11 +4,16 @@ import { emuToPixels } from "../utils/emu.js";
 import type { Emu } from "../utils/unit-types.js";
 import { asEmu } from "../utils/unit-types.js";
 import { renderFillAttrs, renderOutlineAttrs } from "./fill-renderer.js";
+import type { RendererContext } from "./render-context.js";
+import { createLegacyRendererContext } from "./render-context.js";
 import type { RenderResult } from "./render-result.js";
 import { renderTextBody } from "./text-renderer.js";
 import { buildTransformAttr } from "./transform.js";
 
-export function renderTable(element: TableElement): RenderResult {
+export function renderTable(
+  element: TableElement,
+  context: RendererContext = createLegacyRendererContext(),
+): RenderResult {
   const { transform, table } = element;
   const transformAttr = buildTransformAttr(transform);
 
@@ -82,7 +87,7 @@ export function renderTable(element: TableElement): RenderResult {
           flipH: false,
           flipV: false,
         };
-        const textSvg = renderTextBody(cell.textBody, cellTransform);
+        const textSvg = renderTextBody(cell.textBody, cellTransform, context);
         if (textSvg) {
           parts.push(`<g transform="translate(${x}, ${y})">${textSvg}</g>`);
         }

--- a/packages/renderer/src/renderer/text-renderer.ts
+++ b/packages/renderer/src/renderer/text-renderer.ts
@@ -193,6 +193,7 @@ export function renderTextBody(
         scaledDefaultFontSizePt,
         fontScale,
         context.textMeasurer,
+        context,
       );
       for (let lineIdx = 0; lineIdx < wrappedLines.length; lineIdx++) {
         const line = wrappedLines[lineIdx];
@@ -580,6 +581,7 @@ function computeLineNaturalHeight(
     const ratio = context.textMeasurer.getLineHeightRatio(
       seg.properties.fontFamily,
       seg.properties.fontFamilyEa,
+      context,
     );
     maxHeight = Math.max(maxHeight, fontSize * ratio);
   }
@@ -809,6 +811,7 @@ function getDefaultLineHeightRatio(
         return context.textMeasurer.getLineHeightRatio(
           r.properties.fontFamily,
           r.properties.fontFamilyEa,
+          context,
         );
       }
     }
@@ -826,6 +829,7 @@ function getDefaultAscenderRatio(
         return context.textMeasurer.getAscenderRatio(
           r.properties.fontFamily,
           r.properties.fontFamilyEa,
+          context,
         );
       }
     }
@@ -946,6 +950,7 @@ function estimateTextHeight(
         scaledDefaultForWrap,
         fontScale,
         context.textMeasurer,
+        context,
       );
       lineCount = wrappedLines.length;
     } else {
@@ -1022,6 +1027,7 @@ function measureLineWidth(
       seg.properties.bold,
       seg.properties.fontFamily,
       seg.properties.fontFamilyEa,
+      context,
     );
   }
   return totalWidth;
@@ -1122,6 +1128,7 @@ function renderSegmentAsPath(
           props.bold,
           props.fontFamily,
           props.fontFamilyEa,
+          context,
         );
 
     if (font) {
@@ -1166,6 +1173,7 @@ function renderSegmentAsPath(
             props.bold,
             props.fontFamily,
             props.fontFamilyEa,
+            context,
           );
 
       if (font) {
@@ -1377,6 +1385,7 @@ function renderTextBodyAsPath(
         scaledDefaultFontSizePt,
         fontScale,
         context.textMeasurer,
+        context,
       );
 
       for (let lineIdx = 0; lineIdx < wrappedLines.length; lineIdx++) {

--- a/packages/renderer/src/renderer/text-renderer.ts
+++ b/packages/renderer/src/renderer/text-renderer.ts
@@ -1,10 +1,5 @@
 import { getMetricsFallbackFont } from "../data/font-metrics.js";
-import { getCurrentMappedFont } from "../font/font-mapping-context.js";
-import { getFontUsageCollector } from "../font/font-usage-collector.js";
-import { getJpanFallbackFont } from "../font/script-font-context.js";
-import { getTextMeasurer } from "../font/text-measurer.js";
 import type { TextPathFontResolver } from "../font/text-path-context.js";
-import { getTextPathFontResolver } from "../font/text-path-context.js";
 import type { Transform } from "../model/shape.js";
 import type {
   AutoNumScheme,
@@ -21,6 +16,12 @@ import { emuToPixels } from "../utils/emu.js";
 import { wrapParagraph } from "../utils/text-wrap.js";
 import type { Emu } from "../utils/unit-types.js";
 import { asEmu } from "../utils/unit-types.js";
+import type { RendererContext } from "./render-context.js";
+import {
+  createLegacyRendererContext,
+  getJpanFallbackFontFromContext,
+  getMappedFontFromContext,
+} from "./render-context.js";
 
 const PX_PER_PT = 96 / 72;
 const DEFAULT_LINE_SPACING = 1.0;
@@ -87,10 +88,14 @@ function resolveTextDimensions(
   };
 }
 
-export function renderTextBody(textBody: TextBody, transform: Transform): string {
-  const fontResolver = getTextPathFontResolver();
+export function renderTextBody(
+  textBody: TextBody,
+  transform: Transform,
+  context: RendererContext = createLegacyRendererContext(),
+): string {
+  const fontResolver = context.textPathFontResolver;
   if (fontResolver) {
-    return renderTextBodyAsPath(textBody, transform, fontResolver);
+    return renderTextBodyAsPath(textBody, transform, fontResolver, context);
   }
 
   const { bodyProperties, paragraphs } = textBody;
@@ -122,14 +127,15 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
       lnSpcReduction,
       textWidth,
       availableHeight,
+      context,
     );
   }
 
   const scaledDefaultFontSizePt = defaultFontSize * fontScale;
 
   // Default font line height ratio
-  const defaultLineHeightRatio = getDefaultLineHeightRatio(paragraphs);
-  const defaultAscenderRatio = getDefaultAscenderRatio(paragraphs);
+  const defaultLineHeightRatio = getDefaultLineHeightRatio(paragraphs, context);
+  const defaultAscenderRatio = getDefaultAscenderRatio(paragraphs, context);
   const defaultNaturalHeightPt = scaledDefaultFontSizePt * defaultLineHeightRatio;
 
   const tspans: string[] = [];
@@ -186,6 +192,7 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
         effectiveTextWidth,
         scaledDefaultFontSizePt,
         fontScale,
+        context.textMeasurer,
       );
       for (let lineIdx = 0; lineIdx < wrappedLines.length; lineIdx++) {
         const line = wrappedLines[lineIdx];
@@ -208,6 +215,7 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
             line.segments,
             defaultFontSize,
             fontScale,
+            context,
           );
           const dy = computeDy(
             isFirstLine,
@@ -225,8 +233,9 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
             lineFontSize,
             fontScale,
             bulletFontChain,
+            context,
           );
-          getFontUsageCollector()?.record(bulletFontChain, bulletText);
+          context.fontUsageCollector?.record(bulletFontChain, bulletText);
           tspans.push(
             `<tspan x="${bulletX}" dy="${dy}" text-anchor="start" ${bulletStyles}>${escapeXml(bulletText)}</tspan>`,
           );
@@ -234,7 +243,7 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
           for (let segIdx = 0; segIdx < line.segments.length; segIdx++) {
             const seg = line.segments[segIdx];
             const prefix = segIdx === 0 ? `x="${xPos}" text-anchor="${anchorValue}" ` : "";
-            tspans.push(renderSegment(seg.text, seg.properties, fontScale, prefix));
+            tspans.push(renderSegment(seg.text, seg.properties, fontScale, prefix, context));
           }
         } else {
           for (let segIdx = 0; segIdx < line.segments.length; segIdx++) {
@@ -245,6 +254,7 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
                 line.segments,
                 defaultFontSize,
                 fontScale,
+                context,
               );
               const dy = computeDy(
                 isFirstLine,
@@ -252,9 +262,9 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
                 lineGapPx,
               );
               const prefix = `x="${xPos}" dy="${dy}" text-anchor="${anchorValue}" `;
-              tspans.push(renderSegment(seg.text, seg.properties, fontScale, prefix));
+              tspans.push(renderSegment(seg.text, seg.properties, fontScale, prefix, context));
             } else {
-              tspans.push(renderSegment(seg.text, seg.properties, fontScale, ""));
+              tspans.push(renderSegment(seg.text, seg.properties, fontScale, "", context));
             }
           }
         }
@@ -266,7 +276,12 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
       if (bulletText) {
         const firstRun = para.runs.find((r) => r.text.length > 0);
         const fontSize = (firstRun?.properties.fontSize ?? defaultFontSize) * fontScale;
-        const naturalHeightPt = computeLineNaturalHeight(para.runs, defaultFontSize, fontScale);
+        const naturalHeightPt = computeLineNaturalHeight(
+          para.runs,
+          defaultFontSize,
+          fontScale,
+          context,
+        );
         const dy = computeDy(
           isFirstLine,
           getLineHeightPx(para, naturalHeightPt, lnSpcReduction),
@@ -282,8 +297,9 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
           fontSize,
           fontScale,
           bulletFontChain,
+          context,
         );
-        getFontUsageCollector()?.record(bulletFontChain, bulletText);
+        context.fontUsageCollector?.record(bulletFontChain, bulletText);
         tspans.push(
           `<tspan x="${bulletX}" dy="${dy}" text-anchor="start" ${bulletStyles}>${escapeXml(bulletText)}</tspan>`,
         );
@@ -297,20 +313,25 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
           if (bulletText) {
             // If there is a bullet, the text specifies the x position (no dy, same line as the bullet)
             const prefix = `x="${xPos}" text-anchor="${anchorValue}" `;
-            tspans.push(renderSegment(run.text, run.properties, fontScale, prefix));
+            tspans.push(renderSegment(run.text, run.properties, fontScale, prefix, context));
           } else {
-            const naturalHeightPt = computeLineNaturalHeight(para.runs, defaultFontSize, fontScale);
+            const naturalHeightPt = computeLineNaturalHeight(
+              para.runs,
+              defaultFontSize,
+              fontScale,
+              context,
+            );
             const dy = computeDy(
               isFirstLine,
               getLineHeightPx(para, naturalHeightPt, lnSpcReduction),
               paragraphGapPx,
             );
             const prefix = `x="${xPos}" dy="${dy}" text-anchor="${anchorValue}" `;
-            tspans.push(renderSegment(run.text, run.properties, fontScale, prefix));
+            tspans.push(renderSegment(run.text, run.properties, fontScale, prefix, context));
           }
           firstRunRendered = true;
         } else {
-          tspans.push(renderSegment(run.text, run.properties, fontScale, ""));
+          tspans.push(renderSegment(run.text, run.properties, fontScale, "", context));
         }
       }
       isFirstLine = false;
@@ -328,6 +349,7 @@ export function renderTextBody(textBody: TextBody, transform: Transform): string
     textWidth,
     lnSpcReduction,
     fontScale,
+    context,
   );
   if (bodyProperties.anchor === "ctr") {
     yStart = Math.max(marginTopPx, (height - totalTextHeight) / 2);
@@ -451,6 +473,7 @@ function buildBulletStyleAttrs(
   textFontSizePt: number,
   fontScale: number,
   bulletFontChain: (string | null)[],
+  context: RendererContext = createLegacyRendererContext(),
 ): string {
   const styles: string[] = [];
 
@@ -459,7 +482,7 @@ function buildBulletStyleAttrs(
     styles.push(`font-size="${size}pt"`);
   }
 
-  const fontFamilyValue = buildFontFamilyValue(bulletFontChain);
+  const fontFamilyValue = buildFontFamilyValue(bulletFontChain, context);
   if (fontFamilyValue) {
     styles.push(`font-family="${fontFamilyValue}"`);
   }
@@ -549,11 +572,12 @@ function computeLineNaturalHeight(
   segments: { properties: RunProperties }[],
   defaultFontSize: number,
   fontScale: number,
+  context: RendererContext = createLegacyRendererContext(),
 ): number {
   let maxHeight = 0;
   for (const seg of segments) {
     const fontSize = (seg.properties.fontSize ?? defaultFontSize) * fontScale;
-    const ratio = getTextMeasurer().getLineHeightRatio(
+    const ratio = context.textMeasurer.getLineHeightRatio(
       seg.properties.fontFamily,
       seg.properties.fontFamilyEa,
     );
@@ -631,7 +655,10 @@ function escapeFontName(name: string): string {
     .replace(/"/g, "&quot;");
 }
 
-export function buildFontFamilyValue(fonts: (string | null)[]): string | null {
+export function buildFontFamilyValue(
+  fonts: (string | null)[],
+  context: RendererContext = createLegacyRendererContext(),
+): string | null {
   const uniqueFonts: string[] = [];
   const seen = new Set<string>();
 
@@ -641,7 +668,7 @@ export function buildFontFamilyValue(fonts: (string | null)[]): string | null {
       uniqueFonts.push(font);
 
       // Add OSS alternative font from mapping table
-      const mapped = getCurrentMappedFont(font);
+      const mapped = getMappedFontFromContext(font, context);
       if (mapped && !seen.has(mapped)) {
         seen.add(mapped);
         uniqueFonts.push(mapped);
@@ -673,6 +700,7 @@ function buildStyleAttrs(
   props: RunProperties,
   fontScale: number = 1,
   fontFamilies?: (string | null)[],
+  context: RendererContext = createLegacyRendererContext(),
 ): string {
   const styles: string[] = [];
 
@@ -681,7 +709,7 @@ function buildStyleAttrs(
     styles.push(`font-size="${scaledSize}pt"`);
   }
   const fonts = fontFamilies ?? [props.fontFamily, props.fontFamilyEa];
-  const fontFamilyValue = buildFontFamilyValue(fonts);
+  const fontFamilyValue = buildFontFamilyValue(fonts, context);
   if (fontFamilyValue) {
     styles.push(`font-family="${fontFamilyValue}"`);
   }
@@ -729,11 +757,12 @@ function renderSegment(
   props: RunProperties,
   fontScale: number,
   prefix: string,
+  context: RendererContext,
 ): string {
   let tspanContent: string;
   if (!needsScriptSplit(props)) {
-    const styles = buildStyleAttrs(props, fontScale);
-    getFontUsageCollector()?.record([props.fontFamily, props.fontFamilyEa], text);
+    const styles = buildStyleAttrs(props, fontScale, undefined, context);
+    context.fontUsageCollector?.record([props.fontFamily, props.fontFamilyEa], text);
     tspanContent = `<tspan ${prefix}${styles}>${escapeXml(text)}</tspan>`;
   } else {
     const parts = splitByScript(text);
@@ -741,10 +770,10 @@ function renderSegment(
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
       const fonts = part.isEa
-        ? [props.fontFamilyEa, getJpanFallbackFont(), props.fontFamily]
+        ? [props.fontFamilyEa, getJpanFallbackFontFromContext(context), props.fontFamily]
         : [props.fontFamily, props.fontFamilyEa];
-      const styles = buildStyleAttrs(props, fontScale, fonts);
-      getFontUsageCollector()?.record(fonts, part.text);
+      const styles = buildStyleAttrs(props, fontScale, fonts, context);
+      context.fontUsageCollector?.record(fonts, part.text);
       if (i === 0) {
         result.push(`<tspan ${prefix}${styles}>${escapeXml(part.text)}</tspan>`);
       } else {
@@ -770,11 +799,14 @@ function getDefaultFontSize(paragraphs: TextBody["paragraphs"]): number {
   return DEFAULT_FONT_SIZE_PT;
 }
 
-function getDefaultLineHeightRatio(paragraphs: TextBody["paragraphs"]): number {
+function getDefaultLineHeightRatio(
+  paragraphs: TextBody["paragraphs"],
+  context: RendererContext = createLegacyRendererContext(),
+): number {
   for (const p of paragraphs) {
     for (const r of p.runs) {
       if (r.properties.fontFamily || r.properties.fontFamilyEa) {
-        return getTextMeasurer().getLineHeightRatio(
+        return context.textMeasurer.getLineHeightRatio(
           r.properties.fontFamily,
           r.properties.fontFamilyEa,
         );
@@ -784,11 +816,14 @@ function getDefaultLineHeightRatio(paragraphs: TextBody["paragraphs"]): number {
   return 1.2;
 }
 
-function getDefaultAscenderRatio(paragraphs: TextBody["paragraphs"]): number {
+function getDefaultAscenderRatio(
+  paragraphs: TextBody["paragraphs"],
+  context: RendererContext = createLegacyRendererContext(),
+): number {
   for (const p of paragraphs) {
     for (const r of p.runs) {
       if (r.properties.fontFamily || r.properties.fontFamilyEa) {
-        return getTextMeasurer().getAscenderRatio(
+        return context.textMeasurer.getAscenderRatio(
           r.properties.fontFamily,
           r.properties.fontFamilyEa,
         );
@@ -802,7 +837,11 @@ function getDefaultAscenderRatio(paragraphs: TextBody["paragraphs"]): number {
  * spAutofit: Calculates the required shape height (EMU) depending on the amount of text.
  * Returns null if the text fits within the original shape.
  */
-export function computeSpAutofitHeight(textBody: TextBody, transform: Transform): Emu | null {
+export function computeSpAutofitHeight(
+  textBody: TextBody,
+  transform: Transform,
+  context: RendererContext = createLegacyRendererContext(),
+): Emu | null {
   const { bodyProperties, paragraphs } = textBody;
 
   const hasText = paragraphs.some((p) => p.runs.some((r) => r.text.length > 0));
@@ -820,7 +859,15 @@ export function computeSpAutofitHeight(textBody: TextBody, transform: Transform)
   const defaultFontSize = getDefaultFontSize(paragraphs);
   const shouldWrap = bodyProperties.wrap !== "none";
 
-  const textHeight = estimateTextHeight(paragraphs, defaultFontSize, shouldWrap, textWidth);
+  const textHeight = estimateTextHeight(
+    paragraphs,
+    defaultFontSize,
+    shouldWrap,
+    textWidth,
+    undefined,
+    undefined,
+    context,
+  );
   const requiredHeightPx = textHeight + marginTopPx + marginBottomPx;
 
   if (requiredHeightPx <= height) return null;
@@ -836,6 +883,7 @@ function computeShrinkToFitScale(
   lnSpcReduction: number,
   textWidth: number,
   availableHeight: number,
+  context: RendererContext = createLegacyRendererContext(),
 ): number {
   if (availableHeight <= 0) return fontScale;
 
@@ -851,6 +899,7 @@ function computeShrinkToFitScale(
       textWidth,
       lnSpcReduction,
       scale,
+      context,
     );
     if (textHeight <= availableHeight) break;
     const newScale = scale * (availableHeight / textHeight);
@@ -868,9 +917,10 @@ function estimateTextHeight(
   textWidth: number,
   lnSpcReduction: number = 0,
   fontScale: number = 1,
+  context: RendererContext = createLegacyRendererContext(),
 ): number {
   let totalHeight = 0;
-  const defaultRatio = getDefaultLineHeightRatio(paragraphs);
+  const defaultRatio = getDefaultLineHeightRatio(paragraphs, context);
   let prevSpaceAfterPx = 0;
   // wrapParagraph expects a pre-scaled defaultFontSize
   const scaledDefaultForWrap = defaultFontSize * fontScale;
@@ -881,7 +931,7 @@ function estimateTextHeight(
     const naturalHeightPt =
       isEmpty && para.endParaRunProperties?.fontSize
         ? para.endParaRunProperties.fontSize * fontScale * defaultRatio
-        : computeLineNaturalHeight(para.runs, defaultFontSize, fontScale);
+        : computeLineNaturalHeight(para.runs, defaultFontSize, fontScale, context);
     const lineHeight = getLineHeightPx(
       para,
       naturalHeightPt > 0 ? naturalHeightPt : defaultFontSize * fontScale * defaultRatio,
@@ -890,7 +940,13 @@ function estimateTextHeight(
 
     let lineCount: number;
     if (shouldWrap && para.runs.length > 0 && para.runs.some((r) => r.text.length > 0)) {
-      const wrappedLines = wrapParagraph(para, textWidth, scaledDefaultForWrap, fontScale);
+      const wrappedLines = wrapParagraph(
+        para,
+        textWidth,
+        scaledDefaultForWrap,
+        fontScale,
+        context.textMeasurer,
+      );
       lineCount = wrappedLines.length;
     } else {
       lineCount = para.runs.some((r) => r.text.length > 0) ? 1 : 1;
@@ -941,9 +997,10 @@ function measureLineWidth(
   defaultFontSize: number,
   fontScale: number,
   fontResolver?: TextPathFontResolver | null,
+  context: RendererContext = createLegacyRendererContext(),
 ): number {
   let totalWidth = 0;
-  const jpanFallback = fontResolver ? getJpanFallbackFont() : null;
+  const jpanFallback = fontResolver ? getJpanFallbackFontFromContext(context) : null;
   for (const seg of segments) {
     const fontSize = (seg.properties.fontSize ?? defaultFontSize) * fontScale;
     if (fontResolver) {
@@ -952,13 +1009,14 @@ function measureLineWidth(
         seg.properties.fontFamily,
         seg.properties.fontFamilyEa,
         jpanFallback,
+        context,
       );
       if (font) {
         totalWidth += font.getAdvanceWidth(seg.text, fontSizePx);
         continue;
       }
     }
-    totalWidth += getTextMeasurer().measureTextWidth(
+    totalWidth += context.textMeasurer.measureTextWidth(
       seg.text,
       fontSize,
       seg.properties.bold,
@@ -1029,6 +1087,7 @@ function renderSegmentAsPath(
   fontScale: number,
   defaultFontSize: number,
   fontResolver: TextPathFontResolver,
+  context: RendererContext,
   vert?: TextVerticalType,
 ): { svg: string; width: number } {
   const fontSize = (props.fontSize ?? defaultFontSize) * fontScale;
@@ -1045,7 +1104,7 @@ function renderSegmentAsPath(
   else if (props.baseline < 0) yOffset = fontSizePx * 0.2;
   const effectiveY = y + yOffset;
 
-  const jpanFallback = getJpanFallbackFont();
+  const jpanFallback = getJpanFallbackFontFromContext(context);
 
   const processSegment = (
     segText: string,
@@ -1054,10 +1113,10 @@ function renderSegmentAsPath(
   ) => {
     if (segText.length === 0) return;
 
-    const font = fontResolver.resolveFont(fontFamily, fontFamilyEa, jpanFallback);
+    const font = fontResolver.resolveFont(fontFamily, fontFamilyEa, jpanFallback, context);
     const segWidth = font
       ? font.getAdvanceWidth(segText, fontSizePx)
-      : getTextMeasurer().measureTextWidth(
+      : context.textMeasurer.measureTextWidth(
           segText,
           fontSize,
           props.bold,
@@ -1095,13 +1154,13 @@ function renderSegmentAsPath(
   ) => {
     if (segText.length === 0) return;
 
-    const font = fontResolver.resolveFont(fontFamily, fontFamilyEa, jpanFallback);
+    const font = fontResolver.resolveFont(fontFamily, fontFamilyEa, jpanFallback, context);
     const fillAttrs = buildPathFillAttrs(props);
 
     for (const char of segText) {
       const charWidth = font
         ? font.getAdvanceWidth(char, fontSizePx)
-        : getTextMeasurer().measureTextWidth(
+        : context.textMeasurer.measureTextWidth(
             char,
             fontSize,
             props.bold,
@@ -1180,6 +1239,7 @@ function renderBulletAsPath(
   textFontSizePt: number,
   fontScale: number,
   fontResolver: TextPathFontResolver,
+  context: RendererContext,
   runFontFamily?: string | null,
   runFontFamilyEa?: string | null,
 ): string[] {
@@ -1191,8 +1251,8 @@ function renderBulletAsPath(
 
   // Use bulletFont if specified, fallback to text run font if not specified
   const font = paraProps.bulletFont
-    ? fontResolver.resolveFont(paraProps.bulletFont, null)
-    : fontResolver.resolveFont(runFontFamily ?? null, runFontFamilyEa ?? null);
+    ? fontResolver.resolveFont(paraProps.bulletFont, null, undefined, context)
+    : fontResolver.resolveFont(runFontFamily ?? null, runFontFamilyEa ?? null, undefined, context);
   if (!font) return [];
 
   const path = font.getPath(bulletText, x, y, fontSizePx);
@@ -1220,6 +1280,7 @@ function renderTextBodyAsPath(
   textBody: TextBody,
   transform: Transform,
   fontResolver: TextPathFontResolver,
+  context: RendererContext,
 ): string {
   const { bodyProperties, paragraphs } = textBody;
   const originalWidth = emuToPixels(transform.extentWidth);
@@ -1249,12 +1310,13 @@ function renderTextBodyAsPath(
       lnSpcReduction,
       textWidth,
       availableHeight,
+      context,
     );
   }
 
   const scaledDefaultFontSizePt = defaultFontSize * fontScale;
-  const defaultLineHeightRatio = getDefaultLineHeightRatio(paragraphs);
-  const defaultAscenderRatio = getDefaultAscenderRatio(paragraphs);
+  const defaultLineHeightRatio = getDefaultLineHeightRatio(paragraphs, context);
+  const defaultAscenderRatio = getDefaultAscenderRatio(paragraphs, context);
   const defaultNaturalHeightPt = scaledDefaultFontSizePt * defaultLineHeightRatio;
 
   // Vertical position calculation (reusing existing logic)
@@ -1266,6 +1328,7 @@ function renderTextBodyAsPath(
     textWidth,
     lnSpcReduction,
     fontScale,
+    context,
   );
   if (bodyProperties.anchor === "ctr") {
     yStart = Math.max(marginTopPx, (height - totalTextHeight) / 2);
@@ -1313,6 +1376,7 @@ function renderTextBodyAsPath(
         effectiveTextWidth,
         scaledDefaultFontSizePt,
         fontScale,
+        context.textMeasurer,
       );
 
       for (let lineIdx = 0; lineIdx < wrappedLines.length; lineIdx++) {
@@ -1332,13 +1396,20 @@ function renderTextBodyAsPath(
           line.segments,
           defaultFontSize,
           fontScale,
+          context,
         );
         if (!isFirstLine) {
           currentY += getLineHeightPx(para, lineNaturalHeightPt, lnSpcReduction) + lineGapPx;
         }
 
         // Calculate x position for alignment by measuring line width
-        const lineWidth = measureLineWidth(line.segments, defaultFontSize, fontScale, fontResolver);
+        const lineWidth = measureLineWidth(
+          line.segments,
+          defaultFontSize,
+          fontScale,
+          fontResolver,
+          context,
+        );
         const lineStartX = computePathLineX(
           para.properties.alignment,
           textStartX,
@@ -1363,6 +1434,7 @@ function renderTextBodyAsPath(
               lineFontSize,
               fontScale,
               fontResolver,
+              context,
               firstSeg?.properties.fontFamily,
               firstSeg?.properties.fontFamilyEa,
             ),
@@ -1379,6 +1451,7 @@ function renderTextBodyAsPath(
             fontScale,
             defaultFontSize,
             fontResolver,
+            context,
             bodyProperties.vert,
           );
           if (result.svg) elements.push(result.svg);
@@ -1389,7 +1462,12 @@ function renderTextBodyAsPath(
       }
     } else {
       // wrap="none": no wrapping
-      const naturalHeightPt = computeLineNaturalHeight(para.runs, defaultFontSize, fontScale);
+      const naturalHeightPt = computeLineNaturalHeight(
+        para.runs,
+        defaultFontSize,
+        fontScale,
+        context,
+      );
       if (!isFirstLine) {
         currentY += getLineHeightPx(para, naturalHeightPt, lnSpcReduction) + paragraphGapPx;
       }
@@ -1398,7 +1476,13 @@ function renderTextBodyAsPath(
       const runsAsSegments = para.runs
         .filter((r) => r.text.length > 0)
         .map((r) => ({ text: r.text, properties: r.properties }));
-      const lineWidth = measureLineWidth(runsAsSegments, defaultFontSize, fontScale, fontResolver);
+      const lineWidth = measureLineWidth(
+        runsAsSegments,
+        defaultFontSize,
+        fontScale,
+        fontResolver,
+        context,
+      );
       const lineStartX = computePathLineX(
         para.properties.alignment,
         textStartX,
@@ -1423,6 +1507,7 @@ function renderTextBodyAsPath(
             fontSize,
             fontScale,
             fontResolver,
+            context,
             firstRun?.properties.fontFamily,
             firstRun?.properties.fontFamilyEa,
           ),
@@ -1440,6 +1525,7 @@ function renderTextBodyAsPath(
           fontScale,
           defaultFontSize,
           fontResolver,
+          context,
           bodyProperties.vert,
         );
         if (result.svg) elements.push(result.svg);

--- a/packages/renderer/src/utils/text-wrap.ts
+++ b/packages/renderer/src/utils/text-wrap.ts
@@ -1,3 +1,4 @@
+import type { TextMeasurer } from "../font/text-measurer.js";
 import { getTextMeasurer } from "../font/text-measurer.js";
 import type { Paragraph, RunProperties } from "../model/text.js";
 
@@ -99,6 +100,7 @@ function tokenizeRuns(
   runs: Paragraph["runs"],
   defaultFontSize: number,
   fontScale: number,
+  textMeasurer: TextMeasurer,
 ): Token[] {
   const tokens: Token[] = [];
   let isFirst = true;
@@ -131,7 +133,7 @@ function tokenizeRuns(
         const fontFamilyEa = run.properties.fontFamilyEa;
         const fragments = splitTextIntoFragments(part);
         for (const { fragment, breakable } of fragments) {
-          const width = getTextMeasurer().measureTextWidth(
+          const width = textMeasurer.measureTextWidth(
             fragment,
             fontSize,
             bold,
@@ -159,7 +161,7 @@ function tokenizeRuns(
     const fragments = splitTextIntoFragments(run.text);
 
     for (const { fragment, breakable } of fragments) {
-      const width = getTextMeasurer().measureTextWidth(
+      const width = textMeasurer.measureTextWidth(
         fragment,
         fontSize,
         bold,
@@ -194,6 +196,7 @@ function splitTokenByChars(
   availableWidth: number,
   defaultFontSize: number,
   fontScale: number,
+  textMeasurer: TextMeasurer,
 ): Token[][] {
   const lines: Token[][] = [];
   let currentLine: Token[] = [];
@@ -206,13 +209,7 @@ function splitTokenByChars(
   const fontFamilyEa = token.properties.fontFamilyEa;
 
   for (const char of token.text) {
-    const charWidth = getTextMeasurer().measureTextWidth(
-      char,
-      fontSize,
-      bold,
-      fontFamily,
-      fontFamilyEa,
-    );
+    const charWidth = textMeasurer.measureTextWidth(char, fontSize, bold, fontFamily, fontFamilyEa);
 
     if (currentWidth + charWidth > availableWidth && currentLine.length > 0) {
       lines.push(currentLine);
@@ -276,6 +273,7 @@ function layoutTokensIntoLines(
   availableWidth: number,
   defaultFontSize: number,
   fontScale: number,
+  textMeasurer: TextMeasurer,
 ): WrappedLine[] {
   if (tokens.length === 0) return [{ segments: [] }];
 
@@ -305,7 +303,13 @@ function layoutTokensIntoLines(
         // Skip blank tokens
         continue;
       }
-      const splitLines = splitTokenByChars(token, availableWidth, defaultFontSize, fontScale);
+      const splitLines = splitTokenByChars(
+        token,
+        availableWidth,
+        defaultFontSize,
+        fontScale,
+        textMeasurer,
+      );
       for (let j = 0; j < splitLines.length; j++) {
         if (j < splitLines.length - 1) {
           const segments = trimTrailingSpaces(mergeSegments(splitLines[j]));
@@ -354,15 +358,16 @@ export function wrapParagraph(
   availableWidth: number,
   defaultFontSize: number = DEFAULT_FONT_SIZE,
   fontScale: number = 1,
+  textMeasurer: TextMeasurer = getTextMeasurer(),
 ): WrappedLine[] {
   if (paragraph.runs.length === 0 || !paragraph.runs.some((r) => r.text.length > 0)) {
     return [{ segments: [] }];
   }
 
   const safeWidth = Math.max(availableWidth, 1);
-  const tokens = tokenizeRuns(paragraph.runs, defaultFontSize, fontScale);
+  const tokens = tokenizeRuns(paragraph.runs, defaultFontSize, fontScale, textMeasurer);
 
   if (tokens.length === 0) return [{ segments: [] }];
 
-  return layoutTokensIntoLines(tokens, safeWidth, defaultFontSize, fontScale);
+  return layoutTokensIntoLines(tokens, safeWidth, defaultFontSize, fontScale, textMeasurer);
 }

--- a/packages/renderer/src/utils/text-wrap.ts
+++ b/packages/renderer/src/utils/text-wrap.ts
@@ -1,4 +1,4 @@
-import type { TextMeasurer } from "../font/text-measurer.js";
+import type { TextMeasurementContext, TextMeasurer } from "../font/text-measurer.js";
 import { getTextMeasurer } from "../font/text-measurer.js";
 import type { Paragraph, RunProperties } from "../model/text.js";
 
@@ -101,6 +101,7 @@ function tokenizeRuns(
   defaultFontSize: number,
   fontScale: number,
   textMeasurer: TextMeasurer,
+  measurementContext?: TextMeasurementContext,
 ): Token[] {
   const tokens: Token[] = [];
   let isFirst = true;
@@ -139,6 +140,7 @@ function tokenizeRuns(
             bold,
             fontFamily,
             fontFamilyEa,
+            measurementContext,
           );
           tokens.push({
             text: fragment,
@@ -167,6 +169,7 @@ function tokenizeRuns(
         bold,
         fontFamily,
         fontFamilyEa,
+        measurementContext,
       );
       tokens.push({
         text: fragment,
@@ -197,6 +200,7 @@ function splitTokenByChars(
   defaultFontSize: number,
   fontScale: number,
   textMeasurer: TextMeasurer,
+  measurementContext?: TextMeasurementContext,
 ): Token[][] {
   const lines: Token[][] = [];
   let currentLine: Token[] = [];
@@ -209,7 +213,14 @@ function splitTokenByChars(
   const fontFamilyEa = token.properties.fontFamilyEa;
 
   for (const char of token.text) {
-    const charWidth = textMeasurer.measureTextWidth(char, fontSize, bold, fontFamily, fontFamilyEa);
+    const charWidth = textMeasurer.measureTextWidth(
+      char,
+      fontSize,
+      bold,
+      fontFamily,
+      fontFamilyEa,
+      measurementContext,
+    );
 
     if (currentWidth + charWidth > availableWidth && currentLine.length > 0) {
       lines.push(currentLine);
@@ -274,6 +285,7 @@ function layoutTokensIntoLines(
   defaultFontSize: number,
   fontScale: number,
   textMeasurer: TextMeasurer,
+  measurementContext?: TextMeasurementContext,
 ): WrappedLine[] {
   if (tokens.length === 0) return [{ segments: [] }];
 
@@ -309,6 +321,7 @@ function layoutTokensIntoLines(
         defaultFontSize,
         fontScale,
         textMeasurer,
+        measurementContext,
       );
       for (let j = 0; j < splitLines.length; j++) {
         if (j < splitLines.length - 1) {
@@ -359,15 +372,29 @@ export function wrapParagraph(
   defaultFontSize: number = DEFAULT_FONT_SIZE,
   fontScale: number = 1,
   textMeasurer: TextMeasurer = getTextMeasurer(),
+  measurementContext?: TextMeasurementContext,
 ): WrappedLine[] {
   if (paragraph.runs.length === 0 || !paragraph.runs.some((r) => r.text.length > 0)) {
     return [{ segments: [] }];
   }
 
   const safeWidth = Math.max(availableWidth, 1);
-  const tokens = tokenizeRuns(paragraph.runs, defaultFontSize, fontScale, textMeasurer);
+  const tokens = tokenizeRuns(
+    paragraph.runs,
+    defaultFontSize,
+    fontScale,
+    textMeasurer,
+    measurementContext,
+  );
 
   if (tokens.length === 0) return [{ segments: [] }];
 
-  return layoutTokensIntoLines(tokens, safeWidth, defaultFontSize, fontScale, textMeasurer);
+  return layoutTokensIntoLines(
+    tokens,
+    safeWidth,
+    defaultFontSize,
+    fontScale,
+    textMeasurer,
+    measurementContext,
+  );
 }

--- a/packages/renderer/src/warning-logger.ts
+++ b/packages/renderer/src/warning-logger.ts
@@ -38,50 +38,105 @@ export interface WarningSummary {
   features: { feature: string; message: string; count: number }[];
 }
 
+export interface WarningLogger {
+  warn(feature: string, message: string, context?: string): void;
+  debug(feature: string, message: string, context?: string): void;
+  getWarningSummary(): WarningSummary;
+  flushWarnings(): WarningSummary;
+  getWarningEntries(): readonly WarningEntry[];
+  getLogLevel(): LogLevel;
+}
+
 const PREFIX = "[pptx-glimpse]";
 
-let currentLevel: LogLevel = "off";
-let entries: WarningEntry[] = [];
-const featureCounts = new Map<string, { message: string; count: number }>();
+class InMemoryWarningLogger implements WarningLogger {
+  private entries: WarningEntry[] = [];
+  private readonly featureCounts = new Map<string, { message: string; count: number }>();
+
+  constructor(private readonly level: LogLevel) {}
+
+  warn(feature: string, message: string, context?: string): void {
+    if (this.level === "off") return;
+    this.record(feature, message, context);
+
+    if (this.level === "debug") {
+      const ctx = context ? ` (${context})` : "";
+      console.warn(`${PREFIX} SKIP: ${feature} - ${message}${ctx}`);
+    }
+  }
+
+  debug(feature: string, message: string, context?: string): void {
+    if (this.level !== "debug") return;
+    this.record(feature, message, context);
+
+    const ctx = context ? ` (${context})` : "";
+    console.warn(`${PREFIX} DEBUG: ${feature} - ${message}${ctx}`);
+  }
+
+  getWarningSummary(): WarningSummary {
+    const features: WarningSummary["features"] = [];
+    for (const [feature, { message, count }] of this.featureCounts) {
+      features.push({ feature, message, count });
+    }
+    return { totalCount: this.entries.length, features };
+  }
+
+  flushWarnings(): WarningSummary {
+    const summary = this.getWarningSummary();
+
+    if (this.level !== "off" && summary.features.length > 0) {
+      console.warn(`${PREFIX} Summary: ${summary.features.length} unsupported feature(s) detected`);
+      for (const { feature, count } of summary.features) {
+        console.warn(`  - ${feature}: ${count} occurrence(s)`);
+      }
+    }
+
+    this.entries = [];
+    this.featureCounts.clear();
+
+    return summary;
+  }
+
+  getWarningEntries(): readonly WarningEntry[] {
+    return this.entries;
+  }
+
+  getLogLevel(): LogLevel {
+    return this.level;
+  }
+
+  private record(feature: string, message: string, context?: string): void {
+    this.entries.push({ feature, message, ...(context !== undefined && { context }) });
+
+    const existing = this.featureCounts.get(feature);
+    if (existing) {
+      existing.count++;
+    } else {
+      this.featureCounts.set(feature, { message, count: 1 });
+    }
+  }
+}
+
+let activeLogger: WarningLogger = createWarningLogger("off");
+
+export function createWarningLogger(level: LogLevel): WarningLogger {
+  return new InMemoryWarningLogger(level);
+}
 
 export function initWarningLogger(level: LogLevel): void {
-  currentLevel = level;
-  entries = [];
-  featureCounts.clear();
+  activeLogger = createWarningLogger(level);
+}
+
+export function getActiveWarningLogger(): WarningLogger {
+  return activeLogger;
 }
 
 export function warn(feature: string, message: string, context?: string): void {
-  if (currentLevel === "off") return;
-
-  entries.push({ feature, message, ...(context !== undefined && { context }) });
-
-  const existing = featureCounts.get(feature);
-  if (existing) {
-    existing.count++;
-  } else {
-    featureCounts.set(feature, { message, count: 1 });
-  }
-
-  if (currentLevel === "debug") {
-    const ctx = context ? ` (${context})` : "";
-    console.warn(`${PREFIX} SKIP: ${feature} - ${message}${ctx}`);
-  }
+  activeLogger.warn(feature, message, context);
 }
 
 export function debug(feature: string, message: string, context?: string): void {
-  if (currentLevel !== "debug") return;
-
-  entries.push({ feature, message, ...(context !== undefined && { context }) });
-
-  const existing = featureCounts.get(feature);
-  if (existing) {
-    existing.count++;
-  } else {
-    featureCounts.set(feature, { message, count: 1 });
-  }
-
-  const ctx = context ? ` (${context})` : "";
-  console.warn(`${PREFIX} DEBUG: ${feature} - ${message}${ctx}`);
+  activeLogger.debug(feature, message, context);
 }
 
 /**
@@ -94,27 +149,11 @@ export function debug(feature: string, message: string, context?: string): void 
  * that manage the warning cycle directly.
  */
 export function getWarningSummary(): WarningSummary {
-  const features: WarningSummary["features"] = [];
-  for (const [feature, { message, count }] of featureCounts) {
-    features.push({ feature, message, count });
-  }
-  return { totalCount: entries.length, features };
+  return activeLogger.getWarningSummary();
 }
 
 export function flushWarnings(): WarningSummary {
-  const summary = getWarningSummary();
-
-  if (currentLevel !== "off" && summary.features.length > 0) {
-    console.warn(`${PREFIX} Summary: ${summary.features.length} unsupported feature(s) detected`);
-    for (const { feature, count } of summary.features) {
-      console.warn(`  - ${feature}: ${count} occurrence(s)`);
-    }
-  }
-
-  entries = [];
-  featureCounts.clear();
-
-  return summary;
+  return activeLogger.flushWarnings();
 }
 
 /**
@@ -126,9 +165,9 @@ export function flushWarnings(): WarningSummary {
  * manage the warning cycle directly.
  */
 export function getWarningEntries(): readonly WarningEntry[] {
-  return entries;
+  return activeLogger.getWarningEntries();
 }
 
 export function getLogLevel(): LogLevel {
-  return currentLevel;
+  return activeLogger.getLogLevel();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@pptx-glimpse/document':
+        specifier: ^0.1.0
+        version: link:../document
       '@resvg/resvg-wasm':
         specifier: ^2.6.2
         version: 2.6.2
@@ -95,9 +98,6 @@ importers:
         specifier: 1.3.4
         version: 1.3.4
     devDependencies:
-      '@pptx-glimpse/document':
-        specifier: workspace:*
-        version: link:../document
       '@pptx-glimpse/editor-core':
         specifier: workspace:*
         version: link:../editor-core

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -109,6 +109,7 @@ import { collectUsedFonts, convertPptxToSvg, convertPptxToPng, renderPptxSourceM
 import type {
   ConvertOptions,
   PngConversionReport,
+  PptxSourceModel,
   SvgConversionReport,
   UsedFonts,
 } from "pptx-glimpse";
@@ -141,7 +142,9 @@ function _verifyBufferInput(input: Buffer) {
 // Verify @pptx-glimpse/document readPptx() output is accepted by the source-model render API.
 async function _verifyDocumentSourceModel(input: Uint8Array) {
   const source = readPptx(input);
+  const _source: PptxSourceModel = source;
   await renderPptxSourceModelToSvg(source);
+  void _source;
 }
 
 // Verify ConvertOptions includes fontDirs

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -39,9 +39,14 @@ const assert = (condition, message) => {
 
 assert(typeof pkg.convertPptxToSvg === "function", "convertPptxToSvg should be a function");
 assert(typeof pkg.convertPptxToPng === "function", "convertPptxToPng should be a function");
+assert(
+  typeof pkg.renderPptxSourceModelToSvg === "function",
+  "renderPptxSourceModelToSvg should be a function",
+);
 
 console.log("  convertPptxToSvg: function OK");
 console.log("  convertPptxToPng: function OK");
+console.log("  renderPptxSourceModelToSvg: function OK");
 console.log("CJS test passed!");
 TESTEOF
 node test-cjs.cjs
@@ -51,7 +56,7 @@ echo ""
 # --- core ESM test ---
 echo "--- Test: pptx-glimpse ESM (import) ---"
 cat > test-esm.mjs << 'TESTEOF'
-import { convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
+import { convertPptxToSvg, convertPptxToPng, renderPptxSourceModelToSvg } from "pptx-glimpse";
 
 const assert = (condition, message) => {
   if (!condition) {
@@ -62,9 +67,14 @@ const assert = (condition, message) => {
 
 assert(typeof convertPptxToSvg === "function", "convertPptxToSvg should be a function");
 assert(typeof convertPptxToPng === "function", "convertPptxToPng should be a function");
+assert(
+  typeof renderPptxSourceModelToSvg === "function",
+  "renderPptxSourceModelToSvg should be a function",
+);
 
 console.log("  convertPptxToSvg: function OK");
 console.log("  convertPptxToPng: function OK");
+console.log("  renderPptxSourceModelToSvg: function OK");
 console.log("ESM test passed!");
 TESTEOF
 node test-esm.mjs
@@ -94,14 +104,24 @@ cat > tsconfig.json << 'TESTEOF'
 TESTEOF
 
 cat > test-types.ts << 'TESTEOF'
-import { collectUsedFonts, convertPptxToSvg, convertPptxToPng } from "pptx-glimpse";
-import type { ConvertOptions, PngConversionReport, SvgConversionReport, UsedFonts } from "pptx-glimpse";
+import { collectUsedFonts, convertPptxToSvg, convertPptxToPng, renderPptxSourceModelToSvg } from "pptx-glimpse";
+import type {
+  ConvertOptions,
+  PngConversionReport,
+  PptxSourceModel,
+  SvgConversionReport,
+  UsedFonts,
+} from "pptx-glimpse";
 
 // Verify function signatures
 const _svgFn: (input: Uint8Array, options?: ConvertOptions) => Promise<SvgConversionReport> =
   convertPptxToSvg;
 const _pngFn: (input: Uint8Array, options?: ConvertOptions) => Promise<PngConversionReport> =
   convertPptxToPng;
+const _sourceModelSvgFn: (
+  source: PptxSourceModel,
+  options?: ConvertOptions,
+) => Promise<SvgConversionReport> = renderPptxSourceModelToSvg;
 const _fontFn: (input: Uint8Array) => UsedFonts = collectUsedFonts;
 
 // Verify SlideImage.png is Uint8Array
@@ -122,6 +142,7 @@ function _verifyBufferInput(input: Buffer) {
 const _options: ConvertOptions = { slides: [1], width: 960, fontDirs: ["/custom/fonts"] };
 void _svgFn;
 void _pngFn;
+void _sourceModelSvgFn;
 void _fontFn;
 void _options;
 void _verifyPngType;

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -21,7 +21,7 @@ TEST_DIR="$WORK_DIR/core-test-project"
 mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 npm init -y > /dev/null 2>&1
-npm install "$TARBALL_PATH" > /dev/null 2>&1
+npm install "$DOCUMENT_TARBALL_PATH" "$TARBALL_PATH" > /dev/null 2>&1
 
 echo ""
 
@@ -104,11 +104,11 @@ cat > tsconfig.json << 'TESTEOF'
 TESTEOF
 
 cat > test-types.ts << 'TESTEOF'
+import { readPptx } from "@pptx-glimpse/document";
 import { collectUsedFonts, convertPptxToSvg, convertPptxToPng, renderPptxSourceModelToSvg } from "pptx-glimpse";
 import type {
   ConvertOptions,
   PngConversionReport,
-  PptxSourceModel,
   SvgConversionReport,
   UsedFonts,
 } from "pptx-glimpse";
@@ -119,7 +119,7 @@ const _svgFn: (input: Uint8Array, options?: ConvertOptions) => Promise<SvgConver
 const _pngFn: (input: Uint8Array, options?: ConvertOptions) => Promise<PngConversionReport> =
   convertPptxToPng;
 const _sourceModelSvgFn: (
-  source: PptxSourceModel,
+  source: ReturnType<typeof readPptx>,
   options?: ConvertOptions,
 ) => Promise<SvgConversionReport> = renderPptxSourceModelToSvg;
 const _fontFn: (input: Uint8Array) => UsedFonts = collectUsedFonts;
@@ -138,6 +138,12 @@ function _verifyBufferInput(input: Buffer) {
   void collectUsedFonts(input);
 }
 
+// Verify @pptx-glimpse/document readPptx() output is accepted by the source-model render API.
+async function _verifyDocumentSourceModel(input: Uint8Array) {
+  const source = readPptx(input);
+  await renderPptxSourceModelToSvg(source);
+}
+
 // Verify ConvertOptions includes fontDirs
 const _options: ConvertOptions = { slides: [1], width: 960, fontDirs: ["/custom/fonts"] };
 void _svgFn;
@@ -147,6 +153,7 @@ void _fontFn;
 void _options;
 void _verifyPngType;
 void _verifyBufferInput;
+void _verifyDocumentSourceModel;
 TESTEOF
 npx tsc --noEmit
 echo "TypeScript type resolution test passed!"


### PR DESCRIPTION
close #351

## 概要

- `readPptx()` 済みの `PptxSourceModel` から SVG を生成する `renderPptxSourceModelToSvg` を公開
- 既存の `convertPptxToSvg` / `convertPptxToPng` は source model render 経由に整理
- renderer のフォント・warning 周辺の可変状態を `RendererContext` でレンダー呼び出しごとに分離
- browser editor の再レンダリングを write + re-read なしの source model render に変更
- README / package verification / changeset を更新

## 検証

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test`
- `bash scripts/test-package.sh`
- Snapshot VRT: Docker で `vrt/snapshot/regression.test.ts` 53 件 pass

## 補足

- `pnpm install --lockfile-only` は既存 lockfile の `minimumReleaseAge` policy 違反（`picomatch@4.0.5`, `postcss@8.5.16`）で停止したため、今回必要な importer 区分のみ最小更新しました。