### PR TITLE
document: editing/writer の一貫性を小修正

### DIFF
--- a/.changeset/fix-document-editing-idempotency.md
+++ b/.changeset/fix-document-editing-idempotency.md
@@ -1,0 +1,5 @@
+---
+"@pptx-glimpse/document": patch
+---
+
+Make text run replacement and shape transform updates idempotent when they do not change the source model.

--- a/packages/document/src/source/editing.test.ts
+++ b/packages/document/src/source/editing.test.ts
@@ -66,6 +66,16 @@ describe("editing text operations", () => {
     ]);
   });
 
+  it("returns the original source when replacing a text run with the same text", () => {
+    const source = buildSourceModel();
+    const runHandle = requireHandle(firstRun(source).handle);
+
+    const edited = replaceTextRunPlainText(source, runHandle, firstRun(source).text);
+
+    expect(edited).toBe(source);
+    expect(source.edits).toBeUndefined();
+  });
+
   it("sets and clears text run properties in source and edit records", () => {
     const source = buildSourceModel();
     const runHandle = requireHandle(firstRun(source).handle);
@@ -124,6 +134,25 @@ describe("editing text operations", () => {
     const runHandle = requireHandle(firstRun(source).handle);
 
     const edited = clearTextRunProperties(source, runHandle, ["underline"]);
+
+    expect(edited).toBe(source);
+    expect(source.edits).toBeUndefined();
+  });
+
+  it("returns the original source for equivalent text properties with different key order", () => {
+    const source = structuredClone(buildSourceModel());
+    const runHandle = requireHandle(firstRun(source).handle);
+    (firstRun(source) as { properties?: unknown }).properties = {
+      color: { hex: "00aa44", kind: "srgb" },
+      bold: true,
+      italic: true,
+      fontSize: asPt(24),
+      typeface: "Calibri",
+    };
+
+    const edited = setTextRunProperties(source, runHandle, {
+      color: { kind: "srgb", hex: "00aa44" },
+    });
 
     expect(edited).toBe(source);
     expect(source.edits).toBeUndefined();
@@ -218,6 +247,23 @@ describe("editing shape operations", () => {
     expect(edited.edits).toEqual([
       { kind: "updateShapeTransform", handle: shapeHandle, ...transform },
     ]);
+  });
+
+  it("returns the original source when updating a shape transform to the same values", () => {
+    const source = buildSourceModel();
+    const shape = shapeByName(source, "Title");
+    const shapeHandle = requireHandle(shape.handle);
+    const transform = {
+      offsetX: shape.transform!.offsetX,
+      offsetY: shape.transform!.offsetY,
+      width: shape.transform!.width,
+      height: shape.transform!.height,
+    };
+
+    const edited = updateShapeTransform(source, shapeHandle, transform);
+
+    expect(edited).toBe(source);
+    expect(source.edits).toBeUndefined();
   });
 
   it("adds a text box with a collision-free id and finalized XML", () => {

--- a/packages/document/src/source/editing.test.ts
+++ b/packages/document/src/source/editing.test.ts
@@ -76,6 +76,17 @@ describe("editing text operations", () => {
     expect(source.edits).toBeUndefined();
   });
 
+  it("does not append another text run edit when the replacement is already applied", () => {
+    const source = buildSourceModel();
+    const runHandle = requireHandle(firstRun(source).handle);
+    const edited = replaceTextRunPlainText(source, runHandle, "Edited");
+
+    const repeated = replaceTextRunPlainText(edited, runHandle, "Edited");
+
+    expect(repeated).toBe(edited);
+    expect(repeated.edits).toHaveLength(1);
+  });
+
   it("sets and clears text run properties in source and edit records", () => {
     const source = buildSourceModel();
     const runHandle = requireHandle(firstRun(source).handle);
@@ -264,6 +275,23 @@ describe("editing shape operations", () => {
 
     expect(edited).toBe(source);
     expect(source.edits).toBeUndefined();
+  });
+
+  it("does not append another shape transform edit when the transform is already applied", () => {
+    const source = buildSourceModel();
+    const shapeHandle = requireHandle(shapeByName(source, "Title").handle);
+    const transform = {
+      offsetX: asEmu(11),
+      offsetY: asEmu(22),
+      width: asEmu(33),
+      height: asEmu(44),
+    };
+    const edited = updateShapeTransform(source, shapeHandle, transform);
+
+    const repeated = updateShapeTransform(edited, shapeHandle, transform);
+
+    expect(repeated).toBe(edited);
+    expect(repeated.edits).toHaveLength(1);
   });
 
   it("adds a text box with a collision-free id and finalized XML", () => {

--- a/packages/document/src/source/editing.ts
+++ b/packages/document/src/source/editing.ts
@@ -1,3 +1,14 @@
+/**
+ * Editing helpers for PptxSourceModel.
+ *
+ * Supported edits update the typed source model immediately and append a compact edit
+ * record that lets the writer patch raw package bytes later. That double
+ * representation is deliberate: the typed model is convenient for callers, while raw
+ * bytes preserve unsupported OOXML. Operations that would need to merge pending dirty
+ * slide edits back into a raw clone, such as duplicating a dirty slide, fail fast until
+ * a future writer slice can reconcile both representations.
+ */
+
 import { getAttr, getChild, getChildArray, parseXml } from "../reader/xml.js";
 import {
   editDirtyPartPath,
@@ -151,13 +162,16 @@ export function replaceTextRunPlainText(
   handle: SourceHandle,
   text: string,
 ): PptxSourceModel {
-  const result = mapMatchingTextRun(source, handle, (run) => ({ ...run, text }));
+  const result = mapMatchingTextRun(source, handle, (run) =>
+    run.text === text ? run : { ...run, text },
+  );
 
   if (!result.matched) {
     throw new Error(
       "replaceTextRunPlainText: text run handle was not found in PptxSourceModel source",
     );
   }
+  if (!result.changed) return source;
 
   return {
     ...source,
@@ -431,19 +445,23 @@ export function updateShapeTransform(
     throw new Error("updateShapeTransform: shape transform edit requires a node id");
   }
 
-  let updated = false;
+  let matched = false;
+  let changed = false;
 
-  const slides = source.slides.map((slide) => ({
-    ...slide,
-    shapes: slide.shapes.map((shape) => {
+  const slides = source.slides.map((slide) => {
+    let slideChanged = false;
+    const shapes = slide.shapes.map((shape) => {
       if (!sourceHandlesEqual(shape.handle, handle)) return shape;
+      matched = true;
       if (hasAlternateContentSidecar(shape)) {
         throw new Error("updateShapeTransform: shapes inside AlternateContent are not supported");
       }
       if (!hasEditableTransform(shape)) {
         throw new Error("updateShapeTransform: shape handle does not reference a shape with xfrm");
       }
-      updated = true;
+      if (shapeTransformPositionAndSizeEqual(shape.transform, transform)) return shape;
+      changed = true;
+      slideChanged = true;
       return {
         ...shape,
         transform: {
@@ -454,15 +472,17 @@ export function updateShapeTransform(
           height: transform.height,
         },
       };
-    }),
-  }));
+    });
+    return slideChanged ? { ...slide, shapes } : slide;
+  });
 
-  if (!updated) {
+  if (!matched) {
     if (source.slides.some((slide) => hasNestedShapeNodeWithHandle(slide.shapes, handle))) {
       throw new Error("updateShapeTransform: nested group shape editing is not supported");
     }
     throw new Error("updateShapeTransform: shape handle was not found in PptxSourceModel source");
   }
+  if (!changed) return source;
 
   return {
     ...source,
@@ -917,6 +937,10 @@ export function deleteSlide(source: PptxSourceModel, slideHandle: SourceHandle):
       const target = resolveInternalRelationshipTarget(slide.partPath, relationship);
       return target === undefined ? [] : [target];
     }) ?? [];
+  // This topology operation removes the slide and its directly attached notes slide
+  // only. It intentionally does not sweep now-orphaned media parts because raw or
+  // unsupported parts may still reference them; media reference counting remains local
+  // to replaceImageBytes.
   const removedPartPaths = [slide.partPath, ...notesPartPaths];
   const removedPartPathSet = new Set<string>(removedPartPaths);
   const retainedEdits = (source.edits ?? []).filter(
@@ -1073,10 +1097,28 @@ function imageRelationshipKey(partPath: PartPath, relationshipId: RelationshipId
 
 function findImagesInTree(shapes: readonly SourceShapeNode[]): SourceImage[] {
   return shapes.flatMap((shape): SourceImage[] => {
-    if (shape.kind === "image") return [shape];
-    if (shape.kind === "group") return findImagesInTree(shape.children);
-    return [];
+    switch (shape.kind) {
+      case "image":
+        return [shape];
+      case "group":
+        return findImagesInTree(shape.children);
+      case "shape":
+      case "connector":
+      case "table":
+      case "chart":
+      case "smartArt":
+      case "raw":
+        // The denominator is for replaceImageBytes' p:pic targets only. Other typed
+        // nodes, image fills, and raw/unsupported relationship users are preserved but
+        // are not replaceImageBytes targets in this editing slice.
+        return [];
+    }
+    return assertNeverShapeNode(shape);
   });
+}
+
+function assertNeverShapeNode(shape: never): never {
+  throw new Error(`editing: unhandled source shape node kind '${String(shape)}'`);
 }
 
 function detectImageContentType(bytes: Uint8Array): string | undefined {
@@ -1182,7 +1224,40 @@ function textRunPropertiesEqual(
   left: SourceRunProperties | undefined,
   right: SourceRunProperties | undefined,
 ): boolean {
-  return JSON.stringify(left ?? {}) === JSON.stringify(right ?? {});
+  return stableValueEqual(left ?? {}, right ?? {});
+}
+
+function stableValueEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    return left.every((value, index) => stableValueEqual(value, right[index]));
+  }
+  if (isPlainRecord(left) || isPlainRecord(right)) {
+    if (!isPlainRecord(left) || !isPlainRecord(right)) return false;
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    if (!stableValueEqual(leftKeys, rightKeys)) return false;
+    return leftKeys.every((key) => stableValueEqual(left[key], right[key]));
+  }
+  return false;
+}
+
+function isPlainRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function shapeTransformPositionAndSizeEqual(
+  current: TransformableShapeNode["transform"],
+  next: UpdateShapeTransformInput,
+): boolean {
+  return (
+    current?.offsetX === next.offsetX &&
+    current.offsetY === next.offsetY &&
+    current.width === next.width &&
+    current.height === next.height
+  );
 }
 
 function createReplacementRunHandle(paragraph: SourceParagraph): SourceHandle | undefined {
@@ -1254,21 +1329,13 @@ function assertArrowEndpoint(endpoint: SourceArrowEndpoint | undefined, fieldNam
   }
 }
 
-function assertFiniteEmu(
-  value: Emu,
-  operationName: "addTextBox" | "addConnector",
-  fieldName: string,
-): void {
+function assertFiniteEmu(value: Emu, operationName: string, fieldName: string): void {
   if (!Number.isFinite(value)) {
     throw new Error(`${operationName}: ${fieldName} must be a finite EMU value`);
   }
 }
 
-function assertPositiveFiniteEmu(
-  value: Emu,
-  operationName: "addTextBox" | "addConnector",
-  fieldName: string,
-): void {
+function assertPositiveFiniteEmu(value: Emu, operationName: string, fieldName: string): void {
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error(`${operationName}: ${fieldName} must be a finite positive EMU value`);
   }
@@ -1444,7 +1511,7 @@ function createNotesSlideCopy(
 function requirePartRelationships(
   source: PptxSourceModel,
   partPath: PartPath,
-  operationName: "addEmptySlideFromLayout" | "duplicateSlide" | "deleteSlide" | "replaceImageBytes",
+  operationName: string,
 ): PartRelationships {
   const relationships = source.packageGraph.relationships.find(
     (candidate) => candidate.sourcePartPath === partPath,
@@ -1459,7 +1526,7 @@ function requireSlideRelationship(
   source: PptxSourceModel,
   relationships: PartRelationships,
   slidePartPath: PartPath,
-  operationName: "addEmptySlideFromLayout" | "duplicateSlide" | "deleteSlide",
+  operationName: string,
 ): Relationship {
   const relationship = relationships.relationships.find(
     (candidate) =>
@@ -1476,7 +1543,7 @@ function requireSlideRelationship(
 function requireRawBinaryPart(
   source: PptxSourceModel,
   partPath: PartPath,
-  operationName: "addEmptySlideFromLayout" | "duplicateSlide",
+  operationName: string,
 ): Extract<RawPackagePart, { readonly kind: "binary" }> {
   const rawPart = source.packageGraph.rawParts?.find((part) => part.partPath === partPath);
   if (rawPart === undefined) {
@@ -1495,10 +1562,7 @@ function requireRawBinaryPart(
  * preserved presentation XML and the ids already claimed by pending slide edits.
  * Ids freed by pending deletes are intentionally never reused.
  */
-function nextSlideNumericId(
-  source: PptxSourceModel,
-  operationName: "addEmptySlideFromLayout" | "duplicateSlide",
-): number {
+function nextSlideNumericId(source: PptxSourceModel, operationName: string): number {
   const rawPart = requireRawBinaryPart(source, source.presentation.partPath, operationName);
   const root = parseXml(textDecoder.decode(rawPart.bytes));
   const presentation = getChild(root, "presentation");

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -14,6 +14,11 @@
  * Unsupported OOXML, vendor extensions, mc:AlternateContent, and unsupported DrawingML
  * are not mixed into the typed operation API. They are preserved as raw sidecars or raw
  * package parts for structural round-tripping.
+ * Editing therefore carries a deliberate double representation: supported changes
+ * update typed nodes immediately and append edit records, while the writer later
+ * patches preserved raw bytes. Operations that cannot soundly merge those pending
+ * edits into raw material, such as duplicating a slide with dirty slide-part edits, are
+ * rejected at runtime instead of guessing.
  *
  * New-content edits (new slides, text boxes, connectors) finalize their XML and id
  * numbering at edit time and record them on the edit; the writer only applies

--- a/packages/document/src/writer/write-pptx.ts
+++ b/packages/document/src/writer/write-pptx.ts
@@ -16,6 +16,8 @@
  * bookkeeping while preserving unrelated raw package material. Per-edit-kind traits
  * (dirty part, topology operation, and so on) come from the descriptor table in
  * `../source/edit-descriptors.ts`; this file keeps only the exhaustive apply switch.
+ * Small package-bookkeeping XML parts are still serialized with handwritten strings so
+ * their emitted attribute/order shape stays deterministic across builder changes.
  * New-content edits (new slides, text boxes, connectors) finalize their XML and id
  * numbering at edit time in `source/editing.ts` / `source/shape-xml.ts`; this writer
  * never generates new-content XML and only applies insertion positions (`p:spTree`


### PR DESCRIPTION
close #648

## 目的

editing.ts / write-pptx.ts の横断レビューで見つかった小さな方針不統一と、暗黙になっていた設計判断を明文化します。

## 変更内容

- `replaceTextRunPlainText` / `updateShapeTransform` を、同値更新時は `source` を返して edit を追加しない方針に統一
- `textRunPropertiesEqual` をキー順に依存しない比較へ変更
- `findImagesInTree` を網羅 switch 化し、共有参照カウントの分母に含める対象をコメント化
- typed model と raw bytes の二重表現、`deleteSlide` の media 非回収方針、writer の手書き XML シリアライズ理由をコメントで明文化
- 汎用 helper の `operationName` 型を呼び出し側 literal union から `string` に緩和
- `@pptx-glimpse/document` の patch changeset を追加

## 影響範囲

- `packages/document/src/source/editing.ts`
- `packages/document/src/source/pptx-source-model.ts`
- `packages/document/src/writer/write-pptx.ts`
- `packages/document/src/source/editing.test.ts`

## ローカル検証

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`

## レビュー

- acceptance-check: 全受け入れ条件を確認済み
- cross-review: critical 0 / warning 0 / info 1。info の追加テスト提案に対応済み
