### PR TITLE
editor: connector 追加をブラウザ UI に反映する

### DIFF
--- a/.changeset/fuzzy-connectors-pull.md
+++ b/.changeset/fuzzy-connectors-pull.md
@@ -1,0 +1,6 @@
+---
+"@pptx-glimpse/document": minor
+"pptx-glimpse": minor
+---
+
+Add browser editor support for inserting free connector arrows and allow connector shapes to be deleted through the editing APIs.

--- a/e2e/browser-standalone-editor.playwright.ts
+++ b/e2e/browser-standalone-editor.playwright.ts
@@ -360,6 +360,7 @@ const editorHtml = `<!doctype html>
         <input data-testid="pptx-input" id="pptx-input" type="file" accept=".pptx">
         <button id="undo-button" type="button" disabled>Undo</button>
         <button id="redo-button" type="button" disabled>Redo</button>
+        <button id="add-connector-button" type="button" disabled>Add connector</button>
         <input data-testid="image-replacement-input" id="image-replacement-input" type="file" disabled>
         <button id="download-button" type="button" disabled>Download</button>
         <div data-testid="status" id="status">Ready</div>
@@ -379,6 +380,7 @@ const message = document.getElementById("message");
 const container = document.getElementById("slide-container");
 const undoButton = document.getElementById("undo-button");
 const redoButton = document.getElementById("redo-button");
+const addConnectorButton = document.getElementById("add-connector-button");
 const downloadButton = document.getElementById("download-button");
 const imageReplacementInput = document.getElementById("image-replacement-input");
 const EMU_PER_PIXEL = 9525;
@@ -402,6 +404,7 @@ pptxInput.addEventListener("change", async () => {
   });
   render();
   status.textContent = editor.slides.length + " slide" + (editor.slides.length === 1 ? "" : "s") + " ready";
+  addConnectorButton.disabled = false;
   downloadButton.disabled = false;
 });
 
@@ -417,6 +420,17 @@ redoButton.addEventListener("click", async () => {
   await editor.redo();
   render();
   message.textContent = "Redone";
+});
+
+addConnectorButton.addEventListener("click", async () => {
+  if (!editor) return;
+  try {
+    await editor.addConnector(1);
+    render();
+    message.textContent = "Connector added";
+  } catch (error) {
+    message.textContent = error instanceof Error ? error.message : String(error);
+  }
 });
 
 imageReplacementInput.addEventListener("change", async () => {

--- a/e2e/dev-server-editor.playwright.ts
+++ b/e2e/dev-server-editor.playwright.ts
@@ -10,6 +10,7 @@ import JSZip from "jszip";
 import {
   type PptxSourceModel,
   readPptx,
+  type SourceConnector,
   type SourceShape,
 } from "../packages/document/src/index.js";
 
@@ -182,6 +183,87 @@ test("adds, edits, moves, resizes, saves, and deletes a text box from the UI", a
     await expect(page.locator("#editor-message")).toContainText(savedPath);
     saved = readPptx(await readFile(savedPath));
     expect(findShapeByText(saved, "Added edited")).toBeUndefined();
+  } finally {
+    if (serverProcess !== undefined) {
+      serverProcess.kill();
+      await waitForExit(serverProcess);
+    }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("adds, moves, resizes, saves, deletes, undoes, and redoes a connector from the UI", async ({
+  page,
+}) => {
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-editor-connector-test-"));
+  let serverProcess: ChildProcessWithoutNullStreams | undefined;
+  try {
+    const sourcePath = join(dir, "fixture.pptx");
+    const savedPath = join(dir, "fixture.edited.pptx");
+    await writeFile(sourcePath, await buildShapeFixture());
+
+    const port = await findFreePort();
+    serverProcess = await startDevServer(sourcePath, port);
+    const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+    await page.goto(baseUrl);
+    await expect(page.getByTestId("shape-hit-area").first()).toBeVisible();
+
+    const addResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/add-connector") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Add connector" }).click();
+    await addResponse;
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "144");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "144");
+
+    await dragSvgPoint(page, { x: 240, y: 192 }, { x: 264, y: 208 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "168");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "160");
+
+    await dragSvgPoint(page, { x: 456, y: 256 }, { x: 504, y: 280 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("height", "120");
+
+    const undoResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/undo") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Undo" }).click();
+    await undoResponse;
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "288");
+
+    const redoResponse = page.waitForResponse(
+      (response) => response.url().endsWith("/api/editor/redo") && response.ok(),
+    );
+    await page.getByRole("button", { name: "Redo" }).click();
+    await redoResponse;
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.locator("#editor-message")).toContainText(savedPath);
+
+    const saved = readPptx(await readFile(savedPath));
+    expect(connectorByName(saved, "Connector 11").transform).toMatchObject({
+      offsetX: 168 * EMU_PER_PIXEL,
+      offsetY: 160 * EMU_PER_PIXEL,
+      width: 336 * EMU_PER_PIXEL,
+      height: 120 * EMU_PER_PIXEL,
+    });
+
+    const deleteResponse = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("/api/editor/command") &&
+        response.request().method() === "POST" &&
+        response.ok(),
+    );
+    await page.getByRole("button", { name: "Delete shape" }).click();
+    await deleteResponse;
+    await expect(page.getByTestId("selection-box")).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expect(page.getByTestId("shape-hit-area")).toHaveCount(2);
+    await page.getByRole("button", { name: "Redo" }).click();
+    await expect(page.getByTestId("shape-hit-area")).toHaveCount(1);
   } finally {
     if (serverProcess !== undefined) {
       serverProcess.kill();
@@ -582,6 +664,14 @@ function firstShape(source: PptxSourceModel): SourceShape {
   const shape = source.slides[0]?.shapes.find((node): node is SourceShape => node.kind === "shape");
   if (shape === undefined) throw new Error("fixture shape not found");
   return shape;
+}
+
+function connectorByName(source: PptxSourceModel, name: string): SourceConnector {
+  const connector = source.slides[0]?.shapes.find(
+    (node): node is SourceConnector => node.kind === "connector" && node.name === name,
+  );
+  if (connector === undefined) throw new Error(`connector not found: ${name}`);
+  return connector;
 }
 
 function firstText(source: PptxSourceModel): string {

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   type PptxSourceModel,
   readPptx,
+  type SourceConnector,
   type SourceTextRun,
 } from "../packages/document/src/index.js";
 import { createDevServerRequestHandler, DevEditorBackend } from "../scripts/dev-server.js";
@@ -289,6 +290,87 @@ describe("dev server editor API", () => {
       const redone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/redo`, {});
       expect(redone.slides[0].svg).not.toContain("New text box");
       expect(redone.history).toMatchObject({ canUndo: true, canRedo: false });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds, selects, moves, saves, deletes, undoes, and redoes a connector through the editor API", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-connector-add-test-"));
+    try {
+      const sourcePath = join(dir, "fixture.pptx");
+      const savedPath = join(dir, "saved.pptx");
+      await writeFile(sourcePath, await buildTextEditFixture());
+
+      const backend = await DevEditorBackend.load(sourcePath, renderPreview);
+      const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
+      servers.push(server);
+      const baseUrl = await listen(server);
+
+      const added = await postJson<SlidesResponse>(`${baseUrl}/api/editor/add-connector`, {
+        slide: 1,
+      });
+      expect(added.selection?.shapeHandle).toBeDefined();
+      expect(added.history).toMatchObject({ canUndo: true, canRedo: false });
+
+      const shapes = await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`);
+      const connector = shapes.shapes.find((shape) => shape.kind === "connector");
+      expect(connector).toMatchObject({
+        name: "Connector 11",
+        bounds: { x: 144, y: 144, width: 288, height: 96 },
+        editableDelete: true,
+      });
+
+      const moved = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "setShapeTransform",
+          handle: connector?.handle,
+          offsetX: 168 * 9525,
+          offsetY: 160 * 9525,
+          width: 336 * 9525,
+          height: 120 * 9525,
+        },
+      });
+      expect(moved.history).toMatchObject({ canUndo: true, canRedo: false });
+
+      await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
+      expect(
+        connectorByName(readPptx(await readFile(savedPath)), "Connector 11").transform,
+      ).toMatchObject({
+        offsetX: 168 * 9525,
+        offsetY: 160 * 9525,
+        width: 336 * 9525,
+        height: 120 * 9525,
+      });
+
+      const deleted = await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "deleteShape",
+          handle: connector?.handle,
+        },
+      });
+      expect(deleted.selection).toBeUndefined();
+      expect(
+        (await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`)).shapes.find(
+          (shape) => shape.kind === "connector",
+        ),
+      ).toBeUndefined();
+
+      const undone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/undo`, {});
+      expect(undone.history).toMatchObject({ canUndo: true, canRedo: true });
+      expect(
+        (await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`)).shapes.find(
+          (shape) => shape.kind === "connector",
+        ),
+      ).toBeDefined();
+
+      const redone = await postJson<SlidesResponse>(`${baseUrl}/api/editor/redo`, {});
+      expect(redone.history).toMatchObject({ canUndo: true, canRedo: false });
+      expect(
+        (await getJson<ShapesResponse>(`${baseUrl}/api/editor/shapes?slide=1`)).shapes.find(
+          (shape) => shape.kind === "connector",
+        ),
+      ).toBeUndefined();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -683,4 +765,12 @@ function mediaBytes(source: PptxSourceModel, partPath: string): Uint8Array {
   const media = source.packageGraph.media.find((part) => part.partPath === partPath);
   if (media === undefined) throw new Error(`media not found: ${partPath}`);
   return media.bytes;
+}
+
+function connectorByName(source: PptxSourceModel, name: string): SourceConnector {
+  const connector = source.slides[0]?.shapes.find(
+    (node): node is SourceConnector => node.kind === "connector" && node.name === name,
+  );
+  if (connector === undefined) throw new Error(`connector not found: ${name}`);
+  return connector;
 }

--- a/e2e/dev-server-editor.test.ts
+++ b/e2e/dev-server-editor.test.ts
@@ -376,6 +376,49 @@ describe("dev server editor API", () => {
     }
   });
 
+  it("preserves addConnector command options through the editor API", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-connector-command-test-"));
+    try {
+      const sourcePath = join(dir, "fixture.pptx");
+      const savedPath = join(dir, "saved.pptx");
+      await writeFile(sourcePath, await buildTextEditFixture());
+
+      const backend = await DevEditorBackend.load(sourcePath, renderPreview);
+      const server = createServer(createDevServerRequestHandler(backend, "fixture.pptx"));
+      servers.push(server);
+      const baseUrl = await listen(server);
+      const slideHandle = backend.slides[0]?.handle;
+
+      await postJson<SlidesResponse>(`${baseUrl}/api/editor/command`, {
+        command: {
+          kind: "addConnector",
+          slideHandle,
+          preset: "curvedConnector3",
+          offsetX: 168 * 9525,
+          offsetY: 160 * 9525,
+          width: 336 * 9525,
+          height: 120 * 9525,
+          outline: {
+            headEnd: { type: "oval", width: "lg", length: "sm" },
+          },
+          name: "Curved connector",
+        },
+      });
+
+      await postJson<SaveResponse>(`${baseUrl}/api/editor/save`, { path: savedPath });
+      const connector = connectorByName(readPptx(await readFile(savedPath)), "Curved connector");
+      expect(connector.geometry).toMatchObject({ preset: "curvedConnector3" });
+      expect(connector.outline?.headEnd).toMatchObject({
+        type: "oval",
+        width: "lg",
+        length: "sm",
+      });
+      expect(connector.outline?.tailEnd).toBeUndefined();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not expose connector-referenced shapes as deletable through the editor API", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-dev-server-connector-test-"));
     try {

--- a/packages/core/src/browser-editor.test.ts
+++ b/packages/core/src/browser-editor.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 
-import { asEmu, readPptx, type SourceShape } from "@pptx-glimpse/document";
+import { asEmu, readPptx, type SourceConnector, type SourceShape } from "@pptx-glimpse/document";
 import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
 
@@ -152,6 +152,54 @@ describe("BrowserPptxEditorSession", () => {
     expect(
       editor.shapes(1).some((shape) => handleKey(shape.handle) === handleKey(addedShape.handle)),
     ).toBe(false);
+  });
+
+  it("adds, selects, moves, resizes, saves, deletes, undoes, and redoes a connector", async () => {
+    const editor = await createBrowserPptxEditorSession(await buildShapeFixture(), {
+      skipSystemFonts: true,
+    });
+
+    const addedResponse = await editor.addConnector(1);
+    const addedHandle = addedResponse.selection?.shapeHandle;
+    if (addedHandle === undefined) throw new Error("added connector was not selected");
+    const addedConnector = editor
+      .shapes(1)
+      .find((shape) => handleKey(shape.handle) === handleKey(addedHandle));
+    if (addedConnector?.handle === undefined) throw new Error("added connector handle not found");
+    expect(addedConnector).toMatchObject({
+      kind: "connector",
+      bounds: { x: 144, y: 144, width: 288, height: 96 },
+      editableDelete: true,
+      editableTransform: true,
+    });
+
+    await editor.apply({
+      kind: "setShapeTransform",
+      handle: addedConnector.handle,
+      offsetX: asEmu(168 * 9525),
+      offsetY: asEmu(160 * 9525),
+      width: asEmu(336 * 9525),
+      height: asEmu(120 * 9525),
+    });
+
+    const saved = readPptx(editor.save().pptx);
+    const savedConnector = connectorByName(saved, "Connector 11");
+    expect(savedConnector.transform).toMatchObject({
+      offsetX: 168 * 9525,
+      offsetY: 160 * 9525,
+      width: 336 * 9525,
+      height: 120 * 9525,
+    });
+    expect(savedConnector.outline?.tailEnd).toMatchObject({ type: "triangle" });
+
+    const deleted = await editor.deleteSelectedShape();
+    expect(deleted.selection).toBeUndefined();
+    expect(editor.shapes(1).find((shape) => shape.name === "Connector 11")).toBeUndefined();
+
+    await editor.undo();
+    expect(editor.shapes(1).find((shape) => shape.name === "Connector 11")).toBeDefined();
+    await editor.redo();
+    expect(editor.shapes(1).find((shape) => shape.name === "Connector 11")).toBeUndefined();
   });
 
   it("marks top-level text shapes without transform as deletable", async () => {
@@ -485,6 +533,14 @@ function shapeByText(source: ReturnType<typeof readPptx>, text: string): SourceS
   );
   if (shape === undefined) throw new Error(`shape text not found: ${text}`);
   return shape;
+}
+
+function connectorByName(source: ReturnType<typeof readPptx>, name: string): SourceConnector {
+  const connector = source.slides[0]?.shapes.find(
+    (node): node is SourceConnector => node.kind === "connector" && node.name === name,
+  );
+  if (connector === undefined) throw new Error(`connector not found: ${name}`);
+  return connector;
 }
 
 function handleKey(handle: unknown): string {

--- a/packages/core/src/browser-editor.ts
+++ b/packages/core/src/browser-editor.ts
@@ -36,6 +36,12 @@ const DEFAULT_TEXT_BOX_BOUNDS_PX = {
   height: 72,
 };
 const DEFAULT_TEXT_BOX_TEXT = "New text box";
+const DEFAULT_CONNECTOR_BOUNDS_PX = {
+  x: 144,
+  y: 144,
+  width: 288,
+  height: 96,
+};
 const IMAGE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
 
 const IMAGE_ACCEPT_BY_CONTENT_TYPE: Readonly<Record<string, string>> = {
@@ -104,6 +110,14 @@ export interface BrowserEditorAddTextBoxOptions {
   readonly width?: number;
   readonly height?: number;
   readonly text?: string;
+  readonly name?: string;
+}
+
+export interface BrowserEditorAddConnectorOptions {
+  readonly x?: number;
+  readonly y?: number;
+  readonly width?: number;
+  readonly height?: number;
   readonly name?: string;
 }
 
@@ -220,6 +234,36 @@ export class BrowserPptxEditorSession {
       width: pxToEmu(options.width ?? DEFAULT_TEXT_BOX_BOUNDS_PX.width),
       height: pxToEmu(options.height ?? DEFAULT_TEXT_BOX_BOUNDS_PX.height),
       text: options.text ?? DEFAULT_TEXT_BOX_TEXT,
+      ...(options.name !== undefined ? { name: options.name } : {}),
+    });
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    this.#selectNewShape(slideNumber, existingShapeKeys);
+    await this.renderCurrentSlides();
+    return this.response(result.warnings);
+  }
+
+  async addConnector(
+    slideNumber = 1,
+    options: BrowserEditorAddConnectorOptions = {},
+  ): Promise<BrowserEditorSlidesResponse> {
+    const slide = this.#session.document.slides[slideNumber - 1];
+    if (slide?.handle === undefined) {
+      throw new Error("addConnector: slide handle was not found in PptxSourceModel source");
+    }
+    const existingShapeKeys = new Set(slide.shapes.map(shapeSourceKey));
+    const result = this.#session.apply({
+      kind: "addConnector",
+      slideHandle: slide.handle,
+      preset: "straightConnector1",
+      offsetX: pxToEmu(options.x ?? DEFAULT_CONNECTOR_BOUNDS_PX.x),
+      offsetY: pxToEmu(options.y ?? DEFAULT_CONNECTOR_BOUNDS_PX.y),
+      width: pxToEmu(options.width ?? DEFAULT_CONNECTOR_BOUNDS_PX.width),
+      height: pxToEmu(options.height ?? DEFAULT_CONNECTOR_BOUNDS_PX.height),
+      outline: {
+        tailEnd: { type: "triangle", width: "med", length: "med" },
+      },
       ...(options.name !== undefined ? { name: options.name } : {}),
     });
     if (!result.ok) {
@@ -382,10 +426,13 @@ function isDeletableShape(
   shape: SourceShapeNode,
   slideShapes: readonly SourceShapeNode[],
 ): boolean {
-  if (shape.kind !== "shape" || shape.handle?.nodeId === undefined) {
+  if (
+    (shape.kind !== "shape" && shape.kind !== "connector") ||
+    shape.handle?.nodeId === undefined
+  ) {
     return false;
   }
-  if (isShapeReferencedByConnector(shape, slideShapes)) {
+  if (shape.kind === "shape" && isShapeReferencedByConnector(shape, slideShapes)) {
     return false;
   }
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -8,6 +8,7 @@ import {
 import { type ConvertOptions, convertPptxToSvg as convertPptxToSvgBase } from "./svg-converter.js";
 
 export type {
+  BrowserEditorAddConnectorOptions,
   BrowserEditorAddTextBoxOptions,
   BrowserEditorHistoryState,
   BrowserEditorImageReplacementInfo,

--- a/packages/document/src/source/editing.test.ts
+++ b/packages/document/src/source/editing.test.ts
@@ -360,7 +360,39 @@ describe("editing shape operations", () => {
     expect(edited.edits?.at(-1)).toHaveProperty("xml", expect.stringContaining("bentConnector3"));
   });
 
-  it("deletes an existing shape, drops stale text edits, and cancels addTextBox followed by deleteShape", () => {
+  it("adds a free connector without native connection sites", () => {
+    const source = buildSourceModel();
+
+    const edited = expectNonMutating(source, () =>
+      addConnector(source, requireHandle(source.slides[0].handle), {
+        preset: "straightConnector1",
+        offsetX: asEmu(10),
+        offsetY: asEmu(20),
+        width: asEmu(30),
+        height: asEmu(40),
+        outline: { tailEnd: { type: "triangle", width: "med", length: "med" } },
+      }),
+    );
+    const connector = edited.slides[0].shapes.at(-1);
+
+    expect(connector).toMatchObject({
+      kind: "connector",
+      nodeId: "31",
+      name: "Connector 31",
+      geometry: { preset: "straightConnector1" },
+      outline: { tailEnd: { type: "triangle" } },
+    });
+    expect(connector).not.toHaveProperty("connection.start");
+    expect(edited.edits?.at(-1)).toMatchObject({
+      kind: "addConnector",
+      slidePartPath: "ppt/slides/slide1.xml",
+      shapeId: "31",
+    });
+    expect(edited.edits?.at(-1)).not.toHaveProperty("startShapeId");
+    expect(edited.edits?.at(-1)).not.toHaveProperty("endShapeId");
+  });
+
+  it("deletes an existing shape, drops stale text edits, and cancels added shapes followed by deleteShape", () => {
     const source = buildSourceModel();
     const existingHandle = requireHandle(shapeByName(source, "Title").handle);
 
@@ -384,6 +416,24 @@ describe("editing shape operations", () => {
     const deletedAdded = expectNonMutating(withTextBox, () =>
       deleteShape(withTextBox, requireHandle(shapeByName(withTextBox, "Temporary").handle)),
     );
+    const withConnector = addConnector(source, requireHandle(source.slides[0].handle), {
+      preset: "straightConnector1",
+      offsetX: asEmu(1),
+      offsetY: asEmu(2),
+      width: asEmu(3),
+      height: asEmu(4),
+      name: "Temporary connector",
+    });
+    const deletedAddedConnector = expectNonMutating(withConnector, () =>
+      deleteShape(
+        withConnector,
+        requireHandle(
+          withConnector.slides[0].shapes.find(
+            (shape) => shape.kind === "connector" && shape.name === "Temporary connector",
+          )?.handle,
+        ),
+      ),
+    );
 
     expect(
       deletedExisting.slides[0].shapes.map((shape) => shape.kind !== "raw" && shape.name),
@@ -394,6 +444,10 @@ describe("editing shape operations", () => {
     expect(
       deletedAdded.slides[0].shapes.map((shape) => shape.kind !== "raw" && shape.name),
     ).not.toContain("Temporary");
+    expect(deletedAddedConnector.edits).toEqual([]);
+    expect(
+      deletedAddedConnector.slides[0].shapes.map((shape) => shape.kind !== "raw" && shape.name),
+    ).not.toContain("Temporary connector");
   });
 
   it("rejects unsupported shape edits with stable error messages", () => {
@@ -410,7 +464,7 @@ describe("editing shape operations", () => {
       }),
     ).toThrow("updateShapeTransform: shape transform edit requires a node id");
     expect(() => deleteShape(source, imageHandle)).toThrow(
-      "deleteShape: only top-level sp shapes can be deleted",
+      "deleteShape: only top-level sp or cxnSp shapes can be deleted",
     );
     expect(() =>
       addConnector(source, requireHandle(source.slides[0].handle), {

--- a/packages/document/src/source/pptx-source-model.ts
+++ b/packages/document/src/source/pptx-source-model.ts
@@ -133,8 +133,8 @@ export interface PptxSourceModelAddConnectorEdit {
   readonly kind: "addConnector";
   readonly slidePartPath: PartPath;
   readonly shapeId: string;
-  readonly startShapeId: string;
-  readonly endShapeId: string;
+  readonly startShapeId?: string;
+  readonly endShapeId?: string;
   /** Serialized `p:cxnSp` fragment finalized at edit time. The writer only splices it. */
   readonly xml: string;
 }

--- a/packages/document/src/source/shape-editing.ts
+++ b/packages/document/src/source/shape-editing.ts
@@ -57,8 +57,8 @@ export interface AddConnectorOutlineInput {
 
 export interface AddConnectorInput extends UpdateShapeTransformInput {
   readonly preset: ConnectorPresetGeometry;
-  readonly start: AddConnectorConnectionEndpointInput;
-  readonly end: AddConnectorConnectionEndpointInput;
+  readonly start?: AddConnectorConnectionEndpointInput;
+  readonly end?: AddConnectorConnectionEndpointInput;
   readonly name?: string;
   readonly outline?: AddConnectorOutlineInput;
 }
@@ -205,14 +205,20 @@ export function addConnector(
   }
 
   const slide = source.slides[slideIndex];
-  const startShape = requireConnectorTargetShape(slide, input.start.shapeHandle, "start");
-  const endShape = requireConnectorTargetShape(slide, input.end.shapeHandle, "end");
+  const startShape =
+    input.start !== undefined
+      ? requireConnectorTargetShape(slide, input.start.shapeHandle, "start")
+      : undefined;
+  const endShape =
+    input.end !== undefined
+      ? requireConnectorTargetShape(slide, input.end.shapeHandle, "end")
+      : undefined;
   const shapeId = nextShapeId(slide.shapes, source.edits ?? [], slide.partPath);
   const shapeIdValue = String(shapeId);
   const name = input.name?.trim() || `Connector ${shapeIdValue}`;
   const orderingSlot = nextOrderingSlot(slide.shapes);
-  const startShapeId = String(startShape.nodeId);
-  const endShapeId = String(endShape.nodeId);
+  const startShapeId = startShape !== undefined ? String(startShape.nodeId) : undefined;
+  const endShapeId = endShape !== undefined ? String(endShape.nodeId) : undefined;
   const xml = buildConnectorXml({
     shapeId: shapeIdValue,
     name,
@@ -221,10 +227,18 @@ export function addConnector(
     offsetY: input.offsetY,
     width: input.width,
     height: input.height,
-    startShapeId,
-    startConnectionSiteIndex: input.start.connectionSiteIndex,
-    endShapeId,
-    endConnectionSiteIndex: input.end.connectionSiteIndex,
+    ...(startShapeId !== undefined && input.start !== undefined
+      ? {
+          startShapeId,
+          startConnectionSiteIndex: input.start.connectionSiteIndex,
+        }
+      : {}),
+    ...(endShapeId !== undefined && input.end !== undefined
+      ? {
+          endShapeId,
+          endConnectionSiteIndex: input.end.connectionSiteIndex,
+        }
+      : {}),
     ...(input.outline !== undefined ? { outline: input.outline } : {}),
   });
   const connector = parseShapeNodeXml(xml, slide.partPath, orderingSlot);
@@ -246,8 +260,8 @@ export function addConnector(
         kind: "addConnector",
         slidePartPath: slide.partPath,
         shapeId: shapeIdValue,
-        startShapeId,
-        endShapeId,
+        ...(startShapeId !== undefined ? { startShapeId } : {}),
+        ...(endShapeId !== undefined ? { endShapeId } : {}),
         xml,
       } satisfies PptxSourceModelAddConnectorEdit,
     ],
@@ -266,8 +280,8 @@ export function deleteShape(source: PptxSourceModel, handle: SourceHandle): Pptx
     const nextShapes = slide.shapes.filter((shape) => {
       if (!sourceHandlesEqual(shape.handle, handle)) return true;
       found = shape;
-      if (shape.kind !== "shape") {
-        throw new Error("deleteShape: only top-level sp shapes can be deleted");
+      if (shape.kind !== "shape" && shape.kind !== "connector") {
+        throw new Error("deleteShape: only top-level sp or cxnSp shapes can be deleted");
       }
       if (hasAlternateContentSidecar(shape)) {
         throw new Error("deleteShape: shapes inside AlternateContent are not supported");
@@ -362,8 +376,9 @@ function assertConnectorInput(input: AddConnectorInput): void {
       "addConnector: preset must be straightConnector1, bentConnector3, or curvedConnector3",
     );
   }
-  assertConnectionSiteIndex(input.start.connectionSiteIndex, "start");
-  assertConnectionSiteIndex(input.end.connectionSiteIndex, "end");
+  if (input.start !== undefined)
+    assertConnectionSiteIndex(input.start.connectionSiteIndex, "start");
+  if (input.end !== undefined) assertConnectionSiteIndex(input.end.connectionSiteIndex, "end");
   if (input.name !== undefined && input.name.trim() === "") {
     throw new Error("addConnector: name must be a non-empty string when provided");
   }

--- a/packages/document/src/source/shape-xml.ts
+++ b/packages/document/src/source/shape-xml.ts
@@ -37,10 +37,10 @@ interface ConnectorXmlParams {
   readonly offsetY: Emu;
   readonly width: Emu;
   readonly height: Emu;
-  readonly startShapeId: string;
-  readonly startConnectionSiteIndex: number;
-  readonly endShapeId: string;
-  readonly endConnectionSiteIndex: number;
+  readonly startShapeId?: string;
+  readonly startConnectionSiteIndex?: number;
+  readonly endShapeId?: string;
+  readonly endConnectionSiteIndex?: number;
   readonly outline?: {
     readonly headEnd?: SourceArrowEndpoint;
     readonly tailEnd?: SourceArrowEndpoint;
@@ -111,16 +111,7 @@ export function buildConnectorXml(params: ConnectorXmlParams): string {
           "@_id": params.shapeId,
           "@_name": params.name,
         },
-        "p:cNvCxnSpPr": {
-          "a:stCxn": {
-            "@_id": params.startShapeId,
-            "@_idx": String(params.startConnectionSiteIndex),
-          },
-          "a:endCxn": {
-            "@_id": params.endShapeId,
-            "@_idx": String(params.endConnectionSiteIndex),
-          },
-        },
+        "p:cNvCxnSpPr": createConnectorConnectionXml(params),
         "p:nvPr": {},
       },
       "p:spPr": {
@@ -142,6 +133,27 @@ export function buildConnectorXml(params: ConnectorXmlParams): string {
       },
     },
   });
+}
+
+function createConnectorConnectionXml(params: ConnectorXmlParams): Record<string, unknown> {
+  return {
+    ...(params.startShapeId !== undefined && params.startConnectionSiteIndex !== undefined
+      ? {
+          "a:stCxn": {
+            "@_id": params.startShapeId,
+            "@_idx": String(params.startConnectionSiteIndex),
+          },
+        }
+      : {}),
+    ...(params.endShapeId !== undefined && params.endConnectionSiteIndex !== undefined
+      ? {
+          "a:endCxn": {
+            "@_id": params.endShapeId,
+            "@_idx": String(params.endConnectionSiteIndex),
+          },
+        }
+      : {}),
+  };
 }
 
 function createConnectorLineXml(params: ConnectorXmlParams): Record<string, unknown> {

--- a/packages/document/src/writer/dirty-part-edits.ts
+++ b/packages/document/src/writer/dirty-part-edits.ts
@@ -240,10 +240,16 @@ function applyAddConnectorEdit(root: XmlNode, edit: PptxSourceModelAddConnectorE
   if (locateShapeTreeNode(spTree, { nodeId: edit.shapeId }) !== undefined) {
     throw new Error(`writePptx: shape id '${edit.shapeId}' already exists in source XML`);
   }
-  if (locateShapeTreeNode(spTree, { nodeId: edit.startShapeId }) === undefined) {
+  if (
+    edit.startShapeId !== undefined &&
+    locateShapeTreeNode(spTree, { nodeId: edit.startShapeId }) === undefined
+  ) {
     throw new Error(`writePptx: connector start shape '${edit.startShapeId}' was not found`);
   }
-  if (locateShapeTreeNode(spTree, { nodeId: edit.endShapeId }) === undefined) {
+  if (
+    edit.endShapeId !== undefined &&
+    locateShapeTreeNode(spTree, { nodeId: edit.endShapeId }) === undefined
+  ) {
     throw new Error(`writePptx: connector end shape '${edit.endShapeId}' was not found`);
   }
 
@@ -256,7 +262,9 @@ function applyDeleteShapeEdit(root: XmlNode, edit: PptxSourceModelDeleteShapeEdi
   const cSld = getChild(slide, "cSld");
   const spTree = getChild(cSld, "spTree");
   if (!deleteShapeXml(spTree, locator.nodeId)) {
-    throw new Error(`writePptx: shape delete handle '${locator.nodeId}' no longer matches p:sp`);
+    throw new Error(
+      `writePptx: shape delete handle '${locator.nodeId}' no longer matches p:sp or p:cxnSp`,
+    );
   }
 }
 

--- a/packages/document/src/writer/write-pptx.test.ts
+++ b/packages/document/src/writer/write-pptx.test.ts
@@ -1027,6 +1027,43 @@ describe("writePptx - shape add/delete edits", () => {
     expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toContain("preserve-me");
   });
 
+  it("adds and deletes a free connector without native connection sites", () => {
+    const source = readPptx(buildShapeDeleteFixture());
+    const edited = addConnector(source, source.slides[0].handle!, {
+      preset: "straightConnector1",
+      offsetX: asEmu(100),
+      offsetY: asEmu(200),
+      width: asEmu(700),
+      height: asEmu(800),
+      outline: {
+        tailEnd: { type: "triangle", width: "med", length: "med" },
+      },
+    });
+    const output = writePptx(edited);
+    const reread = readPptx(output);
+    const added = findConnectorByName(reread, "Connector 31");
+    const slideXml = decoder.decode(getEntry(output, "ppt/slides/slide1.xml"));
+
+    expect(added).toMatchObject({
+      nodeId: "31",
+      name: "Connector 31",
+      geometry: { preset: "straightConnector1" },
+      outline: { tailEnd: { type: "triangle", width: "med", length: "med" } },
+    });
+    expect(added.connection).toBeUndefined();
+    expect(slideXml).toContain(`<p:cxnSp>`);
+    expect(slideXml).not.toContain(`<a:stCxn`);
+    expect(slideXml).not.toContain(`<a:endCxn`);
+
+    const persisted = readPptx(output);
+    const deleted = deleteShape(
+      persisted,
+      requireHandle(findConnectorByName(persisted, "Connector 31").handle),
+    );
+    const deletedOutput = writePptx(deleted);
+    expect(findConnectorByNameOptional(readPptx(deletedOutput), "Connector 31")).toBeUndefined();
+  });
+
   it("rejects deleting a shape referenced by a connector", () => {
     const source = readPptx(buildShapeDeleteFixture());
     const start = findShapeByName(source, "Delete Me");
@@ -1216,11 +1253,11 @@ describe("writePptx - shape add/delete edits", () => {
     expect(decoder.decode(getEntry(output, "docProps/custom.xml"))).toContain("preserve-me");
   });
 
-  it("rejects deleting pic and graphicFrame nodes through the sp-only delete API", () => {
+  it("rejects deleting pic and graphicFrame nodes through the sp/cxnSp delete API", () => {
     const source = readPptx(buildShapeDeleteFixture());
 
     expect(() => deleteShape(source, requireHandle(source.slides[0].shapes[1]?.handle))).toThrow(
-      /only top-level sp shapes/,
+      /only top-level sp or cxnSp shapes/,
     );
   });
 
@@ -1882,11 +1919,18 @@ function findShapeByName(source: ReturnType<typeof readPptx>, name: string): Sou
 }
 
 function findConnectorByName(source: ReturnType<typeof readPptx>, name: string): SourceConnector {
-  const connector = source.slides
-    .flatMap((slide) => slide.shapes)
-    .find((node): node is SourceConnector => node.kind === "connector" && node.name === name);
+  const connector = findConnectorByNameOptional(source, name);
   if (connector === undefined) throw new Error(`connector not found: ${name}`);
   return connector;
+}
+
+function findConnectorByNameOptional(
+  source: ReturnType<typeof readPptx>,
+  name: string,
+): SourceConnector | undefined {
+  return source.slides
+    .flatMap((slide) => slide.shapes)
+    .find((node): node is SourceConnector => node.kind === "connector" && node.name === name);
 }
 
 function requireShape(shape: SourceShape | undefined): SourceShape {

--- a/packages/document/src/writer/xml-locators.ts
+++ b/packages/document/src/writer/xml-locators.ts
@@ -110,19 +110,25 @@ export function locateShapeTreeNode(
 export function deleteShapeXml(spTree: XmlNode | undefined, nodeId: string): boolean {
   if (spTree === undefined) return false;
   const entry = Object.entries(spTree).find(
-    ([key]) => !key.startsWith("@_") && localName(key) === "sp",
+    ([key, value]) =>
+      !key.startsWith("@_") &&
+      (localName(key) === "sp" || localName(key) === "cxnSp") &&
+      getShapeTreeNodes(value).some((shape) => getShapeTreeNodeId(shape) === nodeId),
   );
   if (entry === undefined) return false;
 
   const [key, value] = entry;
-  const shapes = Array.isArray(value) ? unsafeOoxmlBoundaryAssertion<unknown[]>(value) : [value];
-  const nextShapes = shapes.filter(
-    (shape) => getShapeTreeNodeId(unsafeOoxmlBoundaryAssertion<XmlNode>(shape)) !== nodeId,
-  );
+  const shapes = getShapeTreeNodes(value);
+  const nextShapes = shapes.filter((shape) => getShapeTreeNodeId(shape) !== nodeId);
   if (nextShapes.length === shapes.length) return false;
   if (nextShapes.length === 0) delete spTree[key];
   else spTree[key] = Array.isArray(value) ? nextShapes : nextShapes[0];
   return true;
+}
+
+function getShapeTreeNodes(value: unknown): XmlNode[] {
+  const items = Array.isArray(value) ? unsafeOoxmlBoundaryAssertion<unknown[]>(value) : [value];
+  return items.map((item) => unsafeOoxmlBoundaryAssertion<XmlNode>(item));
 }
 
 function getShapeByOrderingSlot(

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -55,6 +55,12 @@ const DEFAULT_TEXT_BOX_BOUNDS_PX = {
   height: 72,
 };
 const DEFAULT_TEXT_BOX_TEXT = "New text box";
+const DEFAULT_CONNECTOR_BOUNDS_PX = {
+  x: 144,
+  y: 144,
+  width: 288,
+  height: 96,
+};
 const IMAGE_REL_TYPE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
 const MAX_JSON_BODY_BYTES = 20 * 1024 * 1024;
 const MAX_IMAGE_REPLACEMENT_BYTES = 5 * 1024 * 1024;
@@ -272,6 +278,35 @@ export class DevEditorBackend {
     });
   }
 
+  async addConnector(slideNumber: number): Promise<EditorSlidesResponse> {
+    return this.#enqueueMutation(async () => {
+      const slide = this.#session.document.slides[slideNumber - 1];
+      if (slide?.handle === undefined) {
+        throw new Error("addConnector: slide handle was not found in PptxSourceModel source");
+      }
+      const existingShapeKeys = new Set(slide.shapes.map(shapeSourceKey));
+      const result = this.#session.apply({
+        kind: "addConnector",
+        slideHandle: slide.handle,
+        preset: "straightConnector1",
+        offsetX: pxToEmu(DEFAULT_CONNECTOR_BOUNDS_PX.x),
+        offsetY: pxToEmu(DEFAULT_CONNECTOR_BOUNDS_PX.y),
+        width: pxToEmu(DEFAULT_CONNECTOR_BOUNDS_PX.width),
+        height: pxToEmu(DEFAULT_CONNECTOR_BOUNDS_PX.height),
+        outline: {
+          tailEnd: { type: "triangle", width: "med", length: "med" },
+        },
+      });
+      if (!result.ok) {
+        throw new Error(result.message);
+      }
+      this.#selectNewShape(slideNumber, existingShapeKeys);
+      this.#dirty = true;
+      await this.renderCurrentSlides();
+      return this.response();
+    });
+  }
+
   async applyTextBodyDocJson(
     handle: SourceHandle,
     docJson: unknown,
@@ -458,10 +493,13 @@ function isDeletableShape(
   shape: SourceShapeNode,
   slideShapes: readonly SourceShapeNode[],
 ): boolean {
-  if (shape.kind !== "shape" || shape.handle?.nodeId === undefined) {
+  if (
+    (shape.kind !== "shape" && shape.kind !== "connector") ||
+    shape.handle?.nodeId === undefined
+  ) {
     return false;
   }
-  if (isShapeReferencedByConnector(shape, slideShapes)) {
+  if (shape.kind === "shape" && isShapeReferencedByConnector(shape, slideShapes)) {
     return false;
   }
   return !shape.rawSidecars?.some((sidecar) => sidecar.node.name === "mc:AlternateContent");
@@ -1024,6 +1062,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
       <label>Image<input id="image-replacement-input" data-testid="image-replacement-input" type="file" disabled></label>
       <div id="editor-actions">
         <button id="add-text-box-button" type="button">Add text box</button>
+        <button id="add-connector-button" type="button">Add connector</button>
         <button id="delete-shape-button" type="button" disabled>Delete shape</button>
         <button id="undo-button" type="button">Undo</button>
         <button id="redo-button" type="button">Redo</button>
@@ -2084,6 +2123,23 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         });
     }
 
+    function addConnector() {
+      if (activeTextEditor) {
+        commitTextEditor()
+          .then(addConnector)
+          .catch(function () {});
+        return;
+      }
+      postJson("/api/editor/add-connector", { slide: currentIndex + 1 })
+        .then(function (data) {
+          applyEditorResponse(data);
+          setEditorMessage("Connector added", false);
+        })
+        .catch(function (err) {
+          setEditorMessage(err.message, true);
+        });
+    }
+
     function deleteSelectedShape() {
       if (activeTextEditor || !selectedShape || !selectedShape.handle || !selectedShape.editableDelete) {
         return;
@@ -2281,6 +2337,7 @@ function generateHtml(slides: SlideSvg[], pptxName: string): string {
         });
     });
     document.getElementById("add-text-box-button").addEventListener("click", addTextBox);
+    document.getElementById("add-connector-button").addEventListener("click", addConnector);
     document.getElementById("delete-shape-button").addEventListener("click", deleteSelectedShape);
     document.getElementById("undo-button").addEventListener("click", function () {
       postJson("/api/editor/undo")
@@ -2453,6 +2510,13 @@ async function handleRequest(
     return;
   }
 
+  if (url.pathname === "/api/editor/add-connector" && req.method === "POST") {
+    const body = await readJsonBody(req);
+    const slideNumber = isRecord(body) ? body.slide : undefined;
+    sendJson(res, 200, await backend.addConnector(normalizeSlideNumber(slideNumber)));
+    return;
+  }
+
   if (url.pathname === "/api/editor/text-body" && req.method === "POST") {
     const body = await readJsonBody(req);
     const handle = normalizeHandle(isRecord(body) ? body.handle : undefined);
@@ -2592,6 +2656,24 @@ function normalizeCommand(command: unknown): EditorCommand {
       width: asEmu(requireFinitePositiveNumber(command.width, "addTextBox.width")),
       height: asEmu(requireFinitePositiveNumber(command.height, "addTextBox.height")),
       text,
+      ...(typeof command.name === "string" ? { name: command.name } : {}),
+    };
+  }
+  if (command.kind === "addConnector") {
+    if (command.name !== undefined && typeof command.name !== "string") {
+      throw new Error("addConnector.name must be a string");
+    }
+    return {
+      kind: "addConnector",
+      slideHandle: normalizeHandle(command.slideHandle),
+      preset: "straightConnector1",
+      offsetX: asEmu(requireFiniteNumber(command.offsetX, "addConnector.offsetX")),
+      offsetY: asEmu(requireFiniteNumber(command.offsetY, "addConnector.offsetY")),
+      width: asEmu(requireFinitePositiveNumber(command.width, "addConnector.width")),
+      height: asEmu(requireFinitePositiveNumber(command.height, "addConnector.height")),
+      outline: {
+        tailEnd: { type: "triangle", width: "med", length: "med" },
+      },
       ...(typeof command.name === "string" ? { name: command.name } : {}),
     };
   }

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -14,6 +14,7 @@ import {
   asPt,
   asRelationshipId,
   asSourceNodeId,
+  type ConnectorPresetGeometry,
   type EditableTextRunProperties,
   type EditableTextRunProperty,
   findShapeNodeBySourceHandle,
@@ -22,6 +23,7 @@ import {
   readPptx,
   type Relationship,
   type RelationshipId,
+  type SourceArrowEndpoint,
   type SourceHandle,
   type SourceImage,
   type SourceShapeNode,
@@ -2663,17 +2665,20 @@ function normalizeCommand(command: unknown): EditorCommand {
     if (command.name !== undefined && typeof command.name !== "string") {
       throw new Error("addConnector.name must be a string");
     }
+    const outline = normalizeConnectorOutline(command.outline);
     return {
       kind: "addConnector",
       slideHandle: normalizeHandle(command.slideHandle),
-      preset: "straightConnector1",
+      preset: normalizeConnectorPreset(command.preset),
       offsetX: asEmu(requireFiniteNumber(command.offsetX, "addConnector.offsetX")),
       offsetY: asEmu(requireFiniteNumber(command.offsetY, "addConnector.offsetY")),
       width: asEmu(requireFinitePositiveNumber(command.width, "addConnector.width")),
       height: asEmu(requireFinitePositiveNumber(command.height, "addConnector.height")),
-      outline: {
-        tailEnd: { type: "triangle", width: "med", length: "med" },
-      },
+      ...(command.start !== undefined
+        ? { start: normalizeConnectorEndpoint(command.start, "start") }
+        : {}),
+      ...(command.end !== undefined ? { end: normalizeConnectorEndpoint(command.end, "end") } : {}),
+      ...(outline !== undefined ? { outline } : {}),
       ...(typeof command.name === "string" ? { name: command.name } : {}),
     };
   }
@@ -2771,6 +2776,92 @@ function normalizeSrgbColor(value: unknown): { kind: "srgb"; hex: string } {
     throw new Error("setTextRunProperties.color.hex must be six hex digits");
   }
   return { kind: "srgb", hex: value.hex.toUpperCase() };
+}
+
+function normalizeConnectorPreset(value: unknown): ConnectorPresetGeometry {
+  const preset = value ?? "straightConnector1";
+  switch (preset) {
+    case "straightConnector1":
+    case "bentConnector3":
+    case "curvedConnector3":
+      return preset;
+  }
+  throw new Error(
+    "addConnector.preset must be straightConnector1, bentConnector3, or curvedConnector3",
+  );
+}
+
+function normalizeConnectorEndpoint(
+  value: unknown,
+  field: "start" | "end",
+): {
+  shapeHandle: SourceHandle;
+  connectionSiteIndex: number;
+} {
+  if (!isRecord(value)) throw new Error(`addConnector.${field} must be an object`);
+  const connectionSiteIndex = value.connectionSiteIndex;
+  if (!Number.isInteger(connectionSiteIndex) || connectionSiteIndex < 0) {
+    throw new Error(`addConnector.${field}.connectionSiteIndex must be a non-negative integer`);
+  }
+  return {
+    shapeHandle: normalizeHandle(value.shapeHandle),
+    connectionSiteIndex,
+  };
+}
+
+function normalizeConnectorOutline(
+  value: unknown,
+): { headEnd?: SourceArrowEndpoint; tailEnd?: SourceArrowEndpoint } | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error("addConnector.outline must be an object");
+  const headEnd = normalizeArrowEndpoint(value.headEnd, "headEnd");
+  const tailEnd = normalizeArrowEndpoint(value.tailEnd, "tailEnd");
+  return {
+    ...(headEnd !== undefined ? { headEnd } : {}),
+    ...(tailEnd !== undefined ? { tailEnd } : {}),
+  };
+}
+
+function normalizeArrowEndpoint(
+  value: unknown,
+  field: "headEnd" | "tailEnd",
+): SourceArrowEndpoint | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) throw new Error(`addConnector.outline.${field} must be an object`);
+  return {
+    type: normalizeArrowType(value.type, field),
+    width: normalizeArrowSize(value.width, field, "width"),
+    length: normalizeArrowSize(value.length, field, "length"),
+  };
+}
+
+function normalizeArrowType(
+  value: unknown,
+  field: "headEnd" | "tailEnd",
+): SourceArrowEndpoint["type"] {
+  switch (value) {
+    case "triangle":
+    case "stealth":
+    case "diamond":
+    case "oval":
+    case "arrow":
+      return value;
+  }
+  throw new Error(`addConnector.outline.${field}.type is not supported`);
+}
+
+function normalizeArrowSize(
+  value: unknown,
+  field: "headEnd" | "tailEnd",
+  sizeField: "width" | "length",
+): SourceArrowEndpoint["width"] {
+  switch (value) {
+    case "sm":
+    case "med":
+    case "lg":
+      return value;
+  }
+  throw new Error(`addConnector.outline.${field}.${sizeField} is not supported`);
 }
 
 function normalizeTextRunPropertyNames(value: unknown): EditableTextRunProperty[] {

--- a/vrt/editor-validity/editor-validity.test.ts
+++ b/vrt/editor-validity/editor-validity.test.ts
@@ -16,6 +16,7 @@ import {
   duplicateSlide,
   readPptx,
   replaceImageBytes,
+  type SourceConnector,
   type SourceHandle,
   type SourceImage,
   type SourceShape,
@@ -260,6 +261,53 @@ describeOrSkip("LibreOffice shape add/delete validity", { timeout: 120000 }, () 
     renderSingleWithLibreOffice(
       libreOfficeImage,
       "editor-validity-shape-connector-edited.pptx",
+      writePptx(edited),
+    );
+  });
+
+  it("opens PPTX after adding a free connector", () => {
+    const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
+    const source = readPptx(sourcePptx);
+    const edited = addConnector(source, requireHandle(source.slides[0]?.handle), {
+      preset: "straightConnector1",
+      offsetX: asEmu(914400),
+      offsetY: asEmu(1371600),
+      width: asEmu(3657600),
+      height: asEmu(914400),
+      outline: {
+        tailEnd: { type: "triangle", width: "med", length: "med" },
+      },
+    });
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-shape-free-connector-edited.pptx",
+      writePptx(edited),
+    );
+  });
+
+  it("opens PPTX after deleting a connector", () => {
+    const sourcePptx = readFileSync(join(FIXTURE_DIR, "basic-shapes.pptx"));
+    const source = readPptx(sourcePptx);
+    const withConnector = addConnector(source, requireHandle(source.slides[0]?.handle), {
+      preset: "straightConnector1",
+      offsetX: asEmu(914400),
+      offsetY: asEmu(1371600),
+      width: asEmu(3657600),
+      height: asEmu(914400),
+      outline: {
+        tailEnd: { type: "triangle", width: "med", length: "med" },
+      },
+    });
+    const persisted = readPptx(writePptx(withConnector));
+    const connector = persisted.slides[0]?.shapes.find(
+      (shape): shape is SourceConnector => shape.kind === "connector",
+    );
+    const edited = deleteShape(persisted, requireHandle(connector?.handle));
+
+    renderSingleWithLibreOffice(
+      libreOfficeImage,
+      "editor-validity-shape-connector-delete-edited.pptx",
       writePptx(edited),
     );
   });


### PR DESCRIPTION
close #669

## 概要

- ブラウザエディター / dev-server UI に `Add connector` 導線を追加
- 接続サイトなしの free connector 追加を document writer / browser editor / dev-server backend で扱えるようにした
- 追加した connector を選択、move / resize / delete、undo / redo、保存できるようにした

## 影響範囲

- `packages/document/src/source`, `packages/document/src/writer`
- `packages/core/src/browser-editor.ts`, `packages/core/src/browser.ts`
- `scripts/dev-server.ts`
- `e2e/`, `vrt/editor-validity/`

## 検証

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test`
- `pnpm run build`
- `pnpm exec vitest run e2e/dev-server-editor.test.ts packages/document/src/source/editing.test.ts packages/document/src/writer/write-pptx.test.ts packages/core/src/browser-editor.test.ts`
- `pnpm exec vitest run vrt/editor-validity/editor-validity.test.ts`（この環境では fixture / Docker 条件により skip）
- `pnpm exec playwright test e2e/dev-server-editor.playwright.ts`
- `pnpm exec playwright test e2e/browser-standalone-editor.playwright.ts`

## 補足

- `pnpm install` は minimum release age policy で通常実行が止まったため、既存 lockfile を信頼する `pnpm install --trust-lockfile` で依存を復元した
- cross-review の warning を受け、`/api/editor/command` の `addConnector` 正規化が入力 preset / endpoint / outline を保持するよう追加修正済み
