### PR TITLE
document: from-scratch PPTX builder を追加

### DIFF
--- a/.changeset/from-scratch-pptx-builder.md
+++ b/.changeset/from-scratch-pptx-builder.md
@@ -1,0 +1,5 @@
+---
+"@pptx-glimpse/document": minor
+---
+
+Add `createPptx()` for constructing a minimal from-scratch `PptxSourceModel` that can be edited with `addTextBox()` and written with `writePptx()`.

--- a/packages/document/README.md
+++ b/packages/document/README.md
@@ -20,6 +20,7 @@ Import supported APIs from the package root:
 import {
   addEmptySlideFromLayout,
   createComputedView,
+  createPptx,
   readPptx,
   replaceTextRunPlainText,
   writePptx,
@@ -29,6 +30,7 @@ import {
 The stable entry point includes:
 
 - `readPptx(input)` for reading PPTX bytes into a `PptxSourceModel`
+- `createPptx(options?)` for creating a minimal from-scratch `PptxSourceModel`
 - `createComputedView(source, options?)` for deriving slide/layout/master/theme effective values without mutating the source
 - `writePptx(source)` for structural round-trip writing
 - Text editing helpers such as `replaceTextRunPlainText(source, handle, text)` and related source handle lookup types exported from the root entry point
@@ -54,6 +56,30 @@ await writeFile("round-trip.pptx", output);
 ```
 
 `writePptx` targets structural round-trip preservation rather than byte-for-byte equality. Unedited package material is preserved where possible, and supported edits mark dirty PPTX parts for serialization.
+
+## From-Scratch PPTX
+
+```ts
+import { writeFile } from "node:fs/promises";
+import { addTextBox, asEmu, createPptx, writePptx } from "@pptx-glimpse/document";
+
+const source = createPptx();
+const firstSlide = source.slides[0];
+
+if (firstSlide?.handle === undefined) {
+  throw new Error("No slide was created");
+}
+
+const edited = addTextBox(source, firstSlide.handle, {
+  offsetX: asEmu(914400),
+  offsetY: asEmu(914400),
+  width: asEmu(3657600),
+  height: asEmu(914400),
+  text: "Hello from pptx-glimpse",
+});
+
+await writeFile("from-scratch.pptx", writePptx(edited));
+```
 
 ## Text-Run Edit
 

--- a/packages/document/src/builder/create-pptx.ts
+++ b/packages/document/src/builder/create-pptx.ts
@@ -29,6 +29,7 @@ import type {
   SlideSize,
   SourceColorMap,
   SourceTheme,
+  SourceThemeFormatScheme,
 } from "../source/index.js";
 import { asEmu, asPartPath, asRelationshipId } from "../source/index.js";
 
@@ -61,60 +62,11 @@ const THEME_PART = asPartPath("ppt/theme/theme1.xml");
 const APP_PROPS_PART = asPartPath("docProps/app.xml");
 const CORE_PROPS_PART = asPartPath("docProps/core.xml");
 
-const DEFAULT_SLIDE_SIZE: SlideSize = {
-  width: asEmu(9144000),
-  height: asEmu(5143500),
-};
-
-const DEFAULT_COLOR_MAP: SourceColorMap = {
-  mapping: {
-    bg1: "lt1",
-    tx1: "dk1",
-    bg2: "lt2",
-    tx2: "dk2",
-    accent1: "accent1",
-    accent2: "accent2",
-    accent3: "accent3",
-    accent4: "accent4",
-    accent5: "accent5",
-    accent6: "accent6",
-    hlink: "hlink",
-    folHlink: "folHlink",
-  },
-};
-
-const THEME_SOURCE: SourceTheme = {
-  partPath: THEME_PART,
-  name: "Office Theme",
-  colorScheme: {
-    colors: {
-      dk1: { kind: "system", value: "windowText", lastColor: "000000" },
-      lt1: { kind: "system", value: "window", lastColor: "FFFFFF" },
-      dk2: { kind: "srgb", hex: "44546A" },
-      lt2: { kind: "srgb", hex: "E7E6E6" },
-      accent1: { kind: "srgb", hex: "4472C4" },
-      accent2: { kind: "srgb", hex: "ED7D31" },
-      accent3: { kind: "srgb", hex: "A5A5A5" },
-      accent4: { kind: "srgb", hex: "FFC000" },
-      accent5: { kind: "srgb", hex: "5B9BD5" },
-      accent6: { kind: "srgb", hex: "70AD47" },
-      hlink: { kind: "srgb", hex: "0563C1" },
-      folHlink: { kind: "srgb", hex: "954F72" },
-    },
-  },
-  fontScheme: {
-    majorLatin: "Aptos Display",
-    minorLatin: "Aptos",
-    majorEastAsian: "",
-    minorEastAsian: "",
-    majorComplexScript: "",
-    minorComplexScript: "",
-  },
-  handle: { partPath: THEME_PART },
-};
+const DEFAULT_SLIDE_WIDTH = 9144000;
+const DEFAULT_SLIDE_HEIGHT = 5143500;
 
 export function createPptx(options: CreatePptxOptions = {}): PptxSourceModel {
-  const slideSize = options.slideSize ?? DEFAULT_SLIDE_SIZE;
+  const slideSize = normalizeSlideSize(options.slideSize);
   const overrides = createContentTypeOverrides();
   const rawParts = createRawParts(slideSize);
   const parts = createPackageParts(overrides);
@@ -162,13 +114,96 @@ export function createPptx(options: CreatePptxOptions = {}): PptxSourceModel {
         partPath: SLIDE_MASTER_PART,
         themePartPath: THEME_PART,
         layoutPartPaths: [SLIDE_LAYOUT_PART],
-        colorMap: DEFAULT_COLOR_MAP,
+        colorMap: createDefaultColorMap(),
         shapes: [],
         handle: { partPath: SLIDE_MASTER_PART },
       },
     ],
-    themes: [THEME_SOURCE],
+    themes: [createThemeSource()],
     diagnostics: [],
+  };
+}
+
+function normalizeSlideSize(slideSize: SlideSize | undefined): SlideSize {
+  const width = slideSize?.width ?? DEFAULT_SLIDE_WIDTH;
+  const height = slideSize?.height ?? DEFAULT_SLIDE_HEIGHT;
+  assertPositiveFiniteNumber(width, "slideSize.width");
+  assertPositiveFiniteNumber(height, "slideSize.height");
+  return { width: asEmu(width), height: asEmu(height) };
+}
+
+function assertPositiveFiniteNumber(value: unknown, fieldName: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`createPptx: ${fieldName} must be a finite positive EMU value`);
+  }
+}
+
+function createDefaultColorMap(): SourceColorMap {
+  return {
+    mapping: {
+      bg1: "lt1",
+      tx1: "dk1",
+      bg2: "lt2",
+      tx2: "dk2",
+      accent1: "accent1",
+      accent2: "accent2",
+      accent3: "accent3",
+      accent4: "accent4",
+      accent5: "accent5",
+      accent6: "accent6",
+      hlink: "hlink",
+      folHlink: "folHlink",
+    },
+  };
+}
+
+function createThemeSource(): SourceTheme {
+  return {
+    partPath: THEME_PART,
+    name: "Office Theme",
+    colorScheme: {
+      colors: {
+        dk1: { kind: "system", value: "windowText", lastColor: "000000" },
+        lt1: { kind: "system", value: "window", lastColor: "FFFFFF" },
+        dk2: { kind: "srgb", hex: "44546A" },
+        lt2: { kind: "srgb", hex: "E7E6E6" },
+        accent1: { kind: "srgb", hex: "4472C4" },
+        accent2: { kind: "srgb", hex: "ED7D31" },
+        accent3: { kind: "srgb", hex: "A5A5A5" },
+        accent4: { kind: "srgb", hex: "FFC000" },
+        accent5: { kind: "srgb", hex: "5B9BD5" },
+        accent6: { kind: "srgb", hex: "70AD47" },
+        hlink: { kind: "srgb", hex: "0563C1" },
+        folHlink: { kind: "srgb", hex: "954F72" },
+      },
+    },
+    fontScheme: {
+      majorLatin: "Aptos Display",
+      minorLatin: "Aptos",
+      majorEastAsian: "",
+      minorEastAsian: "",
+      majorComplexScript: "",
+      minorComplexScript: "",
+    },
+    formatScheme: createThemeFormatScheme(),
+    handle: { partPath: THEME_PART },
+  };
+}
+
+function createThemeFormatScheme(): SourceThemeFormatScheme {
+  const placeholderFill = {
+    kind: "solid" as const,
+    color: { kind: "scheme" as const, scheme: "phClr" },
+  };
+  return {
+    fillStyles: [placeholderFill, placeholderFill, placeholderFill],
+    lineStyles: [
+      { width: asEmu(6350), fill: placeholderFill, dashStyle: "solid" },
+      { width: asEmu(12700), fill: placeholderFill, dashStyle: "solid" },
+      { width: asEmu(19050), fill: placeholderFill, dashStyle: "solid" },
+    ],
+    effectStyles: [undefined, undefined, undefined],
+    backgroundFillStyles: [placeholderFill, placeholderFill, placeholderFill],
   };
 }
 
@@ -291,7 +326,7 @@ function createRawParts(slideSize: SlideSize): RawPackagePart[] {
     rawXml(SLIDE_LAYOUT_PART, SLIDE_LAYOUT_CONTENT_TYPE, slideLayoutXml()),
     rawXml(SLIDE_MASTER_PART, SLIDE_MASTER_CONTENT_TYPE, slideMasterXml()),
     rawXml(THEME_PART, THEME_CONTENT_TYPE, themeXml()),
-    rawXml(APP_PROPS_PART, APP_PROPS_CONTENT_TYPE, appPropertiesXml()),
+    rawXml(APP_PROPS_PART, APP_PROPS_CONTENT_TYPE, appPropertiesXml(slideSize)),
     rawXml(CORE_PROPS_PART, CORE_PROPS_CONTENT_TYPE, corePropertiesXml()),
   ];
 }
@@ -311,11 +346,21 @@ function presentationXml(slideSize: SlideSize): string {
       `xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
       `<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>` +
       `<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>` +
-      `<p:sldSz cx="${slideSize.width}" cy="${slideSize.height}" type="screen16x9"/>` +
+      `<p:sldSz cx="${slideSize.width}" cy="${slideSize.height}"${slideSizeTypeAttribute(
+        slideSize,
+      )}/>` +
       `<p:notesSz cx="6858000" cy="9144000"/>` +
       `<p:defaultTextStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr></p:defaultTextStyle>` +
       `</p:presentation>`,
   );
+}
+
+function slideSizeTypeAttribute(slideSize: SlideSize): string {
+  return isDefaultSlideSize(slideSize) ? ` type="screen16x9"` : "";
+}
+
+function isDefaultSlideSize(slideSize: SlideSize): boolean {
+  return slideSize.width === DEFAULT_SLIDE_WIDTH && slideSize.height === DEFAULT_SLIDE_HEIGHT;
 }
 
 function slideXml(): string {
@@ -425,12 +470,14 @@ function formatSchemeXml(): string {
   );
 }
 
-function appPropertiesXml(): string {
+function appPropertiesXml(slideSize: SlideSize): string {
   return xmlPart(
     `<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" ` +
       `xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">` +
       `<Application>pptx-glimpse</Application>` +
-      `<PresentationFormat>On-screen Show (16:9)</PresentationFormat>` +
+      (isDefaultSlideSize(slideSize)
+        ? `<PresentationFormat>On-screen Show (16:9)</PresentationFormat>`
+        : "") +
       `<Slides>1</Slides>` +
       `</Properties>`,
   );

--- a/packages/document/src/builder/create-pptx.ts
+++ b/packages/document/src/builder/create-pptx.ts
@@ -1,0 +1,450 @@
+/**
+ * From-scratch PptxSourceModel factory.
+ *
+ * MVP scope: create a valid one-slide presentation with the minimum OOXML skeleton
+ * needed by the existing writer path: presentation, slide, blank layout, slide master,
+ * theme, content types, and relationships. Text authoring is intentionally delegated to
+ * the existing `addTextBox` editing API, so the first supported flow is
+ * `createPptx()` -> `addTextBox(...)` -> `writePptx(...)`.
+ *
+ * API choice: this module exposes a factory-style builder entry point (`createPptx`)
+ * instead of asking callers to hand-build `PptxSourceModel`. The source model requires
+ * package parts, relationship ids, part paths, content types, raw writer material, and
+ * typed slide/layout/master/theme references to stay consistent. Keeping those
+ * invariants inside a factory prevents easy creation of broken packages. The alternative
+ * considered for this issue was exporting minimal helpers for direct `PptxSourceModel`
+ * construction and adding a higher-level builder later; that was not chosen because it
+ * would expose the same cross-part invariants to early consumers while the MVP only
+ * needs a stable empty-presentation seed for text-box generation.
+ */
+
+import type {
+  ContentTypeOverride,
+  PackagePartRef,
+  PartPath,
+  PartRelationships,
+  PptxSourceModel,
+  RawPackagePart,
+  Relationship,
+  SlideSize,
+  SourceColorMap,
+  SourceTheme,
+} from "../source/index.js";
+import { asEmu, asPartPath, asRelationshipId } from "../source/index.js";
+
+export interface CreatePptxOptions {
+  readonly slideSize?: SlideSize;
+}
+
+const textEncoder = new TextEncoder();
+
+const RELS_CONTENT_TYPE = "application/vnd.openxmlformats-package.relationships+xml";
+const XML_CONTENT_TYPE = "application/xml";
+const PRESENTATION_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml";
+const SLIDE_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.slide+xml";
+const SLIDE_LAYOUT_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml";
+const SLIDE_MASTER_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml";
+const THEME_CONTENT_TYPE = "application/vnd.openxmlformats-officedocument.theme+xml";
+const APP_PROPS_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.extended-properties+xml";
+const CORE_PROPS_CONTENT_TYPE = "application/vnd.openxmlformats-package.core-properties+xml";
+
+const ROOT_PART = asPartPath("");
+const PRESENTATION_PART = asPartPath("ppt/presentation.xml");
+const SLIDE_PART = asPartPath("ppt/slides/slide1.xml");
+const SLIDE_LAYOUT_PART = asPartPath("ppt/slideLayouts/slideLayout1.xml");
+const SLIDE_MASTER_PART = asPartPath("ppt/slideMasters/slideMaster1.xml");
+const THEME_PART = asPartPath("ppt/theme/theme1.xml");
+const APP_PROPS_PART = asPartPath("docProps/app.xml");
+const CORE_PROPS_PART = asPartPath("docProps/core.xml");
+
+const DEFAULT_SLIDE_SIZE: SlideSize = {
+  width: asEmu(9144000),
+  height: asEmu(5143500),
+};
+
+const DEFAULT_COLOR_MAP: SourceColorMap = {
+  mapping: {
+    bg1: "lt1",
+    tx1: "dk1",
+    bg2: "lt2",
+    tx2: "dk2",
+    accent1: "accent1",
+    accent2: "accent2",
+    accent3: "accent3",
+    accent4: "accent4",
+    accent5: "accent5",
+    accent6: "accent6",
+    hlink: "hlink",
+    folHlink: "folHlink",
+  },
+};
+
+const THEME_SOURCE: SourceTheme = {
+  partPath: THEME_PART,
+  name: "Office Theme",
+  colorScheme: {
+    colors: {
+      dk1: { kind: "system", value: "windowText", lastColor: "000000" },
+      lt1: { kind: "system", value: "window", lastColor: "FFFFFF" },
+      dk2: { kind: "srgb", hex: "44546A" },
+      lt2: { kind: "srgb", hex: "E7E6E6" },
+      accent1: { kind: "srgb", hex: "4472C4" },
+      accent2: { kind: "srgb", hex: "ED7D31" },
+      accent3: { kind: "srgb", hex: "A5A5A5" },
+      accent4: { kind: "srgb", hex: "FFC000" },
+      accent5: { kind: "srgb", hex: "5B9BD5" },
+      accent6: { kind: "srgb", hex: "70AD47" },
+      hlink: { kind: "srgb", hex: "0563C1" },
+      folHlink: { kind: "srgb", hex: "954F72" },
+    },
+  },
+  fontScheme: {
+    majorLatin: "Aptos Display",
+    minorLatin: "Aptos",
+    majorEastAsian: "",
+    minorEastAsian: "",
+    majorComplexScript: "",
+    minorComplexScript: "",
+  },
+  handle: { partPath: THEME_PART },
+};
+
+export function createPptx(options: CreatePptxOptions = {}): PptxSourceModel {
+  const slideSize = options.slideSize ?? DEFAULT_SLIDE_SIZE;
+  const overrides = createContentTypeOverrides();
+  const rawParts = createRawParts(slideSize);
+  const parts = createPackageParts(overrides);
+
+  return {
+    packageGraph: {
+      contentTypes: {
+        defaults: [
+          { extension: "rels", contentType: RELS_CONTENT_TYPE },
+          { extension: "xml", contentType: XML_CONTENT_TYPE },
+        ],
+        overrides,
+      },
+      parts,
+      relationships: createRelationships(),
+      media: [],
+      rawParts,
+    },
+    presentation: {
+      partPath: PRESENTATION_PART,
+      slideSize,
+      slidePartPaths: [SLIDE_PART],
+      handle: { partPath: PRESENTATION_PART },
+    },
+    slides: [
+      {
+        partPath: SLIDE_PART,
+        layoutPartPath: SLIDE_LAYOUT_PART,
+        shapes: [],
+        handle: { partPath: SLIDE_PART },
+      },
+    ],
+    slideLayouts: [
+      {
+        partPath: SLIDE_LAYOUT_PART,
+        masterPartPath: SLIDE_MASTER_PART,
+        type: "blank",
+        show: true,
+        shapes: [],
+        handle: { partPath: SLIDE_LAYOUT_PART },
+      },
+    ],
+    slideMasters: [
+      {
+        partPath: SLIDE_MASTER_PART,
+        themePartPath: THEME_PART,
+        layoutPartPaths: [SLIDE_LAYOUT_PART],
+        colorMap: DEFAULT_COLOR_MAP,
+        shapes: [],
+        handle: { partPath: SLIDE_MASTER_PART },
+      },
+    ],
+    themes: [THEME_SOURCE],
+    diagnostics: [],
+  };
+}
+
+function createContentTypeOverrides(): ContentTypeOverride[] {
+  return [
+    { partName: PRESENTATION_PART, contentType: PRESENTATION_CONTENT_TYPE },
+    { partName: SLIDE_PART, contentType: SLIDE_CONTENT_TYPE },
+    { partName: SLIDE_LAYOUT_PART, contentType: SLIDE_LAYOUT_CONTENT_TYPE },
+    { partName: SLIDE_MASTER_PART, contentType: SLIDE_MASTER_CONTENT_TYPE },
+    { partName: THEME_PART, contentType: THEME_CONTENT_TYPE },
+    { partName: APP_PROPS_PART, contentType: APP_PROPS_CONTENT_TYPE },
+    { partName: CORE_PROPS_PART, contentType: CORE_PROPS_CONTENT_TYPE },
+  ];
+}
+
+function createPackageParts(overrides: readonly ContentTypeOverride[]): PackagePartRef[] {
+  const partRefs = overrides.map((override) => ({
+    partPath: override.partName,
+    contentType: override.contentType,
+  }));
+  return [
+    ...partRefs,
+    { partPath: asPartPath("_rels/.rels"), contentType: RELS_CONTENT_TYPE },
+    { partPath: asPartPath("ppt/_rels/presentation.xml.rels"), contentType: RELS_CONTENT_TYPE },
+    { partPath: asPartPath("ppt/slides/_rels/slide1.xml.rels"), contentType: RELS_CONTENT_TYPE },
+    {
+      partPath: asPartPath("ppt/slideLayouts/_rels/slideLayout1.xml.rels"),
+      contentType: RELS_CONTENT_TYPE,
+    },
+    {
+      partPath: asPartPath("ppt/slideMasters/_rels/slideMaster1.xml.rels"),
+      contentType: RELS_CONTENT_TYPE,
+    },
+  ];
+}
+
+function createRelationships(): PartRelationships[] {
+  return [
+    {
+      sourcePartPath: ROOT_PART,
+      relationships: [
+        rel(
+          "rId1",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+          "ppt/presentation.xml",
+        ),
+        rel(
+          "rId2",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties",
+          "docProps/app.xml",
+        ),
+        rel(
+          "rId3",
+          "http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties",
+          "docProps/core.xml",
+        ),
+      ],
+    },
+    {
+      sourcePartPath: PRESENTATION_PART,
+      relationships: [
+        rel(
+          "rId1",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster",
+          "slideMasters/slideMaster1.xml",
+        ),
+        rel(
+          "rId2",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+          "slides/slide1.xml",
+        ),
+      ],
+    },
+    {
+      sourcePartPath: SLIDE_PART,
+      relationships: [
+        rel(
+          "rId1",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout",
+          "../slideLayouts/slideLayout1.xml",
+        ),
+      ],
+    },
+    {
+      sourcePartPath: SLIDE_LAYOUT_PART,
+      relationships: [
+        rel(
+          "rId1",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster",
+          "../slideMasters/slideMaster1.xml",
+        ),
+      ],
+    },
+    {
+      sourcePartPath: SLIDE_MASTER_PART,
+      relationships: [
+        rel(
+          "rId1",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout",
+          "../slideLayouts/slideLayout1.xml",
+        ),
+        rel(
+          "rId2",
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme",
+          "../theme/theme1.xml",
+        ),
+      ],
+    },
+  ];
+}
+
+function rel(id: string, type: string, target: string): Relationship {
+  return { id: asRelationshipId(id), type, target };
+}
+
+function createRawParts(slideSize: SlideSize): RawPackagePart[] {
+  return [
+    rawXml(PRESENTATION_PART, PRESENTATION_CONTENT_TYPE, presentationXml(slideSize)),
+    rawXml(SLIDE_PART, SLIDE_CONTENT_TYPE, slideXml()),
+    rawXml(SLIDE_LAYOUT_PART, SLIDE_LAYOUT_CONTENT_TYPE, slideLayoutXml()),
+    rawXml(SLIDE_MASTER_PART, SLIDE_MASTER_CONTENT_TYPE, slideMasterXml()),
+    rawXml(THEME_PART, THEME_CONTENT_TYPE, themeXml()),
+    rawXml(APP_PROPS_PART, APP_PROPS_CONTENT_TYPE, appPropertiesXml()),
+    rawXml(CORE_PROPS_PART, CORE_PROPS_CONTENT_TYPE, corePropertiesXml()),
+  ];
+}
+
+function rawXml(partPath: PartPath, contentType: string, xml: string): RawPackagePart {
+  return { kind: "binary", partPath, contentType, bytes: textEncoder.encode(xml) };
+}
+
+function xmlPart(content: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${content}`;
+}
+
+function presentationXml(slideSize: SlideSize): string {
+  return xmlPart(
+    `<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ` +
+      `xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ` +
+      `xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
+      `<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>` +
+      `<p:sldIdLst><p:sldId id="256" r:id="rId2"/></p:sldIdLst>` +
+      `<p:sldSz cx="${slideSize.width}" cy="${slideSize.height}" type="screen16x9"/>` +
+      `<p:notesSz cx="6858000" cy="9144000"/>` +
+      `<p:defaultTextStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr></p:defaultTextStyle>` +
+      `</p:presentation>`,
+  );
+}
+
+function slideXml(): string {
+  return xmlPart(
+    `<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ` +
+      `xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ` +
+      `xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
+      `<p:cSld><p:spTree>${emptyGroupShapeProperties()}</p:spTree></p:cSld>` +
+      `<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>` +
+      `</p:sld>`,
+  );
+}
+
+function slideLayoutXml(): string {
+  return xmlPart(
+    `<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ` +
+      `xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ` +
+      `xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" ` +
+      `type="blank" preserve="1">` +
+      `<p:cSld name="Blank"><p:spTree>${emptyGroupShapeProperties()}</p:spTree></p:cSld>` +
+      `<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>` +
+      `</p:sldLayout>`,
+  );
+}
+
+function slideMasterXml(): string {
+  return xmlPart(
+    `<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ` +
+      `xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ` +
+      `xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">` +
+      `<p:cSld><p:spTree>${emptyGroupShapeProperties()}</p:spTree></p:cSld>` +
+      `<p:clrMap bg1="lt1" tx1="dk1" bg2="lt2" tx2="dk2" accent1="accent1" ` +
+      `accent2="accent2" accent3="accent3" accent4="accent4" accent5="accent5" ` +
+      `accent6="accent6" hlink="hlink" folHlink="folHlink"/>` +
+      `<p:sldLayoutIdLst><p:sldLayoutId id="2147483649" r:id="rId1"/></p:sldLayoutIdLst>` +
+      `<p:txStyles><p:titleStyle/><p:bodyStyle/><p:otherStyle/></p:txStyles>` +
+      `</p:sldMaster>`,
+  );
+}
+
+function emptyGroupShapeProperties(): string {
+  return (
+    `<p:nvGrpSpPr><p:cNvPr id="0" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>` +
+    `<p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/>` +
+    `<a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr>`
+  );
+}
+
+function themeXml(): string {
+  return xmlPart(
+    `<a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" ` +
+      `name="Office Theme">` +
+      `<a:themeElements>${colorSchemeXml()}${fontSchemeXml()}${formatSchemeXml()}</a:themeElements>` +
+      `<a:objectDefaults/><a:extraClrSchemeLst/>` +
+      `</a:theme>`,
+  );
+}
+
+function colorSchemeXml(): string {
+  return (
+    `<a:clrScheme name="Office">` +
+    `<a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>` +
+    `<a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>` +
+    `<a:dk2><a:srgbClr val="44546A"/></a:dk2>` +
+    `<a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>` +
+    `<a:accent1><a:srgbClr val="4472C4"/></a:accent1>` +
+    `<a:accent2><a:srgbClr val="ED7D31"/></a:accent2>` +
+    `<a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>` +
+    `<a:accent4><a:srgbClr val="FFC000"/></a:accent4>` +
+    `<a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>` +
+    `<a:accent6><a:srgbClr val="70AD47"/></a:accent6>` +
+    `<a:hlink><a:srgbClr val="0563C1"/></a:hlink>` +
+    `<a:folHlink><a:srgbClr val="954F72"/></a:folHlink>` +
+    `</a:clrScheme>`
+  );
+}
+
+function fontSchemeXml(): string {
+  return (
+    `<a:fontScheme name="Office">` +
+    `<a:majorFont><a:latin typeface="Aptos Display"/><a:ea typeface=""/><a:cs typeface=""/></a:majorFont>` +
+    `<a:minorFont><a:latin typeface="Aptos"/><a:ea typeface=""/><a:cs typeface=""/></a:minorFont>` +
+    `</a:fontScheme>`
+  );
+}
+
+function formatSchemeXml(): string {
+  return (
+    `<a:fmtScheme name="Office">` +
+    `<a:fillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill>` +
+    `<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>` +
+    `<a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:fillStyleLst>` +
+    `<a:lnStyleLst><a:ln w="6350" cap="flat" cmpd="sng" algn="ctr">` +
+    `<a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln>` +
+    `<a:ln w="12700" cap="flat" cmpd="sng" algn="ctr">` +
+    `<a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln>` +
+    `<a:ln w="19050" cap="flat" cmpd="sng" algn="ctr">` +
+    `<a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/></a:ln>` +
+    `</a:lnStyleLst>` +
+    `<a:effectStyleLst><a:effectStyle><a:effectLst/></a:effectStyle>` +
+    `<a:effectStyle><a:effectLst/></a:effectStyle>` +
+    `<a:effectStyle><a:effectLst/></a:effectStyle></a:effectStyleLst>` +
+    `<a:bgFillStyleLst><a:solidFill><a:schemeClr val="phClr"/></a:solidFill>` +
+    `<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>` +
+    `<a:solidFill><a:schemeClr val="phClr"/></a:solidFill></a:bgFillStyleLst>` +
+    `</a:fmtScheme>`
+  );
+}
+
+function appPropertiesXml(): string {
+  return xmlPart(
+    `<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" ` +
+      `xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">` +
+      `<Application>pptx-glimpse</Application>` +
+      `<PresentationFormat>On-screen Show (16:9)</PresentationFormat>` +
+      `<Slides>1</Slides>` +
+      `</Properties>`,
+  );
+}
+
+function corePropertiesXml(): string {
+  return xmlPart(
+    `<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" ` +
+      `xmlns:dc="http://purl.org/dc/elements/1.1/" ` +
+      `xmlns:dcterms="http://purl.org/dc/terms/" ` +
+      `xmlns:dcmitype="http://purl.org/dc/dcmitype/" ` +
+      `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">` +
+      `<dc:creator>pptx-glimpse</dc:creator>` +
+      `<cp:lastModifiedBy>pptx-glimpse</cp:lastModifiedBy>` +
+      `</cp:coreProperties>`,
+  );
+}

--- a/packages/document/src/builder/index.ts
+++ b/packages/document/src/builder/index.ts
@@ -1,0 +1,2 @@
+export type { CreatePptxOptions } from "./create-pptx.js";
+export { createPptx } from "./create-pptx.js";

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -3,14 +3,17 @@
  *
  * This surface is limited to the PptxSourceModel foundation that current
  * conversion, writer, and minimal editing workflows are allowed to depend on:
- * source model types, the PPTX reader, computed view generation, the writer,
- * and focused text / shape / slide topology editing operations.
+ * source model types, the PPTX reader, from-scratch source factory, computed
+ * view generation, the writer, and focused text / shape / slide topology
+ * editing operations.
  *
  * Keep parser helpers, raw replacement/editing APIs, writer dirty-scope
  * implementation details, and other OOXML internals behind their owning
  * modules until those contracts are intentionally promoted.
  */
 
+export type { CreatePptxOptions } from "./builder/index.js";
+export { createPptx } from "./builder/index.js";
 export type {
   ComputedBackground,
   ComputedBlipEffects,

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -587,6 +587,38 @@ describe("writePptx - from-scratch builder", () => {
     expect(computed.slideSize).toEqual({ width: asEmu(9144000), height: asEmu(5143500) });
     expect(computed.slides[0]?.elements).toHaveLength(1);
   });
+
+  it("writes custom slide size without fixed 16:9 metadata", () => {
+    const source = createPptx({
+      slideSize: { width: asEmu(7315200), height: asEmu(5486400) },
+    });
+    const output = writePptx(source);
+    const reread = readPptx(output);
+
+    expect(reread.presentation.slideSize).toEqual({
+      width: asEmu(7315200),
+      height: asEmu(5486400),
+    });
+    expect(decoder.decode(getEntry(output, "ppt/presentation.xml"))).toContain(
+      `<p:sldSz cx="7315200" cy="5486400"/>`,
+    );
+    expect(decoder.decode(getEntry(output, "docProps/app.xml"))).not.toContain(
+      "On-screen Show (16:9)",
+    );
+  });
+
+  it("rejects invalid custom slide sizes", () => {
+    expect(() =>
+      createPptx({
+        slideSize: { width: asEmu(Number.NaN), height: asEmu(5486400) },
+      }),
+    ).toThrow(/slideSize\.width/);
+    expect(() =>
+      createPptx({
+        slideSize: { width: asEmu(7315200), height: asEmu(0) },
+      }),
+    ).toThrow(/slideSize\.height/);
+  });
 });
 
 describe("writePptx - no-edit round-trip", () => {

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -12,6 +12,7 @@ import {
   asPt,
   asSourceNodeId,
   createComputedView,
+  createPptx,
   readPptx,
   writePptx,
 } from "../index.js";
@@ -33,6 +34,7 @@ import {
   type SourceConnector,
   type SourceShape,
   type SourceShapeNode,
+  type SourceTextRun,
   updateShapeTransform,
 } from "../index.js";
 
@@ -544,6 +546,48 @@ function getEntry(output: Uint8Array, path: string): Uint8Array {
   if (entry === undefined) throw new Error(`missing zip entry: ${path}`);
   return entry;
 }
+
+function findTextRun(source: ReturnType<typeof readPptx>, text: string): SourceTextRun {
+  for (const slide of source.slides) {
+    for (const shape of slide.shapes) {
+      if (shape.kind !== "shape") continue;
+      for (const paragraph of shape.textBody?.paragraphs ?? []) {
+        const run = paragraph.runs.find((candidate) => candidate.text === text);
+        if (run !== undefined) return run;
+      }
+    }
+  }
+  throw new Error(`text run not found: ${text}`);
+}
+
+describe("writePptx - from-scratch builder", () => {
+  it("writes a new presentation after adding a text box through public APIs", () => {
+    const source = createPptx();
+    const slideHandle = source.slides[0]?.handle;
+    if (slideHandle === undefined) throw new Error("createPptx should create a first slide");
+
+    const edited = addTextBox(source, slideHandle, {
+      offsetX: asEmu(914400),
+      offsetY: asEmu(914400),
+      width: asEmu(3657600),
+      height: asEmu(914400),
+      text: "Hello from scratch",
+    });
+
+    const reread = readPptx(writePptx(edited));
+    expect(reread.diagnostics).toEqual([]);
+    expect(reread.presentation.slidePartPaths).toEqual([asPartPath("ppt/slides/slide1.xml")]);
+    expect(reread.slides).toHaveLength(1);
+    expect(reread.slideLayouts).toHaveLength(1);
+    expect(reread.slideMasters).toHaveLength(1);
+    expect(reread.themes).toHaveLength(1);
+    expect(findTextRun(reread, "Hello from scratch").text).toBe("Hello from scratch");
+
+    const computed = createComputedView(reread);
+    expect(computed.slideSize).toEqual({ width: asEmu(9144000), height: asEmu(5143500) });
+    expect(computed.slides[0]?.elements).toHaveLength(1);
+  });
+});
 
 describe("writePptx - no-edit round-trip", () => {
   it("You can write no-edit PPTX from PptxSourceModel source and reload it.", () => {

--- a/vrt/editor-validity/editor-validity.test.ts
+++ b/vrt/editor-validity/editor-validity.test.ts
@@ -151,6 +151,7 @@ const hasFixtures =
       existsSync(join(FIXTURE_DIR, testCase.expectedFixture)),
   );
 const describeOrSkip = libreOfficeImage !== undefined && hasFixtures ? describe : describe.skip;
+const describeFromScratchOrSkip = libreOfficeImage !== undefined ? describe : describe.skip;
 
 describeOrSkip("LibreOffice edited PPTX validity", { timeout: 120000 }, () => {
   for (const testCase of LO_EDITOR_VALIDITY_CASES) {
@@ -214,7 +215,7 @@ describeOrSkip("LibreOffice slide topology validity", { timeout: 120000 }, () =>
   });
 });
 
-describeOrSkip("LibreOffice shape add/delete validity", { timeout: 120000 }, () => {
+describeFromScratchOrSkip("LibreOffice from-scratch PPTX validity", { timeout: 120000 }, () => {
   it("opens from-scratch PPTX after adding a text box", () => {
     const source = createPptx();
     const edited = addTextBox(source, requireHandle(source.slides[0]?.handle), {
@@ -231,7 +232,9 @@ describeOrSkip("LibreOffice shape add/delete validity", { timeout: 120000 }, () 
       writePptx(edited),
     );
   });
+});
 
+describeOrSkip("LibreOffice shape add/delete validity", { timeout: 120000 }, () => {
   it("opens PPTX after adding a text box", () => {
     const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
     const source = readPptx(sourcePptx);

--- a/vrt/editor-validity/editor-validity.test.ts
+++ b/vrt/editor-validity/editor-validity.test.ts
@@ -11,6 +11,7 @@ import {
   addTextBox,
   asEmu,
   asPt,
+  createPptx,
   deleteShape,
   deleteSlide,
   duplicateSlide,
@@ -214,6 +215,23 @@ describeOrSkip("LibreOffice slide topology validity", { timeout: 120000 }, () =>
 });
 
 describeOrSkip("LibreOffice shape add/delete validity", { timeout: 120000 }, () => {
+  it("opens from-scratch PPTX after adding a text box", () => {
+    const source = createPptx();
+    const edited = addTextBox(source, requireHandle(source.slides[0]?.handle), {
+      offsetX: asEmu(914400),
+      offsetY: asEmu(914400),
+      width: asEmu(3657600),
+      height: asEmu(914400),
+      text: "LibreOffice from-scratch text box",
+    });
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-from-scratch-text-box.pptx",
+      writePptx(edited),
+    );
+  });
+
   it("opens PPTX after adding a text box", () => {
     const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
     const source = readPptx(sourcePptx);


### PR DESCRIPTION
close #615

## 概要

- `@pptx-glimpse/document` に `createPptx()` を追加し、最小 theme / master / layout / slide を持つ新規 `PptxSourceModel` を API だけで構築できるようにしました
- `createPptx()` → `addTextBox()` → `writePptx()` の MVP 経路で有効な PPTX を書き出せるよう、package graph / relationships / content types / raw writer material を builder 側で生成します
- builder の採用理由と MVP スコープ、直接 `PptxSourceModel` を手組みする代替案を採らなかった理由を新設 module comment に記録しました
- LibreOffice editor-validity に from-scratch PPTX のオープン確認を追加し、README と changeset も更新しました

## 影響範囲

- `packages/document/src/builder/`
- `packages/document/src/index.ts`
- `packages/document/src/writer/write-pptx.test.ts`
- `vrt/editor-validity/editor-validity.test.ts`
- `packages/document/README.md`

## 検証

- `npm run test -- packages/document/src/writer/write-pptx.test.ts vrt/editor-validity/editor-validity.test.ts`
- `npm run test`
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `npm run knip`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 npm run build`

補足: ローカルの pnpm 設定 `minimumReleaseAge` により通常の `npm run build` は dependency status check で止まるため、ロックファイルは変えず検証時のみ `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` を指定しました。
