### PR TITLE
vrt: fixture / snapshot の選択的再生成オプションを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ developer machine's full OS font inventory.
 ```bash
 npm run vrt:snapshot:docker-build   # Build the Docker image
 npm run vrt:snapshot:update          # Generate fixtures + snapshots (Docker required)
+npm run vrt:snapshot:update -- shapes text  # Regenerate only the named VRT cases
 ```
 
 ### VRT Update Procedure
@@ -136,7 +137,7 @@ npm run vrt:snapshot:update          # Generate fixtures + snapshots (Docker req
 When changes to the parser, renderer, or model affect rendering output:
 
 1. **Update fixtures** (if adding new features or modifying existing fixtures): Edit the appropriate `vrt/snapshot/fixtures-src/*.ts` domain creator module and run `npm run vrt:snapshot:update`
-2. **Update snapshots**: `npm run vrt:snapshot:update` regenerates both fixtures and snapshots in Docker
+2. **Update snapshots**: `npm run vrt:snapshot:update` regenerates both fixtures and snapshots in Docker. To update only specific cases, pass the `vrt/snapshot/vrt-cases.ts` `name` values, e.g. `npm run vrt:snapshot:update -- shapes text`.
 3. **Verify tests**: Confirm VRT tests pass in CI after pushing
 
 ### 3 Locations That Must Stay in Sync

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "inspect": "tsx scripts/inspect-pptx.ts",
     "vrt:snapshot:docker-build": "docker build -t pptx-glimpse-snapshot-vrt docker/snapshot-vrt",
     "vrt:snapshot:fixtures": "tsx vrt/snapshot/create-fixtures.ts",
-    "vrt:snapshot:update": "docker run --rm -v \"$(pwd)\":/workspace -v pptx-glimpse-snapshot-vrt-nm:/workspace/node_modules pptx-glimpse-snapshot-vrt bash /workspace/vrt/snapshot/docker-run.sh bash -c \"npx tsx vrt/snapshot/create-fixtures.ts && npx tsx vrt/snapshot/update-snapshots.ts\"",
+    "vrt:snapshot:update": "docker run --rm -v \"$(pwd)\":/workspace -v pptx-glimpse-snapshot-vrt-nm:/workspace/node_modules pptx-glimpse-snapshot-vrt bash /workspace/vrt/snapshot/docker-run.sh bash -c 'npx tsx vrt/snapshot/create-fixtures.ts \"$@\" && npx tsx vrt/snapshot/update-snapshots.ts \"$@\"' --",
     "vrt:lo:docker-build": "docker build -t pptx-glimpse-vrt docker/libreoffice-vrt",
     "vrt:lo:fixtures": "docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt python3 /workspace/vrt/libreoffice/create_fixtures.py",
     "vrt:lo:update": "pnpm run vrt:lo:docker-build && pnpm run vrt:lo:fixtures && docker run --rm -v \"$(pwd)\":/workspace pptx-glimpse-vrt bash /workspace/vrt/libreoffice/update_snapshots.sh",

--- a/vrt/snapshot/create-fixtures.ts
+++ b/vrt/snapshot/create-fixtures.ts
@@ -1,7 +1,7 @@
 /**
  * PPTX fixture generation script for VRT (Visual Regression Testing)
  *
- * Usage: npx tsx vrt/snapshot/create-fixtures.ts
+ * Usage: npx tsx vrt/snapshot/create-fixtures.ts [case-name...]
  */
 import { pathToFileURL } from "url";
 
@@ -14,7 +14,7 @@ import { placeholderFixtureCreators } from "./fixtures-src/placeholder.js";
 import { shapeFixtureCreators } from "./fixtures-src/shapes.js";
 import { tableFixtureCreators } from "./fixtures-src/tables.js";
 import { textFixtureCreators } from "./fixtures-src/text.js";
-import { VRT_CASES } from "./vrt-cases.js";
+import { resolveGeneratedVrtCases } from "./vrt-cases.js";
 
 export {
   buildPptx,
@@ -36,9 +36,12 @@ const FIXTURE_CREATORS: FixtureCreatorMap = {
 };
 
 async function main(): Promise<void> {
+  const caseNames = process.argv.slice(2);
+  const selectedCases = resolveGeneratedVrtCases(caseNames);
+
   console.log("Creating VRT fixtures...\n");
 
-  for (const { fixture } of VRT_CASES) {
+  for (const { fixture } of selectedCases) {
     const creator = FIXTURE_CREATORS[fixture];
     if (!creator) {
       throw new Error(
@@ -50,9 +53,16 @@ async function main(): Promise<void> {
     await creator();
   }
 
+  if (caseNames.length > 0 && selectedCases.length === 0) {
+    console.log("No generated VRT fixtures selected.");
+  }
+
   console.log("\nDone!");
 }
 
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch(console.error);
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
 }

--- a/vrt/snapshot/update-snapshots.ts
+++ b/vrt/snapshot/update-snapshots.ts
@@ -63,8 +63,7 @@ async function main(): Promise<void> {
         : join(SHARED_FIXTURE_DIR, fixture);
 
       if (!existsSync(fixturePath)) {
-        console.warn(`  Skipped (not found): ${fixturePath}`);
-        continue;
+        throw new Error(`Selected VRT fixture not found for "${name}": ${fixturePath}`);
       }
       tasks.push(() => processFixture(fixturePath, name));
     }

--- a/vrt/snapshot/update-snapshots.ts
+++ b/vrt/snapshot/update-snapshots.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 
 import { convertPptxToPng } from "../../packages/core/src/converter.js";
 import { getVrtRenderOptions } from "./render-options.js";
-import { SHARED_FIXTURE_CASES } from "./vrt-cases.js";
+import { resolveSnapshotCases, SHARED_FIXTURE_CASES, VRT_CASES } from "./vrt-cases.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = join(__dirname, "fixtures");
@@ -51,26 +51,44 @@ async function main(): Promise<void> {
   mkdirSync(SNAPSHOT_DIR, { recursive: true });
 
   const tasks: (() => Promise<number>)[] = [];
+  const caseNames = process.argv.slice(2);
 
-  // Generated fixtures
-  const fixtures = existsSync(FIXTURE_DIR)
-    ? readdirSync(FIXTURE_DIR).filter((f) => f.endsWith(".pptx"))
-    : [];
+  if (caseNames.length > 0) {
+    const selectedCases = resolveSnapshotCases(caseNames);
+    const generatedCaseNames = new Set(VRT_CASES.map(({ name }) => name));
 
-  for (const fixture of fixtures.sort()) {
-    const name = fixture.replace(".pptx", "");
-    const fixturePath = join(FIXTURE_DIR, fixture);
-    tasks.push(() => processFixture(fixturePath, name));
-  }
+    for (const { name, fixture } of selectedCases) {
+      const fixturePath = generatedCaseNames.has(name)
+        ? join(FIXTURE_DIR, fixture)
+        : join(SHARED_FIXTURE_DIR, fixture);
 
-  // Shared fixtures
-  for (const { name, fixture } of SHARED_FIXTURE_CASES) {
-    const fixturePath = join(SHARED_FIXTURE_DIR, fixture);
-    if (!existsSync(fixturePath)) {
-      console.warn(`  Skipped (not found): ${fixturePath}`);
-      continue;
+      if (!existsSync(fixturePath)) {
+        console.warn(`  Skipped (not found): ${fixturePath}`);
+        continue;
+      }
+      tasks.push(() => processFixture(fixturePath, name));
     }
-    tasks.push(() => processFixture(fixturePath, name));
+  } else {
+    // Generated fixtures
+    const fixtures = existsSync(FIXTURE_DIR)
+      ? readdirSync(FIXTURE_DIR).filter((f) => f.endsWith(".pptx"))
+      : [];
+
+    for (const fixture of fixtures.sort()) {
+      const name = fixture.replace(".pptx", "");
+      const fixturePath = join(FIXTURE_DIR, fixture);
+      tasks.push(() => processFixture(fixturePath, name));
+    }
+
+    // Shared fixtures
+    for (const { name, fixture } of SHARED_FIXTURE_CASES) {
+      const fixturePath = join(SHARED_FIXTURE_DIR, fixture);
+      if (!existsSync(fixturePath)) {
+        console.warn(`  Skipped (not found): ${fixturePath}`);
+        continue;
+      }
+      tasks.push(() => processFixture(fixturePath, name));
+    }
   }
 
   if (tasks.length === 0) {
@@ -84,4 +102,7 @@ async function main(): Promise<void> {
   console.log(`\nDone! Updated ${totalSlides} snapshot(s).`);
 }
 
-main().catch(console.error);
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/vrt/snapshot/vrt-cases.test.ts
+++ b/vrt/snapshot/vrt-cases.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveGeneratedVrtCases, resolveSnapshotCases } from "./vrt-cases.js";
+
+describe("resolveSnapshotCases", () => {
+  it("resolves selected generated and shared fixture case names", () => {
+    expect(resolveSnapshotCases(["shapes", "real-basic-theme"]).map(({ name }) => name)).toEqual([
+      "shapes",
+      "real-basic-theme",
+    ]);
+  });
+
+  it("deduplicates selected case names", () => {
+    expect(resolveSnapshotCases(["shapes", "shapes"]).map(({ name }) => name)).toEqual(["shapes"]);
+  });
+
+  it("points unknown case names to vrt-cases.ts", () => {
+    expect(() => resolveSnapshotCases(["missing-case"])).toThrow(
+      /Unknown VRT snapshot case name\(s\): "missing-case".*vrt\/snapshot\/vrt-cases\.ts/,
+    );
+  });
+});
+
+describe("resolveGeneratedVrtCases", () => {
+  it("returns all generated cases when no case names are specified", () => {
+    expect(resolveGeneratedVrtCases([]).length).toBeGreaterThan(1);
+  });
+
+  it("filters shared fixture cases out of fixture generation", () => {
+    expect(
+      resolveGeneratedVrtCases(["shapes", "real-basic-theme"]).map(({ name }) => name),
+    ).toEqual(["shapes"]);
+  });
+});

--- a/vrt/snapshot/vrt-cases.ts
+++ b/vrt/snapshot/vrt-cases.ts
@@ -70,3 +70,49 @@ export const VRT_CASES = [
   { name: "placeholder-empty-on-slide", fixture: "placeholder-empty-on-slide.pptx" },
   { name: "interleaved-bullet-ppr", fixture: "interleaved-bullet-ppr.pptx" },
 ] as const;
+
+export const SNAPSHOT_CASES = [...VRT_CASES, ...SHARED_FIXTURE_CASES] as const;
+
+function formatCaseNameList(caseNames: readonly string[]): string {
+  return caseNames.map((name) => `"${name}"`).join(", ");
+}
+
+export function resolveSnapshotCases(
+  caseNames: readonly string[],
+): (typeof SNAPSHOT_CASES)[number][] {
+  const casesByName = new Map(SNAPSHOT_CASES.map((vrtCase) => [vrtCase.name, vrtCase]));
+  const unknownNames = caseNames.filter((caseName) => !casesByName.has(caseName));
+
+  if (unknownNames.length > 0) {
+    throw new Error(
+      `Unknown VRT snapshot case name(s): ${formatCaseNameList(unknownNames)}. Check vrt/snapshot/vrt-cases.ts for valid case names.`,
+    );
+  }
+
+  const selectedCases: (typeof SNAPSHOT_CASES)[number][] = [];
+  const seenNames = new Set<string>();
+
+  for (const caseName of caseNames) {
+    if (seenNames.has(caseName)) {
+      continue;
+    }
+    seenNames.add(caseName);
+    const vrtCase = casesByName.get(caseName);
+    if (vrtCase !== undefined) {
+      selectedCases.push(vrtCase);
+    }
+  }
+
+  return selectedCases;
+}
+
+export function resolveGeneratedVrtCases(
+  caseNames: readonly string[],
+): (typeof VRT_CASES)[number][] {
+  if (caseNames.length === 0) {
+    return [...VRT_CASES];
+  }
+
+  const selectedNames = new Set(resolveSnapshotCases(caseNames).map(({ name }) => name));
+  return VRT_CASES.filter(({ name }) => selectedNames.has(name));
+}

--- a/vrt/snapshot/vrt-cases.ts
+++ b/vrt/snapshot/vrt-cases.ts
@@ -71,16 +71,18 @@ export const VRT_CASES = [
   { name: "interleaved-bullet-ppr", fixture: "interleaved-bullet-ppr.pptx" },
 ] as const;
 
-export const SNAPSHOT_CASES = [...VRT_CASES, ...SHARED_FIXTURE_CASES] as const;
+const SNAPSHOT_CASES = [...VRT_CASES, ...SHARED_FIXTURE_CASES] as const;
+
+type SnapshotCase = (typeof SNAPSHOT_CASES)[number];
 
 function formatCaseNameList(caseNames: readonly string[]): string {
   return caseNames.map((name) => `"${name}"`).join(", ");
 }
 
-export function resolveSnapshotCases(
-  caseNames: readonly string[],
-): (typeof SNAPSHOT_CASES)[number][] {
-  const casesByName = new Map(SNAPSHOT_CASES.map((vrtCase) => [vrtCase.name, vrtCase]));
+export function resolveSnapshotCases(caseNames: readonly string[]): SnapshotCase[] {
+  const casesByName = new Map<string, SnapshotCase>(
+    SNAPSHOT_CASES.map((vrtCase) => [vrtCase.name, vrtCase] as const),
+  );
   const unknownNames = caseNames.filter((caseName) => !casesByName.has(caseName));
 
   if (unknownNames.length > 0) {
@@ -89,7 +91,7 @@ export function resolveSnapshotCases(
     );
   }
 
-  const selectedCases: (typeof SNAPSHOT_CASES)[number][] = [];
+  const selectedCases: SnapshotCase[] = [];
   const seenNames = new Set<string>();
 
   for (const caseName of caseNames) {


### PR DESCRIPTION
close #652

## 目的

Snapshot VRT の fixture / snapshot 再生成で、`vrt/snapshot/vrt-cases.ts` の `name` を指定した選択的更新を可能にします。

## 変更内容

- `create-fixtures.ts` / `update-snapshots.ts` にケース名フィルタを追加
- `npm run vrt:snapshot:update -- <case-name> [<case-name>...]` の引数を Docker 内の両スクリプトへ転送
- 存在しないケース名では `vrt/snapshot/vrt-cases.ts` を案内するエラーで失敗
- `CLAUDE.md` (実体は `AGENTS.md`) の VRT 更新手順に選択的再生成の使い方を追記
- ケース解決の unit test を追加

## 検証

- `npm run knip`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run test`
- `pnpm exec tsc --noEmit --strict --target ES2022 --module Node16 --moduleResolution Node16 --skipLibCheck --types node vrt/snapshot/vrt-cases.ts vrt/snapshot/vrt-cases.test.ts`
- `pnpm exec vitest run --config vitest.vrt.config.ts vrt/snapshot/vrt-cases.test.ts vrt/snapshot/regression.test.ts`
- `pnpm exec tsx vrt/snapshot/create-fixtures.ts missing-case`
- `pnpm exec tsx vrt/snapshot/update-snapshots.ts missing-case`
- `npm run vrt:snapshot:update -- shapes`
- `npm run vrt:snapshot:update`
- `git diff --name-only -- vrt/snapshot/snapshots vrt/snapshot/fixtures` が空であることを確認
