### PR TITLE
document: edit 種別ごとの性質を記述子テーブルに集約し、kind 分岐を網羅 switch 化する

### DIFF
--- a/packages/document/src/source/edit-descriptors.ts
+++ b/packages/document/src/source/edit-descriptors.ts
@@ -1,0 +1,260 @@
+/**
+ * Edit-kind descriptor table.
+ *
+ * Every `PptxSourceModelEdit` kind has cross-cutting traits that are consumed
+ * from several call sites: which part paths it reserves for new-part numbering,
+ * which XML part the writer must reserialize (its dirty part), whether it
+ * targets a given shape, which part removals invalidate it, which shape id it
+ * occupies for numeric shape-id numbering, which `p:sldIdLst` operation it
+ * contributes to presentation.xml, and which slide/shape it inserted. This
+ * mapped table is the single place those traits are declared: adding a new
+ * edit kind to the union fails to compile until the kind declares every trait,
+ * instead of silently falling through hand-maintained switch/filter chains in
+ * editing.ts and write-pptx.ts. The writer keeps exactly one exhaustive apply
+ * switch for XML patching; everything else about an edit kind belongs here.
+ */
+
+import type { PartPath, RelationshipId, SourceHandle } from "./handles.js";
+import type { PptxSourceModelEdit } from "./pptx-source-model.js";
+
+/** Declarative `p:sldIdLst` operation an edit contributes to presentation.xml. */
+export type SlideTopologyOperation =
+  | {
+      readonly kind: "appendSlide";
+      readonly newRelationshipId: RelationshipId;
+    }
+  | {
+      readonly kind: "insertSlideAfter";
+      readonly sourceRelationshipId: RelationshipId;
+      readonly newRelationshipId: RelationshipId;
+    }
+  | {
+      readonly kind: "removeSlide";
+      readonly relationshipId: RelationshipId;
+    };
+
+/** Shape inserted by an edit, identified by its slide part and shape id. */
+export interface InsertedShapeRef {
+  readonly slidePartPath: PartPath;
+  readonly shapeId: string;
+}
+
+type EditOfKind<K extends PptxSourceModelEdit["kind"]> = Extract<
+  PptxSourceModelEdit,
+  { readonly kind: K }
+>;
+
+interface EditKindDescriptor<E extends PptxSourceModelEdit> {
+  /** Part paths the edit names; kept unavailable when numbering new parts. */
+  readonly reservedPartPaths: (edit: E) => readonly PartPath[];
+  /** XML part the writer must reserialize to apply the edit, if any. */
+  readonly dirtyPartPath: (edit: E) => PartPath | undefined;
+  /** Whether the edit targets the shape identified by the handle. */
+  readonly targetsShape: (edit: E, shapeHandle: SourceHandle) => boolean;
+  /** Part paths whose removal from the package invalidates the edit. */
+  readonly invalidatingPartPaths: (edit: E) => readonly PartPath[];
+  /** Shape id the edit occupies on the slide part for numeric id numbering. */
+  readonly reservedShapeId: (edit: E, slidePartPath: PartPath) => string | undefined;
+  /** `p:sldIdLst` operation the writer applies to presentation.xml, if any. */
+  readonly slideTopologyOperation: (edit: E) => SlideTopologyOperation | undefined;
+  /** Slide part the edit inserted; deleting that slide cancels the edit. */
+  readonly insertedSlidePartPath: (edit: E) => PartPath | undefined;
+  /** Shape the edit inserted; deleting that shape cancels the edit. */
+  readonly insertedShape: (edit: E) => InsertedShapeRef | undefined;
+}
+
+const EDIT_KIND_DESCRIPTORS: {
+  readonly [K in PptxSourceModelEdit["kind"]]: EditKindDescriptor<EditOfKind<K>>;
+} = {
+  replaceTextRunPlainText: {
+    reservedPartPaths: () => [],
+    dirtyPartPath: (edit) => edit.handle.partPath,
+    targetsShape: (edit, shapeHandle) =>
+      edit.handle.partPath === shapeHandle.partPath &&
+      textRunShapeId(edit.handle) === shapeHandle.nodeId,
+    invalidatingPartPaths: (edit) => [edit.handle.partPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: () => undefined,
+  },
+  updateTextRunProperties: {
+    reservedPartPaths: () => [],
+    dirtyPartPath: (edit) => edit.handle.partPath,
+    targetsShape: (edit, shapeHandle) =>
+      edit.handle.partPath === shapeHandle.partPath &&
+      textRunShapeId(edit.handle) === shapeHandle.nodeId,
+    invalidatingPartPaths: (edit) => [edit.handle.partPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: () => undefined,
+  },
+  replaceParagraphPlainText: {
+    reservedPartPaths: () => [],
+    dirtyPartPath: (edit) => edit.handle.partPath,
+    targetsShape: (edit, shapeHandle) =>
+      edit.handle.partPath === shapeHandle.partPath &&
+      paragraphShapeId(edit.handle) === shapeHandle.nodeId,
+    invalidatingPartPaths: (edit) => [edit.handle.partPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: () => undefined,
+  },
+  updateShapeTransform: {
+    reservedPartPaths: () => [],
+    dirtyPartPath: (edit) => edit.handle.partPath,
+    targetsShape: (edit, shapeHandle) => sourceHandlesEqual(edit.handle, shapeHandle),
+    invalidatingPartPaths: (edit) => [edit.handle.partPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: () => undefined,
+  },
+  addTextBox: {
+    reservedPartPaths: (edit) => [edit.slidePartPath],
+    dirtyPartPath: (edit) => edit.slidePartPath,
+    targetsShape: (edit, shapeHandle) =>
+      edit.slidePartPath === shapeHandle.partPath && edit.shapeId === String(shapeHandle.nodeId),
+    invalidatingPartPaths: (edit) => [edit.slidePartPath],
+    reservedShapeId: (edit, slidePartPath) =>
+      edit.slidePartPath === slidePartPath ? edit.shapeId : undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: (edit) => ({ slidePartPath: edit.slidePartPath, shapeId: edit.shapeId }),
+  },
+  addConnector: {
+    reservedPartPaths: (edit) => [edit.slidePartPath],
+    dirtyPartPath: (edit) => edit.slidePartPath,
+    targetsShape: (edit, shapeHandle) =>
+      edit.slidePartPath === shapeHandle.partPath && edit.shapeId === String(shapeHandle.nodeId),
+    invalidatingPartPaths: (edit) => [edit.slidePartPath],
+    reservedShapeId: (edit, slidePartPath) =>
+      edit.slidePartPath === slidePartPath ? edit.shapeId : undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: (edit) => ({ slidePartPath: edit.slidePartPath, shapeId: edit.shapeId }),
+  },
+  deleteShape: {
+    reservedPartPaths: () => [],
+    dirtyPartPath: (edit) => edit.handle.partPath,
+    targetsShape: (edit, shapeHandle) => sourceHandlesEqual(edit.handle, shapeHandle),
+    invalidatingPartPaths: (edit) => [edit.handle.partPath],
+    reservedShapeId: (edit, slidePartPath) =>
+      edit.handle.partPath === slidePartPath ? edit.handle.nodeId : undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: () => undefined,
+  },
+  replaceImage: {
+    reservedPartPaths: () => [],
+    dirtyPartPath: () => undefined,
+    targetsShape: (edit, shapeHandle) => sourceHandlesEqual(edit.handle, shapeHandle),
+    invalidatingPartPaths: (edit) => [edit.handle.partPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: () => undefined,
+    insertedSlidePartPath: () => undefined,
+    insertedShape: () => undefined,
+  },
+  addEmptySlideFromLayout: {
+    reservedPartPaths: (edit) => [edit.layoutPartPath, edit.newSlidePartPath],
+    dirtyPartPath: () => undefined,
+    targetsShape: () => false,
+    invalidatingPartPaths: (edit) => [edit.newSlidePartPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: (edit) => ({
+      kind: "appendSlide",
+      newRelationshipId: edit.newRelationshipId,
+    }),
+    insertedSlidePartPath: (edit) => edit.newSlidePartPath,
+    insertedShape: () => undefined,
+  },
+  duplicateSlide: {
+    reservedPartPaths: (edit) => [edit.sourceSlidePartPath, edit.newSlidePartPath],
+    dirtyPartPath: () => undefined,
+    targetsShape: () => false,
+    invalidatingPartPaths: (edit) => [edit.newSlidePartPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: (edit) => ({
+      kind: "insertSlideAfter",
+      sourceRelationshipId: edit.sourceRelationshipId,
+      newRelationshipId: edit.newRelationshipId,
+    }),
+    insertedSlidePartPath: (edit) => edit.newSlidePartPath,
+    insertedShape: () => undefined,
+  },
+  deleteSlide: {
+    reservedPartPaths: (edit) => [edit.slidePartPath],
+    dirtyPartPath: () => undefined,
+    targetsShape: () => false,
+    invalidatingPartPaths: (edit) => [edit.slidePartPath],
+    reservedShapeId: () => undefined,
+    slideTopologyOperation: (edit) => ({
+      kind: "removeSlide",
+      relationshipId: edit.relationshipId,
+    }),
+    insertedSlidePartPath: () => undefined,
+    insertedShape: () => undefined,
+  },
+};
+
+function descriptorFor(edit: PptxSourceModelEdit): EditKindDescriptor<PptxSourceModelEdit> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- The mapped table guarantees the entry at `edit.kind` accepts exactly that edit shape; TypeScript cannot correlate the indexed access with the discriminant, so this single boundary widens the descriptor parameter to the full edit union.
+  return EDIT_KIND_DESCRIPTORS[edit.kind] as EditKindDescriptor<PptxSourceModelEdit>;
+}
+
+export function editReservedPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {
+  return descriptorFor(edit).reservedPartPaths(edit);
+}
+
+export function editDirtyPartPath(edit: PptxSourceModelEdit): PartPath | undefined {
+  return descriptorFor(edit).dirtyPartPath(edit);
+}
+
+export function editTargetsShape(edit: PptxSourceModelEdit, shapeHandle: SourceHandle): boolean {
+  return descriptorFor(edit).targetsShape(edit, shapeHandle);
+}
+
+export function editInvalidatingPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {
+  return descriptorFor(edit).invalidatingPartPaths(edit);
+}
+
+export function editReservedShapeId(
+  edit: PptxSourceModelEdit,
+  slidePartPath: PartPath,
+): string | undefined {
+  return descriptorFor(edit).reservedShapeId(edit, slidePartPath);
+}
+
+export function editSlideTopologyOperation(
+  edit: PptxSourceModelEdit,
+): SlideTopologyOperation | undefined {
+  return descriptorFor(edit).slideTopologyOperation(edit);
+}
+
+export function editInsertedSlidePartPath(edit: PptxSourceModelEdit): PartPath | undefined {
+  return descriptorFor(edit).insertedSlidePartPath(edit);
+}
+
+export function editInsertedShape(edit: PptxSourceModelEdit): InsertedShapeRef | undefined {
+  return descriptorFor(edit).insertedShape(edit);
+}
+
+export function sourceHandlesEqual(left: SourceHandle | undefined, right: SourceHandle): boolean {
+  if (left === undefined) return false;
+  return (
+    left.partPath === right.partPath &&
+    left.nodeId === right.nodeId &&
+    left.relationshipId === right.relationshipId &&
+    left.orderingSlot === right.orderingSlot
+  );
+}
+
+function textRunShapeId(handle: SourceHandle): string | undefined {
+  return /^text:shape:([^:]+):p:\d+:r:\d+$/.exec(String(handle.nodeId ?? ""))?.[1];
+}
+
+function paragraphShapeId(handle: SourceHandle): string | undefined {
+  return /^text:shape:([^:]+):p:\d+$/.exec(String(handle.nodeId ?? ""))?.[1];
+}

--- a/packages/document/src/source/edit-descriptors.ts
+++ b/packages/document/src/source/edit-descriptors.ts
@@ -34,7 +34,7 @@ export type SlideTopologyOperation =
     };
 
 /** Shape inserted by an edit, identified by its slide part and shape id. */
-export interface InsertedShapeRef {
+interface InsertedShapeRef {
   readonly slidePartPath: PartPath;
   readonly shapeId: string;
 }

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1,3 +1,13 @@
+import {
+  editDirtyPartPath,
+  editInsertedShape,
+  editInsertedSlidePartPath,
+  editInvalidatingPartPaths,
+  editReservedPartPaths,
+  editReservedShapeId,
+  editTargetsShape,
+  sourceHandlesEqual,
+} from "./edit-descriptors.js";
 import { asSourceNodeId } from "./handles.js";
 import type {
   ConnectorPresetGeometry,
@@ -688,12 +698,14 @@ export function deleteShape(source: PptxSourceModel, handle: SourceHandle): Pptx
   }
 
   const retainedEdits = (source.edits ?? []).filter((edit) => !editTargetsShape(edit, handle));
-  const deletedInsertedShape = (source.edits ?? []).some(
-    (edit) =>
-      edit.kind === "addTextBox" &&
-      edit.slidePartPath === handle.partPath &&
-      edit.shapeId === String(handle.nodeId),
-  );
+  const deletedInsertedShape = (source.edits ?? []).some((edit) => {
+    const inserted = editInsertedShape(edit);
+    return (
+      inserted !== undefined &&
+      inserted.slidePartPath === handle.partPath &&
+      inserted.shapeId === String(handle.nodeId)
+    );
+  });
 
   return {
     ...source,
@@ -957,9 +969,7 @@ export function deleteSlide(source: PptxSourceModel, slideHandle: SourceHandle):
     (edit) => !editIsInvalidatedByDeletedParts(edit, removedPartPaths),
   );
   const deletedInsertedSlide = (source.edits ?? []).some(
-    (edit) =>
-      (edit.kind === "addEmptySlideFromLayout" || edit.kind === "duplicateSlide") &&
-      edit.newSlidePartPath === slide.partPath,
+    (edit) => editInsertedSlidePartPath(edit) === slide.partPath,
   );
 
   return {
@@ -1465,15 +1475,7 @@ function collectNumericShapeEditIds(
   used: Set<number>,
 ): void {
   for (const edit of edits) {
-    const id =
-      edit.kind === "addTextBox" && edit.slidePartPath === slidePartPath
-        ? edit.shapeId
-        : edit.kind === "addConnector" && edit.slidePartPath === slidePartPath
-          ? edit.shapeId
-          : edit.kind === "deleteShape" && edit.handle.partPath === slidePartPath
-            ? edit.handle.nodeId
-            : undefined;
-    const numericId = Number(id);
+    const numericId = Number(editReservedShapeId(edit, slidePartPath));
     if (Number.isInteger(numericId) && numericId > 0) used.add(numericId);
   }
 }
@@ -1536,16 +1538,6 @@ function findConnectorReferencingShape(
     }
   }
   return undefined;
-}
-
-function sourceHandlesEqual(left: SourceHandle | undefined, right: SourceHandle): boolean {
-  if (left === undefined) return false;
-  return (
-    left.partPath === right.partPath &&
-    left.nodeId === right.nodeId &&
-    left.relationshipId === right.relationshipId &&
-    left.orderingSlot === right.orderingSlot
-  );
 }
 
 interface NotesSlideCopy {
@@ -1666,7 +1658,7 @@ function nextNumberedPartPath(source: PptxSourceModel, prefix: string, suffix: s
     ...source.packageGraph.parts.map((part) => part.partPath),
     ...source.packageGraph.contentTypes.overrides.map((override) => override.partName),
     ...(source.packageGraph.rawParts ?? []).map((part) => part.partPath),
-    ...(source.edits?.flatMap((edit) => topologyEditPartPaths(edit)) ?? []),
+    ...(source.edits?.flatMap((edit) => editReservedPartPaths(edit)) ?? []),
   ]);
   const pattern = new RegExp(`^${escapeRegExp(prefix)}(\\d+)${escapeRegExp(suffix)}$`);
   const max = [...used].reduce((current, path) => {
@@ -1697,27 +1689,6 @@ function relationshipPartOverrides(
   return partPaths
     .filter((partPath) => !existingOverrides.has(partPath))
     .map((partName) => ({ partName, contentType: RELS_CONTENT_TYPE }));
-}
-
-function topologyEditPartPaths(edit: PptxSourceModelEdit): readonly PartPath[] {
-  switch (edit.kind) {
-    case "addEmptySlideFromLayout":
-      return [edit.layoutPartPath, edit.newSlidePartPath];
-    case "duplicateSlide":
-      return [edit.sourceSlidePartPath, edit.newSlidePartPath];
-    case "deleteSlide":
-      return [edit.slidePartPath];
-    case "addTextBox":
-    case "addConnector":
-      return [edit.slidePartPath];
-    case "replaceTextRunPlainText":
-    case "updateTextRunProperties":
-    case "replaceParagraphPlainText":
-    case "updateShapeTransform":
-    case "deleteShape":
-    case "replaceImage":
-      return [];
-  }
 }
 
 function relativeTarget(sourcePartPath: PartPath, targetPartPath: PartPath): string {
@@ -1782,84 +1753,14 @@ function insertAtReadonly<T>(items: readonly T[], index: number, item: T): reado
 }
 
 function hasDirtyEditForPart(edits: readonly PptxSourceModelEdit[], partPath: PartPath): boolean {
-  return edits.some((edit) => {
-    switch (edit.kind) {
-      case "replaceTextRunPlainText":
-      case "updateTextRunProperties":
-      case "replaceParagraphPlainText":
-      case "updateShapeTransform":
-      case "deleteShape":
-        return edit.handle.partPath === partPath;
-      case "replaceImage":
-        return false;
-      case "addTextBox":
-      case "addConnector":
-        return edit.slidePartPath === partPath;
-      case "addEmptySlideFromLayout":
-      case "duplicateSlide":
-      case "deleteSlide":
-        return false;
-    }
-  });
-}
-
-function editTargetsShape(edit: PptxSourceModelEdit, handle: SourceHandle): boolean {
-  switch (edit.kind) {
-    case "replaceTextRunPlainText":
-    case "updateTextRunProperties":
-      return (
-        edit.handle.partPath === handle.partPath && textRunShapeId(edit.handle) === handle.nodeId
-      );
-    case "replaceParagraphPlainText":
-      return (
-        edit.handle.partPath === handle.partPath && paragraphShapeId(edit.handle) === handle.nodeId
-      );
-    case "updateShapeTransform":
-    case "deleteShape":
-      return sourceHandlesEqual(edit.handle, handle);
-    case "replaceImage":
-      return sourceHandlesEqual(edit.handle, handle);
-    case "addTextBox":
-    case "addConnector":
-      return edit.slidePartPath === handle.partPath && edit.shapeId === String(handle.nodeId);
-    case "addEmptySlideFromLayout":
-    case "duplicateSlide":
-    case "deleteSlide":
-      return false;
-  }
-}
-
-function textRunShapeId(handle: SourceHandle): string | undefined {
-  return /^text:shape:([^:]+):p:\d+:r:\d+$/.exec(String(handle.nodeId ?? ""))?.[1];
-}
-
-function paragraphShapeId(handle: SourceHandle): string | undefined {
-  return /^text:shape:([^:]+):p:\d+$/.exec(String(handle.nodeId ?? ""))?.[1];
+  return edits.some((edit) => editDirtyPartPath(edit) === partPath);
 }
 
 function editIsInvalidatedByDeletedParts(
   edit: PptxSourceModelEdit,
   partPaths: ReadonlySet<string>,
 ): boolean {
-  switch (edit.kind) {
-    case "replaceTextRunPlainText":
-    case "updateTextRunProperties":
-    case "replaceParagraphPlainText":
-    case "updateShapeTransform":
-    case "replaceImage":
-      return partPaths.has(edit.handle.partPath);
-    case "addTextBox":
-    case "addConnector":
-      return partPaths.has(edit.slidePartPath);
-    case "addEmptySlideFromLayout":
-      return partPaths.has(edit.newSlidePartPath);
-    case "deleteShape":
-      return partPaths.has(edit.handle.partPath);
-    case "duplicateSlide":
-      return partPaths.has(edit.newSlidePartPath);
-    case "deleteSlide":
-      return partPaths.has(edit.slidePartPath);
-  }
+  return editInvalidatingPartPaths(edit).some((partPath) => partPaths.has(partPath));
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -1123,6 +1123,30 @@ describe("writePptx - shape add/delete edits", () => {
       /only top-level sp shapes/,
     );
   });
+
+  it("rejects conflicting shape additions for the same shape id", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const withTextBox = addTextBox(source, source.slides[0].handle!, {
+      offsetX: asEmu(100),
+      offsetY: asEmu(200),
+      width: asEmu(300),
+      height: asEmu(400),
+      text: "Added once",
+    });
+    const additions = withTextBox.edits?.filter((edit) => edit.kind === "addTextBox") ?? [];
+    const conflicted = { ...withTextBox, edits: [...(withTextBox.edits ?? []), ...additions] };
+
+    expect(() => writePptx(conflicted)).toThrow(/conflicting shape additions/);
+  });
+
+  it("rejects conflicting shape delete edits for the same handle", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const deleted = deleteShape(source, requireHandle(source.slides[0].shapes[0]?.handle));
+    const deletes = deleted.edits?.filter((edit) => edit.kind === "deleteShape") ?? [];
+    const conflicted = { ...deleted, edits: [...(deleted.edits ?? []), ...deletes] };
+
+    expect(() => writePptx(conflicted)).toThrow(/conflicting shape delete edits/);
+  });
 });
 
 describe("writePptx - one plain text-run edit", () => {
@@ -1544,6 +1568,28 @@ describe("writePptx - shape xfrm edit", () => {
       width: 3333,
       height: 4444,
     });
+  });
+
+  it("Rejects conflicting shape transform edits for the same shape", () => {
+    const source = readPptx(buildTextEditFixture());
+    const handle = firstShape(source).handle!;
+    const edited = updateShapeTransform(
+      updateShapeTransform(source, handle, {
+        offsetX: asEmu(1111),
+        offsetY: asEmu(2222),
+        width: asEmu(3333),
+        height: asEmu(4444),
+      }),
+      handle,
+      {
+        offsetX: asEmu(5555),
+        offsetY: asEmu(6666),
+        width: asEmu(7777),
+        height: asEmu(8888),
+      },
+    );
+
+    expect(() => writePptx(edited)).toThrow(/conflicting shape transform edits/);
   });
 
   it("Preserves unrelated package material while replacing only dirty slide XML", () => {

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -8,11 +8,14 @@
  * non-bookkeeping raw parts prefer the raw package material preserved by the reader.
  * Only dirty scopes are updated according to supported PptxSourceModel operations.
  *
- * The current slice supports plain text-run replacement, paragraph replacement,
- * top-level shape transform offset/extent edits, and slide duplicate/delete topology
- * edits. Dirty slide XML parts are reserialized by replacing only targeted values via
- * stable source handles; slide duplicate/delete patches presentation bookkeeping while
- * preserving unrelated raw package material.
+ * The current slice supports text-run replacement and run property edits, paragraph
+ * replacement, top-level shape transform offset/extent edits, text box / connector
+ * insertion, sp shape deletion, media byte replacement, and slide add/duplicate/delete
+ * topology edits. Dirty slide XML parts are reserialized by replacing only targeted
+ * values via stable source handles; slide topology edits patch presentation
+ * bookkeeping while preserving unrelated raw package material. Per-edit-kind traits
+ * (dirty part, topology operation, and so on) come from the descriptor table in
+ * `../source/edit-descriptors.ts`; this file keeps only the exhaustive apply switch.
  * Node-level XML splicing and precise unsupported raw-sidecar invalidation belong to
  * later writer slices, but the API and dirty-scope tracking remain shaped for that
  * extension path.
@@ -157,6 +160,10 @@ function serializeDirtyXmlPart(
   }
 
   const root = parseXml(textDecoder.decode(rawPart.bytes));
+  // Edits are applied in chronological order. This relies on the editing API
+  // invariant that deleteShape drops earlier edits targeting the deleted shape,
+  // so no stale-target edit can follow its delete within one part. Hand-built
+  // edit arrays that violate the invariant fail fast in the apply functions.
   for (const edit of edits) {
     if (editDirtyPartPath(edit) !== partPath) continue;
     applyDirtyPartEdit(root, edit);

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -30,17 +30,19 @@ import {
   parseXml,
   type XmlNode,
 } from "../reader/xml.js";
+import {
+  editDirtyPartPath,
+  editSlideTopologyOperation,
+  type SlideTopologyOperation,
+} from "../source/edit-descriptors.js";
 import type {
   EditableTextRunProperties,
   PartPath,
   PartRelationships,
   PptxSourceModel,
   PptxSourceModelAddConnectorEdit,
-  PptxSourceModelAddEmptySlideFromLayoutEdit,
   PptxSourceModelAddTextBoxEdit,
   PptxSourceModelDeleteShapeEdit,
-  PptxSourceModelDeleteSlideEdit,
-  PptxSourceModelDuplicateSlideEdit,
   PptxSourceModelEdit,
   PptxSourceModelParagraphTextEdit,
   PptxSourceModelShapeTransformEdit,
@@ -79,38 +81,19 @@ const xmlBuilder = new XMLBuilder({
  * it throws instead of regenerating content implicitly.
  */
 export function writePptx(source: PptxSourceModel): WritePptxOutput {
-  const textRunEdits = source.edits?.filter(isTextRunEdit) ?? [];
-  const textRunPropertiesEdits = source.edits?.filter(isTextRunPropertiesEdit) ?? [];
-  const paragraphTextEdits = source.edits?.filter(isParagraphTextEdit) ?? [];
-  const shapeTransformEdits = source.edits?.filter(isShapeTransformEdit) ?? [];
-  const addTextBoxEdits = source.edits?.filter(isAddTextBoxEdit) ?? [];
-  const addConnectorEdits = source.edits?.filter(isAddConnectorEdit) ?? [];
-  const deleteShapeEdits = source.edits?.filter(isDeleteShapeEdit) ?? [];
-  const addEmptySlideFromLayoutEdits = source.edits?.filter(isAddEmptySlideFromLayoutEdit) ?? [];
-  const duplicateSlideEdits = source.edits?.filter(isDuplicateSlideEdit) ?? [];
-  const deleteSlideEdits = source.edits?.filter(isDeleteSlideEdit) ?? [];
-  validateEdits(
-    textRunEdits,
-    textRunPropertiesEdits,
-    paragraphTextEdits,
-    shapeTransformEdits,
-    addTextBoxEdits,
-    addConnectorEdits,
-    deleteShapeEdits,
+  const edits = source.edits ?? [];
+  validateEdits(edits);
+  const dirtyPartPaths = new Set(
+    edits.flatMap((edit) => {
+      const partPath = editDirtyPartPath(edit);
+      return partPath === undefined ? [] : [partPath];
+    }),
   );
-  const dirtyPartPaths = new Set([
-    ...textRunEdits.map((edit) => edit.handle.partPath),
-    ...textRunPropertiesEdits.map((edit) => edit.handle.partPath),
-    ...paragraphTextEdits.map((edit) => edit.handle.partPath),
-    ...shapeTransformEdits.map((edit) => edit.handle.partPath),
-    ...deleteShapeEdits.map((edit) => edit.handle.partPath),
-    ...addTextBoxEdits.map((edit) => edit.slidePartPath),
-    ...addConnectorEdits.map((edit) => edit.slidePartPath),
-  ]);
-  const hasSlideTopologyEdits =
-    addEmptySlideFromLayoutEdits.length > 0 ||
-    duplicateSlideEdits.length > 0 ||
-    deleteSlideEdits.length > 0;
+  const slideTopologyOperations = edits.flatMap((edit) => {
+    const operation = editSlideTopologyOperation(edit);
+    return operation === undefined ? [] : [operation];
+  });
+  const hasSlideTopologyEdits = slideTopologyOperations.length > 0;
   const files: Record<string, Uint8Array> = {
     [CONTENT_TYPES_PART]: encodeXml(serializeContentTypes(source.packageGraph.contentTypes)),
   };
@@ -136,24 +119,14 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   }
 
   for (const partPath of dirtyPartPaths) {
-    files[partPath] = serializeDirtyXmlPart(
-      source,
-      partPath,
-      textRunEdits,
-      textRunPropertiesEdits,
-      paragraphTextEdits,
-      shapeTransformEdits,
-      addTextBoxEdits,
-      addConnectorEdits,
-      deleteShapeEdits,
-    );
+    files[partPath] = serializeDirtyXmlPart(source, partPath, edits);
     written.add(partPath);
   }
 
   if (hasSlideTopologyEdits) {
     files[source.presentation.partPath] = serializePresentationWithSlideTopologyEdits(
       source,
-      mergeSlideTopologyEdits(source.edits ?? []),
+      slideTopologyOperations,
     );
     written.add(source.presentation.partPath);
   }
@@ -170,64 +143,10 @@ export function writePptx(source: PptxSourceModel): WritePptxOutput {
   return zipSync(files);
 }
 
-function isTextRunEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelTextRunEdit {
-  return edit.kind === "replaceTextRunPlainText";
-}
-
-function isTextRunPropertiesEdit(
-  edit: PptxSourceModelEdit,
-): edit is PptxSourceModelTextRunPropertiesEdit {
-  return edit.kind === "updateTextRunProperties";
-}
-
-function isParagraphTextEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelParagraphTextEdit {
-  return edit.kind === "replaceParagraphPlainText";
-}
-
-function isShapeTransformEdit(
-  edit: PptxSourceModelEdit,
-): edit is PptxSourceModelShapeTransformEdit {
-  return edit.kind === "updateShapeTransform";
-}
-
-function isAddTextBoxEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelAddTextBoxEdit {
-  return edit.kind === "addTextBox";
-}
-
-function isAddConnectorEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelAddConnectorEdit {
-  return edit.kind === "addConnector";
-}
-
-function isDeleteShapeEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelDeleteShapeEdit {
-  return edit.kind === "deleteShape";
-}
-
-function isAddEmptySlideFromLayoutEdit(
-  edit: PptxSourceModelEdit,
-): edit is PptxSourceModelAddEmptySlideFromLayoutEdit {
-  return edit.kind === "addEmptySlideFromLayout";
-}
-
-function isDuplicateSlideEdit(
-  edit: PptxSourceModelEdit,
-): edit is PptxSourceModelDuplicateSlideEdit {
-  return edit.kind === "duplicateSlide";
-}
-
-function isDeleteSlideEdit(edit: PptxSourceModelEdit): edit is PptxSourceModelDeleteSlideEdit {
-  return edit.kind === "deleteSlide";
-}
-
 function serializeDirtyXmlPart(
   source: PptxSourceModel,
   partPath: PartPath,
-  textRunEdits: readonly PptxSourceModelTextRunEdit[],
-  textRunPropertiesEdits: readonly PptxSourceModelTextRunPropertiesEdit[],
-  paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
-  shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
-  addTextBoxEdits: readonly PptxSourceModelAddTextBoxEdit[],
-  addConnectorEdits: readonly PptxSourceModelAddConnectorEdit[],
-  deleteShapeEdits: readonly PptxSourceModelDeleteShapeEdit[],
+  edits: readonly PptxSourceModelEdit[],
 ): Uint8Array {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
   if (rawPart === undefined) {
@@ -238,49 +157,52 @@ function serializeDirtyXmlPart(
   }
 
   const root = parseXml(textDecoder.decode(rawPart.bytes));
-  for (const edit of addTextBoxEdits.filter((edit) => edit.slidePartPath === partPath)) {
-    applyAddTextBoxEdit(root, edit);
-  }
-  for (const edit of addConnectorEdits.filter((edit) => edit.slidePartPath === partPath)) {
-    applyAddConnectorEdit(root, edit);
-  }
-  for (const edit of paragraphTextEdits.filter((edit) => edit.handle.partPath === partPath)) {
-    applyParagraphTextEdit(root, edit);
-  }
-  for (const edit of textRunEdits.filter((edit) => edit.handle.partPath === partPath)) {
-    applyTextRunEdit(root, edit);
-  }
-  for (const edit of textRunPropertiesEdits.filter((edit) => edit.handle.partPath === partPath)) {
-    applyTextRunPropertiesEdit(root, edit);
-  }
-  for (const edit of shapeTransformEdits.filter((edit) => edit.handle.partPath === partPath)) {
-    applyShapeTransformEdit(root, edit);
-  }
-  for (const edit of deleteShapeEdits.filter((edit) => edit.handle.partPath === partPath)) {
-    applyDeleteShapeEdit(root, edit);
+  for (const edit of edits) {
+    if (editDirtyPartPath(edit) !== partPath) continue;
+    applyDirtyPartEdit(root, edit);
   }
   return encodeXml(XML_DECLARATION + xmlBuilder.build(stripXmlProcessingInstruction(root)));
 }
 
-type SlideTopologyEdit =
-  | PptxSourceModelAddEmptySlideFromLayoutEdit
-  | PptxSourceModelDuplicateSlideEdit
-  | PptxSourceModelDeleteSlideEdit;
-
-function mergeSlideTopologyEdits(
-  edits: readonly PptxSourceModelEdit[],
-): readonly SlideTopologyEdit[] {
-  return edits.filter(
-    (edit): edit is SlideTopologyEdit =>
-      edit.kind === "addEmptySlideFromLayout" ||
-      edit.kind === "duplicateSlide" ||
-      edit.kind === "deleteSlide",
-  );
+/**
+ * The writer-side apply switch: the one place that maps an edit kind to its XML
+ * patch. Kinds that never dirty an XML part (see `editDirtyPartPath`) throw so
+ * a descriptor/apply mismatch fails fast instead of being silently skipped.
+ */
+function applyDirtyPartEdit(root: XmlNode, edit: PptxSourceModelEdit): void {
+  switch (edit.kind) {
+    case "replaceTextRunPlainText":
+      applyTextRunEdit(root, edit);
+      return;
+    case "updateTextRunProperties":
+      applyTextRunPropertiesEdit(root, edit);
+      return;
+    case "replaceParagraphPlainText":
+      applyParagraphTextEdit(root, edit);
+      return;
+    case "updateShapeTransform":
+      applyShapeTransformEdit(root, edit);
+      return;
+    case "addTextBox":
+      applyAddTextBoxEdit(root, edit);
+      return;
+    case "addConnector":
+      applyAddConnectorEdit(root, edit);
+      return;
+    case "deleteShape":
+      applyDeleteShapeEdit(root, edit);
+      return;
+    case "replaceImage":
+    case "addEmptySlideFromLayout":
+    case "duplicateSlide":
+    case "deleteSlide":
+      throw new Error(`writePptx: edit kind '${edit.kind}' does not patch a dirty XML part`);
+  }
 }
 
 function serializePresentationWithSlideTopologyEdits(
   source: PptxSourceModel,
-  edits: readonly SlideTopologyEdit[],
+  operations: readonly SlideTopologyOperation[],
 ): Uint8Array {
   const rawPart = source.packageGraph.rawParts?.find(
     (part) => part.partPath === source.presentation.partPath,
@@ -301,13 +223,17 @@ function serializePresentationWithSlideTopologyEdits(
   }
   const sldIdLst = ensureSlideIdList(presentation);
 
-  for (const edit of edits) {
-    if (edit.kind === "addEmptySlideFromLayout") {
-      appendSlideId(sldIdLst, edit.newRelationshipId);
-    } else if (edit.kind === "duplicateSlide") {
-      insertSlideIdAfter(sldIdLst, edit.sourceRelationshipId, edit.newRelationshipId);
-    } else {
-      removeSlideId(sldIdLst, edit.relationshipId);
+  for (const operation of operations) {
+    switch (operation.kind) {
+      case "appendSlide":
+        appendSlideId(sldIdLst, operation.newRelationshipId);
+        break;
+      case "insertSlideAfter":
+        insertSlideIdAfter(sldIdLst, operation.sourceRelationshipId, operation.newRelationshipId);
+        break;
+      case "removeSlide":
+        removeSlideId(sldIdLst, operation.relationshipId);
+        break;
     }
   }
 
@@ -1109,42 +1035,76 @@ function textRequiresPreserve(text: string): boolean {
   return text.startsWith(" ") || text.endsWith(" ");
 }
 
-function validateEdits(
-  textRunEdits: readonly PptxSourceModelTextRunEdit[],
-  textRunPropertiesEdits: readonly PptxSourceModelTextRunPropertiesEdit[],
-  paragraphTextEdits: readonly PptxSourceModelParagraphTextEdit[],
-  shapeTransformEdits: readonly PptxSourceModelShapeTransformEdit[],
-  addTextBoxEdits: readonly PptxSourceModelAddTextBoxEdit[],
-  addConnectorEdits: readonly PptxSourceModelAddConnectorEdit[],
-  deleteShapeEdits: readonly PptxSourceModelDeleteShapeEdit[],
-): void {
+function validateEdits(edits: readonly PptxSourceModelEdit[]): void {
   const addedShapeKeys = new Set<string>();
-  for (const edit of [...addTextBoxEdits, ...addConnectorEdits]) {
-    const key = [edit.slidePartPath, edit.shapeId].join("\u0000");
-    if (addedShapeKeys.has(key)) {
-      throw new Error(`writePptx: conflicting shape additions for shape id '${edit.shapeId}'`);
-    }
-    addedShapeKeys.add(key);
-  }
-
   const runKeys = new Set<string>();
-  for (const edit of textRunEdits) {
-    const key = editHandleNodeKey(edit);
-    if (runKeys.has(key)) {
-      throw new Error(`writePptx: conflicting text run edits for handle '${edit.handle.nodeId}'`);
-    }
-    runKeys.add(key);
-  }
-
   const paragraphKeys = new Set<string>();
-  for (const edit of paragraphTextEdits) {
-    const key = editHandleNodeKey(edit);
-    if (paragraphKeys.has(key)) {
-      throw new Error(
-        `writePptx: conflicting paragraph text edits for handle '${edit.handle.nodeId}'`,
-      );
+  const shapeKeys = new Set<string>();
+  const deletedShapeKeys = new Set<string>();
+  const textRunEdits: PptxSourceModelTextRunEdit[] = [];
+  const textRunPropertiesEdits: PptxSourceModelTextRunPropertiesEdit[] = [];
+
+  for (const edit of edits) {
+    switch (edit.kind) {
+      case "addTextBox":
+      case "addConnector": {
+        const key = [edit.slidePartPath, edit.shapeId].join("\u0000");
+        if (addedShapeKeys.has(key)) {
+          throw new Error(`writePptx: conflicting shape additions for shape id '${edit.shapeId}'`);
+        }
+        addedShapeKeys.add(key);
+        break;
+      }
+      case "replaceTextRunPlainText": {
+        const key = editHandleNodeKey(edit);
+        if (runKeys.has(key)) {
+          throw new Error(
+            `writePptx: conflicting text run edits for handle '${edit.handle.nodeId}'`,
+          );
+        }
+        runKeys.add(key);
+        textRunEdits.push(edit);
+        break;
+      }
+      case "updateTextRunProperties":
+        textRunPropertiesEdits.push(edit);
+        break;
+      case "replaceParagraphPlainText": {
+        const key = editHandleNodeKey(edit);
+        if (paragraphKeys.has(key)) {
+          throw new Error(
+            `writePptx: conflicting paragraph text edits for handle '${edit.handle.nodeId}'`,
+          );
+        }
+        paragraphKeys.add(key);
+        break;
+      }
+      case "updateShapeTransform": {
+        const key = editHandleNodeKey(edit);
+        if (shapeKeys.has(key)) {
+          throw new Error(
+            `writePptx: conflicting shape transform edits for handle '${String(edit.handle.nodeId)}'`,
+          );
+        }
+        shapeKeys.add(key);
+        break;
+      }
+      case "deleteShape": {
+        const key = editHandleNodeKey(edit);
+        if (deletedShapeKeys.has(key)) {
+          throw new Error(
+            `writePptx: conflicting shape delete edits for handle '${String(edit.handle.nodeId)}'`,
+          );
+        }
+        deletedShapeKeys.add(key);
+        break;
+      }
+      case "replaceImage":
+      case "addEmptySlideFromLayout":
+      case "duplicateSlide":
+      case "deleteSlide":
+        break;
     }
-    paragraphKeys.add(key);
   }
 
   for (const runEdit of textRunEdits) {
@@ -1162,28 +1122,6 @@ function validateEdits(
         `writePptx: conflicting text run properties and paragraph edits for handle '${runPropertiesEdit.handle.nodeId}'`,
       );
     }
-  }
-
-  const shapeKeys = new Set<string>();
-  for (const edit of shapeTransformEdits) {
-    const key = editHandleNodeKey(edit);
-    if (shapeKeys.has(key)) {
-      throw new Error(
-        `writePptx: conflicting shape transform edits for handle '${String(edit.handle.nodeId)}'`,
-      );
-    }
-    shapeKeys.add(key);
-  }
-
-  const deletedShapeKeys = new Set<string>();
-  for (const edit of deleteShapeEdits) {
-    const key = editHandleNodeKey(edit);
-    if (deletedShapeKeys.has(key)) {
-      throw new Error(
-        `writePptx: conflicting shape delete edits for handle '${String(edit.handle.nodeId)}'`,
-      );
-    }
-    deletedShapeKeys.add(key);
   }
 }
 


### PR DESCRIPTION
close #643

## 目的

edit 種別ごとの性質(対象 part、dirty 化、shape 対象性、削除による無効化、shape ID 採番、slide topology 操作)が editing.ts の4並列 switch と write-pptx.ts の型ガード・filter 群に散在し、種別追加のたびに5+箇所の手動同期が必要だった問題を解消する。詳細は #643(親: #641)を参照。

## 変更内容

- **`packages/document/src/source/edit-descriptors.ts`(新規)**: edit 種別→性質のマップド型テーブル。`{ [K in PptxSourceModelEdit["kind"]]: EditKindDescriptor<EditOfKind<K>> }` により、union に新種別を追加すると全性質の宣言漏れが**型エラー**で検出される
- **`packages/document/src/source/editing.ts`**: `topologyEditPartPaths` / `hasDirtyEditForPart` / `editTargetsShape` / `editIsInvalidatedByDeletedParts` の4並列 switch、`collectNumericShapeEditIds` のネスト三項演算子、`deleteShape` / `deleteSlide` 内の kind 直接比較 if をテーブル参照に置換
- **`packages/document/src/writer/write-pptx.ts`**:
  - 型ガード10個・kind 別 filter 群・dirty part 収集リスト・`serializeDirtyXmlPart` の7引数を記述子参照に置換し、XML 適用は単一の網羅 switch(`applyDirtyPartEdit`)に集約
  - slide topology 適用ループの消去法 else(`relationshipId` を持つ新種別が deleteSlide 扱いになる予備軍)を、記述子が返す宣言的 `SlideTopologyOperation` への網羅 switch に置換。`mergeSlideTopologyEdits` の手書き filter 述語も削除
  - `validateEdits` を全 edits 受け取り+網羅 switch の単一パスに再構成
- 網羅 switch は既存の `@typescript-eslint/switch-exhaustiveness-check` により種別追加漏れが **lint エラー**で検出される(ダミー種別追加実験で型エラー・lint エラーの両レイヤーの検出を確認済み)

## 挙動に関する補足(cross-review で確認済み)

- **dirty part への適用順**: kind グループ固定順 → edits 時系列順に変更。editing API は同一ターゲットへの競合 edit を残さない(`deleteShape` が対象を狙う先行 edit を除去、writer の `validateEdits` が同一 kind 重複を拒否)ため、サポートされる edit 列では出力は不変。この invariant はコメントで明記した
- **`insertedShape` の addConnector 宣言**: 旧コードの `deletedInsertedShape` は addTextBox のみ判定していたが、`deleteShape` は connector を先に拒否する(`only top-level sp shapes`)ため到達不能で、観測可能な挙動は不変。将来 connector 削除に対応した際に正しい相殺挙動が自動で得られる意図的な一般化
- 公開 API(barrel export)への変更なし。changeset は不要(public API 影響なしのリファクタリング)

## 影響パッケージ

- `packages/document`(`@pptx-glimpse/document` 内部実装のみ。renderer / core / editor-core は変更なし)

## ローカル検証手順

```bash
npm run typecheck
npm run lint
npm run test -- packages/document   # 117 件(競合チェック3分岐の回帰テスト3件を追加)
npm run test                        # 全体 870 passed / 9 skipped(Docker 不在時の LibreOffice VRT skip)
```

受け入れ条件4項目はすべて確認済み(ダミー種別 `dummyEdit` を一時追加して型エラー/lint エラーの検出を実証後 revert)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
