### PR TITLE
README のブラウザ対応表現を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 No LibreOffice required — just `npm install`.
 
-A lightweight JavaScript library that renders PowerPoint (.pptx) slides as SVG or PNG — in Node.js and in the browser.
+A lightweight JavaScript library that renders PowerPoint (.pptx) slides as SVG or PNG in Node.js and the browser.
 
 **[Try the Demo](https://glimpse.pptx.app/)** | [npm](https://www.npmjs.com/package/pptx-glimpse)
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ rather than pixel-perfect rendering of every PowerPoint feature.
 
 ## Requirements
 
-- **Node.js >= 22** when using pptx-glimpse in Node.js.
-- **Browser usage** should provide font bytes with the `fonts` option; see
+- **Node.js >= 22** for package tooling and Node.js runtime usage.
+- **Browser runtime usage** should provide font bytes with the `fonts` option; see
   [Custom Font Loading](#custom-font-loading). PNG conversion in browser-like
   runtimes also requires explicit resvg WASM initialization; see
   [Browser resvg WASM Loading for PNG](#browser-resvg-wasm-loading-for-png).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 No LibreOffice required — just `npm install`.
 
-A lightweight JavaScript library that renders PowerPoint (.pptx) slides as SVG or PNG in Node.js.
+A lightweight JavaScript library that renders PowerPoint (.pptx) slides as SVG or PNG — in Node.js and in the browser.
 
 **[Try the Demo](https://glimpse.pptx.app/)** | [npm](https://www.npmjs.com/package/pptx-glimpse)
 
@@ -23,9 +23,9 @@ _Upload a .pptx file → get SVG/PNG output instantly_
 
 pptx-glimpse is designed for two primary use cases:
 
-- **Frontend PPTX preview** — Render slide thumbnails without depending on
-  Microsoft Office or LibreOffice. The SVG output can be embedded directly
-  in web pages.
+- **Frontend PPTX preview** — Render slide thumbnails entirely client-side,
+  without a conversion server, Microsoft Office, or LibreOffice. The SVG output
+  can be embedded directly in web pages.
 - **AI image recognition** — Convert slides to PNG so that vision-capable LLMs
   can understand slide content and layout.
 
@@ -34,16 +34,20 @@ rather than pixel-perfect rendering of every PowerPoint feature.
 
 ## Why not LibreOffice?
 
-|              | LibreOffice                | pptx-glimpse                   |
-| ------------ | -------------------------- | ------------------------------ |
-| Install size | ~500 MB+                   | `npm install` (~30 MB)         |
-| Docker image | Large base image required  | Works in any Node.js image     |
-| Startup time | Process spawning overhead  | In-process, no spawning        |
-| Concurrency  | One process per conversion | Async, runs in your event loop |
+|              | LibreOffice                | pptx-glimpse                             |
+| ------------ | -------------------------- | ---------------------------------------- |
+| Install size | ~500 MB+                   | `npm install` (~30 MB)                   |
+| Docker image | Large base image required  | Works in Node.js images and browser apps |
+| Startup time | Process spawning overhead  | In-process, no spawning                  |
+| Concurrency  | One process per conversion | Async, runs in your event loop           |
 
 ## Requirements
 
-- **Node.js >= 22**
+- **Node.js >= 22** when using pptx-glimpse in Node.js.
+- **Browser usage** should provide font bytes with the `fonts` option; see
+  [Custom Font Loading](#custom-font-loading). PNG conversion in browser-like
+  runtimes also requires explicit resvg WASM initialization; see
+  [Browser resvg WASM Loading for PNG](#browser-resvg-wasm-loading-for-png).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ getMappedFont("calibri", mapping); // "Ubuntu"
 
 </details>
 
+<a id="custom-font-loading"></a>
+
 <details>
 <summary>Custom Font Loading</summary>
 
@@ -207,6 +209,8 @@ const setup = await createOpentypeSetupFromBuffers([
 ```
 
 </details>
+
+<a id="browser-resvg-wasm-loading-for-png"></a>
 
 <details>
 <summary>Browser resvg WASM Loading for PNG</summary>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pptx-glimpse",
   "version": "3.0.0",
-  "description": "A lightweight JavaScript library for rendering PowerPoint (.pptx) files as SVG or PNG in Node.js. No LibreOffice required.",
+  "description": "A lightweight JavaScript library for rendering PowerPoint (.pptx) files as SVG or PNG in Node.js and the browser. No LibreOffice required.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
close #609

## 目的

README のタグラインと Requirements / Motivation の記述を、Node.js とブラウザの両対応を表す内容に更新します。

## 変更内容

- README のタグラインを Node.js とブラウザ両対応の文言に更新
- Frontend PPTX preview の説明に、サーバー不要・クライアントサイド完結である旨を追加
- Requirements に Node.js 要件とブラウザ実行時の前提（`fonts` オプション、`initResvgWasm`）を明記
- README 内参照リンク用の明示 anchor を追加
- `packages/core/package.json` の npm description もブラウザ対応済みの表現に整合

## 影響範囲

- `README.md`
- `packages/core/package.json`

## 検証

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `./node_modules/.bin/prettier --check README.md packages/core/package.json`
- 受け入れ条件チェック: 全件 OK
- cross-review: 指摘 0 件

## changeset

- docs / metadata のみで公開 API・挙動変更なしのため不要
