### PR TITLE
document: テキスト編集の走査ヘルパーを集約

### DIFF
--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1117,6 +1117,8 @@ function startsWithBytes(bytes: Uint8Array, prefix: readonly number[]): boolean 
 function assertEditableTextRunProperties(properties: EditableTextRunProperties): void {
   for (const property of Object.keys(properties)) {
     assertEditableTextRunPropertyName(property);
+  }
+  for (const property of EDITABLE_TEXT_RUN_PROPERTIES) {
     validateEditableTextRunProperty(property, properties[property]);
   }
 }

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -79,14 +79,36 @@ const EMPTY_SLIDE_XML =
   `<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>` +
   `</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>`;
 
-const EDITABLE_TEXT_RUN_PROPERTIES = [
-  "bold",
-  "italic",
-  "underline",
-  "fontSize",
-  "color",
-  "typeface",
-] as const satisfies readonly EditableTextRunProperty[];
+const EDITABLE_TEXT_RUN_PROPERTY_VALIDATORS: {
+  readonly [K in EditableTextRunProperty]: (value: EditableTextRunProperties[K]) => void;
+} = {
+  bold: (value) => requireBooleanOrUndefined(value, "bold"),
+  italic: (value) => requireBooleanOrUndefined(value, "italic"),
+  underline: (value) => requireBooleanOrUndefined(value, "underline"),
+  fontSize: (value) => {
+    if (value !== undefined && (!Number.isFinite(value) || value <= 0)) {
+      throw new Error("updateTextRunProperties: fontSize must be a finite positive pt value");
+    }
+  },
+  color: (value) => {
+    if (value === undefined) return;
+    if (value.kind !== "srgb") {
+      throw new Error("updateTextRunProperties: only srgb text run color is supported");
+    }
+    if (!/^[0-9A-Fa-f]{6}$/.test(value.hex)) {
+      throw new Error("updateTextRunProperties: srgb text run color must be a 6-digit hex value");
+    }
+  },
+  typeface: (value) => {
+    if (value !== undefined && value.trim() === "") {
+      throw new Error("updateTextRunProperties: typeface must be a non-empty string");
+    }
+  },
+};
+const EDITABLE_TEXT_RUN_PROPERTIES = Object.keys(EDITABLE_TEXT_RUN_PROPERTY_VALIDATORS).filter(
+  (property): property is EditableTextRunProperty =>
+    property in EDITABLE_TEXT_RUN_PROPERTY_VALIDATORS,
+);
 const EDITABLE_TEXT_RUN_PROPERTY_SET: ReadonlySet<string> = new Set(EDITABLE_TEXT_RUN_PROPERTIES);
 const CONNECTOR_PRESETS: ReadonlySet<ConnectorPresetGeometry> = new Set([
   "straightConnector1",
@@ -129,38 +151,9 @@ export function replaceTextRunPlainText(
   handle: SourceHandle,
   text: string,
 ): PptxSourceModel {
-  let replaced = false;
+  const result = mapMatchingTextRun(source, handle, (run) => ({ ...run, text }));
 
-  const slides = source.slides.map((slide) => ({
-    ...slide,
-    shapes: slide.shapes.map((shape) => {
-      if (shape.kind !== "shape" || shape.textBody === undefined) return shape;
-
-      let shapeChanged = false;
-      const paragraphs = shape.textBody.paragraphs.map((paragraph) => {
-        let paragraphChanged = false;
-        const runs = paragraph.runs.map((run) => {
-          if (!sourceHandlesEqual(run.handle, handle)) return run;
-          replaced = true;
-          paragraphChanged = true;
-          shapeChanged = true;
-          return { ...run, text };
-        });
-        return !paragraphChanged ? paragraph : ({ ...paragraph, runs } satisfies SourceParagraph);
-      });
-
-      if (!shapeChanged) return shape;
-      return {
-        ...shape,
-        textBody: {
-          ...shape.textBody,
-          paragraphs,
-        },
-      } satisfies SourceShape;
-    }),
-  }));
-
-  if (!replaced) {
+  if (!result.matched) {
     throw new Error(
       "replaceTextRunPlainText: text run handle was not found in PptxSourceModel source",
     );
@@ -168,7 +161,7 @@ export function replaceTextRunPlainText(
 
   return {
     ...source,
-    slides,
+    slides: result.slides,
     edits: [...(source.edits ?? []), { kind: "replaceTextRunPlainText", handle, text }],
   };
 }
@@ -200,46 +193,24 @@ export function replaceParagraphPlainText(
   handle: SourceHandle,
   text: string,
 ): PptxSourceModel {
-  let replaced = false;
-
-  const slides = source.slides.map((slide) => ({
-    ...slide,
-    shapes: slide.shapes.map((shape) => {
-      if (shape.kind !== "shape" || shape.textBody === undefined) return shape;
-
-      let shapeChanged = false;
-      const paragraphs = shape.textBody.paragraphs.map((paragraph) => {
-        if (!sourceHandlesEqual(paragraph.handle, handle)) return paragraph;
-        const replacementHandle = createReplacementRunHandle(paragraph);
-        replaced = true;
-        shapeChanged = true;
-        return {
-          ...paragraph,
-          runs: [
-            {
-              kind: "textRun",
-              text,
-              ...(paragraph.runs[0]?.properties !== undefined
-                ? { properties: paragraph.runs[0].properties }
-                : {}),
-              ...(replacementHandle !== undefined ? { handle: replacementHandle } : {}),
-            },
-          ],
-        } satisfies SourceParagraph;
-      });
-
-      if (!shapeChanged) return shape;
-      return {
-        ...shape,
-        textBody: {
-          ...shape.textBody,
-          paragraphs,
+  const result = mapMatchingParagraph(source, handle, (paragraph) => {
+    const replacementHandle = createReplacementRunHandle(paragraph);
+    return {
+      ...paragraph,
+      runs: [
+        {
+          kind: "textRun",
+          text,
+          ...(paragraph.runs[0]?.properties !== undefined
+            ? { properties: paragraph.runs[0].properties }
+            : {}),
+          ...(replacementHandle !== undefined ? { handle: replacementHandle } : {}),
         },
-      } satisfies SourceShape;
-    }),
-  }));
+      ],
+    } satisfies SourceParagraph;
+  });
 
-  if (!replaced) {
+  if (!result.matched) {
     throw new Error(
       "replaceParagraphPlainText: paragraph handle was not found in PptxSourceModel source",
     );
@@ -247,7 +218,7 @@ export function replaceParagraphPlainText(
 
   return {
     ...source,
-    slides,
+    slides: result.slides,
     edits: [...(source.edits ?? []), { kind: "replaceParagraphPlainText", handle, text }],
   };
 }
@@ -269,57 +240,28 @@ function updateTextRunProperties(
     throw new Error("updateTextRunProperties: patch must set or clear at least one property");
   }
 
-  let found = false;
-  let changed = false;
+  const result = mapMatchingTextRun(source, handle, (run) => {
+    const properties = patchTextRunProperties(run.properties, { set, clear: patch.clear });
+    if (textRunPropertiesEqual(run.properties, properties)) return run;
+    return {
+      kind: run.kind,
+      text: run.text,
+      ...(run.handle !== undefined ? { handle: run.handle } : {}),
+      ...(run.rawSidecars !== undefined ? { rawSidecars: run.rawSidecars } : {}),
+      ...(properties !== undefined ? { properties } : {}),
+    } satisfies SourceTextRun;
+  });
 
-  const slides = source.slides.map((slide) => ({
-    ...slide,
-    shapes: slide.shapes.map((shape) => {
-      if (shape.kind !== "shape" || shape.textBody === undefined) return shape;
-
-      let shapeChanged = false;
-      const paragraphs = shape.textBody.paragraphs.map((paragraph) => {
-        let paragraphChanged = false;
-        const runs = paragraph.runs.map((run) => {
-          if (!sourceHandlesEqual(run.handle, handle)) return run;
-          found = true;
-          const properties = patchTextRunProperties(run.properties, { set, clear: patch.clear });
-          if (textRunPropertiesEqual(run.properties, properties)) return run;
-          changed = true;
-          paragraphChanged = true;
-          shapeChanged = true;
-          return {
-            kind: run.kind,
-            text: run.text,
-            ...(run.handle !== undefined ? { handle: run.handle } : {}),
-            ...(run.rawSidecars !== undefined ? { rawSidecars: run.rawSidecars } : {}),
-            ...(properties !== undefined ? { properties } : {}),
-          } satisfies SourceTextRun;
-        });
-        return !paragraphChanged ? paragraph : ({ ...paragraph, runs } satisfies SourceParagraph);
-      });
-
-      if (!shapeChanged) return shape;
-      return {
-        ...shape,
-        textBody: {
-          ...shape.textBody,
-          paragraphs,
-        },
-      } satisfies SourceShape;
-    }),
-  }));
-
-  if (!found) {
+  if (!result.matched) {
     throw new Error(
       "updateTextRunProperties: text run handle was not found in PptxSourceModel source",
     );
   }
-  if (!changed) return source;
+  if (!result.changed) return source;
 
   return {
     ...source,
-    slides,
+    slides: result.slides,
     edits: [
       ...(source.edits ?? []),
       {
@@ -332,6 +274,97 @@ function updateTextRunProperties(
   };
 }
 
+interface TextEditMappingResult {
+  readonly slides: readonly SourceSlide[];
+  readonly matched: boolean;
+  readonly changed: boolean;
+}
+
+interface ParagraphMappingResult {
+  readonly paragraph: SourceParagraph;
+  readonly matched: boolean;
+}
+
+function mapMatchingTextRun(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+  mapRun: (run: SourceTextRun) => SourceTextRun,
+): TextEditMappingResult {
+  return mapTextBodyParagraphs(source, (paragraph) => {
+    let matched = false;
+    let changed = false;
+    const runs = paragraph.runs.map((run) => {
+      if (!sourceHandlesEqual(run.handle, handle)) return run;
+      matched = true;
+      const mapped = mapRun(run);
+      if (mapped === run) return run;
+      changed = true;
+      return mapped;
+    });
+
+    return {
+      paragraph: changed ? ({ ...paragraph, runs } satisfies SourceParagraph) : paragraph,
+      matched,
+    };
+  });
+}
+
+function mapMatchingParagraph(
+  source: PptxSourceModel,
+  handle: SourceHandle,
+  mapParagraph: (paragraph: SourceParagraph) => SourceParagraph,
+): TextEditMappingResult {
+  return mapTextBodyParagraphs(source, (paragraph) => {
+    if (!sourceHandlesEqual(paragraph.handle, handle)) {
+      return { paragraph, matched: false };
+    }
+    return { paragraph: mapParagraph(paragraph), matched: true };
+  });
+}
+
+function mapTextBodyParagraphs(
+  source: PptxSourceModel,
+  mapParagraph: (paragraph: SourceParagraph) => ParagraphMappingResult,
+): TextEditMappingResult {
+  let matched = false;
+  let changed = false;
+
+  const slides = source.slides.map((slide) => {
+    let slideChanged = false;
+    const shapes = slide.shapes.map((shape) => {
+      if (shape.kind !== "shape" || shape.textBody === undefined) return shape;
+
+      let shapeChanged = false;
+      const paragraphs = shape.textBody.paragraphs.map((paragraph) => {
+        const result = mapParagraph(paragraph);
+        if (result.matched) matched = true;
+        if (result.paragraph === paragraph) return paragraph;
+        changed = true;
+        shapeChanged = true;
+        slideChanged = true;
+        return result.paragraph;
+      });
+
+      if (!shapeChanged) return shape;
+      return {
+        ...shape,
+        textBody: {
+          ...shape.textBody,
+          paragraphs,
+        },
+      } satisfies SourceShape;
+    });
+
+    return slideChanged ? { ...slide, shapes } : slide;
+  });
+
+  return {
+    slides: changed ? slides : source.slides,
+    matched,
+    changed,
+  };
+}
+
 function patchTextRunProperties(
   current: SourceRunProperties | undefined,
   patch: UpdateTextRunPropertiesPatch,
@@ -340,12 +373,7 @@ function patchTextRunProperties(
   for (const property of patch.clear) {
     delete next[property];
   }
-  if (patch.set.bold !== undefined) next.bold = patch.set.bold;
-  if (patch.set.italic !== undefined) next.italic = patch.set.italic;
-  if (patch.set.underline !== undefined) next.underline = patch.set.underline;
-  if (patch.set.fontSize !== undefined) next.fontSize = patch.set.fontSize;
-  if (patch.set.color !== undefined) next.color = patch.set.color;
-  if (patch.set.typeface !== undefined) next.typeface = patch.set.typeface;
+  Object.assign(next, patch.set);
   return Object.keys(next).length > 0 ? next : undefined;
 }
 
@@ -1088,34 +1116,13 @@ function startsWithBytes(bytes: Uint8Array, prefix: readonly number[]): boolean 
 
 function assertEditableTextRunProperties(properties: EditableTextRunProperties): void {
   for (const property of Object.keys(properties)) {
-    if (!EDITABLE_TEXT_RUN_PROPERTY_SET.has(property)) {
-      throw new Error(`updateTextRunProperties: unsupported text run property '${property}'`);
-    }
-  }
-  requireBooleanOrUndefined(properties.bold, "bold");
-  requireBooleanOrUndefined(properties.italic, "italic");
-  requireBooleanOrUndefined(properties.underline, "underline");
-  if (
-    properties.fontSize !== undefined &&
-    (!Number.isFinite(properties.fontSize) || properties.fontSize <= 0)
-  ) {
-    throw new Error("updateTextRunProperties: fontSize must be a finite positive pt value");
-  }
-  if (properties.typeface !== undefined && properties.typeface.trim() === "") {
-    throw new Error("updateTextRunProperties: typeface must be a non-empty string");
-  }
-  if (properties.color !== undefined) {
-    if (properties.color.kind !== "srgb") {
-      throw new Error("updateTextRunProperties: only srgb text run color is supported");
-    }
-    if (!/^[0-9A-Fa-f]{6}$/.test(properties.color.hex)) {
-      throw new Error("updateTextRunProperties: srgb text run color must be a 6-digit hex value");
-    }
+    assertEditableTextRunPropertyName(property);
+    validateEditableTextRunProperty(property, properties[property]);
   }
 }
 
 function requireBooleanOrUndefined(
-  value: boolean | undefined,
+  value: unknown,
   fieldName: "bold" | "italic" | "underline",
 ): void {
   if (value !== undefined && typeof value !== "boolean") {
@@ -1125,9 +1132,7 @@ function requireBooleanOrUndefined(
 
 function assertEditableTextRunPropertyNames(properties: readonly EditableTextRunProperty[]): void {
   for (const property of properties) {
-    if (!EDITABLE_TEXT_RUN_PROPERTY_SET.has(property)) {
-      throw new Error(`updateTextRunProperties: unsupported text run property '${property}'`);
-    }
+    assertEditableTextRunPropertyName(property);
   }
 }
 
@@ -1135,13 +1140,40 @@ function definedEditableTextRunProperties(
   properties: EditableTextRunProperties,
 ): EditableTextRunProperties {
   const defined: MutableEditableTextRunProperties = {};
-  if (properties.bold !== undefined) defined.bold = properties.bold;
-  if (properties.italic !== undefined) defined.italic = properties.italic;
-  if (properties.underline !== undefined) defined.underline = properties.underline;
-  if (properties.fontSize !== undefined) defined.fontSize = properties.fontSize;
-  if (properties.color !== undefined) defined.color = properties.color;
-  if (properties.typeface !== undefined) defined.typeface = properties.typeface;
+  for (const property of EDITABLE_TEXT_RUN_PROPERTIES) {
+    copyDefinedEditableTextRunProperty(defined, properties, property);
+  }
   return defined;
+}
+
+function assertEditableTextRunPropertyName(
+  property: string,
+): asserts property is EditableTextRunProperty {
+  if (!isEditableTextRunProperty(property)) {
+    throw new Error(`updateTextRunProperties: unsupported text run property '${property}'`);
+  }
+}
+
+function isEditableTextRunProperty(property: string): property is EditableTextRunProperty {
+  return EDITABLE_TEXT_RUN_PROPERTY_SET.has(property);
+}
+
+function validateEditableTextRunProperty<K extends EditableTextRunProperty>(
+  property: K,
+  value: EditableTextRunProperties[K],
+): void {
+  EDITABLE_TEXT_RUN_PROPERTY_VALIDATORS[property](value);
+}
+
+function copyDefinedEditableTextRunProperty<K extends EditableTextRunProperty>(
+  target: MutableEditableTextRunProperties,
+  source: EditableTextRunProperties,
+  property: K,
+): void {
+  const value = source[property];
+  if (value !== undefined) {
+    target[property] = value;
+  }
 }
 
 function textRunPropertiesEqual(

--- a/vrt/snapshot/render-options.ts
+++ b/vrt/snapshot/render-options.ts
@@ -272,18 +272,26 @@ async function ensureSourceFont(source: VrtFontSource): Promise<string> {
 
 async function downloadSourceFont(source: VrtFontSource): Promise<Buffer> {
   let lastStatus: number | undefined;
+  let lastError: unknown;
   for (let attempt = 1; attempt <= VRT_FONT_DOWNLOAD_ATTEMPTS; attempt += 1) {
-    const response = await fetch(source.url);
-    if (response.ok) return Buffer.from(await response.arrayBuffer());
+    try {
+      const response = await fetch(source.url);
+      if (response.ok) return Buffer.from(await response.arrayBuffer());
 
-    lastStatus = response.status;
-    if (attempt === VRT_FONT_DOWNLOAD_ATTEMPTS || !isRetryableFontDownloadStatus(lastStatus)) {
-      break;
+      lastStatus = response.status;
+      if (attempt === VRT_FONT_DOWNLOAD_ATTEMPTS || !isRetryableFontDownloadStatus(lastStatus)) {
+        break;
+      }
+      await delay(fontDownloadRetryDelayMs(response, attempt));
+    } catch (error) {
+      lastError = error;
+      if (attempt === VRT_FONT_DOWNLOAD_ATTEMPTS) break;
+      await delay(attempt * 1000);
     }
-    await delay(fontDownloadRetryDelayMs(response, attempt));
   }
 
-  throw new Error(`Failed to download VRT source font ${source.fileName}: ${lastStatus}`);
+  const reason = lastStatus ?? errorMessage(lastError);
+  throw new Error(`Failed to download VRT source font ${source.fileName}: ${reason}`);
 }
 
 function isRetryableFontDownloadStatus(status: number): boolean {
@@ -299,6 +307,10 @@ function fontDownloadRetryDelayMs(response: Response, attempt: number): number {
     }
   }
   return attempt * 1000;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function readBufferIfExists(path: string): Promise<Buffer | null> {

--- a/vrt/snapshot/render-options.ts
+++ b/vrt/snapshot/render-options.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 import JSZip from "jszip";
@@ -18,6 +19,7 @@ type VrtRenderOptions = Pick<ConvertOptions, "fontDirs" | "skipSystemFonts">;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const VRT_FONT_GENERATOR_VERSION = 7;
+const VRT_FONT_DOWNLOAD_ATTEMPTS = 4;
 const VRT_FONT_DIR = join(tmpdir(), `pptx-glimpse-vrt-fonts-v${VRT_FONT_GENERATOR_VERSION}`);
 const VRT_FONT_SOURCE_DIR = join(
   tmpdir(),
@@ -244,13 +246,11 @@ async function loadSourceFonts(): Promise<Map<VrtFontSourceId, OpentypeFullFont>
   const opentype: { parse: (buffer: ArrayBuffer) => OpentypeFullFont } =
     await import("opentype.js");
   const fonts = new Map<VrtFontSourceId, OpentypeFullFont>();
-  await Promise.all(
-    VRT_FONT_SOURCES.map(async (source) => {
-      const sourcePath = await ensureSourceFont(source);
-      const sourceBuffer = await readFile(sourcePath);
-      fonts.set(source.id, opentype.parse(toArrayBuffer(sourceBuffer)));
-    }),
-  );
+  for (const source of VRT_FONT_SOURCES) {
+    const sourcePath = await ensureSourceFont(source);
+    const sourceBuffer = await readFile(sourcePath);
+    fonts.set(source.id, opentype.parse(toArrayBuffer(sourceBuffer)));
+  }
   return fonts;
 }
 
@@ -259,11 +259,7 @@ async function ensureSourceFont(source: VrtFontSource): Promise<string> {
   const existing = await readBufferIfExists(path);
   if (existing !== null && sha256(existing) === source.sha256) return path;
 
-  const response = await fetch(source.url);
-  if (!response.ok) {
-    throw new Error(`Failed to download VRT source font ${source.fileName}: ${response.status}`);
-  }
-  const buffer = Buffer.from(await response.arrayBuffer());
+  const buffer = await downloadSourceFont(source);
   const actualSha256 = sha256(buffer);
   if (actualSha256 !== source.sha256) {
     throw new Error(
@@ -272,6 +268,37 @@ async function ensureSourceFont(source: VrtFontSource): Promise<string> {
   }
   await writeFile(path, buffer);
   return path;
+}
+
+async function downloadSourceFont(source: VrtFontSource): Promise<Buffer> {
+  let lastStatus: number | undefined;
+  for (let attempt = 1; attempt <= VRT_FONT_DOWNLOAD_ATTEMPTS; attempt += 1) {
+    const response = await fetch(source.url);
+    if (response.ok) return Buffer.from(await response.arrayBuffer());
+
+    lastStatus = response.status;
+    if (attempt === VRT_FONT_DOWNLOAD_ATTEMPTS || !isRetryableFontDownloadStatus(lastStatus)) {
+      break;
+    }
+    await delay(fontDownloadRetryDelayMs(response, attempt));
+  }
+
+  throw new Error(`Failed to download VRT source font ${source.fileName}: ${lastStatus}`);
+}
+
+function isRetryableFontDownloadStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function fontDownloadRetryDelayMs(response: Response, attempt: number): number {
+  const retryAfter = response.headers.get("retry-after");
+  if (retryAfter !== null) {
+    const retryAfterSeconds = Number(retryAfter);
+    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+      return retryAfterSeconds * 1000;
+    }
+  }
+  return attempt * 1000;
 }
 
 async function readBufferIfExists(path: string): Promise<Buffer | null> {


### PR DESCRIPTION
close #646

## 目的

テキスト編集 API の `slides → shapes → paragraphs → runs` 走査と変更フラグ管理の重複を解消し、編集操作ごとの差分をマッチ時の変換関数だけに寄せます。あわせて editable text run property の列挙・検査を単一定義から派生する形に整理します。

## 変更内容

- `packages/document/src/source/editing.ts` に `mapMatchingTextRun` / `mapMatchingParagraph` / `mapTextBodyParagraphs` を追加し、`replaceTextRunPlainText` / `replaceParagraphPlainText` / `updateTextRunProperties` の走査を共通化
- editable property の定義を `EDITABLE_TEXT_RUN_PROPERTY_VALIDATORS` に集約し、キー配列・Set・assert・defined copy・patch 処理をそこから派生
- CI の snapshot VRT が raw GitHub のフォント取得 429 で落ちていたため、`vrt/snapshot/render-options.ts` の VRT source font 取得を逐次化し、429 / 5xx / 一時的 fetch 失敗を retry
- 公開 API と編集対象プロパティの追加変更はなし

## ローカル検証

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run test`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npm run build`

補足: 通常の `npm run build` は、この環境の pnpm `minimumReleaseAge` policy により lockfile 内の `picomatch@4.0.5` が cutoff にかかって停止したため、検証時のみ `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` を付与しました。lockfile は変更していません。
