### PR TITLE
editor: slide duplicate/delete をブラウザ UI に追加

### DIFF
--- a/.changeset/few-slides-edit.md
+++ b/.changeset/few-slides-edit.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+Add browser editor slide duplicate and delete controls backed by slide handles.

--- a/README.md
+++ b/README.md
@@ -425,8 +425,10 @@ const { slides } = await convertPptxToSvg(pptx, {
 ## Development
 
 The local editor preview (`npm run dev -- <pptx-file>`) includes an MVP text editing
-overlay for text shapes. IME behavior is intentionally not automated in CI; verify IME
-composition manually as part of the release checklist before shipping editor changes.
+overlay for text shapes plus thumbnail-level slide duplicate/delete controls. IME
+behavior is intentionally not automated in CI; verify IME composition, slide
+duplicate/delete, and undo/redo manually as part of the release checklist before
+shipping editor changes.
 
 Browser conversion smoke tests run with Playwright and cover browser-only SVG conversion
 plus PNG conversion after explicit resvg WASM initialization:

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -205,6 +205,16 @@ test("duplicates and deletes slides from thumbnails with undo and redo", async (
     await expect(page.locator(".thumbnail")).toHaveCount(2);
     await expect(page.locator("#slide-container")).toContainText("First");
 
+    await dblclickSvgPoint(page, 150, 130);
+    await expect(page.getByTestId("text-editor-overlay")).toBeVisible();
+    await page.getByTestId("duplicate-slide-0").click();
+    await expect(page.locator("#editor-message")).toContainText(
+      "Finish text editing before slide operations",
+    );
+    await expect(page.locator(".thumbnail")).toHaveCount(2);
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("text-editor-overlay")).toBeHidden();
+
     let commandResponse = page.waitForResponse(
       (response) =>
         response.url().endsWith("/api/editor/command") &&

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -188,6 +188,91 @@ test("applies text run decoration from the overlay toolbar with undo and redo", 
   }
 });
 
+test("duplicates and deletes slides from thumbnails with undo and redo", async ({ page }) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-editor-slide-test-"));
+  let serverProcess: ChildProcessWithoutNullStreams | undefined;
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    await writeFile(sourcePath, await buildTwoSlideFixture());
+
+    const port = await findFreePort();
+    serverProcess = await startDevServer(sourcePath, port);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+    await page.goto(baseUrl);
+    await expect(page.locator("#info")).toContainText("Slide 1 / 2");
+    await expect(page.locator(".thumbnail")).toHaveCount(2);
+    await expect(page.locator("#slide-container")).toContainText("First");
+
+    let commandResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/command") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("duplicate-slide-0").click();
+    await commandResponse;
+    await expect(page.locator(".thumbnail")).toHaveCount(3);
+    await expect(page.locator("#info")).toContainText("Slide 2 / 3");
+    await expect(page.locator("#slide-container")).toContainText("First");
+
+    commandResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/command") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("delete-slide-1").click();
+    await commandResponse;
+    await expect(page.locator(".thumbnail")).toHaveCount(2);
+    await expect(page.locator("#info")).toContainText("Slide 2 / 2");
+    await expect(page.locator("#slide-container")).toContainText("Second");
+
+    const undoResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/undo") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Undo" }).click();
+    await undoResponse;
+    await expect(page.locator(".thumbnail")).toHaveCount(3);
+    await expect(page.locator("#info")).toContainText("Slide 2 / 3");
+    await expect(page.locator("#slide-container")).toContainText("First");
+
+    const redoResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/redo") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Redo" }).click();
+    await redoResponse;
+    await expect(page.locator(".thumbnail")).toHaveCount(2);
+    await expect(page.locator("#info")).toContainText("Slide 2 / 2");
+    await expect(page.locator("#slide-container")).toContainText("Second");
+
+    commandResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/command") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("delete-slide-0").click();
+    await commandResponse;
+    await expect(page.locator(".thumbnail")).toHaveCount(1);
+    await expect(page.locator("#info")).toContainText("Slide 1 / 1");
+    await expect(page.locator("#slide-container")).toContainText("Second");
+    await expect(page.getByTestId("delete-slide-0")).toBeDisabled();
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+    const saved = readPptx(await readFile(savedPath));
+    expect(saved.presentation.slidePartPaths).toEqual(["ppt/slides/slide2.xml"]);
+  } finally {
+    if (serverProcess !== undefined) {
+      serverProcess.kill();
+      await waitForExit(serverProcess);
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 async function clickSvgPoint(page: Page, x: number, y: number) {
   const point = await svgPointToClient(page, x, y);
   await page.mouse.click(point.x, point.y);
@@ -340,6 +425,65 @@ async function buildShapeFixture(): Promise<Uint8Array> {
   );
 
   return zip.generateAsync({ type: "uint8array" });
+}
+
+async function buildTwoSlideFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/><p:sldId id="257" r:id="rIdSlide2"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `<Relationship Id="rIdSlide2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file("ppt/slides/slide1.xml", textSlideXml(10, "First"));
+  zip.file("ppt/slides/slide2.xml", textSlideXml(20, "Second"));
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function textSlideXml(shapeId: number, text: string): Uint8Array {
+  return xml(
+    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+      `<p:cSld><p:spTree>` +
+      `<p:sp><p:nvSpPr><p:cNvPr id="${String(shapeId)}" name="${text}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:xfrm><a:off x="914400" y="914400"/><a:ext cx="2743200" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>${text}</a:t></a:r></a:p></p:txBody>` +
+      `</p:sp>` +
+      `</p:spTree></p:cSld>` +
+      `</p:sld>`,
+  );
 }
 
 function firstShape(source: PptxSourceModel): SourceShape {

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -85,6 +85,58 @@ describe("BrowserPptxEditorSession", () => {
     ]);
     expect(mediaBytes(editor.document, "ppt/media/image1.png")).toEqual(BLUE_PNG);
   });
+
+  it("duplicates and deletes slides with render state and history updates", async () => {
+    const editor = await createBrowserPptxEditorSession(await buildTwoSlideFixture(), {
+      skipSystemFonts: true,
+    });
+    const firstSlide = editor.slides[0];
+    if (firstSlide?.handle === undefined) throw new Error("first slide handle not found");
+
+    const duplicated = await editor.apply({ kind: "duplicateSlide", handle: firstSlide.handle });
+    expect(duplicated.slides).toHaveLength(3);
+    expect(duplicated.slides.map((slide) => slide.handle?.partPath)).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide3.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(duplicated.slides[0]?.svg).toContain("First");
+    expect(duplicated.slides[1]?.svg).toContain("First");
+    expect(duplicated.history).toMatchObject({ canUndo: true, undoDepth: 1 });
+
+    const duplicateSlide = duplicated.slides[1];
+    if (duplicateSlide?.handle === undefined) throw new Error("duplicate slide handle not found");
+    const deleted = await editor.apply({ kind: "deleteSlide", handle: duplicateSlide.handle });
+    expect(deleted.slides.map((slide) => slide.handle?.partPath)).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect(deleted.history.undoDepth).toBe(2);
+
+    expect((await editor.undo()).slides.map((slide) => slide.handle?.partPath)).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide3.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+    expect((await editor.redo()).slides.map((slide) => slide.handle?.partPath)).toEqual([
+      "ppt/slides/slide1.xml",
+      "ppt/slides/slide2.xml",
+    ]);
+  });
+
+  it("rejects deleting the last slide without changing the browser editor state", async () => {
+    const editor = await createBrowserPptxEditorSession(await buildShapeFixture(), {
+      skipSystemFonts: true,
+    });
+    const slide = editor.slides[0];
+    if (slide?.handle === undefined) throw new Error("slide handle not found");
+
+    await expect(editor.apply({ kind: "deleteSlide", handle: slide.handle })).rejects.toThrow(
+      /last slide/,
+    );
+    expect(editor.slides).toHaveLength(1);
+    expect(editor.history).toMatchObject({ canUndo: false, undoDepth: 0 });
+  });
 });
 
 function xml(content: string): Uint8Array {
@@ -217,6 +269,65 @@ async function buildImageFixture(): Promise<Uint8Array> {
   zip.file("ppt/media/image1.png", RED_PNG);
 
   return zip.generateAsync({ type: "uint8array" });
+}
+
+async function buildTwoSlideFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `<Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/><p:sldId id="257" r:id="rIdSlide2"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `<Relationship Id="rIdSlide2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide2.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file("ppt/slides/slide1.xml", textSlideXml(10, "First"));
+  zip.file("ppt/slides/slide2.xml", textSlideXml(20, "Second"));
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
+function textSlideXml(shapeId: number, text: string): Uint8Array {
+  return xml(
+    `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+      `<p:cSld><p:spTree>` +
+      `<p:sp><p:nvSpPr><p:cNvPr id="${String(shapeId)}" name="${text}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:xfrm><a:off x="914400" y="914400"/><a:ext cx="2743200" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>${text}</a:t></a:r></a:p></p:txBody>` +
+      `</p:sp>` +
+      `</p:spTree></p:cSld>` +
+      `</p:sld>`,
+  );
 }
 
 function firstShape(source: ReturnType<typeof readPptx>): SourceShape {

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -60,8 +60,12 @@ export interface BrowserEditorShapeInfo {
   readonly editableTextBody?: BrowserEditorTextBodyInfo;
 }
 
+export interface BrowserEditorSlideSvg extends SlideSvg {
+  readonly handle?: SourceHandle;
+}
+
 export interface BrowserEditorSlidesResponse {
-  readonly slides: readonly SlideSvg[];
+  readonly slides: readonly BrowserEditorSlideSvg[];
   readonly history: BrowserEditorHistoryState;
   readonly selection?: BrowserEditorSelectionInfo;
   readonly warnings?: readonly EditorCommandWarning[];
@@ -77,7 +81,7 @@ export type BrowserEditorRenderOptions = Omit<ConvertOptions, "slides">;
 
 export class BrowserPptxEditorSession {
   #session: ReturnType<typeof createEditorSession>;
-  #slides: readonly SlideSvg[] = [];
+  #slides: readonly BrowserEditorSlideSvg[] = [];
   readonly #renderOptions: BrowserEditorRenderOptions;
 
   private constructor(source: PptxSourceModel, renderOptions: BrowserEditorRenderOptions) {
@@ -98,7 +102,7 @@ export class BrowserPptxEditorSession {
     return this.#session.document;
   }
 
-  get slides(): readonly SlideSvg[] {
+  get slides(): readonly BrowserEditorSlideSvg[] {
     return this.#slides;
   }
 
@@ -130,13 +134,18 @@ export class BrowserPptxEditorSession {
     return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index));
   }
 
-  async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
+  async renderCurrentSlides(): Promise<readonly BrowserEditorSlideSvg[]> {
     const report = await renderPptxSourceModelToSvg(this.#session.document, {
       textOutput: "text",
       skipSystemFonts: true,
       ...this.#renderOptions,
     });
-    this.#slides = report.slides;
+    this.#slides = report.slides.map((slide) => ({
+      ...slide,
+      ...(this.#session.document.slides[slide.slideNumber - 1]?.handle !== undefined
+        ? { handle: this.#session.document.slides[slide.slideNumber - 1]?.handle }
+        : {}),
+    }));
     return this.#slides;
   }
 

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -15,6 +15,7 @@ export type {
   BrowserEditorShapeBoundsPx,
   BrowserEditorShapeInfo,
   BrowserEditorSlidesResponse,
+  BrowserEditorSlideSvg,
   BrowserEditorTextBodyInfo,
   BrowserEditorTextRunInfo,
 } from "./browser-editor.js";

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -47,6 +47,7 @@ const execFileAsync = promisify(execFile);
 interface SlideSvg {
   slideNumber: number;
   svg: string;
+  handle?: SourceHandle;
 }
 
 interface EditorHistoryState {
@@ -190,7 +191,7 @@ export class DevEditorBackend {
   }
 
   async renderSlidesFromBytes(input: Uint8Array): Promise<readonly SlideSvg[]> {
-    this.#slides = await this.#render(input);
+    this.#slides = addSlideHandles(await this.#render(input), this.#session.document);
     return this.#slides;
   }
 
@@ -410,6 +411,18 @@ function emuToPixels(value: number): number {
   return (value / EMU_PER_INCH) * DEFAULT_DPI;
 }
 
+function addSlideHandles(
+  slides: readonly SlideSvg[],
+  source: ReturnType<typeof readPptx>,
+): SlideSvg[] {
+  return slides.map((slide) => ({
+    ...slide,
+    ...(source.slides[slide.slideNumber - 1]?.handle !== undefined
+      ? { handle: source.slides[slide.slideNumber - 1]?.handle }
+      : {}),
+  }));
+}
+
 // --- WebSocket ---
 
 function broadcast(wss: WebSocketServer, data: unknown): void {
@@ -548,12 +561,31 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     .thumbnail.active { border-color: #4472c4; }
     .thumbnail:hover { border-color: #6090d0; }
     .thumb-label {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 4px;
       font-size: 10px;
       color: #888;
-      text-align: center;
       padding: 2px 0;
       background: #16213e;
     }
+    .thumb-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .thumb-actions { display: flex; gap: 3px; }
+    .thumb-action {
+      min-width: 22px;
+      min-height: 20px;
+      border: 1px solid #334155;
+      border-radius: 3px;
+      background: #0f172a;
+      color: #e5e7eb;
+      cursor: pointer;
+      font-size: 10px;
+      font-weight: 700;
+      line-height: 1;
+    }
+    .thumb-action:hover:not(:disabled) { background: #1d4ed8; }
+    .thumb-action:disabled { opacity: 0.4; cursor: not-allowed; }
     .thumb-svg svg { width: 100%; height: auto; display: block; }
     #viewer {
       flex: 1;
@@ -772,7 +804,14 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         .map(function (s, i) {
           return '<div class="thumbnail' + (i === currentIndex ? ' active' : '') +
             '" data-index="' + i + '">' +
-            '<div class="thumb-label">Slide ' + s.slideNumber + '</div>' +
+            '<div class="thumb-label">' +
+            '<span class="thumb-title">Slide ' + s.slideNumber + '</span>' +
+            '<span class="thumb-actions">' +
+            '<button class="thumb-action" data-testid="duplicate-slide-' + i + '" data-action="duplicate" data-index="' + i + '" type="button" title="Duplicate slide">D</button>' +
+            '<button class="thumb-action" data-testid="delete-slide-' + i + '" data-action="delete" data-index="' + i + '" type="button" title="Delete slide"' +
+            (slideCount <= 1 ? ' disabled' : '') + '>X</button>' +
+            '</span>' +
+            '</div>' +
             '<div class="thumb-svg">' + s.svg + '</div>' +
             '</div>';
         })
@@ -786,6 +825,17 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           });
         })(i);
       }
+
+      Array.prototype.forEach.call(sidebar.querySelectorAll("[data-action]"), function (button) {
+        button.addEventListener("click", function (event) {
+          event.preventDefault();
+          event.stopPropagation();
+          var index = Number(button.getAttribute("data-index") || "-1");
+          var action = button.getAttribute("data-action");
+          if (action === "duplicate") duplicateSlide(index);
+          if (action === "delete") deleteSlide(index);
+        });
+      });
     }
 
     function updateHistory(history) {
@@ -889,7 +939,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       input.disabled = !option;
     }
 
-    function applyEditorResponse(data) {
+    function applyEditorResponse(data, preferredIndex) {
       slides = data.slides || slides;
       slideCount = slides.length;
       updateHistory(data.history);
@@ -897,7 +947,8 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         selectedShapeKey = handleKey(data.selection.shapeHandle);
       }
       renderThumbnails();
-      selectSlide(Math.min(currentIndex, Math.max(slides.length - 1, 0)));
+      var nextIndex = preferredIndex == null ? currentIndex : preferredIndex;
+      selectSlide(Math.min(Math.max(nextIndex, 0), Math.max(slides.length - 1, 0)));
     }
 
     function renderSelectionOverlay() {
@@ -1699,6 +1750,52 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       });
     }
 
+    function duplicateSlide(index) {
+      var slide = slides[index];
+      if (!slide || !slide.handle) {
+        setEditorMessage("Slide handle is unavailable", true);
+        return;
+      }
+      postJson("/api/editor/command", {
+        command: {
+          kind: "duplicateSlide",
+          handle: slide.handle
+        }
+      })
+        .then(function (data) {
+          applyEditorResponse(data, index + 1);
+          setEditorMessage("Duplicated slide", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
+    function deleteSlide(index) {
+      if (slideCount <= 1) {
+        setEditorMessage("Cannot delete the last slide", true);
+        return;
+      }
+      var slide = slides[index];
+      if (!slide || !slide.handle) {
+        setEditorMessage("Slide handle is unavailable", true);
+        return;
+      }
+      postJson("/api/editor/command", {
+        command: {
+          kind: "deleteSlide",
+          handle: slide.handle
+        }
+      })
+        .then(function (data) {
+          applyEditorResponse(data, Math.min(index, (data.slides || slides).length - 1));
+          setEditorMessage("Deleted slide", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
     function postJson(url, payload) {
       return fetch(url, {
         method: "POST",
@@ -1832,7 +1929,11 @@ function generateThumbnailsHtml(slides: SlideSvg[]): string {
     .map(
       (s, i) =>
         `<div class="thumbnail${i === 0 ? " active" : ""}" data-index="${i}">` +
-        `<div class="thumb-label">Slide ${String(s.slideNumber)}</div>` +
+        `<div class="thumb-label"><span class="thumb-title">Slide ${String(s.slideNumber)}</span>` +
+        `<span class="thumb-actions">` +
+        `<button class="thumb-action" data-testid="duplicate-slide-${String(i)}" data-action="duplicate" data-index="${String(i)}" type="button" title="Duplicate slide">D</button>` +
+        `<button class="thumb-action" data-testid="delete-slide-${String(i)}" data-action="delete" data-index="${String(i)}" type="button" title="Delete slide"${slides.length <= 1 ? " disabled" : ""}>X</button>` +
+        `</span></div>` +
         `<div class="thumb-svg">${s.svg}</div>` +
         `</div>`,
     )
@@ -2017,6 +2118,18 @@ function normalizeCommand(command: unknown): EditorCommand {
       offsetY: asEmu(requireFiniteNumber(command.offsetY, "setShapeTransform.offsetY")),
       width: asEmu(requireFiniteNumber(command.width, "setShapeTransform.width")),
       height: asEmu(requireFiniteNumber(command.height, "setShapeTransform.height")),
+    };
+  }
+  if (command.kind === "duplicateSlide") {
+    return {
+      kind: "duplicateSlide",
+      handle: normalizeHandle(command.handle),
+    };
+  }
+  if (command.kind === "deleteSlide") {
+    return {
+      kind: "deleteSlide",
+      handle: normalizeHandle(command.handle),
     };
   }
   throw new Error("unsupported command kind");

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -827,6 +827,9 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       }
 
       Array.prototype.forEach.call(sidebar.querySelectorAll("[data-action]"), function (button) {
+        button.addEventListener("mousedown", function (event) {
+          event.preventDefault();
+        });
         button.addEventListener("click", function (event) {
           event.preventDefault();
           event.stopPropagation();
@@ -1751,6 +1754,10 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function duplicateSlide(index) {
+      if (activeTextEditor) {
+        setEditorMessage("Finish text editing before slide operations", true);
+        return;
+      }
       var slide = slides[index];
       if (!slide || !slide.handle) {
         setEditorMessage("Slide handle is unavailable", true);
@@ -1772,6 +1779,10 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function deleteSlide(index) {
+      if (activeTextEditor) {
+        setEditorMessage("Finish text editing before slide operations", true);
+        return;
+      }
       if (slideCount <= 1) {
         setEditorMessage("Cannot delete the last slide", true);
         return;


### PR DESCRIPTION
close #633

## 目的

ブラウザエディターの slide thumbnail 一覧から slide の複製・削除を実行できるようにします。最後の 1 枚は UI 上で削除不可にし、操作後の thumbnails / current slide / slide count / render state / undo-redo を同じレスポンス更新経路で同期します。

## 変更内容

- `packages/core/src/browser-editor.ts` / `packages/core/src/browser.ts`
  - browser editor の slide レスポンスに slide handle を含め、UI から `duplicateSlide` / `deleteSlide` command を送れるようにしました。
- `scripts/dev-server.ts`
  - thumbnail に Duplicate / Delete 操作を追加し、dev server API の command 正規化で slide command を受け付けるようにしました。
  - text overlay 編集中の slide 操作は dirty edit 制約を避けるため明確にブロックします。
- `e2e/dev-server-editor.playwright.ts` / `packages/core/src/browser-editor.test.ts`
  - 複製・削除・最後の 1 枚削除不可・undo/redo・表示更新の回帰テストを追加しました。
- `README.md`
  - dev editor preview の手動確認対象を更新しました。

## 検証

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `npx playwright test e2e/dev-server-editor.playwright.ts --grep "duplicates and deletes slides"`
- `npm run build`
- acceptance-check: 6 件すべて充足
- cross-review: critical 0 / warning 0 / info 0
