### PR TITLE
chore: ignore local pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.pnpm-store/
 dist/
 *.tgz
 .DS_Store


### PR DESCRIPTION
## 概要
- Docker repro などで repo 直下に再生成される `.pnpm-store/` を gitignore に追加

## 確認
- 差分が `.gitignore` のみであることを確認
- テスト未実行（ignore 追加のみのため）