### PR TITLE
ci: Node 26 を test matrix に追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     strategy:
       matrix:
-        node-version: [22, 24]
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ npm run dev -- file.pptx  # Live preview dev server (auto-reload on packages/*/s
 CI consists of 4 jobs:
 
 - **lint**: `knip` → `lint` → `format:check` → `typecheck` (Node 22 only, runs once)
-- **test**: `test` with coverage → `build` → package verification (Node 22/24, coverage report on Node 22)
+- **test**: `test` with coverage → `build` → package verification (Node 22/24/26, coverage report on Node 22)
 - **vrt**: Snapshot VRT (Docker-based, self-comparison)
 - **libreoffice-vrt**: LibreOffice VRT (generates fixtures and reference images via Docker)
 


### PR DESCRIPTION
close #620

## 目的

CI の test job の Node.js matrix に Node 26 を追加し、Node 22 / 24 / 26 で継続的にテスト・ビルド・package verification を実行できるようにします。

## 変更内容

- `.github/workflows/ci.yml` の test job matrix を `22, 24, 26` に更新
- `AGENTS.md` の CI 説明も Node 26 追加後の内容に同期
- coverage report / coverage comment / demo verification の `matrix.node-version == 22` 条件は維持

## ローカル検証

- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `node node_modules/prettier/bin/prettier.cjs --check .github/workflows/ci.yml`
- `npm run test`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npm run build`
- `bash scripts/test-package.sh`

補足: 通常の `pnpm exec prettier` と `npm run build` は、ローカル pnpm config の `minimumReleaseAge: 10080` により既存 lockfile 依存の `picomatch@4.0.5` / `postcss@8.5.16` が policy rejection になったため、build 検証のみ `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` を付けて実行しました。
