### PR TITLE
fix: release PR の workspace dependency 解決を修正

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
   "author": "hirokisakabe",
   "license": "MIT",
   "dependencies": {
-    "@pptx-glimpse/document": "^0.1.0",
+    "@pptx-glimpse/document": "workspace:^",
     "@resvg/resvg-wasm": "^2.6.2",
     "fast-xml-parser": "^5.7.3",
     "fflate": "^0.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
   packages/core:
     dependencies:
       '@pptx-glimpse/document':
-        specifier: ^0.1.0
+        specifier: workspace:^
         version: link:../document
       '@resvg/resvg-wasm':
         specifier: ^2.6.2

--- a/scripts/test-package.sh
+++ b/scripts/test-package.sh
@@ -8,11 +8,14 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 echo "=== Package publish verification ==="
 echo "Working directory: $WORK_DIR"
 
-# Generate tarballs for publishing target package and document workspace package with npm pack
-TARBALL=$(cd packages/core && npm pack --pack-destination "$WORK_DIR" 2>/dev/null)
-TARBALL_PATH="$WORK_DIR/$TARBALL"
-DOCUMENT_TARBALL=$(cd packages/document && npm pack --pack-destination "$WORK_DIR" 2>/dev/null)
-DOCUMENT_TARBALL_PATH="$WORK_DIR/$DOCUMENT_TARBALL"
+# Generate tarballs for publishing target package and document workspace package with pnpm pack.
+# pnpm rewrites workspace: dependency ranges the same way publish does.
+pnpm --dir packages/core pack --pack-destination "$WORK_DIR" > /dev/null
+TARBALL_PATH=$(find "$WORK_DIR" -maxdepth 1 -type f -name "pptx-glimpse-[0-9]*.tgz" -print -quit)
+TARBALL=$(basename "$TARBALL_PATH")
+pnpm --dir packages/document pack --pack-destination "$WORK_DIR" > /dev/null
+DOCUMENT_TARBALL_PATH=$(find "$WORK_DIR" -maxdepth 1 -type f -name "pptx-glimpse-document-*.tgz" -print -quit)
+DOCUMENT_TARBALL=$(basename "$DOCUMENT_TARBALL_PATH")
 echo "Packed: $TARBALL"
 echo "Packed: $DOCUMENT_TARBALL"
 


### PR DESCRIPTION
## 概要

release workflow の Version Packages PR branch で、まだ未公開の `@pptx-glimpse/document@^0.2.0` を npm registry から解決しようとして失敗していた問題を修正します。

`pptx-glimpse` から `@pptx-glimpse/document` への依存を `workspace:^` に変更し、release PR branch の install 時は workspace package を参照するようにしました。pnpm pack/publish 時には通常の semver range に変換されます。

## 確認

- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run build`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec vitest run --exclude 'vrt/**'`
- release PR branch 相当で `changeset version` 後の `pnpm install --no-frozen-lockfile` が成功することを確認
- `pnpm pack` で公開 manifest の `@pptx-glimpse/document` が `^0.2.0` に変換されることを確認

## 補足

ローカル環境の global pnpm config に `minimumReleaseAge=10080` が設定されているため、検証コマンドでは `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` を明示しています。