### PR TITLE
demo: 公開デモサイトにブラウザエディターを搭載する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Install demo dependencies
+        run: cd demo && npm ci
+
       - name: Playwright tests
         run: pnpm run test:playwright
 
@@ -110,7 +113,7 @@ jobs:
 
       - name: Verify demo production samples
         if: matrix.node-version == 22
-        run: cd demo && npm ci && npx playwright install chromium && npm run verify:samples
+        run: cd demo && npx playwright install chromium && npm run verify:samples
 
   vrt:
     runs-on: ubuntu-latest

--- a/demo/src/app/globals.css
+++ b/demo/src/app/globals.css
@@ -247,10 +247,309 @@ header .description {
   gap: 10px;
 }
 
+.viewer-toolbar {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
 .viewer-summary span {
   background: var(--surface-2);
   border-radius: 999px;
   padding: 6px 10px;
+}
+
+.mode-switch {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  display: inline-grid;
+  grid-auto-flow: column;
+  overflow: hidden;
+}
+
+.mode-switch button {
+  background: transparent;
+  border: 0;
+  border-left: 1px solid var(--line);
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  min-height: 36px;
+  padding: 0 14px;
+}
+
+.mode-switch button:first-child {
+  border-left: 0;
+}
+
+.mode-switch button[aria-pressed="true"] {
+  background: var(--blueprint);
+  color: white;
+}
+
+.editor-workspace {
+  display: grid;
+  gap: 12px;
+}
+
+.editor-topbar {
+  align-items: center;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.editor-status {
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  gap: 8px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.editor-status span {
+  background: var(--surface-2);
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+.primary-action,
+.editor-panel button,
+.button-row button {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.primary-action {
+  background: var(--green);
+  border-color: transparent;
+  color: white;
+}
+
+.editor-panel button,
+.button-row button {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.editor-panel button:disabled,
+.button-row button:disabled,
+.format-toolbar button:disabled,
+.text-property-row button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.editor-shell {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 140px minmax(0, 1fr) 280px;
+  min-height: 620px;
+}
+
+.editor-thumbnails {
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.editor-thumbnail {
+  background: var(--surface);
+  border: 2px solid var(--line);
+  border-radius: 5px;
+  color: var(--muted);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  gap: 4px;
+  margin-bottom: 8px;
+  padding: 4px;
+  text-align: left;
+  width: 100%;
+}
+
+.editor-thumbnail.active {
+  border-color: var(--blueprint);
+  color: var(--blueprint);
+}
+
+.editor-thumbnail svg {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+.editor-stage {
+  align-items: center;
+  background:
+    linear-gradient(90deg, rgba(23, 33, 43, 0.05) 1px, transparent 1px),
+    linear-gradient(rgba(23, 33, 43, 0.05) 1px, transparent 1px), #dfe8ed;
+  background-size: 20px 20px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+  overflow: auto;
+  padding: 18px;
+}
+
+.editor-slide-frame {
+  background: var(--surface);
+  border: 1px solid #b8c4ca;
+  box-shadow: 0 12px 28px rgba(23, 33, 43, 0.18);
+  max-width: 100%;
+  position: relative;
+  width: min(960px, 100%);
+}
+
+.editor-slide-frame svg:not(.editor-selection-overlay) {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+.editor-selection-overlay {
+  height: 100%;
+  inset: 0;
+  overflow: visible;
+  position: absolute;
+  touch-action: none;
+  width: 100%;
+  z-index: 2;
+}
+
+.shape-hit-area {
+  cursor: move;
+  fill: transparent;
+  pointer-events: all;
+}
+
+.selection-box {
+  fill: none;
+  pointer-events: none;
+  stroke: var(--green);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.selection-handle {
+  fill: var(--surface);
+  pointer-events: all;
+  stroke: var(--green);
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.selection-handle.nw,
+.selection-handle.se {
+  cursor: nwse-resize;
+}
+
+.selection-handle.ne,
+.selection-handle.sw {
+  cursor: nesw-resize;
+}
+
+.editor-panel {
+  align-content: start;
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.panel-group {
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  gap: 8px;
+  padding-bottom: 12px;
+}
+
+.panel-group:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.panel-title {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.button-row,
+.format-toolbar,
+.text-property-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.format-toolbar {
+  grid-template-columns: repeat(3, 36px) 44px;
+}
+
+.editor-panel select,
+.editor-panel textarea,
+.editor-panel input[type="number"],
+.editor-panel input[type="text"],
+.text-property-row input {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  font: inherit;
+  min-height: 36px;
+  min-width: 0;
+  padding: 7px 9px;
+  width: 100%;
+}
+
+.editor-panel textarea {
+  line-height: 1.4;
+  resize: vertical;
+}
+
+.format-toolbar button {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 850;
+  min-height: 36px;
+}
+
+.format-toolbar input[type="color"] {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  height: 36px;
+  padding: 2px;
+  width: 44px;
+}
+
+.compact-error {
+  margin-bottom: 0;
 }
 
 footer {
@@ -285,6 +584,31 @@ footer a:hover {
   .drop-zone {
     grid-template-columns: 1fr;
     padding: 22px;
+  }
+
+  .viewer-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .editor-topbar {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .editor-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-thumbnails {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+  }
+
+  .editor-thumbnail {
+    flex: 0 0 120px;
+    margin-bottom: 0;
   }
 
   .file-actions {

--- a/demo/src/components/EditorWorkspace.tsx
+++ b/demo/src/components/EditorWorkspace.tsx
@@ -84,6 +84,7 @@ export function EditorWorkspace({
   const overlayRef = useRef<SVGSVGElement | null>(null);
   const dragStateRef = useRef<DragState | null>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const busyRef = useRef(true);
 
   const currentSlide = slides[currentIndex];
   const selectedShape = useMemo(() => {
@@ -137,6 +138,7 @@ export function EditorWorkspace({
     let cancelled = false;
 
     async function openEditor() {
+      busyRef.current = true;
       setBusy(true);
       setLoadError("");
       setOperationError("");
@@ -158,7 +160,10 @@ export function EditorWorkspace({
       } catch (error) {
         if (!cancelled) setLoadError(error instanceof Error ? error.message : String(error));
       } finally {
-        if (!cancelled) setBusy(false);
+        if (!cancelled) {
+          busyRef.current = false;
+          setBusy(false);
+        }
       }
     }
 
@@ -187,7 +192,8 @@ export function EditorWorkspace({
       success: string,
       preferredIndex = currentIndex,
     ) => {
-      if (editor === null) return;
+      if (editor === null || busyRef.current) return;
+      busyRef.current = true;
       setBusy(true);
       setOperationError("");
       try {
@@ -197,6 +203,7 @@ export function EditorWorkspace({
       } catch (error) {
         setOperationError(error instanceof Error ? error.message : String(error));
       } finally {
+        busyRef.current = false;
         setBusy(false);
       }
     },
@@ -214,6 +221,7 @@ export function EditorWorkspace({
 
   const handleSelectShape = useCallback(
     (shape: BrowserEditorShapeInfo, event?: React.PointerEvent<SVGRectElement>) => {
+      if (busyRef.current) return;
       if (shape.handle === undefined) return;
       editor?.selectShape(shape.handle);
       setSelectedShapeKey(shapeKey(shape));
@@ -259,18 +267,22 @@ export function EditorWorkspace({
         dragState.kind === "move"
           ? movedBounds(dragState.startBounds, dx, dy)
           : resizedBounds(dragState.startBounds, dragState.handle ?? "se", dx, dy);
-      if (nextBounds === undefined || sameBounds(dragState.startBounds, nextBounds)) return;
-      await applyCommand(
-        {
-          kind: "setShapeTransform",
-          handle: selectedShape.handle,
-          offsetX: pxToEmu(nextBounds.x),
-          offsetY: pxToEmu(nextBounds.y),
-          width: pxToEmu(nextBounds.width),
-          height: pxToEmu(nextBounds.height),
-        } satisfies ShapeTransformCommand,
-        "Shape updated",
-      );
+      try {
+        if (nextBounds === undefined || sameBounds(dragState.startBounds, nextBounds)) return;
+        await applyCommand(
+          {
+            kind: "setShapeTransform",
+            handle: selectedShape.handle,
+            offsetX: pxToEmu(nextBounds.x),
+            offsetY: pxToEmu(nextBounds.y),
+            width: pxToEmu(nextBounds.width),
+            height: pxToEmu(nextBounds.height),
+          } satisfies ShapeTransformCommand,
+          "Shape updated",
+        );
+      } finally {
+        setDraftBounds(null);
+      }
     },
     [applyCommand, selectedShape],
   );
@@ -298,6 +310,7 @@ export function EditorWorkspace({
 
   const handleResizeStart = useCallback(
     (handle: ResizeHandle, event: React.PointerEvent<SVGRectElement>) => {
+      if (busyRef.current) return;
       if (selectedShape?.bounds === undefined) return;
       event.preventDefault();
       event.stopPropagation();
@@ -422,20 +435,30 @@ export function EditorWorkspace({
   );
 
   const handleDownload = useCallback(() => {
-    if (editor === null) return;
-    const saved = editor.save();
-    setHistory(saved.history);
-    const href = URL.createObjectURL(
-      new Blob([uint8ArrayToArrayBuffer(saved.pptx)], {
-        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      }),
-    );
-    const link = document.createElement("a");
-    link.href = href;
-    link.download = editedFileName(fileName);
-    link.click();
-    URL.revokeObjectURL(href);
-    setMessage("PPTX downloaded");
+    if (editor === null || busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setOperationError("");
+    try {
+      const saved = editor.save();
+      setHistory(saved.history);
+      const href = URL.createObjectURL(
+        new Blob([uint8ArrayToArrayBuffer(saved.pptx)], {
+          type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        }),
+      );
+      const link = document.createElement("a");
+      link.href = href;
+      link.download = editedFileName(fileName);
+      link.click();
+      URL.revokeObjectURL(href);
+      setMessage("PPTX downloaded");
+    } catch (error) {
+      setOperationError(error instanceof Error ? error.message : String(error));
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
   }, [editor, fileName]);
 
   if (loadError !== "") {
@@ -459,7 +482,7 @@ export function EditorWorkspace({
     <section className="editor-workspace" aria-label="PPTX editor" data-testid="editor-workspace">
       <div className="editor-topbar">
         <div className="mode-switch" role="group" aria-label="Demo mode">
-          <button type="button" onClick={onBackToViewer}>
+          <button disabled={busy} type="button" onClick={onBackToViewer}>
             View
           </button>
           <button aria-pressed="true" type="button">
@@ -470,7 +493,7 @@ export function EditorWorkspace({
           <span>{message}</span>
           {busy ? <span>Working...</span> : null}
         </div>
-        <button className="primary-action" type="button" onClick={handleDownload}>
+        <button className="primary-action" disabled={busy} type="button" onClick={handleDownload}>
           Download PPTX
         </button>
       </div>
@@ -483,6 +506,7 @@ export function EditorWorkspace({
               data-testid="editor-thumbnail"
               key={`${slide.slideNumber.toString()}-${index.toString()}`}
               type="button"
+              disabled={busy}
               onClick={() => setCurrentIndex(index)}
             >
               <span>Slide {slide.slideNumber}</span>
@@ -528,7 +552,7 @@ export function EditorWorkspace({
                     width={selectedShape.bounds.width}
                     height={selectedShape.bounds.height}
                   />
-                  {selectedShape.editableTransform
+                  {selectedShape.editableTransform && !busy
                     ? (["nw", "ne", "sw", "se"] as const).map((handle) => {
                         const point = handlePoint(selectedShape.bounds!, handle);
                         return (
@@ -555,18 +579,22 @@ export function EditorWorkspace({
           <div className="panel-group">
             <div className="panel-title">Slide</div>
             <div className="button-row">
-              <button type="button" onClick={handleDuplicateSlide}>
+              <button disabled={busy} type="button" onClick={handleDuplicateSlide}>
                 Duplicate
               </button>
-              <button disabled={slides.length <= 1} type="button" onClick={handleDeleteSlide}>
+              <button
+                disabled={busy || slides.length <= 1}
+                type="button"
+                onClick={handleDeleteSlide}
+              >
                 Delete
               </button>
             </div>
             <div className="button-row">
-              <button disabled={!history.canUndo} type="button" onClick={handleUndo}>
+              <button disabled={busy || !history.canUndo} type="button" onClick={handleUndo}>
                 Undo
               </button>
-              <button disabled={!history.canRedo} type="button" onClick={handleRedo}>
+              <button disabled={busy || !history.canRedo} type="button" onClick={handleRedo}>
                 Redo
               </button>
             </div>
@@ -574,11 +602,11 @@ export function EditorWorkspace({
 
           <div className="panel-group">
             <div className="panel-title">Shape</div>
-            <button type="button" onClick={handleAddTextBox}>
+            <button disabled={busy} type="button" onClick={handleAddTextBox}>
               Add text box
             </button>
             <button
-              disabled={selectedShape?.editableDelete !== true}
+              disabled={busy || selectedShape?.editableDelete !== true}
               type="button"
               onClick={handleDeleteShape}
             >
@@ -586,7 +614,7 @@ export function EditorWorkspace({
             </button>
             <button
               data-testid="replace-image-button"
-              disabled={selectedShape?.editableImageReplacement === undefined}
+              disabled={busy || selectedShape?.editableImageReplacement === undefined}
               type="button"
               onClick={() => imageInputRef.current?.click()}
             >
@@ -595,7 +623,7 @@ export function EditorWorkspace({
             <input
               ref={imageInputRef}
               data-testid="image-replacement-input"
-              disabled={selectedShape?.editableImageReplacement === undefined}
+              disabled={busy || selectedShape?.editableImageReplacement === undefined}
               hidden
               type="file"
               accept={selectedShape?.editableImageReplacement?.accept}
@@ -607,7 +635,7 @@ export function EditorWorkspace({
             <div className="panel-title">Text</div>
             <select
               data-testid="text-run-select"
-              disabled={textRuns.length === 0}
+              disabled={busy || textRuns.length === 0}
               value={Math.min(selectedRunIndex, Math.max(textRuns.length - 1, 0))}
               onChange={(event) => setSelectedRunIndex(Number(event.target.value))}
             >
@@ -620,31 +648,35 @@ export function EditorWorkspace({
             </select>
             <textarea
               data-testid="text-run-input"
-              disabled={selectedRun === undefined}
+              disabled={busy || selectedRun === undefined}
               rows={3}
               value={textValue}
               onChange={(event) => setTextValue(event.target.value)}
             />
-            <button disabled={selectedRun === undefined} type="button" onClick={handleApplyText}>
+            <button
+              disabled={busy || selectedRun === undefined}
+              type="button"
+              onClick={handleApplyText}
+            >
               Apply text
             </button>
             <div className="format-toolbar" role="group" aria-label="Text style">
               <button
-                disabled={selectedRun === undefined}
+                disabled={busy || selectedRun === undefined}
                 type="button"
                 onClick={() => handleApplyTextProperties({ bold: true })}
               >
                 B
               </button>
               <button
-                disabled={selectedRun === undefined}
+                disabled={busy || selectedRun === undefined}
                 type="button"
                 onClick={() => handleApplyTextProperties({ italic: true })}
               >
                 I
               </button>
               <button
-                disabled={selectedRun === undefined}
+                disabled={busy || selectedRun === undefined}
                 type="button"
                 onClick={() => handleApplyTextProperties({ underline: true })}
               >
@@ -652,7 +684,7 @@ export function EditorWorkspace({
               </button>
               <input
                 aria-label="Text color"
-                disabled={selectedRun === undefined}
+                disabled={busy || selectedRun === undefined}
                 type="color"
                 value={color}
                 onChange={(event) => {
@@ -666,14 +698,14 @@ export function EditorWorkspace({
             <div className="text-property-row">
               <input
                 aria-label="Font size"
-                disabled={selectedRun === undefined}
+                disabled={busy || selectedRun === undefined}
                 min={1}
                 type="number"
                 value={fontSize}
                 onChange={(event) => setFontSize(event.target.value)}
               />
               <button
-                disabled={selectedRun === undefined || !isPositiveFiniteNumber(fontSize)}
+                disabled={busy || selectedRun === undefined || !isPositiveFiniteNumber(fontSize)}
                 type="button"
                 onClick={() => handleApplyTextProperties({ fontSize: pt(Number(fontSize)) })}
               >
@@ -683,13 +715,13 @@ export function EditorWorkspace({
             <div className="text-property-row">
               <input
                 aria-label="Typeface"
-                disabled={selectedRun === undefined}
+                disabled={busy || selectedRun === undefined}
                 placeholder="Typeface"
                 value={typeface}
                 onChange={(event) => setTypeface(event.target.value)}
               />
               <button
-                disabled={selectedRun === undefined || typeface.trim() === ""}
+                disabled={busy || selectedRun === undefined || typeface.trim() === ""}
                 type="button"
                 onClick={() => handleApplyTextProperties({ typeface: typeface.trim() })}
               >
@@ -697,7 +729,7 @@ export function EditorWorkspace({
               </button>
             </div>
             <button
-              disabled={selectedRun === undefined}
+              disabled={busy || selectedRun === undefined}
               type="button"
               onClick={handleClearTextProperties}
             >

--- a/demo/src/components/EditorWorkspace.tsx
+++ b/demo/src/components/EditorWorkspace.tsx
@@ -13,6 +13,7 @@ import {
 
 const EMU_PER_PIXEL = 9525;
 const MIN_SHAPE_SIZE = 8;
+const MAX_IMAGE_REPLACEMENT_BYTES = 5 * 1024 * 1024;
 
 type EditorSession = Awaited<ReturnType<typeof createBrowserPptxEditorSession>>;
 type ShapeTransformCommand = Extract<EditorCommand, { readonly kind: "setShapeTransform" }>;
@@ -182,7 +183,7 @@ export function EditorWorkspace({
 
   const runEditorOperation = useCallback(
     async (
-      operation: (session: EditorSession) => Promise<void> | void,
+      operation: (session: EditorSession) => Promise<string | void> | string | void,
       success: string,
       preferredIndex = currentIndex,
     ) => {
@@ -190,9 +191,9 @@ export function EditorWorkspace({
       setBusy(true);
       setOperationError("");
       try {
-        await operation(editor);
+        const messageOverride = await operation(editor);
         syncFromEditor(editor, preferredIndex);
-        setMessage(success);
+        setMessage(messageOverride ?? success);
       } catch (error) {
         setOperationError(error instanceof Error ? error.message : String(error));
       } finally {
@@ -206,7 +207,7 @@ export function EditorWorkspace({
     (command: EditorCommand, success: string) =>
       runEditorOperation(async (session) => {
         const result = await session.apply(command);
-        setMessage(commandMessage(success, result.warnings));
+        return commandMessage(success, result.warnings);
       }, success),
     [runEditorOperation],
   );
@@ -241,16 +242,23 @@ export function EditorWorkspace({
   const finishDrag = useCallback(
     async (event: PointerEvent) => {
       const dragState = dragStateRef.current;
+      const point = eventPoint(overlayRef.current, event.clientX, event.clientY);
       if (
         dragState === null ||
         event.pointerId !== dragState.pointerId ||
-        selectedShape?.handle === undefined
+        selectedShape?.handle === undefined ||
+        point === null
       ) {
         return;
       }
       dragStateRef.current = null;
 
-      const nextBounds = selectedShape.bounds;
+      const dx = point.x - dragState.startPoint.x;
+      const dy = point.y - dragState.startPoint.y;
+      const nextBounds =
+        dragState.kind === "move"
+          ? movedBounds(dragState.startBounds, dx, dy)
+          : resizedBounds(dragState.startBounds, dragState.handle ?? "se", dx, dy);
       if (nextBounds === undefined || sameBounds(dragState.startBounds, nextBounds)) return;
       await applyCommand(
         {
@@ -272,11 +280,19 @@ export function EditorWorkspace({
     const up = (event: PointerEvent) => {
       void finishDrag(event);
     };
+    const cancelDrag = () => {
+      dragStateRef.current = null;
+      setDraftBounds(null);
+    };
     window.addEventListener("pointermove", move);
     window.addEventListener("pointerup", up);
+    window.addEventListener("pointercancel", cancelDrag);
+    window.addEventListener("blur", cancelDrag);
     return () => {
       window.removeEventListener("pointermove", move);
       window.removeEventListener("pointerup", up);
+      window.removeEventListener("pointercancel", cancelDrag);
+      window.removeEventListener("blur", cancelDrag);
     };
   }, [finishDrag, updateDrag]);
 
@@ -383,6 +399,16 @@ export function EditorWorkspace({
       const file = event.target.files?.[0];
       event.target.value = "";
       if (file === undefined || selectedShape?.handle === undefined) return;
+      const replacement = selectedShape.editableImageReplacement;
+      if (replacement === undefined) return;
+      if (file.size > MAX_IMAGE_REPLACEMENT_BYTES) {
+        setOperationError("Replacement image must be 5 MB or smaller.");
+        return;
+      }
+      if (file.type !== "" && file.type !== replacement.contentType) {
+        setOperationError(`Replacement image must use ${replacement.contentType}.`);
+        return;
+      }
       await applyCommand(
         {
           kind: "replaceImage",
@@ -479,6 +505,9 @@ export function EditorWorkspace({
                 return (
                   <rect
                     className="shape-hit-area"
+                    data-editable-image-replacement={
+                      shape.editableImageReplacement !== undefined ? "true" : undefined
+                    }
                     data-testid="shape-hit-area"
                     key={`${shapeKey(shape)}-${index.toString()}`}
                     x={shape.bounds.x}
@@ -644,7 +673,7 @@ export function EditorWorkspace({
                 onChange={(event) => setFontSize(event.target.value)}
               />
               <button
-                disabled={selectedRun === undefined || Number(fontSize) <= 0}
+                disabled={selectedRun === undefined || !isPositiveFiniteNumber(fontSize)}
                 type="button"
                 onClick={() => handleApplyTextProperties({ fontSize: pt(Number(fontSize)) })}
               >
@@ -789,6 +818,11 @@ function pt(value: number): NonNullable<TextRunProperties["fontSize"]> {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
+}
+
+function isPositiveFiniteNumber(value: string): boolean {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0;
 }
 
 function viewBoxFromSvg(svg: string): string {

--- a/demo/src/components/EditorWorkspace.tsx
+++ b/demo/src/components/EditorWorkspace.tsx
@@ -556,6 +556,7 @@ export function EditorWorkspace({
               Delete shape
             </button>
             <button
+              data-testid="replace-image-button"
               disabled={selectedShape?.editableImageReplacement === undefined}
               type="button"
               onClick={() => imageInputRef.current?.click()}
@@ -565,6 +566,7 @@ export function EditorWorkspace({
             <input
               ref={imageInputRef}
               data-testid="image-replacement-input"
+              disabled={selectedShape?.editableImageReplacement === undefined}
               hidden
               type="file"
               accept={selectedShape?.editableImageReplacement?.accept}

--- a/demo/src/components/EditorWorkspace.tsx
+++ b/demo/src/components/EditorWorkspace.tsx
@@ -42,6 +42,7 @@ interface TextRunOption {
 interface DragState {
   readonly kind: "move" | "resize";
   readonly handle?: ResizeHandle;
+  readonly shapeHandle: SourceHandle;
   readonly pointerId: number;
   readonly startPoint: Point;
   readonly startBounds: BrowserEditorShapeBoundsPx;
@@ -227,7 +228,7 @@ export function EditorWorkspace({
       setSelectedShapeKey(shapeKey(shape));
       setDraftBounds(null);
       if (event !== undefined && shape.editableTransform && shape.bounds !== undefined) {
-        beginDrag("move", undefined, event, shape.bounds, dragStateRef, overlayRef);
+        beginDrag("move", undefined, shape.handle, event, shape.bounds, dragStateRef, overlayRef);
       }
     },
     [editor],
@@ -250,16 +251,13 @@ export function EditorWorkspace({
   const finishDrag = useCallback(
     async (event: PointerEvent) => {
       const dragState = dragStateRef.current;
+      if (dragState === null || event.pointerId !== dragState.pointerId) return;
+      dragStateRef.current = null;
       const point = eventPoint(overlayRef.current, event.clientX, event.clientY);
-      if (
-        dragState === null ||
-        event.pointerId !== dragState.pointerId ||
-        selectedShape?.handle === undefined ||
-        point === null
-      ) {
+      if (point === null) {
+        setDraftBounds(null);
         return;
       }
-      dragStateRef.current = null;
 
       const dx = point.x - dragState.startPoint.x;
       const dy = point.y - dragState.startPoint.y;
@@ -272,7 +270,7 @@ export function EditorWorkspace({
         await applyCommand(
           {
             kind: "setShapeTransform",
-            handle: selectedShape.handle,
+            handle: dragState.shapeHandle,
             offsetX: pxToEmu(nextBounds.x),
             offsetY: pxToEmu(nextBounds.y),
             width: pxToEmu(nextBounds.width),
@@ -284,7 +282,7 @@ export function EditorWorkspace({
         setDraftBounds(null);
       }
     },
-    [applyCommand, selectedShape],
+    [applyCommand],
   );
 
   useEffect(() => {
@@ -311,10 +309,18 @@ export function EditorWorkspace({
   const handleResizeStart = useCallback(
     (handle: ResizeHandle, event: React.PointerEvent<SVGRectElement>) => {
       if (busyRef.current) return;
-      if (selectedShape?.bounds === undefined) return;
+      if (selectedShape?.bounds === undefined || selectedShape.handle === undefined) return;
       event.preventDefault();
       event.stopPropagation();
-      beginDrag("resize", handle, event, selectedShape.bounds, dragStateRef, overlayRef);
+      beginDrag(
+        "resize",
+        handle,
+        selectedShape.handle,
+        event,
+        selectedShape.bounds,
+        dragStateRef,
+        overlayRef,
+      );
     },
     [selectedShape],
   );
@@ -422,11 +428,17 @@ export function EditorWorkspace({
         setOperationError(`Replacement image must use ${replacement.contentType}.`);
         return;
       }
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const detectedContentType = detectImageContentType(bytes);
+      if (detectedContentType !== replacement.contentType) {
+        setOperationError(`Replacement image must use ${replacement.contentType}.`);
+        return;
+      }
       await applyCommand(
         {
           kind: "replaceImage",
           handle: selectedShape.handle,
-          bytes: new Uint8Array(await file.arrayBuffer()),
+          bytes,
         },
         "Image replaced",
       );
@@ -451,7 +463,7 @@ export function EditorWorkspace({
       link.href = href;
       link.download = editedFileName(fileName);
       link.click();
-      URL.revokeObjectURL(href);
+      window.setTimeout(() => URL.revokeObjectURL(href), 0);
       setMessage("PPTX downloaded");
     } catch (error) {
       setOperationError(error instanceof Error ? error.message : String(error));
@@ -751,6 +763,7 @@ export function EditorWorkspace({
 function beginDrag(
   kind: "move" | "resize",
   handle: ResizeHandle | undefined,
+  shapeHandle: SourceHandle,
   event: React.PointerEvent<SVGRectElement>,
   startBounds: BrowserEditorShapeBoundsPx,
   dragStateRef: React.MutableRefObject<DragState | null>,
@@ -762,6 +775,7 @@ function beginDrag(
   dragStateRef.current = {
     kind,
     handle,
+    shapeHandle,
     pointerId: event.pointerId,
     startPoint,
     startBounds,
@@ -858,7 +872,15 @@ function isPositiveFiniteNumber(value: string): boolean {
 }
 
 function viewBoxFromSvg(svg: string): string {
-  return svg.match(/\sviewBox="([^"]+)"/)?.[1] ?? "0 0 960 540";
+  const fallback = svg.match(/\sviewBox="([^"]+)"/)?.[1] ?? "0 0 960 540";
+  if (typeof DOMParser === "undefined") return fallback;
+  const parsed = new DOMParser().parseFromString(svg, "image/svg+xml");
+  const root = parsed.documentElement;
+  const viewBox = root.getAttribute("viewBox");
+  if (viewBox !== null && viewBox.trim() !== "") return viewBox;
+  const width = parsePositiveSvgLength(root.getAttribute("width"));
+  const height = parsePositiveSvgLength(root.getAttribute("height"));
+  return width === undefined || height === undefined ? fallback : `0 0 ${width} ${height}`;
 }
 
 function editedFileName(fileName: string): string {
@@ -886,4 +908,45 @@ function uint8ArrayToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   const copy = new Uint8Array(bytes.byteLength);
   copy.set(bytes);
   return copy.buffer;
+}
+
+function parsePositiveSvgLength(value: string | null): number | undefined {
+  if (value === null) return undefined;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function detectImageContentType(bytes: Uint8Array): string | undefined {
+  if (startsWithBytes(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (startsWithBytes(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (
+    startsWithBytes(bytes, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) ||
+    startsWithBytes(bytes, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+  ) {
+    return "image/gif";
+  }
+  if (startsWithBytes(bytes, [0x42, 0x4d])) return "image/bmp";
+  if (
+    startsWithBytes(bytes, [0x49, 0x49, 0x2a, 0x00]) ||
+    startsWithBytes(bytes, [0x4d, 0x4d, 0x00, 0x2a])
+  ) {
+    return "image/tiff";
+  }
+  if (
+    startsWithBytes(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return undefined;
+}
+
+function startsWithBytes(bytes: Uint8Array, prefix: readonly number[]): boolean {
+  if (bytes.length < prefix.length) return false;
+  return prefix.every((value, index) => bytes[index] === value);
 }

--- a/demo/src/components/EditorWorkspace.tsx
+++ b/demo/src/components/EditorWorkspace.tsx
@@ -1,0 +1,821 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createBrowserPptxEditorSession,
+  type BrowserEditorShapeBoundsPx,
+  type BrowserEditorShapeInfo,
+  type BrowserEditorSlideSvg,
+  type EditorCommand,
+  type FontBuffer,
+  type SourceHandle,
+} from "pptx-glimpse";
+
+const EMU_PER_PIXEL = 9525;
+const MIN_SHAPE_SIZE = 8;
+
+type EditorSession = Awaited<ReturnType<typeof createBrowserPptxEditorSession>>;
+type ShapeTransformCommand = Extract<EditorCommand, { readonly kind: "setShapeTransform" }>;
+type TextRunProperties = Extract<
+  EditorCommand,
+  { readonly kind: "setTextRunProperties" }
+>["properties"];
+type ClearTextRunProperties = Extract<
+  EditorCommand,
+  { readonly kind: "clearTextRunProperties" }
+>["properties"];
+
+interface EditorWorkspaceProps {
+  readonly fileName: string;
+  readonly pptxBytes: Uint8Array;
+  readonly fonts: readonly FontBuffer[];
+  readonly onBackToViewer: () => void;
+}
+
+interface TextRunOption {
+  readonly label: string;
+  readonly text: string;
+  readonly handle: SourceHandle;
+}
+
+interface DragState {
+  readonly kind: "move" | "resize";
+  readonly handle?: ResizeHandle;
+  readonly pointerId: number;
+  readonly startPoint: Point;
+  readonly startBounds: BrowserEditorShapeBoundsPx;
+}
+
+interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+type ResizeHandle = "nw" | "ne" | "sw" | "se";
+
+export function EditorWorkspace({
+  fileName,
+  pptxBytes,
+  fonts,
+  onBackToViewer,
+}: EditorWorkspaceProps) {
+  const [editor, setEditor] = useState<EditorSession | null>(null);
+  const [slides, setSlides] = useState<BrowserEditorSlideSvg[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [shapeOptions, setShapeOptions] = useState<BrowserEditorShapeInfo[]>([]);
+  const [selectedShapeKey, setSelectedShapeKey] = useState<string | null>(null);
+  const [draftBounds, setDraftBounds] = useState<BrowserEditorShapeBoundsPx | null>(null);
+  const [selectedRunIndex, setSelectedRunIndex] = useState(0);
+  const [textValue, setTextValue] = useState("");
+  const [fontSize, setFontSize] = useState("24");
+  const [typeface, setTypeface] = useState("");
+  const [color, setColor] = useState("#2454a6");
+  const [history, setHistory] = useState({
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+    redoDepth: 0,
+  });
+  const [message, setMessage] = useState("Opening editor...");
+  const [busy, setBusy] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [operationError, setOperationError] = useState("");
+  const overlayRef = useRef<SVGSVGElement | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+
+  const currentSlide = slides[currentIndex];
+  const selectedShape = useMemo(() => {
+    if (selectedShapeKey === null) return null;
+    const shape = shapeOptions.find((candidate) => shapeKey(candidate) === selectedShapeKey);
+    if (shape === undefined) return null;
+    return draftBounds === null ? shape : { ...shape, bounds: draftBounds };
+  }, [draftBounds, selectedShapeKey, shapeOptions]);
+
+  const textRuns = useMemo<TextRunOption[]>(() => {
+    const sourceShapes = selectedShape === null ? [] : [selectedShape];
+    return sourceShapes.flatMap((shape) =>
+      (shape.textRuns ?? []).map((run, index) => ({
+        label: `${shape.name ?? shape.kind} / run ${(index + 1).toString()}`,
+        text: run.text,
+        handle: run.handle,
+      })),
+    );
+  }, [selectedShape]);
+
+  const selectedRun = textRuns[selectedRunIndex];
+
+  const syncFromEditor = useCallback(
+    (session: EditorSession, preferredIndex = currentIndex) => {
+      const nextSlides = [...session.slides];
+      const nextIndex = clamp(preferredIndex, 0, Math.max(nextSlides.length - 1, 0));
+      const nextShapes = session
+        .shapes(nextIndex + 1)
+        .filter((shape) => shape.handle !== undefined && shape.bounds !== undefined);
+      const responseSelection = session.selection?.shapeHandle;
+      const nextSelectionKey =
+        responseSelection !== undefined
+          ? handleKey(responseSelection)
+          : selectedShapeKey !== null &&
+              nextShapes.some((shape) => shapeKey(shape) === selectedShapeKey)
+            ? selectedShapeKey
+            : null;
+
+      setSlides(nextSlides);
+      setCurrentIndex(nextIndex);
+      setShapeOptions([...nextShapes]);
+      setSelectedShapeKey(nextSelectionKey);
+      setDraftBounds(null);
+      setHistory(session.history);
+      setSelectedRunIndex(0);
+    },
+    [currentIndex, selectedShapeKey],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function openEditor() {
+      setBusy(true);
+      setLoadError("");
+      setOperationError("");
+      try {
+        const session = await createBrowserPptxEditorSession(new Uint8Array(pptxBytes), {
+          fonts: [...fonts],
+          skipSystemFonts: true,
+          textOutput: "text",
+        });
+        if (cancelled) return;
+        setEditor(session);
+        setSlides([...session.slides]);
+        setShapeOptions([...session.shapes(1).filter((shape) => shape.handle && shape.bounds)]);
+        setHistory(session.history);
+        setCurrentIndex(0);
+        setMessage(
+          `${session.slides.length.toString()} slide${session.slides.length === 1 ? "" : "s"} ready`,
+        );
+      } catch (error) {
+        if (!cancelled) setLoadError(error instanceof Error ? error.message : String(error));
+      } finally {
+        if (!cancelled) setBusy(false);
+      }
+    }
+
+    void openEditor();
+    return () => {
+      cancelled = true;
+    };
+  }, [fonts, pptxBytes]);
+
+  useEffect(() => {
+    setSelectedRunIndex(0);
+  }, [selectedShapeKey]);
+
+  useEffect(() => {
+    setTextValue(selectedRun?.text ?? "");
+  }, [selectedRun]);
+
+  useEffect(() => {
+    if (editor === null) return;
+    syncFromEditor(editor, currentIndex);
+  }, [currentIndex, editor, syncFromEditor]);
+
+  const runEditorOperation = useCallback(
+    async (
+      operation: (session: EditorSession) => Promise<void> | void,
+      success: string,
+      preferredIndex = currentIndex,
+    ) => {
+      if (editor === null) return;
+      setBusy(true);
+      setOperationError("");
+      try {
+        await operation(editor);
+        syncFromEditor(editor, preferredIndex);
+        setMessage(success);
+      } catch (error) {
+        setOperationError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [currentIndex, editor, syncFromEditor],
+  );
+
+  const applyCommand = useCallback(
+    (command: EditorCommand, success: string) =>
+      runEditorOperation(async (session) => {
+        const result = await session.apply(command);
+        setMessage(commandMessage(success, result.warnings));
+      }, success),
+    [runEditorOperation],
+  );
+
+  const handleSelectShape = useCallback(
+    (shape: BrowserEditorShapeInfo, event?: React.PointerEvent<SVGRectElement>) => {
+      if (shape.handle === undefined) return;
+      editor?.selectShape(shape.handle);
+      setSelectedShapeKey(shapeKey(shape));
+      setDraftBounds(null);
+      if (event !== undefined && shape.editableTransform && shape.bounds !== undefined) {
+        beginDrag("move", undefined, event, shape.bounds, dragStateRef, overlayRef);
+      }
+    },
+    [editor],
+  );
+
+  const updateDrag = useCallback((event: PointerEvent) => {
+    const dragState = dragStateRef.current;
+    if (dragState === null || event.pointerId !== dragState.pointerId) return;
+    const point = eventPoint(overlayRef.current, event.clientX, event.clientY);
+    if (point === null) return;
+    const dx = point.x - dragState.startPoint.x;
+    const dy = point.y - dragState.startPoint.y;
+    setDraftBounds(
+      dragState.kind === "move"
+        ? movedBounds(dragState.startBounds, dx, dy)
+        : resizedBounds(dragState.startBounds, dragState.handle ?? "se", dx, dy),
+    );
+  }, []);
+
+  const finishDrag = useCallback(
+    async (event: PointerEvent) => {
+      const dragState = dragStateRef.current;
+      if (
+        dragState === null ||
+        event.pointerId !== dragState.pointerId ||
+        selectedShape?.handle === undefined
+      ) {
+        return;
+      }
+      dragStateRef.current = null;
+
+      const nextBounds = selectedShape.bounds;
+      if (nextBounds === undefined || sameBounds(dragState.startBounds, nextBounds)) return;
+      await applyCommand(
+        {
+          kind: "setShapeTransform",
+          handle: selectedShape.handle,
+          offsetX: pxToEmu(nextBounds.x),
+          offsetY: pxToEmu(nextBounds.y),
+          width: pxToEmu(nextBounds.width),
+          height: pxToEmu(nextBounds.height),
+        } satisfies ShapeTransformCommand,
+        "Shape updated",
+      );
+    },
+    [applyCommand, selectedShape],
+  );
+
+  useEffect(() => {
+    const move = (event: PointerEvent) => updateDrag(event);
+    const up = (event: PointerEvent) => {
+      void finishDrag(event);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+  }, [finishDrag, updateDrag]);
+
+  const handleResizeStart = useCallback(
+    (handle: ResizeHandle, event: React.PointerEvent<SVGRectElement>) => {
+      if (selectedShape?.bounds === undefined) return;
+      event.preventDefault();
+      event.stopPropagation();
+      beginDrag("resize", handle, event, selectedShape.bounds, dragStateRef, overlayRef);
+    },
+    [selectedShape],
+  );
+
+  const handleApplyText = useCallback(() => {
+    if (selectedRun === undefined) return;
+    return applyCommand(
+      { kind: "replaceTextRunPlainText", handle: selectedRun.handle, text: textValue },
+      "Text updated",
+    );
+  }, [applyCommand, selectedRun, textValue]);
+
+  const handleApplyTextProperties = useCallback(
+    (properties: TextRunProperties) => {
+      if (selectedRun === undefined) return;
+      return applyCommand(
+        { kind: "setTextRunProperties", handle: selectedRun.handle, properties },
+        "Text style updated",
+      );
+    },
+    [applyCommand, selectedRun],
+  );
+
+  const handleClearTextProperties = useCallback(() => {
+    if (selectedRun === undefined) return;
+    const properties: ClearTextRunProperties = [
+      "bold",
+      "italic",
+      "underline",
+      "fontSize",
+      "color",
+      "typeface",
+    ];
+    return applyCommand(
+      { kind: "clearTextRunProperties", handle: selectedRun.handle, properties },
+      "Text style cleared",
+    );
+  }, [applyCommand, selectedRun]);
+
+  const handleAddTextBox = useCallback(
+    () =>
+      runEditorOperation(async (session) => {
+        await session.addTextBox(currentIndex + 1);
+      }, "Text box added"),
+    [currentIndex, runEditorOperation],
+  );
+
+  const handleDeleteShape = useCallback(() => {
+    if (selectedShape?.handle === undefined) return;
+    return applyCommand({ kind: "deleteShape", handle: selectedShape.handle }, "Shape deleted");
+  }, [applyCommand, selectedShape]);
+
+  const handleDuplicateSlide = useCallback(() => {
+    if (currentSlide?.handle === undefined) return;
+    const nextIndex = currentIndex + 1;
+    return runEditorOperation(
+      async (session) => {
+        await session.apply({ kind: "duplicateSlide", handle: currentSlide.handle! });
+      },
+      "Slide duplicated",
+      nextIndex,
+    );
+  }, [currentIndex, currentSlide, runEditorOperation]);
+
+  const handleDeleteSlide = useCallback(() => {
+    if (currentSlide?.handle === undefined || slides.length <= 1) return;
+    const nextIndex = Math.max(0, currentIndex - 1);
+    return runEditorOperation(
+      async (session) => {
+        await session.apply({ kind: "deleteSlide", handle: currentSlide.handle! });
+      },
+      "Slide deleted",
+      nextIndex,
+    );
+  }, [currentIndex, currentSlide, runEditorOperation, slides.length]);
+
+  const handleUndo = useCallback(
+    () =>
+      runEditorOperation(async (session) => {
+        await session.undo();
+      }, "Undone"),
+    [runEditorOperation],
+  );
+
+  const handleRedo = useCallback(
+    () =>
+      runEditorOperation(async (session) => {
+        await session.redo();
+      }, "Redone"),
+    [runEditorOperation],
+  );
+
+  const handleImageReplacement = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (file === undefined || selectedShape?.handle === undefined) return;
+      await applyCommand(
+        {
+          kind: "replaceImage",
+          handle: selectedShape.handle,
+          bytes: new Uint8Array(await file.arrayBuffer()),
+        },
+        "Image replaced",
+      );
+    },
+    [applyCommand, selectedShape],
+  );
+
+  const handleDownload = useCallback(() => {
+    if (editor === null) return;
+    const saved = editor.save();
+    setHistory(saved.history);
+    const href = URL.createObjectURL(
+      new Blob([uint8ArrayToArrayBuffer(saved.pptx)], {
+        type: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      }),
+    );
+    const link = document.createElement("a");
+    link.href = href;
+    link.download = editedFileName(fileName);
+    link.click();
+    URL.revokeObjectURL(href);
+    setMessage("PPTX downloaded");
+  }, [editor, fileName]);
+
+  if (loadError !== "") {
+    return (
+      <div className="error" data-testid="editor-error">
+        {loadError}
+      </div>
+    );
+  }
+
+  if (editor === null || currentSlide === undefined) {
+    return (
+      <div className="loading" data-testid="editor-status">
+        <div className="loading-mark" aria-hidden="true" />
+        <p>{message}</p>
+      </div>
+    );
+  }
+
+  return (
+    <section className="editor-workspace" aria-label="PPTX editor" data-testid="editor-workspace">
+      <div className="editor-topbar">
+        <div className="mode-switch" role="group" aria-label="Demo mode">
+          <button type="button" onClick={onBackToViewer}>
+            View
+          </button>
+          <button aria-pressed="true" type="button">
+            Edit
+          </button>
+        </div>
+        <div className="editor-status" data-testid="editor-status">
+          <span>{message}</span>
+          {busy ? <span>Working...</span> : null}
+        </div>
+        <button className="primary-action" type="button" onClick={handleDownload}>
+          Download PPTX
+        </button>
+      </div>
+
+      <div className="editor-shell">
+        <aside className="editor-thumbnails" aria-label="Slides">
+          {slides.map((slide, index) => (
+            <button
+              className={`editor-thumbnail${index === currentIndex ? " active" : ""}`}
+              data-testid="editor-thumbnail"
+              key={`${slide.slideNumber.toString()}-${index.toString()}`}
+              type="button"
+              onClick={() => setCurrentIndex(index)}
+            >
+              <span>Slide {slide.slideNumber}</span>
+              <span dangerouslySetInnerHTML={{ __html: slide.svg }} />
+            </button>
+          ))}
+        </aside>
+
+        <div className="editor-stage">
+          <div className="editor-slide-frame" data-testid="editor-slide-frame">
+            <div dangerouslySetInnerHTML={{ __html: currentSlide.svg }} />
+            <svg
+              ref={overlayRef}
+              className="editor-selection-overlay"
+              data-testid="selection-overlay"
+              viewBox={viewBoxFromSvg(currentSlide.svg)}
+            >
+              {shapeOptions.map((shape, index) => {
+                if (shape.bounds === undefined) return null;
+                return (
+                  <rect
+                    className="shape-hit-area"
+                    data-testid="shape-hit-area"
+                    key={`${shapeKey(shape)}-${index.toString()}`}
+                    x={shape.bounds.x}
+                    y={shape.bounds.y}
+                    width={shape.bounds.width}
+                    height={shape.bounds.height}
+                    onPointerDown={(event) => handleSelectShape(shape, event)}
+                  />
+                );
+              })}
+              {selectedShape?.bounds !== undefined ? (
+                <>
+                  <rect
+                    className="selection-box"
+                    data-testid="selection-box"
+                    x={selectedShape.bounds.x}
+                    y={selectedShape.bounds.y}
+                    width={selectedShape.bounds.width}
+                    height={selectedShape.bounds.height}
+                  />
+                  {selectedShape.editableTransform
+                    ? (["nw", "ne", "sw", "se"] as const).map((handle) => {
+                        const point = handlePoint(selectedShape.bounds!, handle);
+                        return (
+                          <rect
+                            className={`selection-handle ${handle}`}
+                            data-testid={`selection-handle-${handle}`}
+                            key={handle}
+                            x={point.x - 4}
+                            y={point.y - 4}
+                            width={8}
+                            height={8}
+                            onPointerDown={(event) => handleResizeStart(handle, event)}
+                          />
+                        );
+                      })
+                    : null}
+                </>
+              ) : null}
+            </svg>
+          </div>
+        </div>
+
+        <aside className="editor-panel" aria-label="Editing controls">
+          <div className="panel-group">
+            <div className="panel-title">Slide</div>
+            <div className="button-row">
+              <button type="button" onClick={handleDuplicateSlide}>
+                Duplicate
+              </button>
+              <button disabled={slides.length <= 1} type="button" onClick={handleDeleteSlide}>
+                Delete
+              </button>
+            </div>
+            <div className="button-row">
+              <button disabled={!history.canUndo} type="button" onClick={handleUndo}>
+                Undo
+              </button>
+              <button disabled={!history.canRedo} type="button" onClick={handleRedo}>
+                Redo
+              </button>
+            </div>
+          </div>
+
+          <div className="panel-group">
+            <div className="panel-title">Shape</div>
+            <button type="button" onClick={handleAddTextBox}>
+              Add text box
+            </button>
+            <button
+              disabled={selectedShape?.editableDelete !== true}
+              type="button"
+              onClick={handleDeleteShape}
+            >
+              Delete shape
+            </button>
+            <button
+              disabled={selectedShape?.editableImageReplacement === undefined}
+              type="button"
+              onClick={() => imageInputRef.current?.click()}
+            >
+              Replace image
+            </button>
+            <input
+              ref={imageInputRef}
+              data-testid="image-replacement-input"
+              hidden
+              type="file"
+              accept={selectedShape?.editableImageReplacement?.accept}
+              onChange={handleImageReplacement}
+            />
+          </div>
+
+          <div className="panel-group">
+            <div className="panel-title">Text</div>
+            <select
+              data-testid="text-run-select"
+              disabled={textRuns.length === 0}
+              value={Math.min(selectedRunIndex, Math.max(textRuns.length - 1, 0))}
+              onChange={(event) => setSelectedRunIndex(Number(event.target.value))}
+            >
+              {textRuns.length === 0 ? <option>No text run selected</option> : null}
+              {textRuns.map((run, index) => (
+                <option key={handleKey(run.handle)} value={index}>
+                  {run.label}
+                </option>
+              ))}
+            </select>
+            <textarea
+              data-testid="text-run-input"
+              disabled={selectedRun === undefined}
+              rows={3}
+              value={textValue}
+              onChange={(event) => setTextValue(event.target.value)}
+            />
+            <button disabled={selectedRun === undefined} type="button" onClick={handleApplyText}>
+              Apply text
+            </button>
+            <div className="format-toolbar" role="group" aria-label="Text style">
+              <button
+                disabled={selectedRun === undefined}
+                type="button"
+                onClick={() => handleApplyTextProperties({ bold: true })}
+              >
+                B
+              </button>
+              <button
+                disabled={selectedRun === undefined}
+                type="button"
+                onClick={() => handleApplyTextProperties({ italic: true })}
+              >
+                I
+              </button>
+              <button
+                disabled={selectedRun === undefined}
+                type="button"
+                onClick={() => handleApplyTextProperties({ underline: true })}
+              >
+                U
+              </button>
+              <input
+                aria-label="Text color"
+                disabled={selectedRun === undefined}
+                type="color"
+                value={color}
+                onChange={(event) => {
+                  setColor(event.target.value);
+                  void handleApplyTextProperties({
+                    color: { kind: "srgb", hex: event.target.value.slice(1).toUpperCase() },
+                  });
+                }}
+              />
+            </div>
+            <div className="text-property-row">
+              <input
+                aria-label="Font size"
+                disabled={selectedRun === undefined}
+                min={1}
+                type="number"
+                value={fontSize}
+                onChange={(event) => setFontSize(event.target.value)}
+              />
+              <button
+                disabled={selectedRun === undefined || Number(fontSize) <= 0}
+                type="button"
+                onClick={() => handleApplyTextProperties({ fontSize: pt(Number(fontSize)) })}
+              >
+                Size
+              </button>
+            </div>
+            <div className="text-property-row">
+              <input
+                aria-label="Typeface"
+                disabled={selectedRun === undefined}
+                placeholder="Typeface"
+                value={typeface}
+                onChange={(event) => setTypeface(event.target.value)}
+              />
+              <button
+                disabled={selectedRun === undefined || typeface.trim() === ""}
+                type="button"
+                onClick={() => handleApplyTextProperties({ typeface: typeface.trim() })}
+              >
+                Font
+              </button>
+            </div>
+            <button
+              disabled={selectedRun === undefined}
+              type="button"
+              onClick={handleClearTextProperties}
+            >
+              Clear style
+            </button>
+          </div>
+
+          {operationError !== "" ? (
+            <div className="error compact-error" data-testid="editor-error">
+              {operationError}
+            </div>
+          ) : null}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function beginDrag(
+  kind: "move" | "resize",
+  handle: ResizeHandle | undefined,
+  event: React.PointerEvent<SVGRectElement>,
+  startBounds: BrowserEditorShapeBoundsPx,
+  dragStateRef: React.MutableRefObject<DragState | null>,
+  overlayRef: React.MutableRefObject<SVGSVGElement | null>,
+) {
+  const startPoint = eventPoint(overlayRef.current, event.clientX, event.clientY);
+  if (startPoint === null) return;
+  event.currentTarget.setPointerCapture(event.pointerId);
+  dragStateRef.current = {
+    kind,
+    handle,
+    pointerId: event.pointerId,
+    startPoint,
+    startBounds,
+  };
+}
+
+function eventPoint(svg: SVGSVGElement | null, clientX: number, clientY: number): Point | null {
+  const matrix = svg?.getScreenCTM();
+  if (svg === null || matrix === null || matrix === undefined) return null;
+  const point = svg.createSVGPoint();
+  point.x = clientX;
+  point.y = clientY;
+  const transformed = point.matrixTransform(matrix.inverse());
+  return { x: transformed.x, y: transformed.y };
+}
+
+function movedBounds(
+  bounds: BrowserEditorShapeBoundsPx,
+  dx: number,
+  dy: number,
+): BrowserEditorShapeBoundsPx {
+  return { ...bounds, x: bounds.x + dx, y: bounds.y + dy };
+}
+
+function resizedBounds(
+  bounds: BrowserEditorShapeBoundsPx,
+  handle: ResizeHandle,
+  dx: number,
+  dy: number,
+): BrowserEditorShapeBoundsPx {
+  const right = bounds.x + bounds.width;
+  const bottom = bounds.y + bounds.height;
+  const next = { ...bounds };
+  if (handle === "nw" || handle === "sw") {
+    next.x = Math.min(bounds.x + dx, right - MIN_SHAPE_SIZE);
+    next.width = right - next.x;
+  }
+  if (handle === "ne" || handle === "se") next.width = Math.max(MIN_SHAPE_SIZE, bounds.width + dx);
+  if (handle === "nw" || handle === "ne") {
+    next.y = Math.min(bounds.y + dy, bottom - MIN_SHAPE_SIZE);
+    next.height = bottom - next.y;
+  }
+  if (handle === "sw" || handle === "se")
+    next.height = Math.max(MIN_SHAPE_SIZE, bounds.height + dy);
+  return next;
+}
+
+function handlePoint(bounds: BrowserEditorShapeBoundsPx, handle: ResizeHandle): Point {
+  const right = bounds.x + bounds.width;
+  const bottom = bounds.y + bounds.height;
+  if (handle === "nw") return { x: bounds.x, y: bounds.y };
+  if (handle === "ne") return { x: right, y: bounds.y };
+  if (handle === "sw") return { x: bounds.x, y: bottom };
+  return { x: right, y: bottom };
+}
+
+function sameBounds(a: BrowserEditorShapeBoundsPx, b: BrowserEditorShapeBoundsPx): boolean {
+  return (
+    Math.round(a.x) === Math.round(b.x) &&
+    Math.round(a.y) === Math.round(b.y) &&
+    Math.round(a.width) === Math.round(b.width) &&
+    Math.round(a.height) === Math.round(b.height)
+  );
+}
+
+function shapeKey(shape: BrowserEditorShapeInfo): string {
+  return shape.handle === undefined ? "" : handleKey(shape.handle);
+}
+
+function handleKey(handle: SourceHandle): string {
+  return [
+    handle.partPath ?? "",
+    handle.nodeId ?? "",
+    handle.relationshipId ?? "",
+    handle.orderingSlot === undefined ? "" : String(handle.orderingSlot),
+  ].join("\u0000");
+}
+
+function pxToEmu(value: number): ShapeTransformCommand["offsetX"] {
+  return Math.round(value * EMU_PER_PIXEL) as ShapeTransformCommand["offsetX"];
+}
+
+function pt(value: number): NonNullable<TextRunProperties["fontSize"]> {
+  return value as NonNullable<TextRunProperties["fontSize"]>;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function viewBoxFromSvg(svg: string): string {
+  return svg.match(/\sviewBox="([^"]+)"/)?.[1] ?? "0 0 960 540";
+}
+
+function editedFileName(fileName: string): string {
+  return fileName.replace(/\.pptx$/i, "") + ".edited.pptx";
+}
+
+function commandMessage(
+  fallback: string,
+  warnings?: readonly {
+    readonly code: string;
+    readonly referenceCount?: number;
+    readonly mediaPartPath?: string;
+  }[],
+): string {
+  const sharedMedia = warnings?.find((warning) => warning.code === "shared-media-part");
+  if (sharedMedia !== undefined) {
+    return `${fallback}; shared media affects ${String(sharedMedia.referenceCount)} pictures: ${
+      sharedMedia.mediaPartPath ?? "media part"
+    }`;
+  }
+  return fallback;
+}
+
+function uint8ArrayToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}

--- a/demo/src/components/UploadViewer.tsx
+++ b/demo/src/components/UploadViewer.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { convertPptxToSvg, type FontBuffer } from "pptx-glimpse";
 
 import { DropZone, type SamplePptx } from "./DropZone";
+import { EditorWorkspace } from "./EditorWorkspace";
 import { SlideViewer } from "./SlideViewer";
 import { ThumbnailStrip } from "./ThumbnailStrip";
 
@@ -13,6 +14,7 @@ interface Slide {
 }
 
 type Phase = "upload" | "loading" | "viewing" | "error";
+type DemoMode = "view" | "edit";
 
 export function UploadViewer() {
   const [phase, setPhase] = useState<Phase>("upload");
@@ -20,7 +22,12 @@ export function UploadViewer() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [errorMessage, setErrorMessage] = useState("");
   const [fontFiles, setFontFiles] = useState<File[]>([]);
+  const [fontBuffers, setFontBuffers] = useState<FontBuffer[]>([]);
   const [renderedFontCount, setRenderedFontCount] = useState(0);
+  const [sourceFile, setSourceFile] = useState<{ fileName: string; bytes: Uint8Array } | null>(
+    null,
+  );
+  const [mode, setMode] = useState<DemoMode>("view");
 
   const handleFontFiles = useCallback((files: File[]) => {
     setFontFiles(files);
@@ -32,10 +39,11 @@ export function UploadViewer() {
       setErrorMessage("");
 
       try {
-        const [pptxBytes, fonts] = await Promise.all([
+        const [pptxArrayBuffer, fonts] = await Promise.all([
           file.arrayBuffer(),
           readFontBuffers(fontFiles),
         ]);
+        const pptxBytes = new Uint8Array(pptxArrayBuffer);
         const report = await convertPptxToSvg(new Uint8Array(pptxBytes), {
           fonts,
           skipSystemFonts: true,
@@ -46,8 +54,11 @@ export function UploadViewer() {
         }
 
         setSlides([...report.slides]);
+        setSourceFile({ fileName: file.name, bytes: pptxBytes });
+        setFontBuffers(fonts);
         setRenderedFontCount(fonts.length);
         setCurrentIndex(0);
+        setMode("view");
         setPhase("viewing");
       } catch (err) {
         setErrorMessage(err instanceof Error ? err.message : String(err));
@@ -114,14 +125,35 @@ export function UploadViewer() {
   }
 
   if (phase === "viewing") {
+    if (mode === "edit" && sourceFile !== null) {
+      return (
+        <EditorWorkspace
+          fileName={sourceFile.fileName}
+          fonts={fontBuffers}
+          pptxBytes={sourceFile.bytes}
+          onBackToViewer={() => setMode("view")}
+        />
+      );
+    }
+
     return (
       <>
-        <div className="viewer-summary" data-testid="viewer-status">
-          <span>{slides.length} slides rendered</span>
-          <span>
-            {renderedFontCount} font file{renderedFontCount === 1 ? "" : "s"} provided for this
-            render
-          </span>
+        <div className="viewer-toolbar">
+          <div className="viewer-summary" data-testid="viewer-status">
+            <span>{slides.length} slides rendered</span>
+            <span>
+              {renderedFontCount} font file{renderedFontCount === 1 ? "" : "s"} provided for this
+              render
+            </span>
+          </div>
+          <div className="mode-switch" role="group" aria-label="Demo mode">
+            <button aria-pressed="true" type="button">
+              View
+            </button>
+            <button data-testid="open-editor" type="button" onClick={() => setMode("edit")}>
+              Edit
+            </button>
+          </div>
         </div>
         <SlideViewer slides={slides} currentIndex={currentIndex} onNavigate={handleNavigate} />
         <ThumbnailStrip slides={slides} currentIndex={currentIndex} onSelect={handleNavigate} />

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,13 +1,10 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": [
-      "DOM",
-      "DOM.Iterable",
-      "ES2022"
-    ],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "customConditions": ["browser"],
     "jsx": "preserve",
     "strict": true,
     "esModuleInterop": true,
@@ -16,9 +13,7 @@
     "noEmit": true,
     "incremental": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "plugins": [
       {
@@ -35,7 +30,5 @@
     "src/**/*.tsx",
     ".next/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/e2e/demo-browser-editor.playwright.ts
+++ b/e2e/demo-browser-editor.playwright.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -24,6 +24,9 @@ const rendererPackageRoot = resolve(repoRoot, "packages/renderer");
 const corePackageRoot = resolve(repoRoot, "packages/core");
 const execFileAsync = promisify(execFile);
 const EMU_PER_PIXEL = 9525;
+const BLUE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGNkYPjPAANMcBZeDgAx0wEH1s7nlgAAAABJRU5ErkJggg==";
+const BLUE_PNG = new Uint8Array(Buffer.from(BLUE_PNG_BASE64, "base64"));
 
 let coreDistBuildPromise: Promise<void> | null = null;
 let demoBuildPromise: Promise<void> | null = null;
@@ -34,6 +37,9 @@ test("runs the public demo browser editor flow entirely client-side", async ({ p
   const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-demo-editor-test-"));
   try {
     const savedPath = join(dir, "demo.edited.pptx");
+    const replacementImagePath = join(dir, "replacement.png");
+    await writeFile(replacementImagePath, BLUE_PNG);
+
     await page.goto(server.url);
 
     await page.getByTestId("sample-basic-theme").click();
@@ -71,6 +77,16 @@ test("runs the public demo browser editor flow entirely client-side", async ({ p
     await page.getByRole("button", { name: "B", exact: true }).click();
     await expect(page.getByTestId("editor-status")).toContainText("Text style updated");
 
+    await page.getByRole("button", { name: "Delete shape" }).click();
+    await expect(page.getByTestId("editor-slide-frame")).not.toContainText("Added from demo e2e");
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expect(page.getByTestId("editor-slide-frame")).toContainText("Added from demo e2e");
+
+    await page.getByTestId("editor-thumbnail").nth(1).click();
+    await selectFirstReplaceableImage(page);
+    await page.getByTestId("image-replacement-input").setInputFiles(replacementImagePath);
+    await expect(page.getByTestId("editor-status")).toContainText("Image replaced");
+
     const download = page.waitForEvent("download");
     await page.getByRole("button", { name: "Download PPTX" }).click();
     await (await download).saveAs(savedPath);
@@ -84,6 +100,7 @@ test("runs the public demo browser editor flow entirely client-side", async ({ p
       height: 96 * EMU_PER_PIXEL,
     });
     expect(addedShape.textBody?.paragraphs[0]?.runs[0]?.properties?.bold).toBe(true);
+    expect(mediaBytes(saved, "ppt/media/image1.png")).toEqual(BLUE_PNG);
   } finally {
     await server.close();
     await rm(dir, { recursive: true, force: true });
@@ -101,6 +118,17 @@ async function dragSvgPoint(
   await page.mouse.down();
   await page.mouse.move(end.x, end.y, { steps: 6 });
   await page.mouse.up();
+}
+
+async function selectFirstReplaceableImage(page: Page): Promise<void> {
+  const hitAreas = page.getByTestId("shape-hit-area");
+  const imageButton = page.getByTestId("replace-image-button");
+  const count = await hitAreas.count();
+  for (let index = 0; index < count; index += 1) {
+    await hitAreas.nth(index).click();
+    if (!(await imageButton.isDisabled())) return;
+  }
+  throw new Error("replaceable image shape was not found");
 }
 
 async function svgPointToClient(
@@ -232,4 +260,10 @@ function shapeByText(source: PptxSourceModel, text: string): SourceShape {
     });
   if (shape === undefined) throw new Error(`shape not found: ${text}`);
   return shape;
+}
+
+function mediaBytes(source: PptxSourceModel, partPath: string): Uint8Array {
+  const media = source.packageGraph.media.find((part) => part.partPath === partPath);
+  if (media === undefined) throw new Error(`media not found: ${partPath}`);
+  return media.bytes;
 }

--- a/e2e/demo-browser-editor.playwright.ts
+++ b/e2e/demo-browser-editor.playwright.ts
@@ -30,17 +30,28 @@ const BLUE_PNG = new Uint8Array(Buffer.from(BLUE_PNG_BASE64, "base64"));
 
 let coreDistBuildPromise: Promise<void> | null = null;
 let demoBuildPromise: Promise<void> | null = null;
+let demoServer: DemoServer | null = null;
+
+test.beforeAll(async () => {
+  test.setTimeout(240_000);
+  demoServer = await startDemoServer();
+});
+
+test.afterAll(async () => {
+  await demoServer?.close();
+  demoServer = null;
+});
 
 test("runs the public demo browser editor flow entirely client-side", async ({ page }) => {
   test.setTimeout(120_000);
-  const server = await startDemoServer();
+  if (demoServer === null) throw new Error("demo server was not started");
   const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-demo-editor-test-"));
   try {
     const savedPath = join(dir, "demo.edited.pptx");
     const replacementImagePath = join(dir, "replacement.png");
     await writeFile(replacementImagePath, BLUE_PNG);
 
-    await page.goto(server.url);
+    await page.goto(demoServer.url);
 
     await page.getByTestId("sample-basic-theme").click();
     await expect(page.getByTestId("viewer-status")).toContainText("slides rendered");
@@ -102,7 +113,6 @@ test("runs the public demo browser editor flow entirely client-side", async ({ p
     expect(addedShape.textBody?.paragraphs[0]?.runs[0]?.properties?.bold).toBe(true);
     expect(mediaBytes(saved, "ppt/media/image1.png")).toEqual(BLUE_PNG);
   } finally {
-    await server.close();
     await rm(dir, { recursive: true, force: true });
   }
 });
@@ -179,14 +189,16 @@ async function startDemoServer(): Promise<DemoServer> {
     ["run", "start", "--", "--hostname", "127.0.0.1", "--port", String(port)],
     { cwd: demoRoot },
   );
-  await waitForServerReady(child, port);
+  try {
+    await waitForServerReady(child, port);
+  } catch (error) {
+    await stopChild(child);
+    throw error;
+  }
   return {
     url: `http://127.0.0.1:${String(port)}`,
     close: async () => {
-      child.kill();
-      await new Promise<void>((resolveClose) => {
-        child.once("exit", () => resolveClose());
-      });
+      await stopChild(child);
     },
   };
 }
@@ -195,7 +207,7 @@ async function ensureDemoBuild(): Promise<void> {
   demoBuildPromise ??= (async () => {
     await ensureCoreDist();
     if (!existsSync(resolve(demoRoot, "node_modules/.bin/next"))) {
-      await execFileAsync("npm", ["install"], { cwd: demoRoot, maxBuffer: 20 * 1024 * 1024 });
+      await execFileAsync("npm", ["ci"], { cwd: demoRoot, maxBuffer: 20 * 1024 * 1024 });
     }
     await execFileAsync("npm", ["run", "build"], { cwd: demoRoot, maxBuffer: 20 * 1024 * 1024 });
   })();
@@ -239,6 +251,14 @@ async function closeServer(server: Server): Promise<void> {
       if (error) rejectClose(error);
       else resolveClose();
     });
+  });
+}
+
+async function stopChild(child: ReturnType<typeof execFile>): Promise<void> {
+  if (child.exitCode !== null) return;
+  await new Promise<void>((resolveExit) => {
+    child.once("exit", () => resolveExit());
+    child.kill();
   });
 }
 

--- a/e2e/demo-browser-editor.playwright.ts
+++ b/e2e/demo-browser-editor.playwright.ts
@@ -121,14 +121,28 @@ async function dragSvgPoint(
 }
 
 async function selectFirstReplaceableImage(page: Page): Promise<void> {
-  const hitAreas = page.getByTestId("shape-hit-area");
+  const hitAreas = page.locator(
+    '[data-testid="shape-hit-area"][data-editable-image-replacement="true"]',
+  );
   const imageButton = page.getByTestId("replace-image-button");
   const count = await hitAreas.count();
-  for (let index = 0; index < count; index += 1) {
-    await hitAreas.nth(index).click();
-    if (!(await imageButton.isDisabled())) return;
-  }
-  throw new Error("replaceable image shape was not found");
+  if (count === 0) throw new Error("replaceable image shape was not found");
+  const bounds = await hitAreas.first().evaluate((element) => {
+    if (!(element instanceof SVGRectElement)) throw new Error("shape hit area is not a rect");
+    return {
+      x: element.x.baseVal.value,
+      y: element.y.baseVal.value,
+      width: element.width.baseVal.value,
+      height: element.height.baseVal.value,
+    };
+  });
+  const point = await svgPointToClient(
+    page,
+    bounds.x + bounds.width / 2,
+    bounds.y + bounds.height / 2,
+  );
+  await page.mouse.click(point.x, point.y);
+  await expect(imageButton).toBeEnabled();
 }
 
 async function svgPointToClient(

--- a/e2e/demo-browser-editor.playwright.ts
+++ b/e2e/demo-browser-editor.playwright.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { type ChildProcessWithoutNullStreams, execFile, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
@@ -188,7 +188,7 @@ interface DemoServer {
 async function startDemoServer(): Promise<DemoServer> {
   await ensureDemoBuild();
   const port = await findFreePort();
-  const child = execFile(
+  const child = spawn(
     "npm",
     ["run", "start", "--", "--hostname", "127.0.0.1", "--port", String(port)],
     { cwd: demoRoot },
@@ -211,7 +211,7 @@ async function ensureDemoBuild(): Promise<void> {
   demoBuildPromise ??= (async () => {
     await ensureCoreDist();
     if (!existsSync(resolve(demoRoot, "node_modules/.bin/next"))) {
-      await execFileAsync("npm", ["ci"], { cwd: demoRoot, maxBuffer: 20 * 1024 * 1024 });
+      throw new Error("demo dependencies are not installed; run `cd demo && npm ci` first.");
     }
     await execFileAsync("npm", ["run", "build"], { cwd: demoRoot, maxBuffer: 20 * 1024 * 1024 });
   })();
@@ -258,22 +258,25 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
-async function stopChild(child: ReturnType<typeof execFile>): Promise<void> {
-  if (child.exitCode !== null) return;
+async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (hasExited(child)) return;
   await new Promise<void>((resolveExit) => {
     child.once("exit", () => resolveExit());
     child.kill();
   });
 }
 
-async function waitForServerReady(child: ReturnType<typeof execFile>, port: number): Promise<void> {
+async function waitForServerReady(
+  child: ChildProcessWithoutNullStreams,
+  port: number,
+): Promise<void> {
   const output: string[] = [];
   child.stdout?.on("data", (chunk: Buffer) => output.push(chunk.toString()));
   child.stderr?.on("data", (chunk: Buffer) => output.push(chunk.toString()));
 
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
-    if (child.exitCode !== null) {
+    if (hasExited(child)) {
       throw new Error(`demo server exited early:\n${output.join("")}`);
     }
     try {
@@ -285,6 +288,10 @@ async function waitForServerReady(child: ReturnType<typeof execFile>, port: numb
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
   }
   throw new Error(`demo server did not become ready:\n${output.join("")}`);
+}
+
+function hasExited(child: ChildProcessWithoutNullStreams): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
 }
 
 function shapeByText(source: PptxSourceModel, text: string): SourceShape {

--- a/e2e/demo-browser-editor.playwright.ts
+++ b/e2e/demo-browser-editor.playwright.ts
@@ -93,7 +93,10 @@ test("runs the public demo browser editor flow entirely client-side", async ({ p
     await page.getByRole("button", { name: "Undo" }).click();
     await expect(page.getByTestId("editor-slide-frame")).toContainText("Added from demo e2e");
 
-    await page.getByTestId("editor-thumbnail").nth(1).click();
+    const secondThumbnail = page.getByTestId("editor-thumbnail").nth(1);
+    await expect(secondThumbnail).toBeEnabled();
+    await secondThumbnail.click();
+    await expect(secondThumbnail).toHaveClass(/active/);
     await selectFirstReplaceableImage(page);
     await page.getByTestId("image-replacement-input").setInputFiles(replacementImagePath);
     await expect(page.getByTestId("editor-status")).toContainText("Image replaced");
@@ -135,6 +138,7 @@ async function selectFirstReplaceableImage(page: Page): Promise<void> {
     '[data-testid="shape-hit-area"][data-editable-image-replacement="true"]',
   );
   const imageButton = page.getByTestId("replace-image-button");
+  await expect(hitAreas.first()).toBeVisible();
   const count = await hitAreas.count();
   if (count === 0) throw new Error("replaceable image shape was not found");
   const bounds = await hitAreas.first().evaluate((element) => {

--- a/e2e/demo-browser-editor.playwright.ts
+++ b/e2e/demo-browser-editor.playwright.ts
@@ -1,0 +1,235 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { expect, type Page, test } from "@playwright/test";
+
+import {
+  type PptxSourceModel,
+  readPptx,
+  type SourceShape,
+} from "../packages/document/src/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const demoRoot = resolve(repoRoot, "demo");
+const documentPackageRoot = resolve(repoRoot, "packages/document");
+const editorCorePackageRoot = resolve(repoRoot, "packages/editor-core");
+const rendererPackageRoot = resolve(repoRoot, "packages/renderer");
+const corePackageRoot = resolve(repoRoot, "packages/core");
+const execFileAsync = promisify(execFile);
+const EMU_PER_PIXEL = 9525;
+
+let coreDistBuildPromise: Promise<void> | null = null;
+let demoBuildPromise: Promise<void> | null = null;
+
+test("runs the public demo browser editor flow entirely client-side", async ({ page }) => {
+  test.setTimeout(120_000);
+  const server = await startDemoServer();
+  const dir = await mkdtemp(join(tmpdir(), "pptx-glimpse-demo-editor-test-"));
+  try {
+    const savedPath = join(dir, "demo.edited.pptx");
+    await page.goto(server.url);
+
+    await page.getByTestId("sample-basic-theme").click();
+    await expect(page.getByTestId("viewer-status")).toContainText("slides rendered");
+    await page.getByTestId("open-editor").click();
+    await expect(page.getByTestId("editor-workspace")).toBeVisible();
+    await expect(page.getByTestId("editor-status")).toContainText("ready");
+
+    await page.getByRole("button", { name: "Duplicate" }).click();
+    await expect(page.getByTestId("editor-thumbnail")).toHaveCount(3);
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect(page.getByTestId("editor-thumbnail")).toHaveCount(2);
+
+    await page.getByRole("button", { name: "Add text box" }).click();
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "96");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "96");
+
+    await dragSvgPoint(page, { x: 240, y: 132 }, { x: 264, y: 148 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("x", "120");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("y", "112");
+
+    await dragSvgPoint(page, { x: 408, y: 184 }, { x: 456, y: 208 });
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("height", "96");
+
+    await page.getByRole("button", { name: "Undo" }).click();
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "288");
+    await page.getByRole("button", { name: "Redo" }).click();
+    await expect(page.getByTestId("selection-box")).toHaveAttribute("width", "336");
+
+    await page.getByTestId("text-run-input").fill("Added from demo e2e");
+    await page.getByRole("button", { name: "Apply text" }).click();
+    await expect(page.getByTestId("editor-slide-frame")).toContainText("Added from demo e2e");
+
+    await page.getByRole("button", { name: "B", exact: true }).click();
+    await expect(page.getByTestId("editor-status")).toContainText("Text style updated");
+
+    const download = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Download PPTX" }).click();
+    await (await download).saveAs(savedPath);
+
+    const saved = readPptx(await readFile(savedPath));
+    const addedShape = shapeByText(saved, "Added from demo e2e");
+    expect(addedShape.transform).toMatchObject({
+      offsetX: 120 * EMU_PER_PIXEL,
+      offsetY: 112 * EMU_PER_PIXEL,
+      width: 336 * EMU_PER_PIXEL,
+      height: 96 * EMU_PER_PIXEL,
+    });
+    expect(addedShape.textBody?.paragraphs[0]?.runs[0]?.properties?.bold).toBe(true);
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function dragSvgPoint(
+  page: Page,
+  from: { readonly x: number; readonly y: number },
+  to: { readonly x: number; readonly y: number },
+) {
+  const start = await svgPointToClient(page, from.x, from.y);
+  const end = await svgPointToClient(page, to.x, to.y);
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(end.x, end.y, { steps: 6 });
+  await page.mouse.up();
+}
+
+async function svgPointToClient(
+  page: Page,
+  x: number,
+  y: number,
+): Promise<{ readonly x: number; readonly y: number }> {
+  return page.evaluate(
+    ({ svgX, svgY }) => {
+      const overlay = document.querySelector('[data-testid="selection-overlay"]');
+      if (!(overlay instanceof SVGSVGElement)) throw new Error("selection overlay not found");
+      const point = overlay.createSVGPoint();
+      point.x = svgX;
+      point.y = svgY;
+      const matrix = overlay.getScreenCTM();
+      if (matrix === null) throw new Error("selection overlay matrix not found");
+      const screenPoint = point.matrixTransform(matrix);
+      return { x: screenPoint.x, y: screenPoint.y };
+    },
+    { svgX: x, svgY: y },
+  );
+}
+
+interface DemoServer {
+  readonly url: string;
+  close(): Promise<void>;
+}
+
+async function startDemoServer(): Promise<DemoServer> {
+  await ensureDemoBuild();
+  const port = await findFreePort();
+  const child = execFile(
+    "npm",
+    ["run", "start", "--", "--hostname", "127.0.0.1", "--port", String(port)],
+    { cwd: demoRoot },
+  );
+  await waitForServerReady(child, port);
+  return {
+    url: `http://127.0.0.1:${String(port)}`,
+    close: async () => {
+      child.kill();
+      await new Promise<void>((resolveClose) => {
+        child.once("exit", () => resolveClose());
+      });
+    },
+  };
+}
+
+async function ensureDemoBuild(): Promise<void> {
+  demoBuildPromise ??= (async () => {
+    await ensureCoreDist();
+    if (!existsSync(resolve(demoRoot, "node_modules/.bin/next"))) {
+      await execFileAsync("npm", ["install"], { cwd: demoRoot, maxBuffer: 20 * 1024 * 1024 });
+    }
+    await execFileAsync("npm", ["run", "build"], { cwd: demoRoot, maxBuffer: 20 * 1024 * 1024 });
+  })();
+  await demoBuildPromise;
+}
+
+async function ensureCoreDist(): Promise<void> {
+  coreDistBuildPromise ??= (async () => {
+    await runPackageBuild(documentPackageRoot);
+    await runPackageBuild(editorCorePackageRoot);
+    await runPackageBuild(rendererPackageRoot);
+    await runPackageBuild(corePackageRoot);
+  })();
+  await coreDistBuildPromise;
+}
+
+async function runPackageBuild(packageRoot: string): Promise<void> {
+  await execFileAsync(resolve(repoRoot, "node_modules/.bin/tsup"), ["--config", "tsup.config.ts"], {
+    cwd: packageRoot,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+async function findFreePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("server did not expose a TCP port");
+  }
+  const port = address.port;
+  await closeServer(server);
+  return port;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => {
+      if (error) rejectClose(error);
+      else resolveClose();
+    });
+  });
+}
+
+async function waitForServerReady(child: ReturnType<typeof execFile>, port: number): Promise<void> {
+  const output: string[] = [];
+  child.stdout?.on("data", (chunk: Buffer) => output.push(chunk.toString()));
+  child.stderr?.on("data", (chunk: Buffer) => output.push(chunk.toString()));
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`demo server exited early:\n${output.join("")}`);
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${String(port)}`);
+      if (response.ok) return;
+    } catch {
+      // Server is still starting.
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  throw new Error(`demo server did not become ready:\n${output.join("")}`);
+}
+
+function shapeByText(source: PptxSourceModel, text: string): SourceShape {
+  const shape = source.slides
+    .flatMap((slide) => slide.shapes)
+    .find((node): node is SourceShape => {
+      if (node.kind !== "shape") return false;
+      return node.textBody?.paragraphs.some((paragraph) =>
+        paragraph.runs.some((run) => run.text === text),
+      );
+    });
+  if (shape === undefined) throw new Error(`shape not found: ${text}`);
+  return shape;
+}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,6 +12,7 @@ const config: KnipConfig = {
         "e2e/dev-server-editor.playwright.ts",
         "e2e/browser-standalone-viewer.playwright.ts",
         "e2e/browser-standalone-editor.playwright.ts",
+        "e2e/demo-browser-editor.playwright.ts",
       ],
     },
     "packages/core": {


### PR DESCRIPTION
close #666

## 概要

- 公開 demo の viewer から編集モードを開ける `EditorWorkspace` を追加
- `pptx-glimpse` browser entry の editor API を使い、テキスト編集、move / resize、run property 装飾、テキストボックス追加、shape 削除、画像差し替え、slide 複製・削除、undo / redo、PPTX ダウンロードをクライアントサイドで実行
- demo の e2e で主要編集フローと保存済み PPTX の再読込検証を追加
- CI の Playwright job で demo dependencies を事前 install するよう調整

## 確認

- `./node_modules/.bin/playwright test e2e/demo-browser-editor.playwright.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run lint`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run typecheck`
- `./node_modules/.bin/prettier --check demo/src/components/EditorWorkspace.tsx demo/src/components/UploadViewer.tsx demo/src/app/globals.css demo/tsconfig.json e2e/demo-browser-editor.playwright.ts .github/workflows/ci.yml`
- `cd demo && ./node_modules/.bin/tsc --noEmit`
- `cd demo && npm run build`

## 補足

- #668 は closed になっていることを確認済み
- 変換・編集・保存は demo アプリ内のブラウザ処理で完結し、demo 側にアップロード用 API route は追加していません
