### PR TITLE
editor: run property editing controls in dev editor

### DIFF
--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -109,6 +109,60 @@ test("edits a text shape with the overlay editor, re-renders, and saves text", a
   }
 });
 
+test("applies text run decoration from the overlay toolbar with undo and redo", async ({
+  page,
+}) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-editor-decoration-test-"));
+  let serverProcess: ChildProcessWithoutNullStreams | undefined;
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    await writeFile(sourcePath, await buildShapeFixture());
+
+    const port = await findFreePort();
+    serverProcess = await startDevServer(sourcePath, port);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+    await page.goto(baseUrl);
+    await expect(page.getByTestId("shape-hit-area").first()).toBeVisible();
+
+    await dblclickSvgPoint(page, 240, 240);
+    await expect(page.getByTestId("text-run-format-toolbar")).toBeVisible();
+    const commandResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/command") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("text-run-format-bold").click();
+    await commandResponse;
+
+    const undoResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/undo") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Undo" }).click();
+    await undoResponse;
+
+    const redoResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/redo") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Redo" }).click();
+    await redoResponse;
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+
+    const saved = readPptx(await readFile(savedPath));
+    expect(firstRunProperties(saved)).toMatchObject({ bold: true });
+  } finally {
+    if (serverProcess !== undefined) {
+      serverProcess.kill();
+      await waitForExit(serverProcess);
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 async function clickSvgPoint(page: Page, x: number, y: number) {
   const point = await svgPointToClient(page, x, y);
   await page.mouse.click(point.x, point.y);
@@ -273,6 +327,12 @@ function firstText(source: PptxSourceModel): string {
   const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.text;
+}
+
+function firstRunProperties(source: PptxSourceModel) {
+  const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
+  if (run === undefined) throw new Error("fixture text run not found");
+  return run.properties;
 }
 
 async function findFreePort(): Promise<number> {

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -136,12 +136,37 @@ test("applies text run decoration from the overlay toolbar with undo and redo", 
     );
     await page.getByTestId("text-run-format-bold").click();
     await commandResponse;
+    await expect(page.getByTestId("text-run-format-toolbar")).toBeVisible();
+
+    const italicResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/command") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("text-run-format-italic").click();
+    await italicResponse;
+    await expect(page.getByTestId("text-run-format-toolbar")).toBeVisible();
+    const textBodyResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/text-body") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("text-editor-done").click();
+    await textBodyResponse;
 
     const undoResponse = page.waitForResponse(
       (response) => response.url().endsWith("/api/editor/undo") && response.ok(),
     );
     await page.getByRole("button", { name: "Undo" }).click();
     await undoResponse;
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+    let saved = readPptx(await readFile(savedPath));
+    expect(firstRunProperties(saved)).toMatchObject({ bold: true });
+    expect(firstRunProperties(saved)?.italic).toBeUndefined();
 
     const redoResponse = page.waitForResponse(
       (response) => response.url().endsWith("/api/editor/redo") && response.ok(),
@@ -152,8 +177,8 @@ test("applies text run decoration from the overlay toolbar with undo and redo", 
     await page.getByRole("button", { name: "Save" }).click();
     await expect(page.locator("#editor-message")).toContainText(savedPath);
 
-    const saved = readPptx(await readFile(savedPath));
-    expect(firstRunProperties(saved)).toMatchObject({ bold: true });
+    saved = readPptx(await readFile(savedPath));
+    expect(firstRunProperties(saved)).toMatchObject({ bold: true, italic: true });
   } finally {
     if (serverProcess !== undefined) {
       serverProcess.kill();

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -172,6 +172,12 @@ describe("dev server editor API", () => {
         },
       });
       expect(decorated.history).toMatchObject({ canUndo: true, canRedo: false });
+      expect(decorated.slides[0].svg).toContain('data-bold="true"');
+      expect(decorated.slides[0].svg).toContain('data-italic="true"');
+      expect(decorated.slides[0].svg).toContain('data-underline="true"');
+      expect(decorated.slides[0].svg).toContain('data-font-size="32"');
+      expect(decorated.slides[0].svg).toContain('data-color="9C0000"');
+      expect(decorated.slides[0].svg).toContain('data-typeface="Liberation Sans"');
 
       const undone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/undo`, {});
       expect(undone.history).toMatchObject({ canUndo: false, canRedo: true });
@@ -243,8 +249,23 @@ interface SaveResponse {
 function renderPreview(input: Uint8Array): Promise<Array<{ slideNumber: number; svg: string }>> {
   const source = readPptx(input);
   return Promise.resolve([
-    { slideNumber: 1, svg: `<svg><text>${escapeXml(firstRun(source))}</text></svg>` },
+    {
+      slideNumber: 1,
+      svg: `<svg><text${runPropertyAttrs(source)}>${escapeXml(firstRun(source))}</text></svg>`,
+    },
   ]);
+}
+
+function runPropertyAttrs(source: PptxSourceModel): string {
+  const properties = firstRunProperties(source);
+  return [
+    properties?.bold === undefined ? "" : ` data-bold="${String(properties.bold)}"`,
+    properties?.italic === undefined ? "" : ` data-italic="${String(properties.italic)}"`,
+    properties?.underline === undefined ? "" : ` data-underline="${String(properties.underline)}"`,
+    properties?.fontSize === undefined ? "" : ` data-font-size="${String(properties.fontSize)}"`,
+    properties?.color === undefined ? "" : ` data-color="${escapeXml(properties.color.hex)}"`,
+    properties?.typeface === undefined ? "" : ` data-typeface="${escapeXml(properties.typeface)}"`,
+  ].join("");
 }
 
 function escapeXml(value: string): string {

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -140,6 +140,74 @@ describe("dev server editor API", () => {
       }
     }
   });
+
+  it("applies, undoes, redoes, clears, and saves text run property commands", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-run-property-test-"));
+    try {
+      const sourcePath = join(dir, "fixture.pptx");
+      const savedPath = join(dir, "saved.pptx");
+      const clearedPath = join(dir, "cleared.pptx");
+      await writeFile(sourcePath, await buildTextEditFixture());
+
+      const backend = await DevEditorBackend.load(sourcePath, renderPreview);
+      const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
+      servers.push(server);
+      const baseUrl = await listen(server);
+
+      const shapes = await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`);
+      const handle = shapes.shapes[0].textRuns[0].handle;
+
+      const decorated = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "setTextRunProperties",
+          handle,
+          properties: {
+            bold: true,
+            italic: true,
+            underline: true,
+            fontSize: 32,
+            color: { kind: "srgb", hex: "9c0000" },
+            typeface: "Liberation Sans",
+          },
+        },
+      });
+      expect(decorated.history).toMatchObject({ canUndo: true, canRedo: false });
+
+      const undone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/undo`, {});
+      expect(undone.history).toMatchObject({ canUndo: false, canRedo: true });
+      const redone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/redo`, {});
+      expect(redone.history).toMatchObject({ canUndo: true, canRedo: false });
+
+      await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
+      expect(firstRunProperties(readPptx(await readFile(savedPath)))).toMatchObject({
+        bold: true,
+        italic: true,
+        underline: true,
+        fontSize: 32,
+        color: { kind: "srgb", hex: "9C0000" },
+        typeface: "Liberation Sans",
+      });
+
+      await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "clearTextRunProperties",
+          handle,
+          properties: ["bold", "italic", "underline", "fontSize", "color", "typeface"],
+        },
+      });
+      await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: clearedPath });
+
+      const cleared = firstRunProperties(readPptx(await readFile(clearedPath)));
+      expect(cleared?.bold).toBeUndefined();
+      expect(cleared?.italic).toBeUndefined();
+      expect(cleared?.underline).toBeUndefined();
+      expect(cleared?.fontSize).toBeUndefined();
+      expect(cleared?.color).toBeUndefined();
+      expect(cleared?.typeface).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 interface ShapesResponse {
@@ -302,4 +370,11 @@ function firstRun(source: PptxSourceModel): string {
   const run = shape?.textBody?.paragraphs[0].runs[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.text;
+}
+
+function firstRunProperties(source: PptxSourceModel) {
+  const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
+  const run = shape?.textBody?.paragraphs[0].runs[0];
+  if (run === undefined) throw new Error("fixture text run not found");
+  return run.properties;
 }

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -181,8 +181,21 @@ describe("dev server editor API", () => {
 
       const undone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/undo`, {});
       expect(undone.history).toMatchObject({ canUndo: false, canRedo: true });
+      expect(undone.slides[0].svg).not.toContain('data-bold="true"');
+      expect(undone.slides[0].svg).not.toContain('data-italic="true"');
+      expect(undone.slides[0].svg).not.toContain('data-underline="true"');
+      expect(undone.slides[0].svg).not.toContain('data-font-size="32"');
+      expect(undone.slides[0].svg).not.toContain('data-color="9C0000"');
+      expect(undone.slides[0].svg).not.toContain('data-typeface="Liberation Sans"');
+
       const redone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/redo`, {});
       expect(redone.history).toMatchObject({ canUndo: true, canRedo: false });
+      expect(redone.slides[0].svg).toContain('data-bold="true"');
+      expect(redone.slides[0].svg).toContain('data-italic="true"');
+      expect(redone.slides[0].svg).toContain('data-underline="true"');
+      expect(redone.slides[0].svg).toContain('data-font-size="32"');
+      expect(redone.slides[0].svg).toContain('data-color="9C0000"');
+      expect(redone.slides[0].svg).toContain('data-typeface="Liberation Sans"');
 
       await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
       expect(firstRunProperties(readPptx(await readFile(savedPath)))).toMatchObject({
@@ -194,13 +207,20 @@ describe("dev server editor API", () => {
         typeface: "Liberation Sans",
       });
 
-      await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+      const clearedResponse = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
         command: {
           kind: "clearTextRunProperties",
           handle,
           properties: ["bold", "italic", "underline", "fontSize", "color", "typeface"],
         },
       });
+      expect(clearedResponse.slides[0].svg).not.toContain("data-bold=");
+      expect(clearedResponse.slides[0].svg).not.toContain("data-italic=");
+      expect(clearedResponse.slides[0].svg).not.toContain("data-underline=");
+      expect(clearedResponse.slides[0].svg).not.toContain("data-font-size=");
+      expect(clearedResponse.slides[0].svg).not.toContain("data-color=");
+      expect(clearedResponse.slides[0].svg).not.toContain("data-typeface=");
+
       await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: clearedPath });
 
       const cleared = firstRunProperties(readPptx(await readFile(clearedPath)));

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -605,20 +605,24 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
     .text-run-format-toolbar {
       display: grid;
-      grid-template-columns: repeat(3, 28px) minmax(52px, 1fr) 24px 34px 24px minmax(72px, 1fr) 24px;
-      gap: 4px;
+      grid-template-columns: repeat(3, 24px) 44px 20px 28px 20px minmax(48px, 1fr) 20px;
+      gap: 3px;
       align-items: center;
       margin-bottom: 4px;
     }
     .text-run-format-toolbar button,
     .text-run-format-toolbar input {
-      min-height: 24px;
+      min-height: 22px;
       border: 1px solid #94a3b8;
       border-radius: 4px;
       background: #f8fafc;
       color: #0f172a;
-      font-size: 11px;
+      font-size: 10px;
       font-weight: 650;
+    }
+    .text-run-format-toolbar button {
+      padding: 0;
+      min-width: 0;
     }
     .text-run-format-toolbar button[aria-pressed="true"] {
       background: #dbeafe;
@@ -637,11 +641,10 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       cursor: not-allowed;
     }
     .text-editor-actions {
-      position: absolute;
-      right: 4px;
-      bottom: 4px;
       display: flex;
+      justify-content: flex-end;
       gap: 4px;
+      margin-top: 4px;
     }
     .text-editor-actions button {
       min-height: 24px;
@@ -1097,9 +1100,6 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       var toolbar = document.createElement("div");
       toolbar.className = "text-run-format-toolbar";
       toolbar.setAttribute("data-testid", "text-run-format-toolbar");
-      toolbar.addEventListener("mousedown", function (event) {
-        event.preventDefault();
-      });
 
       [["bold", "B"], ["italic", "I"], ["underline", "U"]].forEach(function (item) {
         var button = document.createElement("button");
@@ -1263,7 +1263,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         setEditorMessage("No editable text run selected", true);
         return;
       }
-      if (Object.prototype.hasOwnProperty.call(info.properties || {}, property)) {
+      if ((info.properties || {})[property] === true) {
         applyActiveTextRunPropertyClear([property]);
         return;
       }
@@ -1299,17 +1299,98 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function applyActiveTextRunPropertyCommand(command) {
-      commitTextEditor()
-        .then(function () {
-          return postJson("/api/editor/command", { command: command });
-        })
+      postJson("/api/editor/command", { command: command })
         .then(function (data) {
-          applyEditorResponse(data);
+          applyEditorResponseBehindTextEditor(data);
+          patchActiveTextRunProperties(command);
           setEditorMessage("Applied", false);
         })
         .catch(function (err) {
           setEditorMessage(err.message, true);
         });
+    }
+
+    function applyEditorResponseBehindTextEditor(data) {
+      slides = data.slides || slides;
+      slideCount = slides.length;
+      updateHistory(data.history);
+      if (data.selection && data.selection.shapeHandle) {
+        selectedShapeKey = handleKey(data.selection.shapeHandle);
+      }
+      renderThumbnails();
+      replaceCurrentRenderedSvg();
+      renderSelectionOverlay();
+      loadShapeOptions(currentIndex + 1);
+    }
+
+    function replaceCurrentRenderedSvg() {
+      var container = document.getElementById("slide-container");
+      var previous = container.querySelector("svg:not(#selection-overlay)");
+      var slide = slides[currentIndex];
+      if (!slide) return;
+      var wrapper = document.createElement("div");
+      wrapper.innerHTML = slide.svg;
+      var next = wrapper.querySelector("svg");
+      if (!next) return;
+      next.removeAttribute("width");
+      next.removeAttribute("height");
+      next.style.width = "100%";
+      next.style.height = "auto";
+      if (previous) {
+        previous.replaceWith(next);
+      } else {
+        container.insertBefore(next, container.firstChild);
+      }
+    }
+
+    function patchActiveTextRunProperties(command) {
+      var textNode = activeTextRunTextNode();
+      if (!textNode) return;
+      var mark = (textNode.marks || []).find(function (candidate) {
+        return candidate.type === "pptxRun";
+      });
+      if (!mark) return;
+      var attrs = mark.attrs || {};
+      var properties = { ...(attrs.properties || {}) };
+      if (command.kind === "setTextRunProperties") {
+        Object.keys(command.properties || {}).forEach(function (property) {
+          properties[property] = command.properties[property];
+        });
+      }
+      if (command.kind === "clearTextRunProperties") {
+        (command.properties || []).forEach(function (property) {
+          delete properties[property];
+        });
+      }
+      attrs.properties = Object.keys(properties).length > 0 ? properties : null;
+      mark.attrs = attrs;
+      refreshTextRunFormatToolbar();
+      syncActiveTextRunStyle(properties);
+    }
+
+    function activeTextRunTextNode() {
+      if (!activeTextEditor || !activeTextEditor.selectedRunElement) return null;
+      var element = activeTextEditor.selectedRunElement;
+      var paragraphIndex = Number(element.dataset.paragraphIndex || "-1");
+      var runIndex = Number(element.dataset.runIndex || "-1");
+      var paragraph = (activeTextEditor.originalDocJson.content || [])[paragraphIndex];
+      return paragraph && (paragraph.content || [])[runIndex] ? paragraph.content[runIndex] : null;
+    }
+
+    function syncActiveTextRunStyle(properties) {
+      if (!activeTextEditor || !activeTextEditor.selectedRunElement) return;
+      var run = activeTextEditor.selectedRunElement;
+      run.style.fontWeight = properties.bold === true ? "700" : "";
+      run.style.fontStyle = properties.italic === true ? "italic" : "";
+      run.style.textDecoration = properties.underline === true ? "underline" : "";
+      run.style.fontSize = properties.fontSize != null ? String(properties.fontSize) + "pt" : "";
+      run.style.fontFamily = properties.typeface
+        ? '"' + String(properties.typeface).replace(/"/g, "") + '"'
+        : "";
+      run.style.color =
+        properties.color && properties.color.kind === "srgb" && typeof properties.color.hex === "string"
+          ? "#" + properties.color.hex
+          : "";
     }
 
     function createTextEditorContent(docJson) {

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -11,8 +11,11 @@ import { type WebSocket, WebSocketServer } from "ws";
 import {
   asEmu,
   asPartPath,
+  asPt,
   asRelationshipId,
   asSourceNodeId,
+  type EditableTextRunProperties,
+  type EditableTextRunProperty,
   findShapeNodeBySourceHandle,
   readPptx,
   type SourceHandle,
@@ -600,6 +603,39 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       outline: none;
       white-space: pre-wrap;
     }
+    .text-run-format-toolbar {
+      display: grid;
+      grid-template-columns: repeat(3, 28px) minmax(52px, 1fr) 24px 34px 24px minmax(72px, 1fr) 24px;
+      gap: 4px;
+      align-items: center;
+      margin-bottom: 4px;
+    }
+    .text-run-format-toolbar button,
+    .text-run-format-toolbar input {
+      min-height: 24px;
+      border: 1px solid #94a3b8;
+      border-radius: 4px;
+      background: #f8fafc;
+      color: #0f172a;
+      font-size: 11px;
+      font-weight: 650;
+    }
+    .text-run-format-toolbar button[aria-pressed="true"] {
+      background: #dbeafe;
+      border-color: #2563eb;
+    }
+    .text-run-format-toolbar input {
+      min-width: 0;
+      padding: 2px 4px;
+      font-weight: 500;
+    }
+    .text-run-format-toolbar input[type="color"] {
+      padding: 1px;
+    }
+    .text-run-format-toolbar :disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
     .text-editor-actions {
       position: absolute;
       right: 4px;
@@ -1005,6 +1041,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       overlay.id = "text-editor-overlay";
       overlay.setAttribute("data-testid", "text-editor-overlay");
       overlay.dataset.shapeKey = selectedShapeKey || "";
+      overlay.appendChild(createTextRunFormatToolbar());
       overlay.appendChild(createTextEditorContent(shape.editableTextBody.docJson));
 
       var actions = document.createElement("div");
@@ -1043,15 +1080,236 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         element: overlay,
         shape: cloneShape(shape),
         originalDocJson: shape.editableTextBody.docJson,
+        selectedRunElement: null,
         committing: false,
         commitPromise: null
       };
       positionActiveTextEditor();
       var firstRun = overlay.querySelector(".text-editor-run");
       if (firstRun) {
+        setActiveTextRunElement(firstRun);
         firstRun.focus();
         selectElementContents(firstRun);
       }
+    }
+
+    function createTextRunFormatToolbar() {
+      var toolbar = document.createElement("div");
+      toolbar.className = "text-run-format-toolbar";
+      toolbar.setAttribute("data-testid", "text-run-format-toolbar");
+      toolbar.addEventListener("mousedown", function (event) {
+        event.preventDefault();
+      });
+
+      [["bold", "B"], ["italic", "I"], ["underline", "U"]].forEach(function (item) {
+        var button = document.createElement("button");
+        button.type = "button";
+        button.textContent = item[1];
+        button.dataset.property = item[0];
+        button.setAttribute("data-testid", "text-run-format-" + item[0]);
+        button.setAttribute("aria-pressed", "false");
+        button.addEventListener("click", function () {
+          toggleActiveTextRunBooleanProperty(item[0]);
+        });
+        toolbar.appendChild(button);
+      });
+
+      var size = document.createElement("input");
+      size.type = "number";
+      size.min = "1";
+      size.step = "0.5";
+      size.placeholder = "pt";
+      size.setAttribute("data-testid", "text-run-format-font-size");
+      size.addEventListener("change", function () {
+        var value = Number(size.value);
+        if (size.value.trim() === "") {
+          applyActiveTextRunPropertyClear(["fontSize"]);
+        } else if (Number.isFinite(value) && value > 0) {
+          applyActiveTextRunPropertySet({ fontSize: value });
+        } else {
+          setEditorMessage("font size must be positive", true);
+        }
+      });
+      toolbar.appendChild(size);
+
+      var clearSize = clearButton("font-size", function () {
+        applyActiveTextRunPropertyClear(["fontSize"]);
+      });
+      toolbar.appendChild(clearSize);
+
+      var color = document.createElement("input");
+      color.type = "color";
+      color.setAttribute("data-testid", "text-run-format-color");
+      color.addEventListener("change", function () {
+        applyActiveTextRunPropertySet({
+          color: { kind: "srgb", hex: color.value.replace(/^#/, "").toUpperCase() }
+        });
+      });
+      toolbar.appendChild(color);
+
+      var clearColor = clearButton("color", function () {
+        applyActiveTextRunPropertyClear(["color"]);
+      });
+      toolbar.appendChild(clearColor);
+
+      var typeface = document.createElement("input");
+      typeface.type = "text";
+      typeface.placeholder = "Font";
+      typeface.setAttribute("data-testid", "text-run-format-typeface");
+      typeface.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          applyTypefaceInput(typeface);
+        }
+      });
+      typeface.addEventListener("change", function () {
+        applyTypefaceInput(typeface);
+      });
+      toolbar.appendChild(typeface);
+
+      var clearTypeface = clearButton("typeface", function () {
+        applyActiveTextRunPropertyClear(["typeface"]);
+      });
+      toolbar.appendChild(clearTypeface);
+
+      window.setTimeout(refreshTextRunFormatToolbar, 0);
+      return toolbar;
+    }
+
+    function clearButton(name, onClick) {
+      var button = document.createElement("button");
+      button.type = "button";
+      button.textContent = "x";
+      button.setAttribute("data-testid", "text-run-format-clear-" + name);
+      button.addEventListener("click", onClick);
+      return button;
+    }
+
+    function applyTypefaceInput(input) {
+      var value = input.value.trim();
+      if (value.length === 0) {
+        applyActiveTextRunPropertyClear(["typeface"]);
+        return;
+      }
+      applyActiveTextRunPropertySet({ typeface: value });
+    }
+
+    function setActiveTextRunElement(element) {
+      if (!activeTextEditor) return;
+      activeTextEditor.selectedRunElement = element;
+      refreshTextRunFormatToolbar();
+    }
+
+    function activeTextRunInfo() {
+      if (!activeTextEditor || !activeTextEditor.selectedRunElement) return null;
+      var element = activeTextEditor.selectedRunElement;
+      var paragraphIndex = Number(element.dataset.paragraphIndex || "-1");
+      var runIndex = Number(element.dataset.runIndex || "-1");
+      var paragraph = (activeTextEditor.originalDocJson.content || [])[paragraphIndex];
+      var textNode = paragraph && (paragraph.content || [])[runIndex];
+      var mark = textNode && (textNode.marks || []).find(function (candidate) {
+        return candidate.type === "pptxRun";
+      });
+      var attrs = mark && mark.attrs ? mark.attrs : {};
+      return {
+        handle: attrs.handle || null,
+        properties: attrs.properties || {}
+      };
+    }
+
+    function refreshTextRunFormatToolbar() {
+      if (!activeTextEditor) return;
+      var toolbar = activeTextEditor.element.querySelector('[data-testid="text-run-format-toolbar"]');
+      if (!toolbar) return;
+      var info = activeTextRunInfo();
+      var properties = info && info.properties ? info.properties : {};
+      var disabled = !info || !info.handle;
+      setToolbarControl(toolbar, "bold", disabled, Boolean(properties.bold));
+      setToolbarControl(toolbar, "italic", disabled, Boolean(properties.italic));
+      setToolbarControl(toolbar, "underline", disabled, Boolean(properties.underline));
+      var size = toolbar.querySelector('[data-testid="text-run-format-font-size"]');
+      if (size) {
+        size.disabled = disabled;
+        size.value = properties.fontSize == null ? "" : String(properties.fontSize);
+      }
+      var color = toolbar.querySelector('[data-testid="text-run-format-color"]');
+      if (color) {
+        color.disabled = disabled;
+        color.value =
+          properties.color && properties.color.kind === "srgb" && typeof properties.color.hex === "string"
+            ? "#" + properties.color.hex
+            : "#000000";
+      }
+      var typeface = toolbar.querySelector('[data-testid="text-run-format-typeface"]');
+      if (typeface) {
+        typeface.disabled = disabled;
+        typeface.value = typeof properties.typeface === "string" ? properties.typeface : "";
+      }
+      Array.prototype.forEach.call(toolbar.querySelectorAll('[data-testid^="text-run-format-clear-"]'), function (control) {
+        control.disabled = disabled;
+      });
+    }
+
+    function setToolbarControl(toolbar, property, disabled, pressed) {
+      var control = toolbar.querySelector('[data-testid="text-run-format-' + property + '"]');
+      if (!control) return;
+      control.disabled = disabled;
+      control.setAttribute("aria-pressed", pressed ? "true" : "false");
+    }
+
+    function toggleActiveTextRunBooleanProperty(property) {
+      var info = activeTextRunInfo();
+      if (!info || !info.handle) {
+        setEditorMessage("No editable text run selected", true);
+        return;
+      }
+      if (Object.prototype.hasOwnProperty.call(info.properties || {}, property)) {
+        applyActiveTextRunPropertyClear([property]);
+        return;
+      }
+      var properties = {};
+      properties[property] = true;
+      applyActiveTextRunPropertySet(properties);
+    }
+
+    function applyActiveTextRunPropertySet(properties) {
+      var info = activeTextRunInfo();
+      if (!info || !info.handle) {
+        setEditorMessage("No editable text run selected", true);
+        return;
+      }
+      applyActiveTextRunPropertyCommand({
+        kind: "setTextRunProperties",
+        handle: info.handle,
+        properties: properties
+      });
+    }
+
+    function applyActiveTextRunPropertyClear(properties) {
+      var info = activeTextRunInfo();
+      if (!info || !info.handle) {
+        setEditorMessage("No editable text run selected", true);
+        return;
+      }
+      applyActiveTextRunPropertyCommand({
+        kind: "clearTextRunProperties",
+        handle: info.handle,
+        properties: properties
+      });
+    }
+
+    function applyActiveTextRunPropertyCommand(command) {
+      commitTextEditor()
+        .then(function () {
+          return postJson("/api/editor/command", { command: command });
+        })
+        .then(function (data) {
+          applyEditorResponse(data);
+          setEditorMessage("Applied", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
     }
 
     function createTextEditorContent(docJson) {
@@ -1069,6 +1327,13 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           run.dataset.paragraphIndex = String(paragraphIndex);
           run.dataset.runIndex = String(runIndex);
           run.textContent = textNode.text || "";
+          applyTextRunStyle(run, textNode);
+          run.addEventListener("focus", function () {
+            setActiveTextRunElement(run);
+          });
+          run.addEventListener("pointerdown", function () {
+            setActiveTextRunElement(run);
+          });
           run.addEventListener("beforeinput", function (event) {
             if (event.inputType === "insertParagraph" || event.inputType === "insertLineBreak") {
               event.preventDefault();
@@ -1086,6 +1351,21 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         body.appendChild(paragraphElement);
       });
       return body;
+    }
+
+    function applyTextRunStyle(run, textNode) {
+      var mark = (textNode.marks || []).find(function (candidate) {
+        return candidate.type === "pptxRun";
+      });
+      var properties = mark && mark.attrs && mark.attrs.properties ? mark.attrs.properties : {};
+      if (properties.bold === true) run.style.fontWeight = "700";
+      if (properties.italic === true) run.style.fontStyle = "italic";
+      if (properties.underline === true) run.style.textDecoration = "underline";
+      if (properties.fontSize != null) run.style.fontSize = String(properties.fontSize) + "pt";
+      if (properties.typeface) run.style.fontFamily = '"' + String(properties.typeface).replace(/"/g, "") + '"';
+      if (properties.color && properties.color.kind === "srgb" && typeof properties.color.hex === "string") {
+        run.style.color = "#" + properties.color.hex;
+      }
     }
 
     function selectElementContents(element) {
@@ -1618,6 +1898,20 @@ function normalizeCommand(command: unknown): EditorCommand {
       text: command.text,
     };
   }
+  if (command.kind === "setTextRunProperties") {
+    return {
+      kind: "setTextRunProperties",
+      handle: normalizeHandle(command.handle),
+      properties: normalizeTextRunProperties(command.properties),
+    };
+  }
+  if (command.kind === "clearTextRunProperties") {
+    return {
+      kind: "clearTextRunProperties",
+      handle: normalizeHandle(command.handle),
+      properties: normalizeTextRunPropertyNames(command.properties),
+    };
+  }
   if (command.kind === "moveShape") {
     return {
       kind: "moveShape",
@@ -1647,6 +1941,74 @@ function normalizeCommand(command: unknown): EditorCommand {
   throw new Error("unsupported command kind");
 }
 
+function normalizeTextRunProperties(value: unknown): EditableTextRunProperties {
+  if (!isRecord(value)) throw new Error("setTextRunProperties.properties must be an object");
+  const properties: EditableTextRunProperties = {};
+  if ("bold" in value) {
+    if (typeof value.bold !== "boolean")
+      throw new Error("setTextRunProperties.bold must be boolean");
+    properties.bold = value.bold;
+  }
+  if ("italic" in value) {
+    if (typeof value.italic !== "boolean") {
+      throw new Error("setTextRunProperties.italic must be boolean");
+    }
+    properties.italic = value.italic;
+  }
+  if ("underline" in value) {
+    if (typeof value.underline !== "boolean") {
+      throw new Error("setTextRunProperties.underline must be boolean");
+    }
+    properties.underline = value.underline;
+  }
+  if ("fontSize" in value) {
+    properties.fontSize = asPt(requireFinitePositiveNumber(value.fontSize, "fontSize"));
+  }
+  if ("color" in value) {
+    properties.color = normalizeSrgbColor(value.color);
+  }
+  if ("typeface" in value) {
+    if (typeof value.typeface !== "string" || value.typeface.trim().length === 0) {
+      throw new Error("setTextRunProperties.typeface must be a non-empty string");
+    }
+    properties.typeface = value.typeface;
+  }
+  return properties;
+}
+
+function normalizeSrgbColor(value: unknown): { kind: "srgb"; hex: string } {
+  if (!isRecord(value) || value.kind !== "srgb" || typeof value.hex !== "string") {
+    throw new Error("setTextRunProperties.color must be an srgb color object");
+  }
+  if (!/^[0-9a-fA-F]{6}$/.test(value.hex)) {
+    throw new Error("setTextRunProperties.color.hex must be six hex digits");
+  }
+  return { kind: "srgb", hex: value.hex.toUpperCase() };
+}
+
+function normalizeTextRunPropertyNames(value: unknown): EditableTextRunProperty[] {
+  if (!Array.isArray(value)) throw new Error("clearTextRunProperties.properties must be an array");
+  return value.map((property): EditableTextRunProperty => {
+    if (!isEditableTextRunProperty(property)) {
+      throw new Error(
+        `clearTextRunProperties: unsupported text run property '${String(property)}'`,
+      );
+    }
+    return property;
+  });
+}
+
+function isEditableTextRunProperty(value: unknown): value is EditableTextRunProperty {
+  return (
+    value === "bold" ||
+    value === "italic" ||
+    value === "underline" ||
+    value === "fontSize" ||
+    value === "color" ||
+    value === "typeface"
+  );
+}
+
 function normalizeHandle(value: unknown): SourceHandle {
   if (!isRecord(value)) throw new Error("command.handle must be an object");
   if (typeof value.partPath !== "string") {
@@ -1667,6 +2029,12 @@ function requireFiniteNumber(value: unknown, field: string): number {
     throw new Error(`${field} must be a finite number`);
   }
   return value;
+}
+
+function requireFinitePositiveNumber(value: unknown, field: string): number {
+  const number = requireFiniteNumber(value, field);
+  if (number <= 0) throw new Error(`${field} must be positive`);
+  return number;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
close #630

## 目的

ブラウザ dev editor の ProseMirror text overlay から、headless editor-core の run property 編集 command を操作できるようにします。

## 変更内容

- text overlay に bold / italic / underline / font size / text color / typeface の set / clear toolbar を追加
- `/api/editor/command` で `setTextRunProperties` / `clearTextRunProperties` を受け付ける normalize を追加
- toolbar 操作後も overlay を維持しつつ背面 SVG と履歴状態を更新
- dev server API と Playwright UI の回帰テストを追加

## 影響範囲

- `scripts/dev-server.ts`
- `e2e/dev-server-editor.test.ts`
- `e2e/dev-server-editor.playwright.ts`

## 検証

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test -- e2e/dev-server-editor.test.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npm run test:playwright -- e2e/dev-server-editor.playwright.ts`

補足: 通常の Playwright 実行では、現在のローカル pnpm supply-chain policy が `picomatch@4.0.5` / `postcss@8.5.16` の minimumReleaseAge を検出して dev server 子プロセス起動前に落ちるため、検証時のみ `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` を付けています。
