### PR TITLE
document: 数値風テキストを文字列として保持する

### DIFF
--- a/.changeset/preserve-numeric-text.md
+++ b/.changeset/preserve-numeric-text.md
@@ -1,0 +1,6 @@
+---
+"@pptx-glimpse/document": patch
+"pptx-glimpse": patch
+---
+
+Preserve numeric-like OOXML text values such as `007`, `1e5`, and `12.50` when reading and writing PPTX slides.

--- a/packages/document/src/reader/xml.ts
+++ b/packages/document/src/reader/xml.ts
@@ -28,6 +28,7 @@ const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: "@_",
   parseAttributeValue: false,
+  parseTagValue: false,
   // Retain prefix. See the comment at the beginning of the file for the reason.
   removeNSPrefix: false,
   // Do not trim text run (`a:t`) to preserve significant white space at the beginning and end.

--- a/packages/document/src/source/editing.test.ts
+++ b/packages/document/src/source/editing.test.ts
@@ -303,7 +303,7 @@ describe("editing shape operations", () => {
         offsetY: asEmu(600),
         width: asEmu(700),
         height: asEmu(800),
-        text: "Added",
+        text: "007",
       }),
     );
     const added = shapeByName(edited, "TextBox 31");
@@ -312,7 +312,7 @@ describe("editing shape operations", () => {
       source.slides[0].shapes.map((shape) => shape.kind !== "raw" && shape.name),
     ).not.toContain("TextBox 31");
     expect(added.nodeId).toBe("31");
-    expect(added.textBody?.paragraphs[0]?.runs[0]?.text).toBe("Added");
+    expect(added.textBody?.paragraphs[0]?.runs[0]?.text).toBe("007");
     expect(edited.edits?.at(-1)).toMatchObject({
       kind: "addTextBox",
       slidePartPath: "ppt/slides/slide1.xml",

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -6,7 +6,15 @@ import { unzipSync, zipSync } from "fflate";
 import { describe, expect, it } from "vitest";
 
 // Import via the actual public surface (`@pptx-glimpse/document`).
-import { asEmu, asPartPath, asPt, asSourceNodeId, readPptx, writePptx } from "../index.js";
+import {
+  asEmu,
+  asPartPath,
+  asPt,
+  asSourceNodeId,
+  createComputedView,
+  readPptx,
+  writePptx,
+} from "../index.js";
 import {
   addConnector,
   addEmptySlideFromLayout,
@@ -429,6 +437,21 @@ function buildMultipleTextEditFixture(): Uint8Array {
       `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
       `<p:txBody><a:bodyPr/><a:lstStyle/>` +
       `<a:p><a:r><a:t>Other shape</a:t></a:r></a:p>` +
+      `</p:txBody></p:sp>`,
+  );
+}
+
+function buildNumericLikeTextFixture(): Uint8Array {
+  return buildTextEditFixtureFromSlide(
+    `<p:sp><p:nvSpPr><p:cNvPr id="10" name="Numeric Text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+      `<a:p><a:r><a:t>007</a:t></a:r><a:r><a:t>1e5</a:t></a:r><a:r><a:t>12.50</a:t></a:r></a:p>` +
+      `</p:txBody></p:sp>` +
+      `<p:sp><p:nvSpPr><p:cNvPr id="11" name="Edit Me"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>` +
+      `<p:spPr><a:prstGeom prst="rect"/></p:spPr>` +
+      `<p:txBody><a:bodyPr/><a:lstStyle/>` +
+      `<a:p><a:r><a:t>Original</a:t></a:r></a:p>` +
       `</p:txBody></p:sp>`,
   );
 }
@@ -1227,6 +1250,26 @@ describe("writePptx - shape add/delete edits", () => {
 });
 
 describe("writePptx - one plain text-run edit", () => {
+  it("keeps numeric-like text strings in the source and computed view", () => {
+    const source = readPptx(buildNumericLikeTextFixture());
+    const shape = findShapeByName(source, "Numeric Text");
+    const computed = createComputedView(source);
+    const computedShape = computed.slides[0]?.elements.find(
+      (element) => element.kind === "shape" && element.sourceNode.name === "Numeric Text",
+    );
+
+    expect(shape.textBody?.paragraphs[0]?.runs.map((run) => run.text)).toEqual([
+      "007",
+      "1e5",
+      "12.50",
+    ]);
+    expect(
+      computedShape?.kind === "shape"
+        ? computedShape.textBody?.paragraphs[0]?.runs.map((run) => run.text)
+        : undefined,
+    ).toEqual(["007", "1e5", "12.50"]);
+  });
+
   it("Existing text run can be identified with stable source handle", () => {
     const source = readPptx(buildTextEditFixture());
     const run = firstRun(source);
@@ -1252,6 +1295,25 @@ describe("writePptx - one plain text-run edit", () => {
     expect(firstRun(edited).text).toBe("Edited text");
     expect(editedRun.text).toBe("Edited text");
     expect(firstParagraph(reread).runs[1].text).toBe(" Keep ");
+  });
+
+  it("does not transform unrelated numeric-like runs when writing a dirty slide", () => {
+    const source = readPptx(buildNumericLikeTextFixture());
+    const editRun = findShapeByName(source, "Edit Me").textBody?.paragraphs[0]?.runs[0];
+    if (editRun?.handle === undefined) throw new Error("edit run handle not found");
+
+    const edited = replaceTextRunPlainText(source, editRun.handle, "Dirty");
+    const output = writePptx(edited);
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+    const reread = readPptx(output);
+
+    expect(slideXml).toContain("<a:t>007</a:t>");
+    expect(slideXml).toContain("<a:t>1e5</a:t>");
+    expect(slideXml).toContain("<a:t>12.50</a:t>");
+    expect(
+      findShapeByName(reread, "Numeric Text").textBody?.paragraphs[0]?.runs.map((run) => run.text),
+    ).toEqual(["007", "1e5", "12.50"]);
+    expect(findShapeByName(reread, "Edit Me").textBody?.paragraphs[0]?.runs[0]?.text).toBe("Dirty");
   });
 
   it("Writes dirty slide XML with a single XML declaration", () => {


### PR DESCRIPTION
close #655

## 目的

`@pptx-glimpse/document` の OOXML object parser がタグ本文を数値・真偽値へ自動変換していたため、`<a:t>007</a:t>` などの数値風テキストが読み込み・computed view・dirty slide 書き出しで変形する問題を修正します。

## 変更内容

- `packages/document/src/reader/xml.ts` の object parser に `parseTagValue: false` を追加
- `readPptx` / computed view で `007`, `1e5`, `12.50` が文字列のまま残る回帰テストを追加
- `addTextBox(..., { text: "007" })` 直後の in-memory shape を検証
- dirty slide 書き出し時に無関係な数値風 run が変形しないことを検証
- published packages 向け changeset を追加

## 検証

- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm format:check`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm lint`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm typecheck`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm test`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm knip`
- `env PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm build`
- Docker snapshot VRT: `npx tsx vrt/snapshot/create-fixtures.ts && npx vitest run --config vitest.vrt.config.ts vrt/snapshot/regression.test.ts`

補足: ローカル pnpm config の `minimumReleaseAge=10080` が lockfile 内の既存 dependency に当たったため、検証コマンドでは環境変数でこの run に限り解除しています。
