### PR TITLE
editor: 画像差し替えをブラウザ UI に反映する

### DIFF
--- a/.changeset/browser-image-replacement-ui.md
+++ b/.changeset/browser-image-replacement-ui.md
@@ -1,0 +1,5 @@
+---
+"pptx-glimpse": minor
+---
+
+Add browser editor image replacement UI support for selected picture shapes.

--- a/e2e/browser-standalone-editor.playwright.ts
+++ b/e2e/browser-standalone-editor.playwright.ts
@@ -663,9 +663,11 @@ async function replaceSelectedImage(file) {
   if (!selectedShape?.handle || !selectedShape.editableImageReplacement) {
     throw new Error("Select an image shape before replacing media.");
   }
+  const handle = selectedShape.handle;
+  imageReplacementInput.disabled = true;
   const result = await editor.apply({
     kind: "replaceImage",
-    handle: selectedShape.handle,
+    handle,
     bytes: new Uint8Array(await file.arrayBuffer()),
   });
   render();

--- a/e2e/browser-standalone-editor.playwright.ts
+++ b/e2e/browser-standalone-editor.playwright.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
@@ -25,6 +26,12 @@ const rendererPackageRoot = resolve(repoRoot, "packages/renderer");
 const execFileAsync = promisify(execFile);
 const encoder = new TextEncoder();
 const EMU_PER_PIXEL = 9525;
+const RED_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAEUlEQVR4nGP8z4AATEhsPBwAM9EBBzDn4UwAAAAASUVORK5CYII=";
+const BLUE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGNkYPjPAANMcBZeDgAx0wEH1s7nlgAAAABJRU5ErkJggg==";
+const RED_PNG = pngBytes(RED_PNG_BASE64);
+const BLUE_PNG = pngBytes(BLUE_PNG_BASE64);
 let coreDistBuildPromise: Promise<void> | null = null;
 
 test("runs a browser-only editor move, resize, text, undo, redo, download, and reopen flow", async ({
@@ -45,6 +52,7 @@ test("runs a browser-only editor move, resize, text, undo, redo, download, and r
     await clickSvgPoint(page, 240, 240);
     await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "96");
     await expect(page.getByTestId("selection-handle-se")).toBeVisible();
+    await expect(page.getByTestId("image-replacement-input")).toBeDisabled();
 
     await dragSvgPoint(page, { x: 240, y: 240 }, { x: 264, y: 256 });
     await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "120");
@@ -88,6 +96,58 @@ test("runs a browser-only editor move, resize, text, undo, redo, download, and r
     await page.getByTestId("pptx-input").setInputFiles(savedPath);
     await expect(page.getByTestId("status")).toContainText("1 slide ready");
     await expect(page.locator("#slide-container")).toContainText("Browser edited");
+  } finally {
+    await editor.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("replaces a selected image in the browser-only editor with warning, reject, undo, and redo", async ({
+  page,
+}) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-browser-editor-image-test-"));
+  const editor = await startStandaloneEditor();
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    const replacementPath = join(dir, "replacement.png");
+    const wrongFormatPath = join(dir, "wrong-format.jpg");
+    await writeFile(sourcePath, await buildImageFixture());
+    await writeFile(replacementPath, BLUE_PNG);
+    await writeFile(wrongFormatPath, new Uint8Array([0xff, 0xd8, 0xff, 0xd9]));
+
+    await page.goto(editor.url);
+    await page.getByTestId("pptx-input").setInputFiles(sourcePath);
+    await expect(page.getByTestId("status")).toContainText("1 slide ready");
+    await expect(page.getByTestId("image-replacement-input")).toBeDisabled();
+    await expectImageHref(page, RED_PNG_BASE64);
+
+    await clickSvgPoint(page, 120, 120);
+    await expect(page.getByTestId("image-replacement-input")).toBeEnabled();
+    await expect(page.getByTestId("image-replacement-input")).toHaveAttribute(
+      "accept",
+      /image\/png/,
+    );
+
+    await page.getByTestId("image-replacement-input").setInputFiles(wrongFormatPath);
+    await expect(page.getByTestId("message")).toContainText("does not match existing media");
+    await expectImageHref(page, RED_PNG_BASE64);
+
+    await page.getByTestId("image-replacement-input").setInputFiles(replacementPath);
+    await expect(page.getByTestId("message")).toContainText("shared media part affects 2 pictures");
+    await expectImageHref(page, BLUE_PNG_BASE64);
+
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expectImageHref(page, RED_PNG_BASE64);
+    await page.getByRole("button", { name: "Redo" }).click();
+    await expectImageHref(page, BLUE_PNG_BASE64);
+
+    const download = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Download" }).click();
+    await (await download).saveAs(savedPath);
+    expect(mediaBytes(readPptx(await readFile(savedPath)), "ppt/media/image1.png")).toEqual(
+      BLUE_PNG,
+    );
   } finally {
     await editor.close();
     await rm(dir, { recursive: true, force: true });
@@ -178,6 +238,12 @@ async function expectOverlayNearSvgBounds(
   expect(Math.abs(rects.actual.top - rects.expected.top)).toBeLessThan(3);
   expect(Math.abs(rects.actual.width - rects.expected.width)).toBeLessThan(3);
   expect(Math.abs(rects.actual.height - rects.expected.height)).toBeLessThan(3);
+}
+
+async function expectImageHref(page: Page, base64: string) {
+  await expect
+    .poll(async () => page.locator("#slide-container image").first().getAttribute("href"))
+    .toContain(base64);
 }
 
 interface EditorServer {
@@ -294,9 +360,10 @@ const editorHtml = `<!doctype html>
         <input data-testid="pptx-input" id="pptx-input" type="file" accept=".pptx">
         <button id="undo-button" type="button" disabled>Undo</button>
         <button id="redo-button" type="button" disabled>Redo</button>
+        <input data-testid="image-replacement-input" id="image-replacement-input" type="file" disabled>
         <button id="download-button" type="button" disabled>Download</button>
         <div data-testid="status" id="status">Ready</div>
-        <div id="message"></div>
+        <div data-testid="message" id="message"></div>
       </aside>
     </main>
     <script type="module" src="/app.js"></script>
@@ -313,6 +380,7 @@ const container = document.getElementById("slide-container");
 const undoButton = document.getElementById("undo-button");
 const redoButton = document.getElementById("redo-button");
 const downloadButton = document.getElementById("download-button");
+const imageReplacementInput = document.getElementById("image-replacement-input");
 const EMU_PER_PIXEL = 9525;
 
 let editor = null;
@@ -351,6 +419,18 @@ redoButton.addEventListener("click", async () => {
   message.textContent = "Redone";
 });
 
+imageReplacementInput.addEventListener("change", async () => {
+  const file = imageReplacementInput.files?.[0];
+  if (!file) return;
+  try {
+    await replaceSelectedImage(file);
+  } catch (error) {
+    message.textContent = error instanceof Error ? error.message : String(error);
+  } finally {
+    syncImageReplacementInput();
+  }
+});
+
 downloadButton.addEventListener("click", () => {
   if (!editor) return;
   const saved = editor.save();
@@ -377,7 +457,9 @@ function render() {
     svg.style.width = "100%";
     svg.style.height = "auto";
   }
-  shapes = editor.shapes(1).filter((shape) => shape.handle && shape.bounds && shape.editableTransform);
+  shapes = editor.shapes(1).filter(
+    (shape) => shape.handle && shape.bounds && (shape.editableTransform || shape.editableImageReplacement),
+  );
   window.__pptxGlimpseEditorSmoke = {
     hasEditableTextBody: shapes.some((shape) => Boolean(shape.editableTextBody)),
   };
@@ -385,6 +467,7 @@ function render() {
     ? shapes.find((shape) => shapeKey(shape) === selectedShapeKey) || null
     : null;
   updateHistory(editor.history);
+  syncImageReplacementInput();
   renderSelectionOverlay();
 }
 
@@ -458,6 +541,7 @@ function selectShape(shape, event) {
   selectedShape = cloneShape(shape);
   selectedShapeKey = shapeKey(shape);
   editor.selectShape(shape.handle);
+  syncImageReplacementInput();
   beginDrag("move", null, event);
   window.setTimeout(renderSelectionOverlay, 0);
 }
@@ -573,6 +657,41 @@ async function commitTextEditor() {
   await editor.applyTextBodyDocJson(handle, docJson);
   render();
   message.textContent = "Applied";
+}
+
+async function replaceSelectedImage(file) {
+  if (!selectedShape?.handle || !selectedShape.editableImageReplacement) {
+    throw new Error("Select an image shape before replacing media.");
+  }
+  const result = await editor.apply({
+    kind: "replaceImage",
+    handle: selectedShape.handle,
+    bytes: new Uint8Array(await file.arrayBuffer()),
+  });
+  render();
+  message.textContent = imageReplacementMessage(result);
+}
+
+function imageReplacementMessage(result) {
+  const shared = result.warnings?.find((warning) => warning.code === "shared-media-part");
+  if (!shared) return "Image replaced";
+  return (
+    "Image replaced; shared media part affects " +
+    shared.referenceCount +
+    " pictures: " +
+    shared.mediaPartPath
+  );
+}
+
+function syncImageReplacementInput() {
+  const replacement = selectedShape?.editableImageReplacement;
+  imageReplacementInput.disabled = !replacement;
+  imageReplacementInput.value = "";
+  if (replacement) {
+    imageReplacementInput.setAttribute("accept", replacement.accept);
+  } else {
+    imageReplacementInput.removeAttribute("accept");
+  }
 }
 
 function textEditorDocJson() {
@@ -695,6 +814,10 @@ function xml(content: string): Uint8Array {
   return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
 }
 
+function pngBytes(base64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(base64, "base64"));
+}
+
 async function buildShapeFixture(): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file(
@@ -752,6 +875,73 @@ async function buildShapeFixture(): Promise<Uint8Array> {
   return zip.generateAsync({ type: "uint8array" });
 }
 
+async function buildImageFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Default Extension="png" ContentType="image/png"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree>` +
+        `<p:pic><p:nvPicPr><p:cNvPr id="20" name="Shared Picture A"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>` +
+        `<p:blipFill><a:blip r:embed="rIdImage"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>` +
+        `<p:spPr><a:xfrm><a:off x="914400" y="914400"/><a:ext cx="914400" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr></p:pic>` +
+        `<p:pic><p:nvPicPr><p:cNvPr id="21" name="Shared Picture B"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>` +
+        `<p:blipFill><a:blip r:embed="rIdImage"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>` +
+        `<p:spPr><a:xfrm><a:off x="1828800" y="914400"/><a:ext cx="914400" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr></p:pic>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/_rels/slide1.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file("ppt/media/image1.png", RED_PNG);
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
 function firstShape(source: PptxSourceModel): SourceShape {
   const shape = source.slides[0]?.shapes.find((node): node is SourceShape => node.kind === "shape");
   if (shape === undefined) throw new Error("fixture shape not found");
@@ -762,6 +952,12 @@ function firstText(source: PptxSourceModel): string {
   const run = firstShape(source).textBody?.paragraphs[0]?.runs[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.text;
+}
+
+function mediaBytes(source: PptxSourceModel, partPath: string): Uint8Array {
+  const media = source.packageGraph.media.find((part) => part.partPath === partPath);
+  if (media === undefined) throw new Error(`media not found: ${partPath}`);
+  return media.bytes;
 }
 
 async function listen(server: Server): Promise<string> {

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
@@ -15,9 +16,19 @@ import { createDevServerRequestHandler, DevEditorBackend } from "../scripts/dev-
 import { unsafeScriptInputAssertion } from "../scripts/unsafe-type-assertion.js";
 
 const encoder = new TextEncoder();
+const RED_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAEUlEQVR4nGP8z4AATEhsPBwAM9EBBzDn4UwAAAAASUVORK5CYII=";
+const BLUE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGNkYPjPAANMcBZeDgAx0wEH1s7nlgAAAABJRU5ErkJggg==";
+const RED_PNG = pngBytes(RED_PNG_BASE64);
+const BLUE_PNG = pngBytes(BLUE_PNG_BASE64);
 
 function xml(content: string): Uint8Array {
   return encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n${content}`);
+}
+
+function pngBytes(base64: string): Uint8Array {
+  return new Uint8Array(Buffer.from(base64, "base64"));
 }
 
 describe("dev server editor API", () => {
@@ -234,12 +245,73 @@ describe("dev server editor API", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("applies image replacement commands with shared media warnings, undo, redo, and save", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-image-test-"));
+    try {
+      const sourcePath = join(dir, "fixture.pptx");
+      const savedPath = join(dir, "saved.pptx");
+      await writeFile(sourcePath, await buildImageFixture());
+
+      const backend = await DevEditorBackend.load(sourcePath, renderImagePreview);
+      const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
+      servers.push(server);
+      const baseUrl = await listen(server);
+
+      const shapes = await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`);
+      const image = shapes.shapes.find((shape) => shape.kind === "image");
+      expect(image?.editableImageReplacement).toEqual({
+        contentType: "image/png",
+        accept: "image/png,.png",
+        mediaPartPath: "ppt/media/image1.png",
+        sharedReferenceCount: 2,
+      });
+
+      const rejected = await postJsonError(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "replaceImage",
+          handle: shapes.shapes[0].handle,
+          bytes: [0xff, 0xd8, 0xff, 0xd9],
+        },
+      });
+      expect(rejected.error).toContain("does not match existing media content type");
+
+      const replaced = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "replaceImage",
+          handle: image?.handle,
+          bytes: Array.from(BLUE_PNG),
+        },
+      });
+      expect(replaced.slides[0].svg).toContain(BLUE_PNG_BASE64);
+      expect(replaced.warnings).toEqual([
+        expect.objectContaining({
+          code: "shared-media-part",
+          mediaPartPath: "ppt/media/image1.png",
+          referenceCount: 2,
+        }),
+      ]);
+
+      const undone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/undo`, {});
+      expect(undone.slides[0].svg).toContain(RED_PNG_BASE64);
+      const redone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/redo`, {});
+      expect(redone.slides[0].svg).toContain(BLUE_PNG_BASE64);
+
+      await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
+      expect(mediaBytes(readPptx(await readFile(savedPath)), "ppt/media/image1.png")).toEqual(
+        BLUE_PNG,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 interface ShapesResponse {
   shapes: Array<{
     handle: unknown;
     id: string;
+    kind: string;
     name?: string;
     bounds?: { x: number; y: number; width: number; height: number };
     textRuns: Array<{ text: string; handle: unknown }>;
@@ -253,12 +325,23 @@ interface ShapesResponse {
         }>;
       };
     };
+    editableImageReplacement?: {
+      contentType: string;
+      accept: string;
+      mediaPartPath: string;
+      sharedReferenceCount: number;
+    };
   }>;
 }
 
 interface SlidesResponse {
   slides: Array<{ slideNumber: number; svg: string }>;
   history: { canUndo: boolean; canRedo: boolean };
+  warnings?: Array<{
+    code: string;
+    mediaPartPath: string;
+    referenceCount: number;
+  }>;
 }
 
 interface SaveResponse {
@@ -272,6 +355,20 @@ function renderPreview(input: Uint8Array): Promise<Array<{ slideNumber: number; 
     {
       slideNumber: 1,
       svg: `<svg><text${runPropertyAttrs(source)}>${escapeXml(firstRun(source))}</text></svg>`,
+    },
+  ]);
+}
+
+function renderImagePreview(
+  input: Uint8Array,
+): Promise<Array<{ slideNumber: number; svg: string }>> {
+  const source = readPptx(input);
+  return Promise.resolve([
+    {
+      slideNumber: 1,
+      svg: `<svg><image href="data:image/png;base64,${Buffer.from(
+        mediaBytes(source, "ppt/media/image1.png"),
+      ).toString("base64")}"/></svg>`,
     },
   ]);
 }
@@ -406,6 +503,73 @@ async function buildTextEditFixture(): Promise<Uint8Array> {
   return zip.generateAsync({ type: "uint8array" });
 }
 
+async function buildImageFixture(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    xml(
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Default Extension="png" ContentType="image/png"/>` +
+        `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>` +
+        `<Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>` +
+        `</Types>`,
+    ),
+  );
+  zip.file(
+    "_rels/.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/presentation.xml",
+    xml(
+      `<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:sldIdLst><p:sldId id="256" r:id="rIdSlide1"/></p:sldIdLst>` +
+        `<p:sldSz cx="9144000" cy="5143500"/>` +
+        `</p:presentation>`,
+    ),
+  );
+  zip.file(
+    "ppt/_rels/presentation.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdSlide1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/slide1.xml",
+    xml(
+      `<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<p:cSld><p:spTree>` +
+        `<p:pic><p:nvPicPr><p:cNvPr id="20" name="Shared Picture A"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>` +
+        `<p:blipFill><a:blip r:embed="rIdImage"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>` +
+        `<p:spPr><a:xfrm><a:off x="914400" y="914400"/><a:ext cx="914400" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr></p:pic>` +
+        `<p:pic><p:nvPicPr><p:cNvPr id="21" name="Shared Picture B"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>` +
+        `<p:blipFill><a:blip r:embed="rIdImage"/><a:stretch><a:fillRect/></a:stretch></p:blipFill>` +
+        `<p:spPr><a:xfrm><a:off x="1828800" y="914400"/><a:ext cx="914400" cy="914400"/></a:xfrm><a:prstGeom prst="rect"/></p:spPr></p:pic>` +
+        `</p:spTree></p:cSld>` +
+        `</p:sld>`,
+    ),
+  );
+  zip.file(
+    "ppt/slides/_rels/slide1.xml.rels",
+    xml(
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>` +
+        `</Relationships>`,
+    ),
+  );
+  zip.file("ppt/media/image1.png", RED_PNG);
+
+  return zip.generateAsync({ type: "uint8array" });
+}
+
 function firstRun(source: PptxSourceModel): string {
   const shape = source.slides[0].shapes.find((node): node is SourceShape => node.kind === "shape");
   const run = shape?.textBody?.paragraphs[0].runs[0];
@@ -418,4 +582,10 @@ function firstRunProperties(source: PptxSourceModel) {
   const run = shape?.textBody?.paragraphs[0].runs[0];
   if (run === undefined) throw new Error("fixture text run not found");
   return run.properties;
+}
+
+function mediaBytes(source: PptxSourceModel, partPath: string): Uint8Array {
+  const media = source.packageGraph.media.find((part) => part.partPath === partPath);
+  if (media === undefined) throw new Error(`media not found: ${partPath}`);
+  return media.bytes;
 }

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -69,6 +69,12 @@ describe("BrowserPptxEditorSession", () => {
     });
     const image = editor.shapes(1).find((shape) => shape.kind === "image");
     if (image?.handle === undefined) throw new Error("image handle not found");
+    expect(image.editableImageReplacement).toEqual({
+      contentType: "image/png",
+      accept: "image/png,.png",
+      mediaPartPath: "ppt/media/image1.png",
+      sharedReferenceCount: 2,
+    });
 
     const result = await editor.apply({
       kind: "replaceImage",

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -91,6 +91,16 @@ describe("BrowserPptxEditorSession", () => {
     ]);
     expect(mediaBytes(editor.document, "ppt/media/image1.png")).toEqual(BLUE_PNG);
   });
+
+  it("counts unparsed image relationships in image replacement metadata", async () => {
+    const editor = await createBrowserPptxEditorSession(
+      await buildImageFixture({ includeUnusedImageRelationship: true }),
+      { skipSystemFonts: true },
+    );
+    const image = editor.shapes(1).find((shape) => shape.kind === "image");
+
+    expect(image?.editableImageReplacement?.sharedReferenceCount).toBe(3);
+  });
 });
 
 function xml(content: string): Uint8Array {
@@ -158,7 +168,9 @@ async function buildShapeFixture(): Promise<Uint8Array> {
   return zip.generateAsync({ type: "uint8array" });
 }
 
-async function buildImageFixture(): Promise<Uint8Array> {
+async function buildImageFixture(
+  options: { readonly includeUnusedImageRelationship?: boolean } = {},
+): Promise<Uint8Array> {
   const zip = new JSZip();
   zip.file(
     "[Content_Types].xml",
@@ -217,6 +229,9 @@ async function buildImageFixture(): Promise<Uint8Array> {
     xml(
       `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
         `<Relationship Id="rIdImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>` +
+        (options.includeUnusedImageRelationship === true
+          ? `<Relationship Id="rIdUnusedImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>`
+          : "") +
         `</Relationships>`,
     ),
   );

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -1,8 +1,13 @@
 import {
   findShapeNodeBySourceHandle,
+  type MediaPart,
+  type PartPath,
   type PptxSourceModel,
   readPptx,
+  type Relationship,
+  type RelationshipId,
   type SourceHandle,
+  type SourceImage,
   type SourceShapeNode,
   type SourceTextBody,
   type SourceTextRun,
@@ -18,9 +23,20 @@ import {
 } from "@pptx-glimpse/editor-core";
 
 import { type ConvertOptions, renderPptxSourceModelToSvg, type SlideSvg } from "./svg-converter.js";
+import { unsafeBrandAssertion } from "./unsafe-type-assertion.js";
 
 const EMU_PER_INCH = 914400;
 const DEFAULT_DPI = 96;
+const IMAGE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+
+const IMAGE_ACCEPT_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
+  "image/png": "image/png,.png",
+  "image/jpeg": "image/jpeg,.jpg,.jpeg",
+  "image/gif": "image/gif,.gif",
+  "image/bmp": "image/bmp,.bmp",
+  "image/tiff": "image/tiff,.tif,.tiff",
+  "image/webp": "image/webp,.webp",
+};
 
 export interface BrowserEditorHistoryState {
   readonly canUndo: boolean;
@@ -42,6 +58,13 @@ export interface BrowserEditorTextBodyInfo {
   readonly docJson: PptxTextBodyProseMirrorDocJson;
 }
 
+export interface BrowserEditorImageReplacementInfo {
+  readonly contentType: string;
+  readonly accept: string;
+  readonly mediaPartPath: string;
+  readonly sharedReferenceCount: number;
+}
+
 export interface BrowserEditorShapeBoundsPx {
   readonly x: number;
   readonly y: number;
@@ -58,6 +81,7 @@ export interface BrowserEditorShapeInfo {
   readonly editableTransform?: boolean;
   readonly textRuns?: readonly BrowserEditorTextRunInfo[];
   readonly editableTextBody?: BrowserEditorTextBodyInfo;
+  readonly editableImageReplacement?: BrowserEditorImageReplacementInfo;
 }
 
 export interface BrowserEditorSlidesResponse {
@@ -127,7 +151,7 @@ export class BrowserPptxEditorSession {
   shapes(slideNumber: number): readonly BrowserEditorShapeInfo[] {
     const slide = this.#session.document.slides[slideNumber - 1];
     if (slide === undefined) return [];
-    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index));
+    return slide.shapes.flatMap((shape, index) => shapeInfo(this.#session.document, shape, index));
   }
 
   async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
@@ -217,6 +241,7 @@ export function createBrowserPptxEditorSession(
 }
 
 function shapeInfo(
+  source: PptxSourceModel,
   shape: SourceShapeNode,
   index: number,
   editableTransform = true,
@@ -247,12 +272,13 @@ function shapeInfo(
     ...(shape.kind === "shape" && canEditTransform && shape.textBody !== undefined
       ? editableTextBody(shape.textBody)
       : {}),
+    ...(shape.kind === "image" ? editableImageReplacement(source, shape) : {}),
   };
 
   if (shape.kind !== "group") return [base];
   return [
     base,
-    ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex, false)),
+    ...shape.children.flatMap((child, childIndex) => shapeInfo(source, child, childIndex, false)),
   ];
 }
 
@@ -282,6 +308,116 @@ function editableTextBody(
   } catch {
     return {};
   }
+}
+
+function editableImageReplacement(
+  source: PptxSourceModel,
+  image: SourceImage,
+): Partial<Pick<BrowserEditorShapeInfo, "editableImageReplacement">> {
+  const media = imageMediaPart(source, image);
+  if (media === undefined) return {};
+  const accept = IMAGE_ACCEPT_BY_CONTENT_TYPE[media.contentType];
+  if (accept === undefined) return {};
+
+  return {
+    editableImageReplacement: {
+      contentType: media.contentType,
+      accept,
+      mediaPartPath: media.partPath,
+      sharedReferenceCount: countImageReferencesToMedia(source, media.partPath),
+    },
+  };
+}
+
+function imageMediaPart(source: PptxSourceModel, image: SourceImage): MediaPart | undefined {
+  if (image.blipRelationshipId === undefined || image.handle?.partPath === undefined) {
+    return undefined;
+  }
+  const mediaPartPath = imageMediaPartPath(source, image.handle.partPath, image.blipRelationshipId);
+  if (mediaPartPath === undefined) return undefined;
+  return source.packageGraph.media.find((part) => part.partPath === mediaPartPath);
+}
+
+function imageMediaPartPath(
+  source: PptxSourceModel,
+  sourcePartPath: PartPath,
+  relationshipId: RelationshipId,
+): PartPath | undefined {
+  const relationships = source.packageGraph.relationships.find(
+    (candidate) => candidate.sourcePartPath === sourcePartPath,
+  );
+  const relationship = relationships?.relationships.find(
+    (candidate) => candidate.id === relationshipId && candidate.type === IMAGE_REL_TYPE,
+  );
+  if (relationship === undefined) return undefined;
+  return resolveInternalRelationshipTarget(sourcePartPath, relationship);
+}
+
+function countImageReferencesToMedia(source: PptxSourceModel, mediaPartPath: PartPath): number {
+  let count = 0;
+  for (const slide of source.slides) {
+    count += countImageReferencesInTree(source, slide.partPath, slide.shapes, mediaPartPath);
+  }
+  for (const layout of source.slideLayouts) {
+    count += countImageReferencesInTree(source, layout.partPath, layout.shapes, mediaPartPath);
+  }
+  for (const master of source.slideMasters) {
+    count += countImageReferencesInTree(source, master.partPath, master.shapes, mediaPartPath);
+  }
+  return count;
+}
+
+function countImageReferencesInTree(
+  source: PptxSourceModel,
+  sourcePartPath: PartPath,
+  shapes: readonly SourceShapeNode[],
+  mediaPartPath: PartPath,
+): number {
+  let count = 0;
+  for (const shape of shapes) {
+    if (shape.kind === "group") {
+      count += countImageReferencesInTree(source, sourcePartPath, shape.children, mediaPartPath);
+      continue;
+    }
+    if (shape.kind !== "image" || shape.blipRelationshipId === undefined) continue;
+    if (imageMediaPartPath(source, sourcePartPath, shape.blipRelationshipId) === mediaPartPath) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function resolveInternalRelationshipTarget(
+  sourcePartPath: PartPath,
+  relationship: Relationship,
+): PartPath | undefined {
+  if (relationship.targetMode === "External") return undefined;
+  return unsafeBrandAssertion<PartPath>(
+    normalizePackagePath(
+      relationship.target.startsWith("/")
+        ? relationship.target.slice(1)
+        : joinPackageRelativeTarget(sourcePartPath, relationship.target),
+    ),
+  );
+}
+
+function joinPackageRelativeTarget(sourcePartPath: string, target: string): string {
+  const slash = sourcePartPath.lastIndexOf("/");
+  const baseDir = slash === -1 ? "" : sourcePartPath.slice(0, slash);
+  return baseDir === "" ? target : `${baseDir}/${target}`;
+}
+
+function normalizePackagePath(path: string): string {
+  const segments: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join("/");
 }
 
 function transformBoundsPx(transform: {

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -354,15 +354,53 @@ function imageMediaPartPath(
 }
 
 function countImageReferencesToMedia(source: PptxSourceModel, mediaPartPath: PartPath): number {
+  const parsedImageRelationshipKeys = new Set<string>();
   let count = 0;
   for (const slide of source.slides) {
-    count += countImageReferencesInTree(source, slide.partPath, slide.shapes, mediaPartPath);
+    count += countImageReferencesInTree(
+      source,
+      slide.partPath,
+      slide.shapes,
+      mediaPartPath,
+      parsedImageRelationshipKeys,
+    );
   }
   for (const layout of source.slideLayouts) {
-    count += countImageReferencesInTree(source, layout.partPath, layout.shapes, mediaPartPath);
+    count += countImageReferencesInTree(
+      source,
+      layout.partPath,
+      layout.shapes,
+      mediaPartPath,
+      parsedImageRelationshipKeys,
+    );
   }
   for (const master of source.slideMasters) {
-    count += countImageReferencesInTree(source, master.partPath, master.shapes, mediaPartPath);
+    count += countImageReferencesInTree(
+      source,
+      master.partPath,
+      master.shapes,
+      mediaPartPath,
+      parsedImageRelationshipKeys,
+    );
+  }
+
+  for (const relationships of source.packageGraph.relationships) {
+    for (const relationship of relationships.relationships) {
+      if (relationship.type !== IMAGE_REL_TYPE) continue;
+      if (
+        parsedImageRelationshipKeys.has(
+          imageRelationshipKey(relationships.sourcePartPath, relationship.id),
+        )
+      ) {
+        continue;
+      }
+      if (
+        resolveInternalRelationshipTarget(relationships.sourcePartPath, relationship) ===
+        mediaPartPath
+      ) {
+        count += 1;
+      }
+    }
   }
   return count;
 }
@@ -372,19 +410,33 @@ function countImageReferencesInTree(
   sourcePartPath: PartPath,
   shapes: readonly SourceShapeNode[],
   mediaPartPath: PartPath,
+  parsedImageRelationshipKeys: Set<string>,
 ): number {
   let count = 0;
   for (const shape of shapes) {
     if (shape.kind === "group") {
-      count += countImageReferencesInTree(source, sourcePartPath, shape.children, mediaPartPath);
+      count += countImageReferencesInTree(
+        source,
+        sourcePartPath,
+        shape.children,
+        mediaPartPath,
+        parsedImageRelationshipKeys,
+      );
       continue;
     }
     if (shape.kind !== "image" || shape.blipRelationshipId === undefined) continue;
     if (imageMediaPartPath(source, sourcePartPath, shape.blipRelationshipId) === mediaPartPath) {
       count += 1;
+      parsedImageRelationshipKeys.add(
+        imageRelationshipKey(sourcePartPath, shape.blipRelationshipId),
+      );
     }
   }
   return count;
+}
+
+function imageRelationshipKey(partPath: PartPath, relationshipId: RelationshipId): string {
+  return `${partPath}\0${relationshipId}`;
 }
 
 function resolveInternalRelationshipTarget(

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -9,6 +9,7 @@ import { type ConvertOptions, convertPptxToSvg as convertPptxToSvgBase } from ".
 
 export type {
   BrowserEditorHistoryState,
+  BrowserEditorImageReplacementInfo,
   BrowserEditorRenderOptions,
   BrowserEditorSaveResponse,
   BrowserEditorSelectionInfo,

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -471,15 +471,53 @@ function countImageReferencesToMedia(
   source: ReturnType<typeof readPptx>,
   mediaPartPath: PartPath,
 ): number {
+  const parsedImageRelationshipKeys = new Set<string>();
   let count = 0;
   for (const slide of source.slides) {
-    count += countImageReferencesInTree(source, slide.partPath, slide.shapes, mediaPartPath);
+    count += countImageReferencesInTree(
+      source,
+      slide.partPath,
+      slide.shapes,
+      mediaPartPath,
+      parsedImageRelationshipKeys,
+    );
   }
   for (const layout of source.slideLayouts) {
-    count += countImageReferencesInTree(source, layout.partPath, layout.shapes, mediaPartPath);
+    count += countImageReferencesInTree(
+      source,
+      layout.partPath,
+      layout.shapes,
+      mediaPartPath,
+      parsedImageRelationshipKeys,
+    );
   }
   for (const master of source.slideMasters) {
-    count += countImageReferencesInTree(source, master.partPath, master.shapes, mediaPartPath);
+    count += countImageReferencesInTree(
+      source,
+      master.partPath,
+      master.shapes,
+      mediaPartPath,
+      parsedImageRelationshipKeys,
+    );
+  }
+
+  for (const relationships of source.packageGraph.relationships) {
+    for (const relationship of relationships.relationships) {
+      if (relationship.type !== IMAGE_REL_TYPE) continue;
+      if (
+        parsedImageRelationshipKeys.has(
+          imageRelationshipKey(relationships.sourcePartPath, relationship.id),
+        )
+      ) {
+        continue;
+      }
+      if (
+        resolveInternalRelationshipTarget(relationships.sourcePartPath, relationship) ===
+        mediaPartPath
+      ) {
+        count += 1;
+      }
+    }
   }
   return count;
 }
@@ -489,19 +527,33 @@ function countImageReferencesInTree(
   sourcePartPath: PartPath,
   shapes: readonly SourceShapeNode[],
   mediaPartPath: PartPath,
+  parsedImageRelationshipKeys: Set<string>,
 ): number {
   let count = 0;
   for (const shape of shapes) {
     if (shape.kind === "group") {
-      count += countImageReferencesInTree(source, sourcePartPath, shape.children, mediaPartPath);
+      count += countImageReferencesInTree(
+        source,
+        sourcePartPath,
+        shape.children,
+        mediaPartPath,
+        parsedImageRelationshipKeys,
+      );
       continue;
     }
     if (shape.kind !== "image" || shape.blipRelationshipId === undefined) continue;
     if (imageMediaPartPath(source, sourcePartPath, shape.blipRelationshipId) === mediaPartPath) {
       count += 1;
+      parsedImageRelationshipKeys.add(
+        imageRelationshipKey(sourcePartPath, shape.blipRelationshipId),
+      );
     }
   }
   return count;
+}
+
+function imageRelationshipKey(partPath: PartPath, relationshipId: RelationshipId): string {
+  return `${partPath}\0${relationshipId}`;
 }
 
 function resolveInternalRelationshipTarget(

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -17,8 +17,13 @@ import {
   type EditableTextRunProperties,
   type EditableTextRunProperty,
   findShapeNodeBySourceHandle,
+  type MediaPart,
+  type PartPath,
   readPptx,
+  type Relationship,
+  type RelationshipId,
   type SourceHandle,
+  type SourceImage,
   type SourceShapeNode,
   type SourceTextBody,
   type SourceTextRun,
@@ -27,6 +32,7 @@ import {
 import {
   createEditorSession,
   type EditorCommand,
+  type EditorCommandWarning,
   type PptxTextBodyProseMirrorDocJson,
   proseMirrorDocJsonToEditorCommands,
   textBodyToProseMirrorDocJson,
@@ -41,6 +47,17 @@ const RENDER_TIMEOUT_MS = 30_000;
 const MAX_BUFFER = 50 * 1024 * 1024;
 const EMU_PER_INCH = 914400;
 const DEFAULT_DPI = 96;
+const IMAGE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+const MAX_JSON_BODY_BYTES = 20 * 1024 * 1024;
+
+const IMAGE_ACCEPT_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
+  "image/png": "image/png,.png",
+  "image/jpeg": "image/jpeg,.jpg,.jpeg",
+  "image/gif": "image/gif,.gif",
+  "image/bmp": "image/bmp,.bmp",
+  "image/tiff": "image/tiff,.tif,.tiff",
+  "image/webp": "image/webp,.webp",
+};
 
 const execFileAsync = promisify(execFile);
 
@@ -72,6 +89,13 @@ interface EditorTextBodyInfo {
   docJson: PptxTextBodyProseMirrorDocJson;
 }
 
+interface EditorImageReplacementInfo {
+  contentType: string;
+  accept: string;
+  mediaPartPath: string;
+  sharedReferenceCount: number;
+}
+
 interface EditorShapeInfo {
   id: string;
   kind: SourceShapeNode["kind"];
@@ -81,12 +105,14 @@ interface EditorShapeInfo {
   editableTransform?: boolean;
   textRuns?: EditorTextRunInfo[];
   editableTextBody?: EditorTextBodyInfo;
+  editableImageReplacement?: EditorImageReplacementInfo;
 }
 
 interface EditorSlidesResponse {
   slides: SlideSvg[];
   history: EditorHistoryState;
   selection?: EditorSelectionInfo;
+  warnings?: readonly EditorCommandWarning[];
 }
 
 interface EditorSaveResponse {
@@ -166,18 +192,19 @@ export class DevEditorBackend {
     return this.#session.selection;
   }
 
-  response(): EditorSlidesResponse {
+  response(warnings?: readonly EditorCommandWarning[]): EditorSlidesResponse {
     return {
       slides: this.#slides,
       history: this.history,
       ...(this.selection !== undefined ? { selection: this.selection } : {}),
+      ...(warnings !== undefined && warnings.length > 0 ? { warnings } : {}),
     };
   }
 
   shapes(slideNumber: number): EditorShapeInfo[] {
     const slide = this.#session.document.slides[slideNumber - 1];
     if (slide === undefined) return [];
-    return slide.shapes.flatMap((shape, index) => shapeInfo(shape, index));
+    return slide.shapes.flatMap((shape, index) => shapeInfo(this.#session.document, shape, index));
   }
 
   async renderCurrentSlides(): Promise<readonly SlideSvg[]> {
@@ -202,7 +229,7 @@ export class DevEditorBackend {
       }
       this.#dirty = true;
       await this.renderCurrentSlides();
-      return this.response();
+      return this.response(result.warnings);
     });
   }
 
@@ -330,6 +357,7 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
 }
 
 function shapeInfo(
+  source: ReturnType<typeof readPptx>,
   shape: SourceShapeNode,
   index: number,
   editableTransform = true,
@@ -355,12 +383,13 @@ function shapeInfo(
     ...(shape.kind === "shape" && shape.textBody !== undefined && shape.transform !== undefined
       ? editableTextBody(shape.textBody)
       : {}),
+    ...(shape.kind === "image" ? editableImageReplacement(source, shape) : {}),
   };
 
   if (shape.kind !== "group") return [base];
   return [
     base,
-    ...shape.children.flatMap((child, childIndex) => shapeInfo(child, childIndex, false)),
+    ...shape.children.flatMap((child, childIndex) => shapeInfo(source, child, childIndex, false)),
   ];
 }
 
@@ -390,6 +419,122 @@ function editableTextBody(
   } catch {
     return {};
   }
+}
+
+function editableImageReplacement(
+  source: ReturnType<typeof readPptx>,
+  image: SourceImage,
+): Partial<Pick<EditorShapeInfo, "editableImageReplacement">> {
+  const media = imageMediaPart(source, image);
+  if (media === undefined) return {};
+  const accept = IMAGE_ACCEPT_BY_CONTENT_TYPE[media.contentType];
+  if (accept === undefined) return {};
+
+  return {
+    editableImageReplacement: {
+      contentType: media.contentType,
+      accept,
+      mediaPartPath: media.partPath,
+      sharedReferenceCount: countImageReferencesToMedia(source, media.partPath),
+    },
+  };
+}
+
+function imageMediaPart(
+  source: ReturnType<typeof readPptx>,
+  image: SourceImage,
+): MediaPart | undefined {
+  if (image.blipRelationshipId === undefined || image.handle?.partPath === undefined) {
+    return undefined;
+  }
+  const mediaPartPath = imageMediaPartPath(source, image.handle.partPath, image.blipRelationshipId);
+  if (mediaPartPath === undefined) return undefined;
+  return source.packageGraph.media.find((part) => part.partPath === mediaPartPath);
+}
+
+function imageMediaPartPath(
+  source: ReturnType<typeof readPptx>,
+  sourcePartPath: PartPath,
+  relationshipId: RelationshipId,
+): PartPath | undefined {
+  const relationships = source.packageGraph.relationships.find(
+    (candidate) => candidate.sourcePartPath === sourcePartPath,
+  );
+  const relationship = relationships?.relationships.find(
+    (candidate) => candidate.id === relationshipId && candidate.type === IMAGE_REL_TYPE,
+  );
+  if (relationship === undefined) return undefined;
+  return resolveInternalRelationshipTarget(sourcePartPath, relationship);
+}
+
+function countImageReferencesToMedia(
+  source: ReturnType<typeof readPptx>,
+  mediaPartPath: PartPath,
+): number {
+  let count = 0;
+  for (const slide of source.slides) {
+    count += countImageReferencesInTree(source, slide.partPath, slide.shapes, mediaPartPath);
+  }
+  for (const layout of source.slideLayouts) {
+    count += countImageReferencesInTree(source, layout.partPath, layout.shapes, mediaPartPath);
+  }
+  for (const master of source.slideMasters) {
+    count += countImageReferencesInTree(source, master.partPath, master.shapes, mediaPartPath);
+  }
+  return count;
+}
+
+function countImageReferencesInTree(
+  source: ReturnType<typeof readPptx>,
+  sourcePartPath: PartPath,
+  shapes: readonly SourceShapeNode[],
+  mediaPartPath: PartPath,
+): number {
+  let count = 0;
+  for (const shape of shapes) {
+    if (shape.kind === "group") {
+      count += countImageReferencesInTree(source, sourcePartPath, shape.children, mediaPartPath);
+      continue;
+    }
+    if (shape.kind !== "image" || shape.blipRelationshipId === undefined) continue;
+    if (imageMediaPartPath(source, sourcePartPath, shape.blipRelationshipId) === mediaPartPath) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function resolveInternalRelationshipTarget(
+  sourcePartPath: PartPath,
+  relationship: Relationship,
+): PartPath | undefined {
+  if (relationship.targetMode === "External") return undefined;
+  return unsafeScriptInputAssertion<PartPath>(
+    normalizePackagePath(
+      relationship.target.startsWith("/")
+        ? relationship.target.slice(1)
+        : joinPackageRelativeTarget(sourcePartPath, relationship.target),
+    ),
+  );
+}
+
+function joinPackageRelativeTarget(sourcePartPath: string, target: string): string {
+  const slash = sourcePartPath.lastIndexOf("/");
+  const baseDir = slash === -1 ? "" : sourcePartPath.slice(0, slash);
+  return baseDir === "" ? target : `${baseDir}/${target}`;
+}
+
+function normalizePackagePath(path: string): string {
+  const segments: string[] = [];
+  for (const segment of path.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join("/");
 }
 
 function transformBoundsPx(transform: {
@@ -703,6 +848,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       <label>Text run<select id="text-run-select"></select></label>
       <label>Text<input id="text-run-input" type="text"></label>
       <button id="apply-text-button" type="button">Apply</button>
+      <label>Image<input id="image-replacement-input" data-testid="image-replacement-input" type="file" disabled></label>
       <div id="editor-actions">
         <button id="undo-button" type="button">Undo</button>
         <button id="redo-button" type="button">Redo</button>
@@ -743,6 +889,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       textRunOptions = [];
       selectedShape = null;
       if (slideChanged) selectedShapeKey = null;
+      syncImageReplacementInput();
       var thumbs = document.querySelectorAll(".thumbnail");
       for (var i = 0; i < thumbs.length; i++) {
         if (i === index) {
@@ -819,15 +966,18 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         }
       }
       if (!selectedShape) selectedShapeKey = null;
+      syncImageReplacementInput();
       renderSelectionOverlay();
     }
 
     function cloneShape(shape) {
       return {
         id: shape.id,
+        kind: shape.kind,
         name: shape.name,
         handle: shape.handle,
         editableTextBody: shape.editableTextBody,
+        editableImageReplacement: shape.editableImageReplacement,
         bounds: {
           x: shape.bounds.x,
           y: shape.bounds.y,
@@ -853,7 +1003,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         .then(function (data) {
           if (requestId !== shapeRequestId || slideNumber !== currentIndex + 1) return;
           shapeOptions = (data.shapes || []).filter(function (shape) {
-            return shape.handle && shape.bounds && shape.editableTransform;
+            return shape.handle && shape.bounds && (shape.editableTransform || shape.editableImageReplacement);
           });
           textRunOptions = [];
           data.shapes.forEach(function (shape) {
@@ -875,6 +1025,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           document.getElementById("apply-text-button").disabled = textRunOptions.length === 0;
           syncTextInput();
           syncSelection();
+          syncImageReplacementInput();
         })
         .catch(function (err) {
           setEditorMessage(err.message, true);
@@ -995,6 +1146,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       }
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
+      syncImageReplacementInput();
       beginDrag("move", null, event);
       window.setTimeout(renderSelectionOverlay, 0);
       postJson("/api/editor/select", { handle: shape.handle })
@@ -1003,6 +1155,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           if (data.selection && data.selection.shapeHandle) {
             selectedShapeKey = handleKey(data.selection.shapeHandle);
           }
+          syncImageReplacementInput();
           renderSelectionOverlay();
         })
         .catch(function (err) {
@@ -1013,6 +1166,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     function selectShapeAfterCommit(shape) {
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
+      syncImageReplacementInput();
       renderSelectionOverlay();
       postJson("/api/editor/select", { handle: shape.handle })
         .then(function (data) {
@@ -1020,6 +1174,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
           if (data.selection && data.selection.shapeHandle) {
             selectedShapeKey = handleKey(data.selection.shapeHandle);
           }
+          syncImageReplacementInput();
           renderSelectionOverlay();
         })
         .catch(function (err) {
@@ -1699,6 +1854,57 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       });
     }
 
+    function syncImageReplacementInput() {
+      var input = document.getElementById("image-replacement-input");
+      if (!input) return;
+      var replacement = selectedShape && selectedShape.editableImageReplacement;
+      input.disabled = !replacement;
+      input.value = "";
+      if (replacement) {
+        input.setAttribute("accept", replacement.accept);
+        input.title =
+          "Replace " + replacement.mediaPartPath + " with another " + replacement.contentType + " image";
+      } else {
+        input.removeAttribute("accept");
+        input.title = "Select an image shape to replace its media";
+      }
+    }
+
+    function replaceSelectedImage(file) {
+      if (!selectedShape || !selectedShape.handle || !selectedShape.editableImageReplacement) {
+        setEditorMessage("Select an image shape before replacing media.", true);
+        return Promise.resolve();
+      }
+      return file.arrayBuffer()
+        .then(function (buffer) {
+          return postJson("/api/editor/command", {
+            command: {
+              kind: "replaceImage",
+              handle: selectedShape.handle,
+              bytes: Array.from(new Uint8Array(buffer))
+            }
+          });
+        })
+        .then(function (data) {
+          applyEditorResponse(data);
+          setEditorMessage(imageReplacementMessage(data), false);
+        });
+    }
+
+    function imageReplacementMessage(data) {
+      var warnings = (data && data.warnings) || [];
+      var shared = warnings.find(function (warning) {
+        return warning.code === "shared-media-part";
+      });
+      if (!shared) return "Image replaced";
+      return (
+        "Image replaced; shared media part affects " +
+        shared.referenceCount +
+        " pictures: " +
+        shared.mediaPartPath
+      );
+    }
+
     function postJson(url, payload) {
       return fetch(url, {
         method: "POST",
@@ -1725,6 +1931,18 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     loadShapeOptions(1);
 
     document.getElementById("text-run-select").addEventListener("change", syncTextInput);
+    document.getElementById("image-replacement-input").addEventListener("change", function () {
+      var input = document.getElementById("image-replacement-input");
+      var file = input && input.files ? input.files[0] : null;
+      if (!file) return;
+      replaceSelectedImage(file)
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        })
+        .finally(function () {
+          syncImageReplacementInput();
+        });
+    });
     document.getElementById("apply-text-button").addEventListener("click", function () {
       var option = textRunOptions[Number(document.getElementById("text-run-select").value || "0")];
       if (!option) return;
@@ -1948,7 +2166,7 @@ function readJsonBody(req: IncomingMessage): Promise<unknown> {
     req.setEncoding("utf8");
     req.on("data", (chunk: string) => {
       raw += chunk;
-      if (raw.length > 1024 * 1024) {
+      if (raw.length > MAX_JSON_BODY_BYTES) {
         req.destroy(new Error("Request body is too large"));
       }
     });
@@ -2019,7 +2237,26 @@ function normalizeCommand(command: unknown): EditorCommand {
       height: asEmu(requireFiniteNumber(command.height, "setShapeTransform.height")),
     };
   }
+  if (command.kind === "replaceImage") {
+    return {
+      kind: "replaceImage",
+      handle: normalizeHandle(command.handle),
+      bytes: normalizeByteArray(command.bytes, "replaceImage.bytes"),
+    };
+  }
   throw new Error("unsupported command kind");
+}
+
+function normalizeByteArray(value: unknown, field: string): Uint8Array {
+  if (!Array.isArray(value)) throw new Error(`${field} must be an array of bytes`);
+  return new Uint8Array(
+    value.map((byte, index) => {
+      if (!Number.isInteger(byte) || byte < 0 || byte > 255) {
+        throw new Error(`${field}[${String(index)}] must be an integer byte`);
+      }
+      return byte;
+    }),
+  );
 }
 
 function normalizeTextRunProperties(value: unknown): EditableTextRunProperties {

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -49,6 +49,7 @@ const EMU_PER_INCH = 914400;
 const DEFAULT_DPI = 96;
 const IMAGE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
 const MAX_JSON_BODY_BYTES = 20 * 1024 * 1024;
+const MAX_IMAGE_REPLACEMENT_BYTES = 5 * 1024 * 1024;
 
 const IMAGE_ACCEPT_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
   "image/png": "image/png,.png",
@@ -1028,6 +1029,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         kind: shape.kind,
         name: shape.name,
         handle: shape.handle,
+        editableTransform: shape.editableTransform,
         editableTextBody: shape.editableTextBody,
         editableImageReplacement: shape.editableImageReplacement,
         bounds: {
@@ -1148,23 +1150,25 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         setRectAttributes(box, selectedShape.bounds);
         overlay.appendChild(box);
 
-        ["nw", "ne", "sw", "se"].forEach(function (handle) {
-          var point = handlePoint(selectedShape.bounds, handle);
-          var rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-          rect.setAttribute("class", "selection-handle");
-          rect.setAttribute("data-testid", "selection-handle-" + handle);
-          rect.setAttribute("data-handle", handle);
-          rect.setAttribute("x", String(point.x - 4));
-          rect.setAttribute("y", String(point.y - 4));
-          rect.setAttribute("width", "8");
-          rect.setAttribute("height", "8");
-          rect.addEventListener("pointerdown", function (event) {
-            event.preventDefault();
-            event.stopPropagation();
-            beginDrag("resize", handle, event);
+        if (selectedShape.editableTransform) {
+          ["nw", "ne", "sw", "se"].forEach(function (handle) {
+            var point = handlePoint(selectedShape.bounds, handle);
+            var rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+            rect.setAttribute("class", "selection-handle");
+            rect.setAttribute("data-testid", "selection-handle-" + handle);
+            rect.setAttribute("data-handle", handle);
+            rect.setAttribute("x", String(point.x - 4));
+            rect.setAttribute("y", String(point.y - 4));
+            rect.setAttribute("width", "8");
+            rect.setAttribute("height", "8");
+            rect.addEventListener("pointerdown", function (event) {
+              event.preventDefault();
+              event.stopPropagation();
+              beginDrag("resize", handle, event);
+            });
+            overlay.appendChild(rect);
           });
-          overlay.appendChild(rect);
-        });
+        }
       }
 
       container.appendChild(overlay);
@@ -1199,7 +1203,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       selectedShapeKey = shapeKey(shape);
       selectedShape = cloneShape(shape);
       syncImageReplacementInput();
-      beginDrag("move", null, event);
+      if (shape.editableTransform) beginDrag("move", null, event);
       window.setTimeout(renderSelectionOverlay, 0);
       postJson("/api/editor/select", { handle: shape.handle })
         .then(function (data) {
@@ -1881,7 +1885,9 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
     }
 
     function applyShapeBoundsEdit(startBounds, nextBounds) {
-      if (!selectedShape || !selectedShape.handle) return Promise.resolve();
+      if (!selectedShape || !selectedShape.handle || !selectedShape.editableTransform) {
+        return Promise.resolve();
+      }
       var handle = selectedShape.handle;
       var changed =
         Math.round(startBounds.x) !== Math.round(nextBounds.x) ||
@@ -1927,12 +1933,19 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         setEditorMessage("Select an image shape before replacing media.", true);
         return Promise.resolve();
       }
+      if (file.size > ${String(MAX_IMAGE_REPLACEMENT_BYTES)}) {
+        setEditorMessage("Replacement image is too large.", true);
+        return Promise.resolve();
+      }
+      var handle = selectedShape.handle;
+      var input = document.getElementById("image-replacement-input");
+      if (input) input.disabled = true;
       return file.arrayBuffer()
         .then(function (buffer) {
           return postJson("/api/editor/command", {
             command: {
               kind: "replaceImage",
-              handle: selectedShape.handle,
+              handle: handle,
               bytes: Array.from(new Uint8Array(buffer))
             }
           });
@@ -2301,6 +2314,9 @@ function normalizeCommand(command: unknown): EditorCommand {
 
 function normalizeByteArray(value: unknown, field: string): Uint8Array {
   if (!Array.isArray(value)) throw new Error(`${field} must be an array of bytes`);
+  if (value.length > MAX_IMAGE_REPLACEMENT_BYTES) {
+    throw new Error(`${field} must not exceed ${String(MAX_IMAGE_REPLACEMENT_BYTES)} bytes`);
+  }
   return new Uint8Array(
     value.map((byte, index) => {
       if (!Number.isInteger(byte) || byte < 0 || byte > 255) {


### PR DESCRIPTION
close #632

## 概要

- ブラウザエディターの shape 情報に画像差し替えメタデータを追加
- 選択中の `pic` に対して同一フォーマット画像をファイル選択から `replaceImage` command に渡す UI を追加
- 共有 media part の警告、unsupported shape / フォーマットの reject、undo / redo 反映を UI と API の回帰テストで確認

## 受け入れ条件チェック

- ✓ ブラウザエディターから選択中 `pic` の画像を同一フォーマット画像で差し替えられる
- ✓ 差し替え後のレンダリングに新しい画像が反映される
- ✓ unsupported な shape / フォーマットでは操作が disable または明確に reject される
- ✓ 共有 media part への影響が UI 上で確認できる
- ✓ undo / redo が UI 操作からも機能する
- ✓ 主要操作の回帰テストがある

## 検証

- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm run test -- packages/core/src/browser-editor.test.ts e2e/dev-server-editor.test.ts`
- `npx playwright test e2e/browser-standalone-editor.playwright.ts`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npx playwright test e2e/dev-server-editor.playwright.ts`
- `npm run test`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npm run build`

## レビュー

- acceptance-check: 全 6 項目 ✓
- cross-review: 指摘対応済み。最終差分は追加指摘なし