### PR TITLE
editor: テキストボックス追加と shape 削除をブラウザ UI に反映する

### DIFF
--- a/.changeset/editor-add-delete-shapes.md
+++ b/.changeset/editor-add-delete-shapes.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+Add browser editor text box insertion and selected shape deletion UI/API support.

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -82,6 +82,7 @@ test("edits a text shape with the overlay editor, re-renders, and saves text", a
     const overlay = page.getByTestId("text-editor-overlay");
     await expect(overlay).toBeVisible();
     await expect(overlay).toContainText("Original");
+    await expect(page.getByRole("button", { name: "Delete shape" })).toBeDisabled();
     await expectOverlayNearSvgBounds(page, { x: 96, y: 192, width: 288, height: 96 });
 
     const commandResponse = page.waitForResponse(

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -109,6 +109,87 @@ test("edits a text shape with the overlay editor, re-renders, and saves text", a
   }
 });
 
+test("adds, edits, moves, resizes, saves, and deletes a text box from the UI", async ({ page }) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-editor-add-delete-test-"));
+  let serverProcess: ChildProcessWithoutNullStreams | undefined;
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    await writeFile(sourcePath, await buildShapeFixture());
+
+    const port = await findFreePort();
+    serverProcess = await startDevServer(sourcePath, port);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+    await page.goto(baseUrl);
+    await expect(page.getByTestId("shape-hit-area").first()).toBeVisible();
+
+    const addResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/add-text-box") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Add text box" }).click();
+    await addResponse;
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "96");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "96");
+
+    await dblclickSvgPoint(page, 216, 132);
+    const overlay = page.getByTestId("text-editor-overlay");
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toContainText("New text box");
+
+    const textResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/text-body") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByTestId("text-editor-run").first().fill("Added edited");
+    await page.getByTestId("text-editor-done").click();
+    await textResponse;
+    await expect(page.locator("#slide-container")).toContainText("Added edited");
+
+    await dragSvgPoint(page, { x: 240, y: 132 }, { x: 264, y: 148 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "120");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "112");
+
+    await dragSvgPoint(page, { x: 408, y: 184 }, { x: 456, y: 208 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("height", "96");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+
+    let saved = readPptx(await readFile(savedPath));
+    expect(shapeByText(saved, "Added edited").transform).toMatchObject({
+      offsetX: 120 * EMU_PER_PIXEL,
+      offsetY: 112 * EMU_PER_PIXEL,
+      width: 336 * EMU_PER_PIXEL,
+      height: 96 * EMU_PER_PIXEL,
+    });
+
+    const deleteResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/command") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByRole("button", { name: "Delete shape" }).click();
+    await deleteResponse;
+    await expect(page.getByTestId("selection-box")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+    saved = readPptx(await readFile(savedPath));
+    expect(findShapeByText(saved, "Added edited")).toBeUndefined();
+  } finally {
+    if (serverProcess !== undefined) {
+      serverProcess.kill();
+      await waitForExit(serverProcess);
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("applies text run decoration from the overlay toolbar with undo and redo", async ({
   page,
 }) => {
@@ -352,6 +433,22 @@ function firstText(source: PptxSourceModel): string {
   const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.text;
+}
+
+function shapeByText(source: PptxSourceModel, text: string): SourceShape {
+  const shape = findShapeByText(source, text);
+  if (shape === undefined) throw new Error(`shape text not found: ${text}`);
+  return shape;
+}
+
+function findShapeByText(source: PptxSourceModel, text: string): SourceShape | undefined {
+  return source.slides[0]?.shapes.find(
+    (node): node is SourceShape =>
+      node.kind === "shape" &&
+      node.textBody?.paragraphs.some((paragraph) =>
+        paragraph.runs.some((run) => run.text === text),
+      ) === true,
+  );
 }
 
 function firstRunProperties(source: PptxSourceModel) {

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   type PptxSourceModel,
   readPptx,
-  type SourceShape,
+  type SourceTextRun,
 } from "../packages/document/src/index.js";
 import { createDevServerRequestHandler, DevEditorBackend } from "../scripts/dev-server.js";
 import { unsafeScriptInputAssertion } from "../scripts/unsafe-type-assertion.js";
@@ -234,6 +234,54 @@ describe("dev server editor API", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("adds, selects, deletes, undoes, and redoes a text box through the editor API", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-shape-test-"));
+    try {
+      const sourcePath = join(dir, "fixture.pptx");
+      await writeFile(sourcePath, await buildTextEditFixture());
+
+      const backend = await DevEditorBackend.load(sourcePath, renderPreview);
+      const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
+      servers.push(server);
+      const baseUrl = await listen(server);
+
+      const added = await postJson<SlidesResponse>(`${baseUrl}/api/editor/add-text-box`, {
+        slide: 1,
+      });
+      expect(added.slides[0].svg).toContain("New text box");
+      expect(added.selection?.shapeHandle).toBeDefined();
+      expect(added.history).toMatchObject({ canUndo: true, canRedo: false });
+
+      const shapes = await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`);
+      const textBox = shapes.shapes.find((shape) =>
+        shape.textRuns.some((run) => run.text === "New text box"),
+      );
+      expect(textBox).toMatchObject({
+        bounds: { x: 96, y: 96, width: 288, height: 72 },
+        editableDelete: true,
+      });
+
+      const deleted = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "deleteShape",
+          handle: textBox?.handle,
+        },
+      });
+      expect(deleted.selection).toBeUndefined();
+      expect(deleted.slides[0].svg).not.toContain("New text box");
+
+      const undone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/undo`, {});
+      expect(undone.slides[0].svg).toContain("New text box");
+      expect(undone.history).toMatchObject({ canUndo: true, canRedo: true });
+
+      const redone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/redo`, {});
+      expect(redone.slides[0].svg).not.toContain("New text box");
+      expect(redone.history).toMatchObject({ canUndo: true, canRedo: false });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 interface ShapesResponse {
@@ -242,6 +290,7 @@ interface ShapesResponse {
     id: string;
     name?: string;
     bounds?: { x: number; y: number; width: number; height: number };
+    editableDelete?: boolean;
     textRuns: Array<{ text: string; handle: unknown }>;
     editableTextBody?: {
       docJson: {
@@ -259,6 +308,7 @@ interface ShapesResponse {
 interface SlidesResponse {
   slides: Array<{ slideNumber: number; svg: string }>;
   history: { canUndo: boolean; canRedo: boolean };
+  selection?: { shapeHandle: unknown };
 }
 
 interface SaveResponse {
@@ -271,13 +321,15 @@ function renderPreview(input: Uint8Array): Promise<Array<{ slideNumber: number; 
   return Promise.resolve([
     {
       slideNumber: 1,
-      svg: `<svg><text${runPropertyAttrs(source)}>${escapeXml(firstRun(source))}</text></svg>`,
+      svg: `<svg>${allRuns(source)
+        .map((run) => `<text${runPropertyAttrs(run)}>${escapeXml(run.text)}</text>`)
+        .join("")}</svg>`,
     },
   ]);
 }
 
-function runPropertyAttrs(source: PptxSourceModel): string {
-  const properties = firstRunProperties(source);
+function runPropertyAttrs(run: SourceTextRun): string {
+  const properties = run.properties;
   return [
     properties?.bold === undefined ? "" : ` data-bold="${String(properties.bold)}"`,
     properties?.italic === undefined ? "" : ` data-italic="${String(properties.italic)}"`,
@@ -407,15 +459,20 @@ async function buildTextEditFixture(): Promise<Uint8Array> {
 }
 
 function firstRun(source: PptxSourceModel): string {
-  const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
-  const run = shape?.textBody?.paragraphs[0].runs[0];
+  const run = allRuns(source)[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.text;
 }
 
 function firstRunProperties(source: PptxSourceModel) {
-  const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
-  const run = shape?.textBody?.paragraphs[0].runs[0];
+  const run = allRuns(source)[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.properties;
+}
+
+function allRuns(source: PptxSourceModel) {
+  return source.slides[0].shapes.flatMap((node) => {
+    if (node.kind !== "shape") return [];
+    return node.textBody?.paragraphs.flatMap((paragraph) => paragraph.runs) ?? [];
+  });
 }

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -282,6 +282,36 @@ describe("dev server editor API", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("does not expose connector-referenced shapes as deletable through the editor API", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-connector-test-"));
+    try {
+      const sourcePath = join(dir, "fixture.pptx");
+      await writeFile(sourcePath, await buildTextEditFixture({ includeConnector: true }));
+
+      const backend = await DevEditorBackend.load(sourcePath, renderPreview);
+      const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
+      servers.push(server);
+      const baseUrl = await listen(server);
+
+      const shapes = await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`);
+      const connectedShape = shapes.shapes.find((shape) => shape.name === "Title");
+      expect(connectedShape).toMatchObject({
+        bounds: { x: 96, y: 192, width: 288, height: 96 },
+      });
+      expect(connectedShape?.editableDelete).toBeUndefined();
+
+      const rejectedDelete = await postJsonError(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "deleteShape",
+          handle: connectedShape?.handle,
+        },
+      });
+      expect(rejectedDelete.error).toMatch(/referenced by connector/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 interface ShapesResponse {
@@ -402,7 +432,9 @@ async function parseJson<T>(response: Response): Promise<T> {
   return unsafeScriptInputAssertion<T>(json);
 }
 
-async function buildTextEditFixture(): Promise<Uint8Array> {
+async function buildTextEditFixture(
+  options: { includeConnector?: boolean } = {},
+): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file(
     "[Content_Types].xml",
@@ -450,6 +482,12 @@ async function buildTextEditFixture(): Promise<Uint8Array> {
         `<p:txBody><a:bodyPr/><a:lstStyle/>` +
         `<a:p><a:r><a:t>Original</a:t></a:r></a:p>` +
         `</p:txBody></p:sp>` +
+        (options.includeConnector
+          ? `<p:cxnSp><p:nvCxnSpPr><p:cNvPr id="11" name="Connector"/><p:cNvCxnSpPr>` +
+            `<a:stCxn id="10" idx="0"/></p:cNvCxnSpPr><p:nvPr/></p:nvCxnSpPr>` +
+            `<p:spPr><a:xfrm><a:off x="914400" y="914400"/><a:ext cx="914400" cy="914400"/></a:xfrm>` +
+            `<a:prstGeom prst="straightConnector1"/></p:spPr></p:cxnSp>`
+          : "") +
         `</p:spTree></p:cSld>` +
         `</p:sld>`,
     ),

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -165,6 +165,22 @@ describe("BrowserPptxEditorSession", () => {
     await editor.deleteShape(noTransformShape.handle);
     expect(editor.shapes(1).find((shape) => shape.name === "No Transform")).toBeUndefined();
   });
+
+  it("does not mark connector-referenced shapes as deletable", async () => {
+    const editor = await createBrowserPptxEditorSession(
+      await buildShapeFixture({ includeConnector: true }),
+      {
+        skipSystemFonts: true,
+      },
+    );
+
+    const connectedShape = editor.shapes(1).find((shape) => shape.name === "Box");
+    if (connectedShape?.handle === undefined) throw new Error("connected shape not found");
+    expect(connectedShape.editableDelete).toBeUndefined();
+    await expect(editor.deleteShape(connectedShape.handle)).rejects.toThrow(
+      /referenced by connector/,
+    );
+  });
 });
 
 function xml(content: string): Uint8Array {
@@ -176,7 +192,7 @@ function pngBytes(base64: string): Uint8Array {
 }
 
 async function buildShapeFixture(
-  options: { includeNoTransformShape?: boolean } = {},
+  options: { includeNoTransformShape?: boolean; includeConnector?: boolean } = {},
 ): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file(
@@ -233,6 +249,12 @@ async function buildShapeFixture(
             `<a:p><a:r><a:t>No transform</a:t></a:r></a:p>` +
             `</p:txBody>` +
             `</p:sp>`
+          : "") +
+        (options.includeConnector
+          ? `<p:cxnSp><p:nvCxnSpPr><p:cNvPr id="12" name="Connector"/><p:cNvCxnSpPr>` +
+            `<a:stCxn id="10" idx="0"/></p:cNvCxnSpPr><p:nvPr/></p:nvCxnSpPr>` +
+            `<p:spPr><a:xfrm><a:off x="914400" y="914400"/><a:ext cx="914400" cy="914400"/></a:xfrm>` +
+            `<a:prstGeom prst="straightConnector1"/></p:spPr></p:cxnSp>`
           : "") +
         `</p:spTree></p:cSld>` +
         `</p:sld>`,

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -147,6 +147,24 @@ describe("BrowserPptxEditorSession", () => {
       editor.shapes(1).some((shape) => handleKey(shape.handle) === handleKey(addedShape.handle)),
     ).toBe(false);
   });
+
+  it("marks top-level text shapes without transform as deletable", async () => {
+    const editor = await createBrowserPptxEditorSession(
+      await buildShapeFixture({ includeNoTransformShape: true }),
+      {
+        skipSystemFonts: true,
+      },
+    );
+
+    const noTransformShape = editor.shapes(1).find((shape) => shape.name === "No Transform");
+    if (noTransformShape?.handle === undefined) throw new Error("no-transform shape not found");
+    expect(noTransformShape.bounds).toBeUndefined();
+    expect(noTransformShape.editableTransform).toBeUndefined();
+    expect(noTransformShape.editableDelete).toBe(true);
+
+    await editor.deleteShape(noTransformShape.handle);
+    expect(editor.shapes(1).find((shape) => shape.name === "No Transform")).toBeUndefined();
+  });
 });
 
 function xml(content: string): Uint8Array {
@@ -157,7 +175,9 @@ function pngBytes(base64: string): Uint8Array {
   return new Uint8Array(Buffer.from(base64, "base64"));
 }
 
-async function buildShapeFixture(): Promise<Uint8Array> {
+async function buildShapeFixture(
+  options: { includeNoTransformShape?: boolean } = {},
+): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file(
     "[Content_Types].xml",
@@ -206,6 +226,14 @@ async function buildShapeFixture(): Promise<Uint8Array> {
         `<a:p><a:r><a:rPr sz="2400"><a:latin typeface="Aptos"/></a:rPr><a:t>Original</a:t></a:r></a:p>` +
         `</p:txBody>` +
         `</p:sp>` +
+        (options.includeNoTransformShape
+          ? `<p:sp><p:nvSpPr><p:cNvPr id="11" name="No Transform"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+            `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+            `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+            `<a:p><a:r><a:t>No transform</a:t></a:r></a:p>` +
+            `</p:txBody>` +
+            `</p:sp>`
+          : "") +
         `</p:spTree></p:cSld>` +
         `</p:sld>`,
     ),

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -85,6 +85,68 @@ describe("BrowserPptxEditorSession", () => {
     ]);
     expect(mediaBytes(editor.document, "ppt/media/image1.png")).toEqual(BLUE_PNG);
   });
+
+  it("adds, selects, edits, moves, resizes, saves, deletes, undoes, and redoes a text box", async () => {
+    const editor = await createBrowserPptxEditorSession(await buildShapeFixture(), {
+      skipSystemFonts: true,
+    });
+
+    const addedResponse = await editor.addTextBox(1);
+    const addedHandle = addedResponse.selection?.shapeHandle;
+    if (addedHandle === undefined) throw new Error("added shape was not selected");
+    const addedShape = editor
+      .shapes(1)
+      .find((shape) => handleKey(shape.handle) === handleKey(addedHandle));
+    if (addedShape?.handle === undefined) throw new Error("added shape handle not found");
+    expect(addedShape).toMatchObject({
+      bounds: { x: 96, y: 96, width: 288, height: 72 },
+      editableDelete: true,
+    });
+    expect(addedShape.editableTextBody).toBeDefined();
+
+    await editor.applyTextBodyDocJson(addedShape.handle, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          attrs: {},
+          content: [{ type: "text", text: "Added edited", marks: [] }],
+        },
+      ],
+    });
+    await editor.apply({
+      kind: "setShapeTransform",
+      handle: addedShape.handle,
+      offsetX: asEmu(144 * 9525),
+      offsetY: asEmu(120 * 9525),
+      width: asEmu(240 * 9525),
+      height: asEmu(96 * 9525),
+    });
+
+    const saved = readPptx(editor.save().pptx);
+    const savedAdded = shapeByText(saved, "Added edited");
+    expect(savedAdded.transform).toMatchObject({
+      offsetX: 144 * 9525,
+      offsetY: 120 * 9525,
+      width: 240 * 9525,
+      height: 96 * 9525,
+    });
+
+    const deleted = await editor.deleteSelectedShape();
+    expect(deleted.selection).toBeUndefined();
+    expect(
+      editor.shapes(1).some((shape) => handleKey(shape.handle) === handleKey(addedShape.handle)),
+    ).toBe(false);
+
+    await editor.undo();
+    expect(
+      editor.shapes(1).some((shape) => handleKey(shape.handle) === handleKey(addedShape.handle)),
+    ).toBe(true);
+    await editor.redo();
+    expect(
+      editor.shapes(1).some((shape) => handleKey(shape.handle) === handleKey(addedShape.handle)),
+    ).toBe(false);
+  });
 });
 
 function xml(content: string): Uint8Array {
@@ -229,6 +291,34 @@ function firstText(source: ReturnType<typeof readPptx>): string {
   const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.text;
+}
+
+function shapeByText(source: ReturnType<typeof readPptx>, text: string): SourceShape {
+  const shape = source.slides[0]?.shapes.find(
+    (node): node is SourceShape =>
+      node.kind === "shape" &&
+      node.textBody?.paragraphs.some((paragraph) =>
+        paragraph.runs.some((run) => run.text === text),
+      ) === true,
+  );
+  if (shape === undefined) throw new Error(`shape text not found: ${text}`);
+  return shape;
+}
+
+function handleKey(handle: unknown): string {
+  if (handle === undefined || handle === null || typeof handle !== "object") return "";
+  const value = handle as {
+    partPath?: string;
+    nodeId?: string;
+    relationshipId?: string;
+    orderingSlot?: number;
+  };
+  return [
+    value.partPath ?? "",
+    value.nodeId ?? "",
+    value.relationshipId ?? "",
+    value.orderingSlot ?? "",
+  ].join("\u0000");
 }
 
 function mediaBytes(source: ReturnType<typeof readPptx>, partPath: string): Uint8Array {

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -1,4 +1,5 @@
 import {
+  asEmu,
   findShapeNodeBySourceHandle,
   type PptxSourceModel,
   readPptx,
@@ -21,6 +22,15 @@ import { type ConvertOptions, renderPptxSourceModelToSvg, type SlideSvg } from "
 
 const EMU_PER_INCH = 914400;
 const DEFAULT_DPI = 96;
+const EMU_PER_PIXEL = EMU_PER_INCH / DEFAULT_DPI;
+
+const DEFAULT_TEXT_BOX_BOUNDS_PX = {
+  x: 96,
+  y: 96,
+  width: 288,
+  height: 72,
+};
+const DEFAULT_TEXT_BOX_TEXT = "New text box";
 
 export interface BrowserEditorHistoryState {
   readonly canUndo: boolean;
@@ -56,8 +66,18 @@ export interface BrowserEditorShapeInfo {
   readonly handle?: SourceHandle;
   readonly bounds?: BrowserEditorShapeBoundsPx;
   readonly editableTransform?: boolean;
+  readonly editableDelete?: boolean;
   readonly textRuns?: readonly BrowserEditorTextRunInfo[];
   readonly editableTextBody?: BrowserEditorTextBodyInfo;
+}
+
+export interface BrowserEditorAddTextBoxOptions {
+  readonly x?: number;
+  readonly y?: number;
+  readonly width?: number;
+  readonly height?: number;
+  readonly text?: string;
+  readonly name?: string;
 }
 
 export interface BrowserEditorSlidesResponse {
@@ -149,6 +169,50 @@ export class BrowserPptxEditorSession {
     return this.response(result.warnings);
   }
 
+  async addTextBox(
+    slideNumber = 1,
+    options: BrowserEditorAddTextBoxOptions = {},
+  ): Promise<BrowserEditorSlidesResponse> {
+    const slide = this.#session.document.slides[slideNumber - 1];
+    if (slide?.handle === undefined) {
+      throw new Error("addTextBox: slide handle was not found in PptxSourceModel source");
+    }
+    const existingShapeKeys = new Set(slide.shapes.map(shapeSourceKey));
+    const result = this.#session.apply({
+      kind: "addTextBox",
+      slideHandle: slide.handle,
+      offsetX: pxToEmu(options.x ?? DEFAULT_TEXT_BOX_BOUNDS_PX.x),
+      offsetY: pxToEmu(options.y ?? DEFAULT_TEXT_BOX_BOUNDS_PX.y),
+      width: pxToEmu(options.width ?? DEFAULT_TEXT_BOX_BOUNDS_PX.width),
+      height: pxToEmu(options.height ?? DEFAULT_TEXT_BOX_BOUNDS_PX.height),
+      text: options.text ?? DEFAULT_TEXT_BOX_TEXT,
+      ...(options.name !== undefined ? { name: options.name } : {}),
+    });
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    this.#selectNewShape(slideNumber, existingShapeKeys);
+    await this.renderCurrentSlides();
+    return this.response(result.warnings);
+  }
+
+  async deleteShape(handle: SourceHandle): Promise<BrowserEditorSlidesResponse> {
+    const result = this.#session.apply({ kind: "deleteShape", handle });
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    await this.renderCurrentSlides();
+    return this.response(result.warnings);
+  }
+
+  async deleteSelectedShape(): Promise<BrowserEditorSlidesResponse> {
+    const selection = this.#session.selection;
+    if (selection === undefined) {
+      throw new Error("deleteShape: no selected shape");
+    }
+    return this.deleteShape(selection.shapeHandle);
+  }
+
   async applyTextBodyDocJson(
     handle: SourceHandle,
     docJson: unknown,
@@ -207,6 +271,13 @@ export class BrowserPptxEditorSession {
     }
     return shape.textBody;
   }
+
+  #selectNewShape(slideNumber: number, existingShapeKeys: ReadonlySet<string>): void {
+    const slide = this.#session.document.slides[slideNumber - 1];
+    const addedShape = slide?.shapes.find((shape) => !existingShapeKeys.has(shapeSourceKey(shape)));
+    if (addedShape?.handle === undefined) return;
+    this.#session.selectShape(addedShape.handle);
+  }
 }
 
 export function createBrowserPptxEditorSession(
@@ -237,6 +308,7 @@ function shapeInfo(
           editableTransform: true,
         }
       : {}),
+    ...(editableTransform && isDeletableShape(shape) ? { editableDelete: true } : {}),
     ...("textBody" in shape && shape.textBody !== undefined
       ? {
           textRuns: collectTextRuns(
@@ -265,6 +337,10 @@ function isEditableTransformShape(shape: SourceShapeNode): boolean {
     return false;
   }
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
+}
+
+function isDeletableShape(shape: SourceShapeNode): boolean {
+  return shape.kind === "shape" && isEditableTransformShape(shape);
 }
 
 function collectTextRuns(runs: readonly SourceTextRun[]): BrowserEditorTextRunInfo[] {
@@ -300,4 +376,19 @@ function transformBoundsPx(transform: {
 
 function emuToPixels(value: number): number {
   return (value / EMU_PER_INCH) * DEFAULT_DPI;
+}
+
+function pxToEmu(value: number): ReturnType<typeof asEmu> {
+  return asEmu(Math.round(value * EMU_PER_PIXEL));
+}
+
+function shapeSourceKey(shape: SourceShapeNode): string {
+  const handle = shape.handle;
+  return [
+    shape.kind,
+    handle?.partPath ?? "",
+    handle?.nodeId ?? "",
+    handle?.relationshipId ?? "",
+    handle?.orderingSlot ?? "",
+  ].join("\u0000");
 }

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -340,7 +340,10 @@ function isEditableTransformShape(shape: SourceShapeNode): boolean {
 }
 
 function isDeletableShape(shape: SourceShapeNode): boolean {
-  return shape.kind === "shape" && isEditableTransformShape(shape);
+  if (shape.kind !== "shape" || shape.handle?.nodeId === undefined) {
+    return false;
+  }
+  return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
 }
 
 function collectTextRuns(runs: readonly SourceTextRun[]): BrowserEditorTextRunInfo[] {

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -147,7 +147,7 @@ export class BrowserPptxEditorSession {
   shapes(slideNumber: number): readonly BrowserEditorShapeInfo[] {
     const slide = this.#session.document.slides[slideNumber - 1];
     if (slide === undefined) return [];
-    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index));
+    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index, true, slide.shapes));
   }
 
   async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
@@ -291,6 +291,7 @@ function shapeInfo(
   shape: SourceShapeNode,
   index: number,
   editableTransform = true,
+  slideShapes: readonly SourceShapeNode[] = [],
 ): BrowserEditorShapeInfo[] {
   const canEditTransform =
     shape.kind !== "raw" &&
@@ -308,7 +309,7 @@ function shapeInfo(
           editableTransform: true,
         }
       : {}),
-    ...(editableTransform && isDeletableShape(shape) ? { editableDelete: true } : {}),
+    ...(editableTransform && isDeletableShape(shape, slideShapes) ? { editableDelete: true } : {}),
     ...("textBody" in shape && shape.textBody !== undefined
       ? {
           textRuns: collectTextRuns(
@@ -324,7 +325,9 @@ function shapeInfo(
   if (shape.kind !== "group") return [base];
   return [
     base,
-    ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex, false)),
+    ...shape.children.flatMap((child, childIndex) =>
+      shapeInfo(child, childIndex, false, slideShapes),
+    ),
   ];
 }
 
@@ -339,11 +342,29 @@ function isEditableTransformShape(shape: SourceShapeNode): boolean {
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
 }
 
-function isDeletableShape(shape: SourceShapeNode): boolean {
+function isDeletableShape(
+  shape: SourceShapeNode,
+  slideShapes: readonly SourceShapeNode[],
+): boolean {
   if (shape.kind !== "shape" || shape.handle?.nodeId === undefined) {
     return false;
   }
+  if (isShapeReferencedByConnector(shape, slideShapes)) {
+    return false;
+  }
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
+}
+
+function isShapeReferencedByConnector(
+  shape: SourceShapeNode,
+  slideShapes: readonly SourceShapeNode[],
+): boolean {
+  return slideShapes.some(
+    (candidate) =>
+      candidate.kind === "connector" &&
+      (candidate.connection?.start?.shapeId === shape.nodeId ||
+        candidate.connection?.end?.shapeId === shape.nodeId),
+  );
 }
 
 function collectTextRuns(runs: readonly SourceTextRun[]): BrowserEditorTextRunInfo[] {

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -8,6 +8,7 @@ import {
 import { type ConvertOptions, convertPptxToSvg as convertPptxToSvgBase } from "./svg-converter.js";
 
 export type {
+  BrowserEditorAddTextBoxOptions,
   BrowserEditorHistoryState,
   BrowserEditorRenderOptions,
   BrowserEditorSaveResponse,

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -41,6 +41,14 @@ const RENDER_TIMEOUT_MS = 30_000;
 const MAX_BUFFER = 50 * 1024 * 1024;
 const EMU_PER_INCH = 914400;
 const DEFAULT_DPI = 96;
+const EMU_PER_PIXEL = EMU_PER_INCH / DEFAULT_DPI;
+const DEFAULT_TEXT_BOX_BOUNDS_PX = {
+  x: 96,
+  y: 96,
+  width: 288,
+  height: 72,
+};
+const DEFAULT_TEXT_BOX_TEXT = "New text box";
 
 const execFileAsync = promisify(execFile);
 
@@ -79,6 +87,7 @@ interface EditorShapeInfo {
   handle?: SourceHandle;
   bounds?: ShapeBoundsPx;
   editableTransform?: boolean;
+  editableDelete?: boolean;
   textRuns?: EditorTextRunInfo[];
   editableTextBody?: EditorTextBodyInfo;
 }
@@ -206,6 +215,32 @@ export class DevEditorBackend {
     });
   }
 
+  async addTextBox(slideNumber: number): Promise<EditorSlidesResponse> {
+    return this.#enqueueMutation(async () => {
+      const slide = this.#session.document.slides[slideNumber - 1];
+      if (slide?.handle === undefined) {
+        throw new Error("addTextBox: slide handle was not found in PptxSourceModel source");
+      }
+      const existingShapeKeys = new Set(slide.shapes.map(shapeSourceKey));
+      const result = this.#session.apply({
+        kind: "addTextBox",
+        slideHandle: slide.handle,
+        offsetX: pxToEmu(DEFAULT_TEXT_BOX_BOUNDS_PX.x),
+        offsetY: pxToEmu(DEFAULT_TEXT_BOX_BOUNDS_PX.y),
+        width: pxToEmu(DEFAULT_TEXT_BOX_BOUNDS_PX.width),
+        height: pxToEmu(DEFAULT_TEXT_BOX_BOUNDS_PX.height),
+        text: DEFAULT_TEXT_BOX_TEXT,
+      });
+      if (!result.ok) {
+        throw new Error(result.message);
+      }
+      this.#selectNewShape(slideNumber, existingShapeKeys);
+      this.#dirty = true;
+      await this.renderCurrentSlides();
+      return this.response();
+    });
+  }
+
   async applyTextBodyDocJson(
     handle: SourceHandle,
     docJson: unknown,
@@ -290,6 +325,13 @@ export class DevEditorBackend {
     }
     return shape.textBody;
   }
+
+  #selectNewShape(slideNumber: number, existingShapeKeys: ReadonlySet<string>): void {
+    const slide = this.#session.document.slides[slideNumber - 1];
+    const addedShape = slide?.shapes.find((shape) => !existingShapeKeys.has(shapeSourceKey(shape)));
+    if (addedShape?.handle === undefined) return;
+    this.#session.selectShape(addedShape.handle);
+  }
 }
 
 function defaultEditedPath(sourcePath: string): string {
@@ -345,6 +387,7 @@ function shapeInfo(
           editableTransform: editableTransform && isEditableTransformShape(shape),
         }
       : {}),
+    ...(editableTransform && isDeletableShape(shape) ? { editableDelete: true } : {}),
     ...("textBody" in shape && shape.textBody !== undefined
       ? {
           textRuns: collectTextRuns(
@@ -373,6 +416,10 @@ function isEditableTransformShape(shape: SourceShapeNode): boolean {
     return false;
   }
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
+}
+
+function isDeletableShape(shape: SourceShapeNode): boolean {
+  return shape.kind === "shape" && isEditableTransformShape(shape);
 }
 
 function collectTextRuns(runs: readonly SourceTextRun[]): EditorTextRunInfo[] {
@@ -408,6 +455,21 @@ function transformBoundsPx(transform: {
 
 function emuToPixels(value: number): number {
   return (value / EMU_PER_INCH) * DEFAULT_DPI;
+}
+
+function pxToEmu(value: number): ReturnType<typeof asEmu> {
+  return asEmu(Math.round(value * EMU_PER_PIXEL));
+}
+
+function shapeSourceKey(shape: SourceShapeNode): string {
+  const handle = shape.handle;
+  return [
+    shape.kind,
+    handle?.partPath ?? "",
+    handle?.nodeId ?? "",
+    handle?.relationshipId ?? "",
+    handle?.orderingSlot ?? "",
+  ].join("\u0000");
 }
 
 // --- WebSocket ---
@@ -704,6 +766,8 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       <label>Text<input id="text-run-input" type="text"></label>
       <button id="apply-text-button" type="button">Apply</button>
       <div id="editor-actions">
+        <button id="add-text-box-button" type="button">Add text box</button>
+        <button id="delete-shape-button" type="button" disabled>Delete shape</button>
         <button id="undo-button" type="button">Undo</button>
         <button id="redo-button" type="button">Redo</button>
         <button id="save-button" type="button">Save</button>
@@ -792,6 +856,12 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       editorHistory = history || editorHistory;
       document.getElementById("undo-button").disabled = !editorHistory.canUndo;
       document.getElementById("redo-button").disabled = !editorHistory.canRedo;
+      updateSelectedShapeActions();
+    }
+
+    function updateSelectedShapeActions() {
+      document.getElementById("delete-shape-button").disabled =
+        !selectedShape || !selectedShape.editableDelete;
     }
 
     function shapeKey(shape) {
@@ -820,13 +890,16 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       }
       if (!selectedShape) selectedShapeKey = null;
       renderSelectionOverlay();
+      updateSelectedShapeActions();
     }
 
     function cloneShape(shape) {
       return {
         id: shape.id,
+        kind: shape.kind,
         name: shape.name,
         handle: shape.handle,
+        editableDelete: shape.editableDelete === true,
         editableTextBody: shape.editableTextBody,
         bounds: {
           x: shape.bounds.x,
@@ -966,6 +1039,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
 
       container.appendChild(overlay);
       positionActiveTextEditor();
+      updateSelectedShapeActions();
     }
 
     function setRectAttributes(rect, bounds) {
@@ -1699,6 +1773,51 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       });
     }
 
+    function addTextBox() {
+      if (activeTextEditor) {
+        commitTextEditor()
+          .then(addTextBox)
+          .catch(function () {});
+        return;
+      }
+      postJson("/api/editor/add-text-box", { slide: currentIndex + 1 })
+        .then(function (data) {
+          applyEditorResponse(data);
+          setEditorMessage("Text box added", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
+    function deleteSelectedShape() {
+      if (activeTextEditor || !selectedShape || !selectedShape.handle || !selectedShape.editableDelete) {
+        return;
+      }
+      postJson("/api/editor/command", {
+        command: {
+          kind: "deleteShape",
+          handle: selectedShape.handle
+        }
+      })
+        .then(function (data) {
+          selectedShape = null;
+          selectedShapeKey = null;
+          applyEditorResponse(data);
+          setEditorMessage("Deleted", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
+    function isTypingTarget(target) {
+      return target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        (target instanceof HTMLElement && target.isContentEditable);
+    }
+
     function postJson(url, payload) {
       return fetch(url, {
         method: "POST",
@@ -1743,6 +1862,8 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           setEditorMessage(err.message, true);
         });
     });
+    document.getElementById("add-text-box-button").addEventListener("click", addTextBox);
+    document.getElementById("delete-shape-button").addEventListener("click", deleteSelectedShape);
     document.getElementById("undo-button").addEventListener("click", function () {
       postJson("/api/editor/undo")
         .then(function (data) {
@@ -1818,6 +1939,13 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
 
     // Keyboard navigation
     document.addEventListener("keydown", function (e) {
+      if (e.key === "Delete" && !isTypingTarget(e.target)) {
+        if (selectedShape && selectedShape.editableDelete) {
+          e.preventDefault();
+          deleteSelectedShape();
+        }
+        return;
+      }
       if (e.key === "ArrowLeft" && currentIndex > 0) selectSlide(currentIndex - 1);
       if (e.key === "ArrowRight" && currentIndex < slideCount - 1)
         selectSlide(currentIndex + 1);
@@ -1893,6 +2021,13 @@ async function handleRequest(
     const body = await readJsonBody(req);
     const command = normalizeCommand(isRecord(body) ? body.command : undefined);
     sendJson(res, 200, await backend.apply(command));
+    return;
+  }
+
+  if (url.pathname === "/api/editor/add-text-box" && req.method === "POST") {
+    const body = await readJsonBody(req);
+    const slideNumber = isRecord(body) ? body.slide : undefined;
+    sendJson(res, 200, await backend.addTextBox(normalizeSlideNumber(slideNumber)));
     return;
   }
 
@@ -2019,7 +2154,40 @@ function normalizeCommand(command: unknown): EditorCommand {
       height: asEmu(requireFiniteNumber(command.height, "setShapeTransform.height")),
     };
   }
+  if (command.kind === "addTextBox") {
+    const text = command.text ?? DEFAULT_TEXT_BOX_TEXT;
+    if (typeof text !== "string") {
+      throw new Error("addTextBox.text must be a string");
+    }
+    if (command.name !== undefined && typeof command.name !== "string") {
+      throw new Error("addTextBox.name must be a string");
+    }
+    return {
+      kind: "addTextBox",
+      slideHandle: normalizeHandle(command.slideHandle),
+      offsetX: asEmu(requireFiniteNumber(command.offsetX, "addTextBox.offsetX")),
+      offsetY: asEmu(requireFiniteNumber(command.offsetY, "addTextBox.offsetY")),
+      width: asEmu(requireFinitePositiveNumber(command.width, "addTextBox.width")),
+      height: asEmu(requireFinitePositiveNumber(command.height, "addTextBox.height")),
+      text,
+      ...(typeof command.name === "string" ? { name: command.name } : {}),
+    };
+  }
+  if (command.kind === "deleteShape") {
+    return {
+      kind: "deleteShape",
+      handle: normalizeHandle(command.handle),
+    };
+  }
   throw new Error("unsupported command kind");
+}
+
+function normalizeSlideNumber(value: unknown): number {
+  const slideNumber = value === undefined ? 1 : value;
+  if (!Number.isInteger(slideNumber) || slideNumber < 1) {
+    throw new Error("slide must be a positive integer");
+  }
+  return slideNumber;
 }
 
 function normalizeTextRunProperties(value: unknown): EditableTextRunProperties {

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -186,7 +186,7 @@ export class DevEditorBackend {
   shapes(slideNumber: number): EditorShapeInfo[] {
     const slide = this.#session.document.slides[slideNumber - 1];
     if (slide === undefined) return [];
-    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index));
+    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index, true, slide.shapes));
   }
 
   async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
@@ -375,6 +375,7 @@ function shapeInfo(
   shape: SourceShapeNode,
   index: number,
   editableTransform = true,
+  slideShapes: readonly SourceShapeNode[] = [],
 ): EditorShapeInfo[] {
   const base: EditorShapeInfo = {
     id: String(shape.nodeId ?? shape.handle?.nodeId ?? `${shape.kind}:${String(index)}`),
@@ -387,7 +388,7 @@ function shapeInfo(
           editableTransform: editableTransform && isEditableTransformShape(shape),
         }
       : {}),
-    ...(editableTransform && isDeletableShape(shape) ? { editableDelete: true } : {}),
+    ...(editableTransform && isDeletableShape(shape, slideShapes) ? { editableDelete: true } : {}),
     ...("textBody" in shape && shape.textBody !== undefined
       ? {
           textRuns: collectTextRuns(
@@ -403,7 +404,9 @@ function shapeInfo(
   if (shape.kind !== "group") return [base];
   return [
     base,
-    ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex, false)),
+    ...shape.children.flatMap((child, childIndex) =>
+      shapeInfo(child, childIndex, false, slideShapes),
+    ),
   ];
 }
 
@@ -418,11 +421,29 @@ function isEditableTransformShape(shape: SourceShapeNode): boolean {
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
 }
 
-function isDeletableShape(shape: SourceShapeNode): boolean {
+function isDeletableShape(
+  shape: SourceShapeNode,
+  slideShapes: readonly SourceShapeNode[],
+): boolean {
   if (shape.kind !== "shape" || shape.handle?.nodeId === undefined) {
     return false;
   }
+  if (isShapeReferencedByConnector(shape, slideShapes)) {
+    return false;
+  }
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
+}
+
+function isShapeReferencedByConnector(
+  shape: SourceShapeNode,
+  slideShapes: readonly SourceShapeNode[],
+): boolean {
+  return slideShapes.some(
+    (candidate) =>
+      candidate.kind === "connector" &&
+      (candidate.connection?.start?.shapeId === shape.nodeId ||
+        candidate.connection?.end?.shapeId === shape.nodeId),
+  );
 }
 
 function collectTextRuns(runs: readonly SourceTextRun[]): EditorTextRunInfo[] {
@@ -864,7 +885,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
 
     function updateSelectedShapeActions() {
       document.getElementById("delete-shape-button").disabled =
-        !selectedShape || !selectedShape.editableDelete;
+        activeTextEditor || !selectedShape || !selectedShape.editableDelete;
     }
 
     function shapeKey(shape) {
@@ -1164,6 +1185,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         committing: false,
         commitPromise: null
       };
+      updateSelectedShapeActions();
       positionActiveTextEditor();
       var firstRun = overlay.querySelector(".text-editor-run");
       if (firstRun) {
@@ -1633,6 +1655,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       if (!editor && target.committing) return;
       target.element.remove();
       if (activeTextEditor === target) activeTextEditor = null;
+      updateSelectedShapeActions();
     }
 
     function beginDrag(kind, handle, event) {

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -419,7 +419,10 @@ function isEditableTransformShape(shape: SourceShapeNode): boolean {
 }
 
 function isDeletableShape(shape: SourceShapeNode): boolean {
-  return shape.kind === "shape" && isEditableTransformShape(shape);
+  if (shape.kind !== "shape" || shape.handle?.nodeId === undefined) {
+    return false;
+  }
+  return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
 }
 
 function collectTextRuns(runs: readonly SourceTextRun[]): EditorTextRunInfo[] {


### PR DESCRIPTION
close #631

## 目的
headless 実装済みのテキストボックス追加・shape 削除を、ブラウザーエディター UI/API から操作できるようにしました。

## 変更内容
- `BrowserPptxEditorSession` に `addTextBox` / `deleteShape` / `deleteSelectedShape` と削除可否メタ情報を追加
- dev server editor に Add text box / Delete shape ボタン、Delete キー操作、`/api/editor/add-text-box` を追加
- connector 参照中 shape、AlternateContent、nested shape など削除不可の対象を UI で削除可能にしないよう制御
- core/API/Playwright の回帰テストと changeset を追加

## 検証
- `./node_modules/.bin/vitest run packages/core/src/browser-editor.test.ts e2e/dev-server-editor.test.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 ./node_modules/.bin/playwright test e2e/dev-server-editor.playwright.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint packages/core/src/browser-editor.ts packages/core/src/browser.ts packages/core/src/browser-editor.test.ts scripts/dev-server.ts e2e/dev-server-editor.test.ts e2e/dev-server-editor.playwright.ts`
- `./node_modules/.bin/prettier --check packages/core/src/browser-editor.ts packages/core/src/browser.ts packages/core/src/browser-editor.test.ts scripts/dev-server.ts e2e/dev-server-editor.test.ts e2e/dev-server-editor.playwright.ts .changeset/editor-add-delete-shapes.md`
- `git diff --check`
